### PR TITLE
Support invoices with unspecified amount via send_payment

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -249,7 +249,7 @@ interface BlockingBreezServices {
    void stop();
 
    [Throws=SDKError]
-   void send_payment(string bolt11);
+   void send_payment(string bolt11, u64? amount_sats);
     
    [Throws=SDKError]
    void send_spontaneous_payment(string node_id, u64 amount_sats);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -132,8 +132,8 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.stop())
     }
 
-    pub fn send_payment(&self, bolt11: String) -> Result<(), SDKError> {
-        rt().block_on(self.breez_services.send_payment(bolt11))
+    pub fn send_payment(&self, bolt11: String, amount_sats: Option<u64>) -> Result<(), SDKError> {
+        rt().block_on(self.breez_services.send_payment(bolt11, amount_sats))
             .map_err(|e| e.into())
     }
 

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -158,8 +158,12 @@ pub fn stop_node() -> Result<()> {
 /// # Arguments
 ///
 /// * `bolt11` - The bolt11 invoice
-pub fn send_payment(bolt11: String) -> Result<()> {
-    block_on(async { get_breez_services()?.send_payment(bolt11).await })
+pub fn send_payment(bolt11: String, amount_sats: Option<u64>) -> Result<()> {
+    block_on(async {
+        get_breez_services()?
+            .send_payment(bolt11, amount_sats)
+            .await
+    })
 }
 
 /// pay directly to a node id using keysend

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -150,9 +150,9 @@ impl BreezServices {
         sender.send(()).await.map_err(anyhow::Error::msg)
     }
 
-    pub async fn send_payment(&self, bolt11: String) -> Result<()> {
+    pub async fn send_payment(&self, bolt11: String, amount_sats: Option<u64>) -> Result<()> {
         self.start_node().await?;
-        self.node_api.send_payment(bolt11, None).await?;
+        self.node_api.send_payment(bolt11, amount_sats).await?;
         self.sync().await?;
         Ok(())
     }
@@ -177,7 +177,7 @@ impl BreezServices {
                 Ok(LnUrlPayResult::EndpointError { data: e })
             }
             ValidatedCallbackResponse::EndpointSuccess { data: cb } => {
-                self.send_payment(cb.pr).await?;
+                self.send_payment(cb.pr, None).await?;
                 Ok(LnUrlPayResult::EndpointSuccess {
                     data: cb.success_action,
                 })

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -47,8 +47,12 @@ pub extern "C" fn wire_stop_node(port_: i64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_send_payment(port_: i64, bolt11: *mut wire_uint_8_list) {
-    wire_send_payment_impl(port_, bolt11)
+pub extern "C" fn wire_send_payment(
+    port_: i64,
+    bolt11: *mut wire_uint_8_list,
+    amount_sats: *mut u64,
+) {
+    wire_send_payment_impl(port_, bolt11, amount_sats)
 }
 
 #[no_mangle]
@@ -187,6 +191,11 @@ pub extern "C" fn new_box_autoadd_ln_url_pay_request_data_0() -> *mut wire_LnUrl
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_u64_0(value: u64) -> *mut u64 {
+    support::new_leak_box_ptr(value)
+}
+
+#[no_mangle]
 pub extern "C" fn new_uint_8_list_0(len: i32) -> *mut wire_uint_8_list {
     let ans = wire_uint_8_list {
         ptr: support::new_leak_vec_ptr(Default::default(), len),
@@ -224,6 +233,7 @@ impl Wire2Api<LnUrlPayRequestData> for *mut wire_LnUrlPayRequestData {
         Wire2Api::<LnUrlPayRequestData>::wire2api(*wrap).into()
     }
 }
+
 impl Wire2Api<Config> for wire_Config {
     fn wire2api(self) -> Config {
         Config {

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -71,7 +71,7 @@ void wire_breez_log_stream(int64_t port_);
 
 void wire_stop_node(int64_t port_);
 
-void wire_send_payment(int64_t port_, struct wire_uint_8_list *bolt11);
+void wire_send_payment(int64_t port_, struct wire_uint_8_list *bolt11, uint64_t *amount_sats);
 
 void wire_send_spontaneous_payment(int64_t port_,
                                    struct wire_uint_8_list *node_id,
@@ -130,6 +130,8 @@ int64_t *new_box_autoadd_i64_0(int64_t value);
 
 struct wire_LnUrlPayRequestData *new_box_autoadd_ln_url_pay_request_data_0(void);
 
+uint64_t *new_box_autoadd_u64_0(uint64_t value);
+
 struct wire_uint_8_list *new_uint_8_list_0(int32_t len);
 
 void free_WireSyncReturnStruct(struct WireSyncReturnStruct val);
@@ -165,6 +167,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_credentials_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_i64_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_pay_request_data_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_u64_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturnStruct);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -79,7 +79,8 @@ abstract class BreezSdkCore {
   /// # Arguments
   ///
   /// * `bolt11` - The bolt11 invoice
-  Future<void> sendPayment({required String bolt11, dynamic hint});
+  Future<void> sendPayment(
+      {required String bolt11, int? amountSats, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kSendPaymentConstMeta;
 
@@ -849,13 +850,15 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
-  Future<void> sendPayment({required String bolt11, dynamic hint}) {
+  Future<void> sendPayment(
+      {required String bolt11, int? amountSats, dynamic hint}) {
     var arg0 = _platform.api2wire_String(bolt11);
+    var arg1 = _platform.api2wire_opt_box_autoadd_u64(amountSats);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_send_payment(port_, arg0),
+      callFfi: (port_) => _platform.inner.wire_send_payment(port_, arg0, arg1),
       parseSuccessData: _wire2api_unit,
       constMeta: kSendPaymentConstMeta,
-      argValues: [bolt11],
+      argValues: [bolt11, amountSats],
       hint: hint,
     ));
   }
@@ -863,7 +866,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kSendPaymentConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
         debugName: "send_payment",
-        argNames: ["bolt11"],
+        argNames: ["bolt11", "amountSats"],
       );
 
   Future<void> sendSpontaneousPayment(
@@ -1847,6 +1850,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<ffi.Uint64> api2wire_box_autoadd_u64(int raw) {
+    return inner.new_box_autoadd_u64_0(api2wire_u64(raw));
+  }
+
+  @protected
   int api2wire_i64(int raw) {
     return raw;
   }
@@ -1864,6 +1872,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   @protected
   ffi.Pointer<ffi.Int64> api2wire_opt_box_autoadd_i64(int? raw) {
     return raw == null ? ffi.nullptr : api2wire_box_autoadd_i64(raw);
+  }
+
+  @protected
+  ffi.Pointer<ffi.Uint64> api2wire_opt_box_autoadd_u64(int? raw) {
+    return raw == null ? ffi.nullptr : api2wire_box_autoadd_u64(raw);
   }
 
   @protected
@@ -2140,19 +2153,22 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   void wire_send_payment(
     int port_,
     ffi.Pointer<wire_uint_8_list> bolt11,
+    ffi.Pointer<ffi.Uint64> amount_sats,
   ) {
     return _wire_send_payment(
       port_,
       bolt11,
+      amount_sats,
     );
   }
 
   late final _wire_send_paymentPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_send_payment');
-  late final _wire_send_payment = _wire_send_paymentPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Pointer<ffi.Uint64>)>>('wire_send_payment');
+  late final _wire_send_payment = _wire_send_paymentPtr.asFunction<
+      void Function(
+          int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<ffi.Uint64>)>();
 
   void wire_send_spontaneous_payment(
     int port_,
@@ -2508,6 +2524,20 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_ln_url_pay_request_data_0 =
       _new_box_autoadd_ln_url_pay_request_data_0Ptr
           .asFunction<ffi.Pointer<wire_LnUrlPayRequestData> Function()>();
+
+  ffi.Pointer<ffi.Uint64> new_box_autoadd_u64_0(
+    int value,
+  ) {
+    return _new_box_autoadd_u64_0(
+      value,
+    );
+  }
+
+  late final _new_box_autoadd_u64_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint64> Function(ffi.Uint64)>>(
+          'new_box_autoadd_u64_0');
+  late final _new_box_autoadd_u64_0 = _new_box_autoadd_u64_0Ptr
+      .asFunction<ffi.Pointer<ffi.Uint64> Function(int)>();
 
   ffi.Pointer<wire_uint_8_list> new_uint_8_list_0(
     int len,

--- a/tools/sdk-cli/src/main.rs
+++ b/tools/sdk-cli/src/main.rs
@@ -146,8 +146,11 @@ fn main() -> Result<()> {
                             .next()
                             .ok_or("Expected bolt11 arg")
                             .map_err(|err| anyhow!(err))?;
+                        let amount_sats: Option<u64> = command
+                            .next()
+                            .map_or(None, |v| Some(v.parse::<u64>().ok()?));
 
-                        show_results(binding::send_payment(bolt11.into()))
+                        show_results(binding::send_payment(bolt11.into(), amount_sats))
                     }
                     Some("send_spontaneous_payment") => {
                         let node_id = command


### PR DESCRIPTION
This PR addresses https://github.com/breez/c-breez/issues/249 and is part of https://github.com/breez/c-breez/pull/293
- Pass optional amount_sats parameter to send_payment
- Support optional amount_sats parameter on send_payment cli command
- Generate bindings