### PR TITLE
Rename exposed sync function as it's a reserved word in Dart language

### DIFF
--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -278,7 +278,7 @@ pub fn execute_command(command: String) -> Result<String> {
     block_on(async { get_breez_services()?.execute_dev_command(command).await })
 }
 
-pub fn sync() -> Result<()> {
+pub fn sync_node() -> Result<()> {
     block_on(async { get_breez_services()?.sync().await })
 }
 

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -163,8 +163,8 @@ pub extern "C" fn wire_execute_command(port_: i64, command: *mut wire_uint_8_lis
 }
 
 #[no_mangle]
-pub extern "C" fn wire_sync(port_: i64) {
-    wire_sync_impl(port_)
+pub extern "C" fn wire_sync_node(port_: i64) {
+    wire_sync_node_impl(port_)
 }
 
 #[no_mangle]

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -393,14 +393,14 @@ fn wire_execute_command_impl(port_: MessagePort, command: impl Wire2Api<String> 
         },
     )
 }
-fn wire_sync_impl(port_: MessagePort) {
+fn wire_sync_node_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "sync",
+            debug_name: "sync_node",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| sync(),
+        move || move |task_callback| sync_node(),
     )
 }
 fn wire_parse_invoice_impl(port_: MessagePort, invoice: impl Wire2Api<String> + UnwindSafe) {

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -128,7 +128,7 @@ void wire_refund(int64_t port_,
 
 void wire_execute_command(int64_t port_, struct wire_uint_8_list *command);
 
-void wire_sync(int64_t port_);
+void wire_sync_node(int64_t port_);
 
 void wire_parse_invoice(int64_t port_, struct wire_uint_8_list *invoice);
 
@@ -192,7 +192,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_list_refundables);
     dummy_var ^= ((int64_t) (void*) wire_refund);
     dummy_var ^= ((int64_t) (void*) wire_execute_command);
-    dummy_var ^= ((int64_t) (void*) wire_sync);
+    dummy_var ^= ((int64_t) (void*) wire_sync_node);
     dummy_var ^= ((int64_t) (void*) wire_parse_invoice);
     dummy_var ^= ((int64_t) (void*) wire_parse);
     dummy_var ^= ((int64_t) (void*) wire_lnurl_pay);

--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -114,7 +114,7 @@ class BreezBridge {
   /// Cleanup node resources and stop the signer.
   Future<void> stopNode() async => await _lnToolkit.stopNode();
 
-  Future<void> sync() async => await _lnToolkit.sync();
+  Future<void> syncNode() async => await _lnToolkit.syncNode();
 
   /// pay a bolt11 invoice
   ///

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -178,9 +178,9 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kExecuteCommandConstMeta;
 
-  Future<void> sync({dynamic hint});
+  Future<void> syncNode({dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kSyncConstMeta;
+  FlutterRustBridgeTaskConstMeta get kSyncNodeConstMeta;
 
   Future<LNInvoice> parseInvoice({required String invoice, dynamic hint});
 
@@ -1345,19 +1345,19 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["command"],
       );
 
-  Future<void> sync({dynamic hint}) {
+  Future<void> syncNode({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_sync(port_),
+      callFfi: (port_) => _platform.inner.wire_sync_node(port_),
       parseSuccessData: _wire2api_unit,
-      constMeta: kSyncConstMeta,
+      constMeta: kSyncNodeConstMeta,
       argValues: [],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kSyncConstMeta =>
+  FlutterRustBridgeTaskConstMeta get kSyncNodeConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
-        debugName: "sync",
+        debugName: "sync_node",
         argNames: [],
       );
 
@@ -2892,17 +2892,19 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_execute_command = _wire_execute_commandPtr
       .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
-  void wire_sync(
+  void wire_sync_node(
     int port_,
   ) {
-    return _wire_sync(
+    return _wire_sync_node(
       port_,
     );
   }
 
-  late final _wire_syncPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_sync');
-  late final _wire_sync = _wire_syncPtr.asFunction<void Function(int)>();
+  late final _wire_sync_nodePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_sync_node');
+  late final _wire_sync_node =
+      _wire_sync_nodePtr.asFunction<void Function(int)>();
 
   void wire_parse_invoice(
     int port_,


### PR DESCRIPTION
- Rename exposed sync method to sync_node
 - Generate Dart bindings