### PR TITLE
Enforce iOS not to strip symbols for release

### DIFF
--- a/libs/sdk-flutter/ios/Classes/SwiftBreezSDKPlugin.swift
+++ b/libs/sdk-flutter/ios/Classes/SwiftBreezSDKPlugin.swift
@@ -14,7 +14,8 @@ public class SwiftBreezSDKPlugin: NSObject, FlutterPlugin {
   }
 
   public func dummyMethodToEnforceBundling() {
-    dummy_method_to_enforce_bundling();
+    let dummy = dummy_method_to_enforce_bundling();
+    print(dummy)
     // ...
     // This code will force the bundler to use these functions, but will never be called
   }  


### PR DESCRIPTION
It turns out that one issue that prevents iOS from running in release mode is the stripped of unused symbols which effectively sums up to all sdk symbols...
This trick prevents it.