### PR TITLE
Split start from init

### DIFF
--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -63,8 +63,7 @@ class BreezBridge {
       network: network,
       seed: seed,
     );
-    await fetchNodeData();
-    await startNode();
+    await fetchNodeData();    
     return creds;
   }
 
@@ -85,8 +84,7 @@ class BreezBridge {
       network: network,
       seed: seed,
     );
-    await fetchNodeData();
-    await startNode();
+    await fetchNodeData();    
     return creds;
   }
 
@@ -108,8 +106,7 @@ class BreezBridge {
       seed: seed,
       creds: creds,
     );
-    await fetchNodeData();
-    await startNode();
+    await fetchNodeData();    
   }
 
   Future<void> startNode() async => await _lnToolkit.startNode();


### PR DESCRIPTION
The main motivation for this PR is to be able to recover if start fails (for example when no internet connection).
Before this PR start could technically be called several times leaving threads behind so this PR ensures that:
1. start can only be called once in case succeed and several times until success.
2. start invocations are synchronized.

In addition the code decouples the start from the init/recover/register in the bridge allowing the user to call init without internet connection which result in a BreezServices instance in hand where after that successive start invocations can be called until success.

In order to remove the internet connection requirement from the initialization the scheduler connection creation is also deferred to be lazily constructed. 