### PR TITLE
Fix tests on linux by fixing path concat

### DIFF
--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -371,14 +371,14 @@ pub fn create_test_config() -> crate::models::Config {
 }
 
 pub fn create_test_persister(config: crate::models::Config) -> crate::persist::db::SqliteStorage {
-    let storage_path = format!("{}storage.sql", config.working_dir);
+    let storage_path = format!("{}/storage.sql", config.working_dir);
     crate::persist::db::SqliteStorage::from_file(storage_path)
 }
 
 pub fn get_test_working_dir() -> String {
     let mut rng = rand::thread_rng();
     let s = std::env::temp_dir().to_str().unwrap().to_string();
-    let dir = format!("{}{}", s, rng.gen::<u32>());
+    let dir = format!("{}/{}", s, rng.gen::<u32>());
     std::fs::create_dir_all(dir.clone()).unwrap();
     dir
 }


### PR DESCRIPTION
Without this, several tests on linux fail:

```
---- swap::tests::test_expired_swap stdout ----
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }', sdk-core/src/test_utils.rs:382:42

---- swap::tests::test_redeem_swap stdout ----
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }', sdk-core/src/test_utils.rs:382:42

---- swap::tests::test_spent_swap stdout ----
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }', sdk-core/src/test_utils.rs:382:42
```