### PR TITLE
CLI App: Replace binding calls with direct BreezServices calls

### DIFF
--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -368,9 +368,11 @@ dependencies = [
  "env_logger",
  "hex",
  "log",
+ "once_cell",
  "rustyline",
  "serde_json",
  "tiny-bip39",
+ "tokio",
 ]
 
 [[package]]

--- a/tools/sdk-cli/Cargo.toml
+++ b/tools/sdk-cli/Cargo.toml
@@ -11,6 +11,8 @@ breez-sdk-core = { path = "../../libs/sdk-core"}
 env_logger = "*"
 hex = "*"
 log = "*"
+once_cell = "*"
 rustyline = "10.0.0"
 serde_json = "1.0"
 tiny-bip39 = "*"
+tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
Replace all `binding` calls with the `BreezServices` equivalents.