### PR TITLE
Expose lsp_id function

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -335,6 +335,9 @@ interface BlockingBreezServices {
    LspInformation lsp_info();
 
    [Throws=SDKError]
+   string lsp_id();   
+
+   [Throws=SDKError]
    void close_lsp_channels(); 
 
    [Throws=SDKError]

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -232,6 +232,11 @@ impl BlockingBreezServices {
             .map_err(|e| e.into())
     }
 
+    pub fn lsp_id(&self) -> Result<String, SDKError> {
+        rt().block_on(self.breez_services.lsp_id())
+            .map_err(|e| e.into())
+    }
+
     pub fn close_lsp_channels(&self) -> Result<(), SDKError> {
         rt().block_on(self.breez_services.close_lsp_channels())
             .map_err(|e| e.into())

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -247,6 +247,10 @@ pub fn lsp_info() -> Result<LspInformation> {
     block_on(async { get_breez_services()?.lsp_info().await })
 }
 
+pub fn lsp_id() -> Result<String> {
+    block_on(async { get_breez_services()?.lsp_id().await })
+}
+
 /// Fetch live rates of fiat currencies
 pub fn fetch_fiat_rates() -> Result<Vec<Rate>> {
     block_on(async { get_breez_services()?.fetch_fiat_rates().await })

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -262,6 +262,12 @@ impl BreezServices {
         Ok(())
     }
 
+    pub async fn lsp_id(&self) -> Result<String> {
+        self.persister
+            .get_lsp_id()?
+            .ok_or(anyhow!("No LSP ID found"))
+    }
+
     /// Convenience method to look up LSP info based on current LSP ID
     pub async fn lsp_info(&self) -> Result<LspInformation> {
         get_lsp(self.persister.clone(), self.lsp_api.clone()).await

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -109,6 +109,11 @@ pub extern "C" fn wire_lsp_info(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_lsp_id(port_: i64) {
+    wire_lsp_id_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_fetch_fiat_rates(port_: i64) {
     wire_fetch_fiat_rates_impl(port_)
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -277,6 +277,16 @@ fn wire_lsp_info_impl(port_: MessagePort) {
         move || move |task_callback| lsp_info(),
     )
 }
+fn wire_lsp_id_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "lsp_id",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| lsp_id(),
+    )
+}
 fn wire_fetch_fiat_rates_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -105,6 +105,8 @@ void wire_connect_lsp(int64_t port_, struct wire_uint_8_list *lsp_id);
 
 void wire_lsp_info(int64_t port_);
 
+void wire_lsp_id(int64_t port_);
+
 void wire_fetch_fiat_rates(int64_t port_);
 
 void wire_list_fiat_currencies(int64_t port_);
@@ -177,6 +179,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_list_lsps);
     dummy_var ^= ((int64_t) (void*) wire_connect_lsp);
     dummy_var ^= ((int64_t) (void*) wire_lsp_info);
+    dummy_var ^= ((int64_t) (void*) wire_lsp_id);
     dummy_var ^= ((int64_t) (void*) wire_fetch_fiat_rates);
     dummy_var ^= ((int64_t) (void*) wire_list_fiat_currencies);
     dummy_var ^= ((int64_t) (void*) wire_close_lsp_channels);

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -143,6 +143,10 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kLspInfoConstMeta;
 
+  Future<String> lspId({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kLspIdConstMeta;
+
   /// Fetch live rates of fiat currencies
   Future<List<Rate>> fetchFiatRates({dynamic hint});
 
@@ -1109,6 +1113,22 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kLspInfoConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
         debugName: "lsp_info",
+        argNames: [],
+      );
+
+  Future<String> lspId({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_lsp_id(port_),
+      parseSuccessData: _wire2api_String,
+      constMeta: kLspIdConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kLspIdConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "lsp_id",
         argNames: [],
       );
 
@@ -2584,6 +2604,18 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'wire_lsp_info');
   late final _wire_lsp_info =
       _wire_lsp_infoPtr.asFunction<void Function(int)>();
+
+  void wire_lsp_id(
+    int port_,
+  ) {
+    return _wire_lsp_id(
+      port_,
+    );
+  }
+
+  late final _wire_lsp_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_lsp_id');
+  late final _wire_lsp_id = _wire_lsp_idPtr.asFunction<void Function(int)>();
 
   void wire_fetch_fiat_rates(
     int port_,


### PR DESCRIPTION
This exposed the lsp_id to the user. The LSPInformation is already exposed by the `lsp_info` function but this requires connectivity to the lsp and when there is not connectivity the user is not able to know if an lsp was already selected.
required to fix https://github.com/breez/c-breez/issues/336