### PR TITLE
Add cli persistent config and commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ libs/sdk-bindings/storage.sql
 .DS_Store
 .idea/
 
+tools/sdk-cli/config.json

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -145,9 +145,11 @@ impl Config {
 }
 
 /// Indicates the different kinds of supported environments for [crate::BreezServices]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, EnumString)]
 pub enum EnvironmentType {
+    #[strum(serialize = "production")]
     Production,
+    #[strum(serialize = "staging")]
     Staging,
 }
 

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustyline",
+ "serde",
  "serde_json",
  "tiny-bip39",
  "tokio",

--- a/tools/sdk-cli/Cargo.toml
+++ b/tools/sdk-cli/Cargo.toml
@@ -16,3 +16,4 @@ rustyline = "10.0.0"
 serde_json = "1.0"
 tiny-bip39 = "*"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/tools/sdk-cli/src/config.rs
+++ b/tools/sdk-cli/src/config.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use breez_sdk_core::{BreezServices, Config, EnvironmentType};
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+const CONFIG_FILE_NAME: &str = "config.json";
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct CliConfig {
+    pub(crate) api_key: Option<String>,
+    pub(crate) env: EnvironmentType,
+}
+
+impl Default for CliConfig {
+    fn default() -> Self {
+        CliConfig {
+            api_key: None,
+            env: EnvironmentType::Production,
+        }
+    }
+}
+
+impl CliConfig {
+    pub(crate) fn to_sdk_config(&self) -> Config {
+        let mut config = BreezServices::default_config(self.env.clone());
+        config.api_key = self.api_key.clone();
+        config
+    }
+}
+
+pub(crate) fn get_or_create_config() -> Result<CliConfig> {
+    let config: CliConfig = match fs::read(CONFIG_FILE_NAME) {
+        Ok(raw) => serde_json::from_slice(raw.as_slice()).unwrap(),
+        Err(_) => {
+            let config = CliConfig::default();
+            save_config(config.clone())?;
+            config
+        }
+    };
+    Ok(config)
+}
+
+pub(crate) fn save_config(config: CliConfig) -> Result<()> {
+    fs::write(CONFIG_FILE_NAME, serde_json::to_vec(&config)?)?;
+    Ok(())
+}


### PR DESCRIPTION
Now cli has a configuration that is persisted in config.json file.
Default is production config and two commands were added:

1. set_api_key <key> - allow set the api key to the cli config.
2. set_env <production|staging> allow saving the environment type.
