### PR TITLE
Make sync method public

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -366,6 +366,9 @@ interface BlockingBreezServices {
    string execute_dev_command(string command);
 
    [Throws=SDKError]
+   void sync();
+
+   [Throws=SDKError]
    RecommendedFees recommended_fees();
 };
 

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -265,6 +265,11 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.execute_dev_command(command))
     }
 
+    pub fn sync(&self) -> Result<(), SDKError> {
+        rt().block_on(self.breez_services.sync())
+            .map_err(|e| e.into())
+    }
+
     pub fn recommended_fees(&self) -> Result<RecommendedFees, SDKError> {
         rt().block_on(self.breez_services.recommended_fees())
             .map_err(|e| e.into())

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -278,6 +278,10 @@ pub fn execute_command(command: String) -> Result<String> {
     block_on(async { get_breez_services()?.execute_dev_command(command).await })
 }
 
+pub async fn sync() -> Result<()> {
+    block_on(async { get_breez_services()?.sync().await })
+}
+
 fn get_breez_services() -> Result<&'static BreezServices> {
     let n = BREEZ_SERVICES_INSTANCE.get();
     match n {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -375,7 +375,7 @@ impl BreezServices {
     /// * node state - General information about the node and its liquidity status
     /// * channels - The list of channels and their status
     /// * payments - The incoming/outgoing payments
-    async fn sync(&self) -> Result<()> {
+    pub async fn sync(&self) -> Result<()> {
         self.start_node().await?;
         self.connect_lsp_peer().await?;
 

--- a/tools/sdk-cli/src/main.rs
+++ b/tools/sdk-cli/src/main.rs
@@ -170,6 +170,7 @@ async fn main() -> Result<()> {
                         }
                         None => error!("Credentials not found"),
                     },
+                    Some("sync") => show_results(sdk()?.sync().await),
                     Some("receive_payment") => {
                         let amount_sats: u64 = command.next().unwrap().parse()?;
                         let description = command.next().unwrap().parse()?;
@@ -389,6 +390,7 @@ Node:
     register_node
     stop_node
     node_info
+    sync
     execute_command
 LSP:
     close_lsp_channels


### PR DESCRIPTION
This is needed for users to sync with the node until we will get the remote changes streamed to the sdk via gRPC.