### PR TITLE
Add support for AES successAction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,8 @@ jobs:
       - name: clippy
         run: |
           cd libs
-          cargo clippy -- -D warnings
-          cargo clippy --tests -- -D warnings
+          # Explicitly allow clippy::uninlined-format-args lint because it's present in the generated breez_sdk.uniffi.rs
+          cargo clippy -- -D warnings -A clippy::uninlined-format-args
+          cargo clippy --tests -- -D warnings -A clippy::uninlined-format-args
           cd ../tools/sdk-cli
           cargo clippy -- -D warnings

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -109,6 +109,27 @@ interface PaymentDetails {
     ClosedChannel(ClosedChannelPaymentDetails data);
 };
 
+dictionary AesSuccessActionDataDecrypted {
+    string description;
+    string plaintext;
+};
+
+dictionary MessageSuccessActionData {
+    string message;
+};
+
+dictionary UrlSuccessActionData {
+    string description;
+    string url;
+};
+
+[Enum]
+interface SuccessActionProcessed {
+    Aes(AesSuccessActionDataDecrypted data);
+    Message(MessageSuccessActionData data);
+    Url(UrlSuccessActionData data);
+};
+
 dictionary LnPaymentDetails {
     string payment_hash;
     string label;
@@ -116,6 +137,7 @@ dictionary LnPaymentDetails {
     string payment_preimage;
     boolean keysend;
     string bolt11;
+    SuccessActionProcessed? lnurl_success_action;
 };
 
 dictionary ClosedChannelPaymentDetails {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -4,14 +4,15 @@ use anyhow::{anyhow, Result};
 
 use breez_sdk_core::{
     mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
-    parse_invoice as sdk_parse_invoice, BitcoinAddressData, BreezEvent, BreezServices,
-    ChannelState, ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType,
-    EventListener, FeeratePreset, FiatCurrency, GreenlightCredentials, InputType,
+    parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BitcoinAddressData,
+    BreezEvent, BreezServices, ChannelState, ClosedChannelPaymentDetails, Config, CurrencyInfo,
+    EnvironmentType, EventListener, FeeratePreset, FiatCurrency, GreenlightCredentials, InputType,
     InvoicePaidDetails, LNInvoice, LnPaymentDetails, LnUrlAuthRequestData, LnUrlErrorData,
     LnUrlPayRequestData, LnUrlWithdrawCallbackStatus, LnUrlWithdrawRequestData, LocaleOverrides,
-    LocalizedName, LogEntry, LspInformation, MetadataItem, Network, NodeState, Payment,
-    PaymentDetails, PaymentType, PaymentTypeFilter, Rate, RecommendedFees, RouteHint, RouteHintHop,
-    SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput,
+    LocalizedName, LogEntry, LspInformation, MessageSuccessActionData, MetadataItem, Network,
+    NodeState, Payment, PaymentDetails, PaymentType, PaymentTypeFilter, Rate, RecommendedFees,
+    RouteHint, RouteHintHop, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
+    UnspentTransactionOutput, UrlSuccessActionData,
 };
 use log::Metadata;
 use log::Record;

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -9,7 +9,9 @@ crate-type = ["staticlib", "cdylib", "lib"]
 
 [dependencies]
 flutter_rust_bridge = "1"
+aes = "0.8"
 anyhow = { version = "1.0.57", features = ["backtrace"] }
+cbc = { version = "0.1", features = ["std"] }
 hex = "*"
 bip21 = "*"
 bitcoin_hashes = "*"

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -7,7 +7,10 @@ use crate::grpc::information_client::InformationClient;
 use crate::grpc::PaymentInformation;
 use crate::input_parser::LnUrlPayRequestData;
 use crate::invoice::{add_routing_hints, parse_invoice, LNInvoice, RouteHint, RouteHintHop};
-use crate::lnurl::pay::model::{LnUrlPayResult, ValidatedCallbackResponse};
+use crate::lnurl::pay::model::SuccessAction::Aes;
+use crate::lnurl::pay::model::{
+    LnUrlPayResult, SuccessAction, SuccessActionProcessed, ValidatedCallbackResponse,
+};
 use crate::lnurl::pay::validate_lnurl_pay;
 use crate::lnurl::withdraw::model::LnUrlWithdrawCallbackStatus;
 use crate::lnurl::withdraw::validate_lnurl_withdraw;
@@ -43,6 +46,7 @@ pub trait EventListener: Send + Sync {
 /// Event emitted by the SDK. To listen for and react to these events, use an [EventListener] when
 /// initializing the [BreezServices].
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum BreezEvent {
     /// Indicates that a new block has just been found
     NewBlock { block: u32 },
@@ -50,7 +54,7 @@ pub enum BreezEvent {
     InvoicePaid { details: InvoicePaidDetails },
     /// Indicates that the local SDK state has just been sync-ed with the remote components
     Synced,
-    /// Indicates that an outgoing payment has been completed succesfully
+    /// Indicates that an outgoing payment has been completed successfully
     PaymentSucceed { details: Payment },
     /// Indicates that an outgoing payment has been failed to complete
     PaymentFailed { error: String },
@@ -128,6 +132,8 @@ pub struct BreezServices {
     event_listener: Option<Box<dyn EventListener>>,
     shutdown_sender: Mutex<Option<mpsc::Sender<()>>>,
 }
+
+use bitcoin_hashes::{sha256, Hash};
 
 impl BreezServices {
     /// Create a new node for the given network, from the given seed
@@ -219,6 +225,8 @@ impl BreezServices {
     /// This call will validate the given `user_amount_sat` and `comment` against the parameters
     /// of the LNURL endpoint (`req_data`). If they match the endpoint requirements, the LNURL payment
     /// is made.
+    ///
+    /// This method will return an [anyhow::Error] when any validation check fails.
     pub async fn lnurl_pay(
         &self,
         user_amount_sat: u64,
@@ -230,9 +238,43 @@ impl BreezServices {
                 Ok(LnUrlPayResult::EndpointError { data: e })
             }
             ValidatedCallbackResponse::EndpointSuccess { data: cb } => {
-                self.send_payment(cb.pr, None).await?;
+                let payment = self.send_payment(cb.pr, None).await?;
+                let details = match &payment.details {
+                    PaymentDetails::ClosedChannel { .. } => {
+                        return Err(anyhow!("Payment lookup found unexpected payment type"));
+                    }
+                    PaymentDetails::Ln { data } => data,
+                };
+
                 Ok(LnUrlPayResult::EndpointSuccess {
-                    data: cb.success_action,
+                    data: match cb.success_action {
+                        Some(sa) => {
+                            let processed_sa = match sa {
+                                // For AES, we decrypt the contents on the fly
+                                Aes(data) => {
+                                    let preimage =
+                                        sha256::Hash::from_str(&details.payment_preimage)?;
+                                    let preimage_arr: [u8; 32] = preimage.into_inner();
+
+                                    let decrypted = (data, &preimage_arr).try_into()?;
+                                    SuccessActionProcessed::Aes { data: decrypted }
+                                }
+                                SuccessAction::Message(data) => {
+                                    SuccessActionProcessed::Message { data }
+                                }
+                                SuccessAction::Url(data) => SuccessActionProcessed::Url { data },
+                            };
+
+                            // Store SA in its own table, associated to payment_hash
+                            self.persister.insert_lnurl_success_action(
+                                &details.payment_hash,
+                                &processed_sa,
+                            )?;
+
+                            Some(processed_sa)
+                        }
+                        None => None,
+                    },
                 })
             }
         }
@@ -435,7 +477,7 @@ impl BreezServices {
             .map(closed_channel_to_transaction)
             .collect();
 
-        // update both closed channels and lightning transation payments
+        // update both closed channels and lightning transaction payments
         let mut payments = closed_channel_payments_res?;
         payments.extend(new_data.payments.clone());
         self.persister.insert_payments(&payments)?;
@@ -621,6 +663,7 @@ struct BreezServicesBuilder {
     seed: Option<Vec<u8>>,
     lsp_api: Option<Arc<dyn LspAPI>>,
     fiat_api: Option<Arc<dyn FiatAPI>>,
+    persister: Option<Arc<SqliteStorage>>,
     swapper_api: Option<Arc<dyn SwapperAPI>>,
 }
 
@@ -634,6 +677,7 @@ impl BreezServicesBuilder {
             seed: None,
             lsp_api: None,
             fiat_api: None,
+            persister: None,
             swapper_api: None,
         }
     }
@@ -650,6 +694,11 @@ impl BreezServicesBuilder {
 
     pub fn fiat_api(&mut self, fiat_api: Arc<dyn FiatAPI>) -> &mut Self {
         self.fiat_api = Some(fiat_api.clone());
+        self
+    }
+
+    pub fn persister(&mut self, persister: Arc<SqliteStorage>) -> &mut Self {
+        self.persister = Some(persister);
         self
     }
 
@@ -707,10 +756,12 @@ impl BreezServicesBuilder {
         ));
 
         // The storage is implemented via sqlite.
-        let persister = Arc::new(SqliteStorage::from_file(format!(
-            "{}/storage.sql",
-            self.config.working_dir
-        )));
+        let persister = self.persister.clone().unwrap_or_else(|| {
+            Arc::new(SqliteStorage::from_file(format!(
+                "{}/storage.sql",
+                self.config.working_dir
+            )))
+        });
 
         persister.init().unwrap();
         let current_lsp_id = persister.get_lsp_id()?;
@@ -775,7 +826,7 @@ impl BreezServer {
         let channel = Channel::from_shared(s)?.connect().await?;
 
         let api_key_metadata: Option<MetadataValue<Ascii>> = match &self.api_key {
-            Some(key) => Some(format!("Bearer {}", key).parse()?),
+            Some(key) => Some(format!("Bearer {key}").parse()?),
             _ => None,
         };
         let client =
@@ -1003,10 +1054,12 @@ async fn get_lsp_by_id(
 pub(crate) mod tests {
     use std::sync::Arc;
 
-    use anyhow::anyhow;
+    use anyhow::{anyhow, Result};
 
     use crate::breez_services::{BreezServices, BreezServicesBuilder};
     use crate::fiat::Rate;
+    use crate::lnurl::pay::model::MessageSuccessActionData;
+    use crate::lnurl::pay::model::SuccessActionProcessed;
     use crate::models::{LnPaymentDetails, NodeState, Payment, PaymentDetails, PaymentTypeFilter};
     use crate::PaymentType;
     use crate::{parse_short_channel_id, test_utils::*};
@@ -1020,6 +1073,13 @@ pub(crate) mod tests {
 
         let dummy_node_state = get_dummy_node_state();
 
+        let sa = SuccessActionProcessed::Message {
+            data: MessageSuccessActionData {
+                message: "test message".into(),
+            },
+        };
+
+        let payment_hash_with_lnurl_success_action = "3333";
         let dummy_transactions = vec![
             Payment {
                 id: "1111".to_string(),
@@ -1037,11 +1097,12 @@ pub(crate) mod tests {
                         payment_preimage: "2222".to_string(),
                         keysend: false,
                         bolt11: "1111".to_string(),
+                        lnurl_success_action: None,
                     },
                 },
             },
             Payment {
-                id: "3333".to_string(),
+                id: payment_hash_with_lnurl_success_action.to_string(),
                 payment_type: PaymentType::Sent,
                 payment_time: 200000,
                 amount_msat: 8,
@@ -1050,12 +1111,13 @@ pub(crate) mod tests {
                 description: Some("test payment".to_string()),
                 details: PaymentDetails::Ln {
                     data: LnPaymentDetails {
-                        payment_hash: "3333".to_string(),
+                        payment_hash: payment_hash_with_lnurl_success_action.to_string(),
                         label: "".to_string(),
                         destination_pubkey: "123".to_string(),
                         payment_preimage: "4444".to_string(),
                         keysend: false,
                         bolt11: "123".to_string(),
+                        lnurl_success_action: Some(sa.clone()),
                     },
                 },
             },
@@ -1065,11 +1127,18 @@ pub(crate) mod tests {
             transactions: dummy_transactions.clone(),
         });
 
-        let mut builder = BreezServicesBuilder::new(create_test_config());
+        let test_config = create_test_config();
+        let persister = Arc::new(create_test_persister(test_config.clone()));
+        persister.init()?;
+        persister.insert_payments(&dummy_transactions)?;
+        persister.insert_lnurl_success_action(payment_hash_with_lnurl_success_action, &sa)?;
+
+        let mut builder = BreezServicesBuilder::new(test_config.clone());
         let breez_services = builder
             .lsp_api(Arc::new(MockBreezServer {}))
             .fiat_api(Arc::new(MockBreezServer {}))
             .node_api(node_api)
+            .persister(persister)
             .build(None)
             .await?;
 
@@ -1098,6 +1167,8 @@ pub(crate) mod tests {
             .list_payments(PaymentTypeFilter::Sent, None, None)
             .await?;
         assert_eq!(sent, vec![cloned[1].clone()]);
+        assert!(matches!(
+                &sent[0].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_success_action, ..}} if lnurl_success_action == &Some(sa)));
 
         Ok(())
     }
@@ -1141,7 +1212,7 @@ pub(crate) mod tests {
         let storage_path = format!("{}/storage.sql", get_test_working_dir());
         std::fs::remove_file(storage_path).ok();
 
-        let breez_services = breez_services().await;
+        let breez_services = breez_services().await?;
         breez_services.sync().await?;
 
         let node_pubkey = breez_services
@@ -1157,7 +1228,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_fetch_rates() -> Result<(), Box<dyn std::error::Error>> {
-        let breez_services = breez_services().await;
+        let breez_services = breez_services().await?;
         breez_services.sync().await?;
 
         let rates = breez_services.fiat_api.fetch_fiat_rates().await?;
@@ -1173,23 +1244,36 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    /// build node service for tests
-    pub(crate) async fn breez_services() -> Arc<BreezServices> {
+    /// Build node service for tests
+    pub(crate) async fn breez_services() -> Result<Arc<BreezServices>> {
+        breez_services_with(vec![]).await
+    }
+
+    /// Build node service for tests with a list of known payments
+    pub(crate) async fn breez_services_with(
+        known_payments: Vec<Payment>,
+    ) -> Result<Arc<BreezServices>> {
         let node_api = Arc::new(MockNodeAPI {
             node_state: get_dummy_node_state(),
-            transactions: vec![],
+            transactions: known_payments.clone(),
         });
 
-        let mut builder = BreezServicesBuilder::new(create_test_config());
+        let test_config = create_test_config();
+        let persister = Arc::new(create_test_persister(test_config.clone()));
+        persister.init()?;
+        persister.insert_payments(&known_payments)?;
+
+        let mut builder = BreezServicesBuilder::new(test_config.clone());
         let breez_services = builder
             .lsp_api(Arc::new(MockBreezServer {}))
             .fiat_api(Arc::new(MockBreezServer {}))
+            .persister(persister)
             .node_api(node_api)
             .build(None)
             .await
             .unwrap();
 
-        breez_services
+        Ok(breez_services)
     }
 
     /// Build dummy NodeState for tests

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -37,10 +37,10 @@ use crate::input_parser::LnUrlWithdrawRequestData;
 use crate::invoice::LNInvoice;
 use crate::invoice::RouteHint;
 use crate::invoice::RouteHintHop;
-use crate::lnurl::pay::model::AesSuccessActionData;
+use crate::lnurl::pay::model::AesSuccessActionDataDecrypted;
 use crate::lnurl::pay::model::LnUrlPayResult;
 use crate::lnurl::pay::model::MessageSuccessActionData;
-use crate::lnurl::pay::model::SuccessAction;
+use crate::lnurl::pay::model::SuccessActionProcessed;
 use crate::lnurl::pay::model::UrlSuccessActionData;
 use crate::lnurl::withdraw::model::LnUrlWithdrawCallbackStatus;
 use crate::lsp::LspInformation;
@@ -625,17 +625,12 @@ impl Wire2Api<u8> for u8 {
 
 // Section: impl IntoDart
 
-impl support::IntoDart for AesSuccessActionData {
+impl support::IntoDart for AesSuccessActionDataDecrypted {
     fn into_dart(self) -> support::DartAbi {
-        vec![
-            self.description.into_dart(),
-            self.ciphertext.into_dart(),
-            self.iv.into_dart(),
-        ]
-        .into_dart()
+        vec![self.description.into_dart(), self.plaintext.into_dart()].into_dart()
     }
 }
-impl support::IntoDartExceptPrimitive for AesSuccessActionData {}
+impl support::IntoDartExceptPrimitive for AesSuccessActionDataDecrypted {}
 
 impl support::IntoDart for BitcoinAddressData {
     fn into_dart(self) -> support::DartAbi {
@@ -786,6 +781,7 @@ impl support::IntoDart for LnPaymentDetails {
             self.payment_preimage.into_dart(),
             self.keysend.into_dart(),
             self.bolt11.into_dart(),
+            self.lnurl_success_action.into_dart(),
         ]
         .into_dart()
     }
@@ -1023,17 +1019,17 @@ impl support::IntoDart for RouteHintHop {
 }
 impl support::IntoDartExceptPrimitive for RouteHintHop {}
 
-impl support::IntoDart for SuccessAction {
+impl support::IntoDart for SuccessActionProcessed {
     fn into_dart(self) -> support::DartAbi {
         match self {
-            Self::Aes(field0) => vec![0.into_dart(), field0.into_dart()],
-            Self::Message(field0) => vec![1.into_dart(), field0.into_dart()],
-            Self::Url(field0) => vec![2.into_dart(), field0.into_dart()],
+            Self::Aes { data } => vec![0.into_dart(), data.into_dart()],
+            Self::Message { data } => vec![1.into_dart(), data.into_dart()],
+            Self::Url { data } => vec![2.into_dart(), data.into_dart()],
         }
         .into_dart()
     }
 }
-impl support::IntoDartExceptPrimitive for SuccessAction {}
+impl support::IntoDartExceptPrimitive for SuccessActionProcessed {}
 impl support::IntoDart for SwapInfo {
     fn into_dart(self) -> support::DartAbi {
         vec![

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -37,6 +37,7 @@ use crate::input_parser::LnUrlWithdrawRequestData;
 use crate::invoice::LNInvoice;
 use crate::invoice::RouteHint;
 use crate::invoice::RouteHintHop;
+use crate::lnurl::pay::model::AesSuccessActionData;
 use crate::lnurl::pay::model::LnUrlPayResult;
 use crate::lnurl::pay::model::MessageSuccessActionData;
 use crate::lnurl::pay::model::SuccessAction;
@@ -624,6 +625,18 @@ impl Wire2Api<u8> for u8 {
 
 // Section: impl IntoDart
 
+impl support::IntoDart for AesSuccessActionData {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.description.into_dart(),
+            self.ciphertext.into_dart(),
+            self.iv.into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for AesSuccessActionData {}
+
 impl support::IntoDart for BitcoinAddressData {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -1013,8 +1026,9 @@ impl support::IntoDartExceptPrimitive for RouteHintHop {}
 impl support::IntoDart for SuccessAction {
     fn into_dart(self) -> support::DartAbi {
         match self {
-            Self::Message(field0) => vec![0.into_dart(), field0.into_dart()],
-            Self::Url(field0) => vec![1.into_dart(), field0.into_dart()],
+            Self::Aes(field0) => vec![0.into_dart(), field0.into_dart()],
+            Self::Message(field0) => vec![1.into_dart(), field0.into_dart()],
+            Self::Url(field0) => vec![2.into_dart(), field0.into_dart()],
         }
         .into_dart()
     }

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -540,7 +540,7 @@ mod tests {
         let addr = "1andreas3batLhQa2FawWjeyjCqyBzypd";
 
         // Address with amount
-        let addr_1 = format!("bitcoin:{}?amount=0.00002000", addr);
+        let addr_1 = format!("bitcoin:{addr}?amount=0.00002000");
         match parse(&addr_1).await? {
             InputType::BitcoinAddress {
                 address: addr_with_amount_parsed,
@@ -556,7 +556,7 @@ mod tests {
 
         // Address with amount and label
         let label = "test-label";
-        let addr_2 = format!("bitcoin:{}?amount=0.00002000&label={}", addr, label);
+        let addr_2 = format!("bitcoin:{addr}?amount=0.00002000&label={label}");
         match parse(&addr_2).await? {
             InputType::BitcoinAddress {
                 address: addr_with_amount_parsed,
@@ -572,10 +572,7 @@ mod tests {
 
         // Address with amount, label and message
         let message = "test-message";
-        let addr_3 = format!(
-            "bitcoin:{}?amount=0.00002000&label={}&message={}",
-            addr, label, message
-        );
+        let addr_3 = format!("bitcoin:{addr}?amount=0.00002000&label={label}&message={message}");
         match parse(&addr_3).await? {
             InputType::BitcoinAddress {
                 address: addr_with_amount_parsed,
@@ -603,7 +600,7 @@ mod tests {
         ));
 
         // Invoice with prefix
-        let invoice_with_prefix = format!("lightning:{}", bolt11);
+        let invoice_with_prefix = format!("lightning:{bolt11}");
         assert!(matches!(
             parse(&invoice_with_prefix).await?,
             InputType::Bolt11 { invoice: _invoice }
@@ -619,7 +616,7 @@ mod tests {
 
         // Address and invoice
         // BOLT11 is the first URI arg (preceded by '?')
-        let addr_1 = format!("bitcoin:{}?lightning={}", addr, bolt11);
+        let addr_1 = format!("bitcoin:{addr}?lightning={bolt11}");
         assert!(matches!(
             parse(&addr_1).await?,
             InputType::Bolt11 { invoice: _invoice }
@@ -627,7 +624,7 @@ mod tests {
 
         // Address, amount and invoice
         // BOLT11 is not the first URI arg (preceded by '&')
-        let addr_2 = format!("bitcoin:{}?amount=0.00002000&lightning={}", addr, bolt11);
+        let addr_2 = format!("bitcoin:{addr}?amount=0.00002000&lightning={bolt11}");
         assert!(matches!(
             parse(&addr_2).await?,
             InputType::Bolt11 { invoice: _invoice }
@@ -774,7 +771,7 @@ mod tests {
         let lnurl_withdraw_encoded = "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4exctthd96xserjv9mn7um9wdekjmmw843xxwpexdnxzen9vgunsvfexq6rvdecx93rgdmyxcuxverrvcursenpxvukzv3c8qunsdecx33nzwpnvg6ryc3hv93nzvecxgcxgwp3h33lxk";
         assert_eq!(
             lnurl_decode(lnurl_withdraw_encoded)?,
-            format!("https://localhost{}", path)
+            format!("https://localhost{path}")
         );
 
         if let LnUrlWithdraw { data: wd } = parse(lnurl_withdraw_encoded).await? {
@@ -893,7 +890,7 @@ mod tests {
         let lnurl_pay_encoded = "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4excttsv9un7um9wdekjmmw84jxywf5x43rvv35xgmr2enrxanr2cfcvsmnwe3jxcukvde48qukgdec89snwde3vfjxvepjxpjnjvtpxd3kvdnxx5crxwpjvyunsephsz36jf";
         assert_eq!(
             lnurl_decode(lnurl_pay_encoded)?,
-            format!("https://localhost{}", path)
+            format!("https://localhost{path}")
         );
 
         if let LnUrlPay { data: pd } = parse(lnurl_pay_encoded).await? {
@@ -1062,7 +1059,7 @@ mod tests {
             "/lnurl-pay?session=db945b624265fc7f5a8d77f269f7589d789a771bdfd20e91a3cf6f50382a98d7";
         let _m = mock_lnurl_pay_endpoint(pay_path, None);
 
-        let lnurl_pay_url = format!("lnurlp://localhost{}", pay_path);
+        let lnurl_pay_url = format!("lnurlp://localhost{pay_path}");
         if let LnUrlPay { data: pd } = parse(&lnurl_pay_url).await? {
             assert_eq!(pd.callback, "https://localhost/lnurl-pay/callback/db945b624265fc7f5a8d77f269f7589d789a771bdfd20e91a3cf6f50382a98d7");
             assert_eq!(pd.max_sendable, 16000);
@@ -1101,7 +1098,7 @@ mod tests {
         let _m = mock_lnurl_withdraw_endpoint(withdraw_path, None);
 
         if let LnUrlWithdraw { data: wd } =
-            parse(&format!("lnurlw://localhost{}", withdraw_path)).await?
+            parse(&format!("lnurlw://localhost{withdraw_path}")).await?
         {
             assert_eq!(wd.callback, "https://localhost/lnurl-withdraw/callback/e464f841c44dbdd86cee4f09f4ccd3ced58d2e24f148730ec192748317b74538");
             assert_eq!(
@@ -1120,7 +1117,7 @@ mod tests {
     async fn test_lnurl_auth_lud_17() -> Result<()> {
         let auth_path = "/lnurl-login?tag=login&k1=1a855505699c3e01be41bddd32007bfcc5ff93505dec0cbca64b4b8ff590b822";
 
-        if let LnUrlAuth { data: ad } = parse(&format!("keyauth://localhost{}", auth_path)).await? {
+        if let LnUrlAuth { data: ad } = parse(&format!("keyauth://localhost{auth_path}")).await? {
             assert_eq!(
                 ad.k1,
                 "1a855505699c3e01be41bddd32007bfcc5ff93505dec0cbca64b4b8ff590b822"
@@ -1137,7 +1134,7 @@ mod tests {
         let expected_error_msg = "test pay error";
         let _m = mock_lnurl_pay_endpoint(pay_path, Some(expected_error_msg.to_string()));
 
-        if let LnUrlError { data: msg } = parse(&format!("lnurlp://localhost{}", pay_path)).await? {
+        if let LnUrlError { data: msg } = parse(&format!("lnurlp://localhost{pay_path}")).await? {
             assert_eq!(msg.reason, expected_error_msg);
             return Ok(());
         }
@@ -1152,7 +1149,7 @@ mod tests {
         let _m = mock_lnurl_withdraw_endpoint(withdraw_path, Some(expected_error_msg.to_string()));
 
         if let LnUrlError { data: msg } =
-            parse(&format!("lnurlw://localhost{}", withdraw_path)).await?
+            parse(&format!("lnurlw://localhost{withdraw_path}")).await?
         {
             assert_eq!(msg.reason, expected_error_msg);
             return Ok(());

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -201,6 +201,6 @@ mod tests {
 
         let encoded = add_routing_hints(payreq, vec![route_hint], 100).unwrap();
 
-        print!("{:?}", encoded);
+        print!("{encoded:?}");
     }
 }

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -162,7 +162,7 @@ pub use input_parser::{
 };
 pub use invoice::{parse_invoice, LNInvoice, RouteHint, RouteHintHop};
 
-pub use lnurl::pay::model::LnUrlPayResult;
+pub use lnurl::pay::model::*;
 pub use lnurl::withdraw::model::LnUrlWithdrawCallbackStatus;
 pub use lsp::LspInformation;
 pub use models::*;

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -520,7 +520,7 @@ mod tests {
         let key_bytes = key.as_inner();
 
         let iv_bytes = [0x24; 16]; // 16 bytes = 24 chars
-        let iv_base64 = base64::encode(&iv_bytes); // JCQkJCQkJCQkJCQkJCQkJA==
+        let iv_base64 = base64::encode(iv_bytes); // JCQkJCQkJCQkJCQkJCQkJA==
 
         let plaintext = "hello world! this is my plaintext.";
         let plaintext_bytes = plaintext.as_bytes();
@@ -529,11 +529,11 @@ mod tests {
         // base64 = kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK
         let ciphertext_bytes =
             &hex::decode("91239ab5d94369a18474ee58372c7d0fcee5e227903f671bfe19ef32f1cada804d10f0f006265289d936317343dbc0ca")?;
-        let ciphertext_base64 = base64::encode(&ciphertext_bytes);
+        let ciphertext_base64 = base64::encode(ciphertext_bytes);
 
         // Encrypt raw (which returns raw bytes)
         let res = Aes256CbcEnc::new_from_slices(key_bytes, &iv_bytes)?
-            .encrypt_padded_vec_mut::<Pkcs7>(&plaintext_bytes);
+            .encrypt_padded_vec_mut::<Pkcs7>(plaintext_bytes);
         assert_eq!(res[..], ciphertext_bytes[..]);
 
         // Decrypt raw (which returns raw bytes)
@@ -552,7 +552,7 @@ mod tests {
             iv: iv_base64,
         }
         .decrypt(key_bytes)?;
-        assert_eq!(&res.as_bytes()[..], &plaintext_bytes[..]);
+        assert_eq!(res.as_bytes(), plaintext_bytes);
 
         Ok(())
     }
@@ -562,7 +562,7 @@ mod tests {
         assert!(AesSuccessActionData {
             description: "Test AES successData description".into(),
             ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
-            iv: base64::encode(&[0xa; 16]).into()
+            iv: base64::encode([0xa; 16])
         }
         .validate()
         .is_ok());
@@ -571,7 +571,7 @@ mod tests {
         assert!(AesSuccessActionData {
             description: rand_string(150),
             ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
-            iv: base64::encode(&[0xa; 16]).into()
+            iv: base64::encode([0xa; 16])
         }
         .validate()
         .is_err());
@@ -580,7 +580,7 @@ mod tests {
         assert!(AesSuccessActionData {
             description: "Test AES successData description".into(),
             ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
-            iv: base64::encode(&[0xa; 10]).into()
+            iv: base64::encode([0xa; 10])
         }
         .validate()
         .is_err());
@@ -589,7 +589,7 @@ mod tests {
         assert!(AesSuccessActionData {
             description: "Test AES successData description".into(),
             ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
-            iv: base64::encode(&[0xa; 20]).into()
+            iv: base64::encode([0xa; 20])
         }
         .validate()
         .is_err());
@@ -598,7 +598,7 @@ mod tests {
         assert!(AesSuccessActionData {
             description: "Test AES successData description".into(),
             ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
-            iv: ",".repeat(24).into()
+            iv: ",".repeat(24)
         }
         .validate()
         .is_err());
@@ -606,8 +606,8 @@ mod tests {
         // Ciphertext is not base64 encoded
         assert!(AesSuccessActionData {
             description: "Test AES successData description".into(),
-            ciphertext: ",".repeat(96).into(),
-            iv: base64::encode(&[0xa; 16]).into()
+            ciphertext: ",".repeat(96),
+            iv: base64::encode([0xa; 16])
         }
         .validate()
         .is_err());
@@ -615,8 +615,8 @@ mod tests {
         // Ciphertext longer than 4KB
         assert!(AesSuccessActionData {
             description: "Test AES successData description".into(),
-            ciphertext: base64::encode(&rand_string(5000)).into(),
-            iv: base64::encode(&[0xa; 16]).into()
+            ciphertext: base64::encode(rand_string(5000)),
+            iv: base64::encode([0xa; 16])
         }
         .validate()
         .is_err());

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -11,6 +11,7 @@ use tonic::Streaming;
 
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentReply};
+use crate::lnurl::pay::model::SuccessActionProcessed;
 use crate::lsp::LspInformation;
 use crate::models::Network::*;
 
@@ -296,6 +297,10 @@ pub struct LnPaymentDetails {
     pub payment_preimage: String,
     pub keysend: bool,
     pub bolt11: String,
+
+    /// Only set for [PaymentType::Sent] payments that are part of a LNURL-pay workflow where
+    /// the endpoint returns a success action
+    pub lnurl_success_action: Option<SuccessActionProcessed>,
 }
 
 /// Represents the funds that were on the user side of the channel at the time it was closed.

--- a/libs/sdk-core/src/persist/db.rs
+++ b/libs/sdk-core/src/persist/db.rs
@@ -190,6 +190,15 @@ impl SqliteStorage {
              
              DROP TABLE old_swaps;            
             "),
+            M::up(
+                "
+             CREATE TABLE IF NOT EXISTS payments_external_info (
+              payment_id TEXT NOT NULL PRIMARY KEY,
+              lnurl_success_action TEXT,
+              FOREIGN KEY(payment_id) REFERENCES payments(id)
+             ) STRICT;
+            ",
+            ),
         ]);
 
         let mut conn = self.get_connection()?;

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -1,6 +1,6 @@
 use super::db::SqliteStorage;
-use crate::models::{Payment, PaymentDetails};
-use crate::models::{PaymentType, PaymentTypeFilter};
+use crate::lnurl::pay::model::SuccessActionProcessed;
+use crate::models::*;
 use anyhow::{anyhow, Result};
 use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput};
 use rusqlite::OptionalExtension;
@@ -8,9 +8,14 @@ use rusqlite::Row;
 use std::str::FromStr;
 
 impl SqliteStorage {
+    /// Inserts payments into the payments table.
+    ///
+    /// Note that, if a payment has details of type [LnPaymentDetails] which contain a [SuccessActionProcessed],
+    /// then the [LnPaymentDetails] will NOT be persisted. In that case, the [SuccessActionProcessed]
+    /// can be inserted separately via [SqliteStorage::insert_lnurl_success_action].
     pub fn insert_payments(&self, transactions: &[Payment]) -> Result<()> {
         let con = self.get_connection()?;
-        let mut prep_statment = con.prepare(
+        let mut prep_statement = con.prepare(
             "
          INSERT OR REPLACE INTO payments (
            id,
@@ -27,7 +32,7 @@ impl SqliteStorage {
         )?;
 
         for ln_tx in transactions {
-            _ = prep_statment.execute((
+            _ = prep_statement.execute((
                 &ln_tx.id,
                 &ln_tx.payment_type.to_string(),
                 &ln_tx.payment_time,
@@ -41,6 +46,27 @@ impl SqliteStorage {
         Ok(())
     }
 
+    pub fn insert_lnurl_success_action(
+        &self,
+        payment_hash: &str,
+        sa: &SuccessActionProcessed,
+    ) -> Result<()> {
+        let con = self.get_connection()?;
+        let mut prep_statement = con.prepare(
+            "
+         INSERT OR REPLACE INTO payments_external_info (
+           payment_id,
+           lnurl_success_action
+         )
+         VALUES (?1,?2)
+        ",
+        )?;
+
+        _ = prep_statement.execute((payment_hash, &sa))?;
+
+        Ok(())
+    }
+
     pub fn last_payment_timestamp(&self) -> Result<i64> {
         self.get_connection()?
             .query_row("SELECT max(payment_time) FROM payments", [], |row| {
@@ -49,6 +75,7 @@ impl SqliteStorage {
             .map_err(anyhow::Error::msg)
     }
 
+    /// Constructs [Payment] by joining data in the `payment` and `payments_external_info` tables
     pub fn list_payments(
         &self,
         type_filter: PaymentTypeFilter,
@@ -61,15 +88,19 @@ impl SqliteStorage {
             format!(
                 "
             SELECT 
-             id, 
-             payment_type, 
-             payment_time, 
-             amount_msat, 
-             fee_msat, 
-             pending, 
-             description,
-             details
-            FROM payments            
+             p.id,
+             p.payment_type,
+             p.payment_time,
+             p.amount_msat,
+             p.fee_msat,
+             p.pending,
+             p.description,
+             p.details,
+             e.lnurl_success_action
+            FROM payments p
+            LEFT JOIN payments_external_info e
+            ON
+             p.id = e.payment_id
             {where_clause} ORDER BY payment_time DESC
           "
             )
@@ -89,15 +120,21 @@ impl SqliteStorage {
             .query_row(
                 "
                 SELECT
-                 id, 
-                 payment_type, 
-                 payment_time, 
-                 amount_msat, 
-                 fee_msat, 
-                 pending, 
-                 description,
-                 details
-                FROM payments where id = ?1",
+                 p.id,
+                 p.payment_type,
+                 p.payment_time,
+                 p.amount_msat,
+                 p.fee_msat,
+                 p.pending,
+                 p.description,
+                 p.details,
+                 e.lnurl_success_action
+                FROM payments p
+                LEFT JOIN payments_external_info e
+                ON
+                 p.id = e.payment_id
+                WHERE
+                 id = ?1",
                 [hash],
                 |row| self.sql_row_to_payment(row),
             )
@@ -107,7 +144,7 @@ impl SqliteStorage {
 
     fn sql_row_to_payment(&self, row: &Row) -> Result<Payment, rusqlite::Error> {
         let payment_type_str: String = row.get(1)?;
-        Ok(Payment {
+        let mut payment = Payment {
             id: row.get(0)?,
             payment_type: PaymentType::from_str(payment_type_str.as_str()).unwrap(),
             payment_time: row.get(2)?,
@@ -116,7 +153,13 @@ impl SqliteStorage {
             pending: row.get(5)?,
             description: row.get(6)?,
             details: row.get(7)?,
-        })
+        };
+
+        if let PaymentDetails::Ln { ref mut data } = payment.details {
+            data.lnurl_success_action = row.get(8)?;
+        }
+
+        Ok(payment)
     }
 }
 
@@ -170,14 +213,37 @@ impl ToSql for PaymentDetails {
     }
 }
 
+impl FromSql for SuccessActionProcessed {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        serde_json::from_str(value.as_str()?).map_err(|_| FromSqlError::InvalidType)
+    }
+}
+
+impl ToSql for SuccessActionProcessed {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(
+            serde_json::to_string(&self).map_err(|_| FromSqlError::InvalidType)?,
+        ))
+    }
+}
+
 #[test]
-fn test_ln_transactions() {
+fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
+    use crate::lnurl::pay::model::MessageSuccessActionData;
+    use crate::lnurl::pay::model::SuccessActionProcessed;
     use crate::models::{LnPaymentDetails, Payment, PaymentDetails};
     use crate::persist::test_utils;
 
+    let sa = SuccessActionProcessed::Message {
+        data: MessageSuccessActionData {
+            message: "test message".into(),
+        },
+    };
+
+    let payment_hash_with_lnurl_success_action = "123";
     let txs = [
         Payment {
-            id: "123".to_string(),
+            id: payment_hash_with_lnurl_success_action.to_string(),
             payment_type: PaymentType::Sent,
             payment_time: 1001,
             amount_msat: 100,
@@ -186,12 +252,13 @@ fn test_ln_transactions() {
             description: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
-                    payment_hash: "123".to_string(),
+                    payment_hash: payment_hash_with_lnurl_success_action.to_string(),
                     label: "label".to_string(),
                     destination_pubkey: "pubey".to_string(),
                     payment_preimage: "payment_preimage".to_string(),
                     keysend: true,
                     bolt11: "bolt11".to_string(),
+                    lnurl_success_action: Some(sa.clone()),
                 },
             },
         },
@@ -211,43 +278,42 @@ fn test_ln_transactions() {
                     payment_preimage: "payment_preimage".to_string(),
                     keysend: true,
                     bolt11: "bolt11".to_string(),
+                    lnurl_success_action: None,
                 },
             },
         },
     ];
     let storage =
         SqliteStorage::from_file(test_utils::create_test_sql_file("transactions".to_string()));
-    storage.init().unwrap();
-    storage.insert_payments(&txs).unwrap();
+    storage.init()?;
+    storage.insert_payments(&txs)?;
+    storage.insert_lnurl_success_action(payment_hash_with_lnurl_success_action, &sa)?;
 
     // retrieve all
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::All, None, None)
-        .unwrap();
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
 
     //test only sent
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::Sent, None, None)
-        .unwrap();
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::Sent, None, None)?;
     assert_eq!(retrieve_txs.len(), 1);
     assert_eq!(retrieve_txs[0], txs[0]);
+    assert!(
+        matches!( &retrieve_txs[0].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_success_action, ..}} if lnurl_success_action == &Some(sa))
+    );
 
     //test only received
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::Received, None, None)
-        .unwrap();
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::Received, None, None)?;
     assert_eq!(retrieve_txs.len(), 1);
     assert_eq!(retrieve_txs[0], txs[1]);
 
-    let max_ts = storage.last_payment_timestamp().unwrap();
+    let max_ts = storage.last_payment_timestamp()?;
     assert_eq!(max_ts, 1001);
 
-    storage.insert_payments(&txs).unwrap();
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::All, None, None)
-        .unwrap();
+    storage.insert_payments(&txs)?;
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
+
+    Ok(())
 }

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -427,7 +427,7 @@ impl BTCReceiveSwap {
         let mut swap_info = self
             .persister
             .get_swap_info_by_address(bitcoin_address.clone())?
-            .ok_or_else(|| anyhow!(format!("swap address {} was not found", bitcoin_address)))?;
+            .ok_or_else(|| anyhow!(format!("swap address {bitcoin_address} was not found")))?;
 
         // we are creating and invoice for this swap if we didn't
         // do it already
@@ -474,7 +474,7 @@ impl BTCReceiveSwap {
         let swap_info = self
             .persister
             .get_swap_info_by_address(swap_address.clone())?
-            .ok_or_else(|| anyhow!(format!("swap address {} was not found", swap_address)))?;
+            .ok_or_else(|| anyhow!(format!("swap address {swap_address} was not found")))?;
 
         let transactions = self
             .chain_service
@@ -869,6 +869,7 @@ mod tests {
                     payment_preimage: "111".to_string(),
                     keysend: false,
                     bolt11: "".to_string(),
+                    lnurl_success_action: None,
                 },
             },
         };

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -5,13 +5,12 @@ use crate::breez_services::Receiver;
 use crate::chain::{ChainService, OnchainTx, RecommendedFees};
 use crate::fiat::{FiatCurrency, Rate};
 use crate::swap::create_submarine_swap_script;
-use crate::{
-    parse_invoice, Config, LNInvoice, LnPaymentDetails, PaymentDetails, PaymentType, RouteHint,
-};
+use crate::{parse_invoice, Config, LNInvoice, RouteHint};
 use anyhow::{anyhow, Result};
 use bitcoin::secp256k1::ecdsa::RecoverableSignature;
 use bitcoin::secp256k1::{KeyPair, Message};
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use bitcoin_hashes::hex::ToHex;
 use bitcoin_hashes::{sha256, Hash};
 use gl_client::pb::amount::Unit;
 use gl_client::pb::{
@@ -27,9 +26,18 @@ use tonic::Streaming;
 use crate::grpc::{PaymentInformation, RegisterPaymentReply};
 use crate::lsp::LspInformation;
 use crate::models::{FiatAPI, LspAPI, NodeAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse};
-use tokio::sync::mpsc;
+use once_cell::sync::Lazy;
+use tokio::sync::{mpsc, Mutex};
+
 //use bitcoin::secp256k1::{ecdsa::{SigningKey, Signature, signature::Signer, VerifyingKey, signature::Verifier}};
 //use rand_core::OsRng;
+
+/// Simulated repository of confirmed new outgoing payments.
+///
+/// Each call to [MockNodeAPI::add_dummy_payment_for] will add the new payment here such that
+/// [NodeAPI::pull_changed], which is called in [BreezServices::sync], always retrieves the newly
+/// added test payments
+static CLOUD_PAYMENTS: Lazy<Mutex<Vec<gl_client::pb::Payment>>> = Lazy::new(|| Mutex::new(vec![]));
 
 pub struct MockSwapperAPI {}
 
@@ -183,13 +191,19 @@ impl NodeAPI for MockNodeAPI {
     async fn pull_changed(&self, _since_timestamp: i64) -> Result<SyncResponse> {
         Ok(SyncResponse {
             node_state: self.node_state.clone(),
-            payments: self.transactions.clone(),
+            payments: CLOUD_PAYMENTS
+                .lock()
+                .await
+                .iter()
+                .cloned()
+                .flat_map(crate::greenlight::payment_to_transaction)
+                .collect(),
             channels: Vec::new(),
         })
     }
 
-    async fn send_payment(&self, _bolt11: String, _amount_sats: Option<u64>) -> Result<Payment> {
-        Ok(MockNodeAPI::get_dummy_payment())
+    async fn send_payment(&self, bolt11: String, _amount_sats: Option<u64>) -> Result<Payment> {
+        Self::add_dummy_payment_for(bolt11, None).await
     }
 
     async fn send_spontaneous_payment(
@@ -197,7 +211,7 @@ impl NodeAPI for MockNodeAPI {
         _node_id: String,
         _amount_sats: u64,
     ) -> Result<Payment> {
-        Ok(MockNodeAPI::get_dummy_payment())
+        Self::add_dummy_payment_rand().await
     }
 
     async fn start(&self) -> Result<()> {
@@ -250,26 +264,99 @@ impl NodeAPI for MockNodeAPI {
 }
 
 impl MockNodeAPI {
-    fn get_dummy_payment() -> Payment {
-        crate::models::Payment {
-            id: hex::encode(rand_vec_u8(32)),
-            payment_type: PaymentType::Sent,
-            payment_time: random(),
-            amount_msat: random(),
-            fee_msat: random(),
-            pending: false,
-            description: Some("desc".to_string()),
-            details: PaymentDetails::Ln {
-                data: LnPaymentDetails {
-                    payment_hash: hex::encode(rand_vec_u8(32)),
-                    label: "".to_string(),
-                    destination_pubkey: "".to_string(),
-                    payment_preimage: hex::encode(rand_vec_u8(32)),
-                    keysend: false,
-                    bolt11: hex::encode(rand_vec_u8(32)),
-                },
+    /// Creates a (simulated) payment for the specified BOLT11 and adds it to a test-specific
+    /// global state.
+    ///
+    /// This payment and its details are retrieved and stored within [crate::BreezServices::sync]
+    /// by a combination of [NodeAPI::pull_changed] and [crate::persist::db::SqliteStorage::insert_payments].
+    pub(crate) async fn add_dummy_payment_for(
+        bolt11: String,
+        preimage: Option<sha256::Hash>,
+    ) -> Result<Payment> {
+        let inv = bolt11.parse::<lightning_invoice::Invoice>()?;
+
+        let gl_payment = gl_client::pb::Payment {
+            payment_hash: hex::decode(inv.payment_hash().to_hex())?,
+            bolt11: inv.to_string(),
+            amount: inv
+                .amount_milli_satoshis()
+                .map(Unit::Millisatoshi)
+                .map(Some)
+                .map(|amt| Amount { unit: amt }),
+            amount_sent: inv
+                .amount_milli_satoshis()
+                .map(Unit::Millisatoshi)
+                .map(Some)
+                .map(|amt| Amount { unit: amt }),
+            payment_preimage: match preimage {
+                Some(preimage) => hex::decode(preimage.to_hex())?,
+                None => rand_vec_u8(32),
             },
-        }
+            status: 1,
+            created_at: random(),
+            destination: rand_vec_u8(32),
+            completed_at: random(),
+        };
+
+        Self::save_payment_for_future_sync_updates(gl_payment.clone()).await
+    }
+
+    /// Adds a dummy payment with random attributes.
+    pub(crate) async fn add_dummy_payment_rand() -> Result<Payment> {
+        let preimage = sha256::Hash::hash(&rand_vec_u8(10));
+        let inv = rand_invoice_with_description_hash_and_preimage("test".into(), preimage)?;
+
+        let gl_payment = gl_client::pb::Payment {
+            payment_hash: hex::decode(inv.payment_hash().to_hex())?,
+            bolt11: inv.to_string(),
+            amount: inv
+                .amount_milli_satoshis()
+                .map(Unit::Millisatoshi)
+                .map(Some)
+                .map(|amt| Amount { unit: amt }),
+            amount_sent: inv
+                .amount_milli_satoshis()
+                .map(Unit::Millisatoshi)
+                .map(Some)
+                .map(|amt| Amount { unit: amt }),
+            payment_preimage: preimage.to_hex().into_bytes(),
+            status: 1,
+            created_at: random(),
+            destination: rand_vec_u8(32),
+            completed_at: random(),
+        };
+
+        Self::save_payment_for_future_sync_updates(gl_payment.clone()).await
+    }
+
+    /// Include payment in the result of [MockNodeAPI::pull_changed].
+    async fn save_payment_for_future_sync_updates(
+        gl_payment: gl_client::pb::Payment,
+    ) -> Result<Payment> {
+        let mut cloud_payments = CLOUD_PAYMENTS.lock().await;
+
+        // Only store it if a payment with the same ID doesn't already exist
+        // This allows us to initialize a MockBreezServer with a list of known payments using
+        // breez_services::tests::breez_services_with(vec), but not replace them when
+        // send_payment is called in tests for those payments.
+        let gl_payment = match cloud_payments
+            .iter()
+            .find(|p| p.payment_hash == gl_payment.payment_hash)
+        {
+            None => {
+                // If payment is not already known, add it to the list and return it
+                cloud_payments.push(gl_payment.clone());
+                gl_payment
+            }
+            Some(p) => {
+                // If a payment already exists (by ID), then do not replace it and return it
+                // The existing version is returned, because that's initialized with the preimage
+                // on mock breez service init
+                p.clone()
+            }
+        };
+
+        crate::greenlight::payment_to_transaction(gl_payment)
     }
 }
 
@@ -332,25 +419,10 @@ impl FiatAPI for MockBreezServer {
 
 pub(crate) fn rand_invoice_with_description_hash(
     expected_desc: String,
-) -> lightning_invoice::Invoice {
-    let expected_desc_hash = Hash::hash(expected_desc.as_bytes());
+) -> Result<lightning_invoice::Invoice> {
+    let preimage = sha256::Hash::hash(&rand_vec_u8(10));
 
-    let payment_hash = Hash::from_slice(&[0; 32][..]).unwrap();
-    let payment_secret = PaymentSecret([42u8; 32]);
-
-    let secp = Secp256k1::new();
-    let key_pair = KeyPair::new(&secp, &mut rand::thread_rng());
-    let private_key = key_pair.secret_key();
-
-    InvoiceBuilder::new(Currency::Bitcoin)
-        .description_hash(expected_desc_hash)
-        .amount_milli_satoshis(50 * 1000)
-        .payment_hash(payment_hash)
-        .payment_secret(payment_secret)
-        .current_timestamp()
-        .min_final_cltv_expiry(144)
-        .build_signed(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
-        .unwrap()
+    rand_invoice_with_description_hash_and_preimage(expected_desc, preimage)
 }
 
 pub(crate) fn rand_invoice_with_description_hash_and_preimage(

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -230,6 +230,23 @@ abstract class BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kDefaultConfigConstMeta;
 }
 
+class AesSuccessActionData {
+  /// Contents description, up to 144 characters
+  final String description;
+
+  /// Base64, AES-encrypted data where encryption key is payment preimage, up to 4kb of characters
+  final String ciphertext;
+
+  /// Base64, initialization vector, exactly 24 characters
+  final String iv;
+
+  AesSuccessActionData({
+    required this.description,
+    required this.ciphertext,
+    required this.iv,
+  });
+}
+
 /// Wrapped in a [BitcoinAddress], this is the result of [parse] when given a plain or BIP-21 BTC address.
 class BitcoinAddressData {
   final String address;
@@ -806,9 +823,17 @@ class RouteHintHop {
 
 @freezed
 class SuccessAction with _$SuccessAction {
+  /// AES type, described in LUD-10
+  const factory SuccessAction.aes(
+    AesSuccessActionData field0,
+  ) = SuccessAction_Aes;
+
+  /// Message type, described in LUD-09
   const factory SuccessAction.message(
     MessageSuccessActionData field0,
   ) = SuccessAction_Message;
+
+  /// URL type, described in LUD-09
   const factory SuccessAction.url(
     UrlSuccessActionData field0,
   ) = SuccessAction_Url;
@@ -1549,6 +1574,17 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return (raw as List<dynamic>).cast<String>();
   }
 
+  AesSuccessActionData _wire2api_aes_success_action_data(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return AesSuccessActionData(
+      description: _wire2api_String(arr[0]),
+      ciphertext: _wire2api_String(arr[1]),
+      iv: _wire2api_String(arr[2]),
+    );
+  }
+
   BitcoinAddressData _wire2api_bitcoin_address_data(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 5)
@@ -1564,6 +1600,11 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   bool _wire2api_bool(dynamic raw) {
     return raw as bool;
+  }
+
+  AesSuccessActionData _wire2api_box_autoadd_aes_success_action_data(
+      dynamic raw) {
+    return _wire2api_aes_success_action_data(raw);
   }
 
   BitcoinAddressData _wire2api_box_autoadd_bitcoin_address_data(dynamic raw) {
@@ -2165,10 +2206,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   SuccessAction _wire2api_success_action(dynamic raw) {
     switch (raw[0]) {
       case 0:
+        return SuccessAction_Aes(
+          _wire2api_box_autoadd_aes_success_action_data(raw[1]),
+        );
+      case 1:
         return SuccessAction_Message(
           _wire2api_box_autoadd_message_success_action_data(raw[1]),
         );
-      case 1:
+      case 2:
         return SuccessAction_Url(
           _wire2api_box_autoadd_url_success_action_data(raw[1]),
         );

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -3306,18 +3306,21 @@ mixin _$SuccessAction {
   Object get field0 => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(AesSuccessActionData field0) aes,
     required TResult Function(MessageSuccessActionData field0) message,
     required TResult Function(UrlSuccessActionData field0) url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(AesSuccessActionData field0)? aes,
     TResult? Function(MessageSuccessActionData field0)? message,
     TResult? Function(UrlSuccessActionData field0)? url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(AesSuccessActionData field0)? aes,
     TResult Function(MessageSuccessActionData field0)? message,
     TResult Function(UrlSuccessActionData field0)? url,
     required TResult orElse(),
@@ -3325,18 +3328,21 @@ mixin _$SuccessAction {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(SuccessAction_Aes value) aes,
     required TResult Function(SuccessAction_Message value) message,
     required TResult Function(SuccessAction_Url value) url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SuccessAction_Aes value)? aes,
     TResult? Function(SuccessAction_Message value)? message,
     TResult? Function(SuccessAction_Url value)? url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(SuccessAction_Aes value)? aes,
     TResult Function(SuccessAction_Message value)? message,
     TResult Function(SuccessAction_Url value)? url,
     required TResult orElse(),
@@ -3360,6 +3366,147 @@ class _$SuccessActionCopyWithImpl<$Res, $Val extends SuccessAction>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$SuccessAction_AesCopyWith<$Res> {
+  factory _$$SuccessAction_AesCopyWith(
+          _$SuccessAction_Aes value, $Res Function(_$SuccessAction_Aes) then) =
+      __$$SuccessAction_AesCopyWithImpl<$Res>;
+  @useResult
+  $Res call({AesSuccessActionData field0});
+}
+
+/// @nodoc
+class __$$SuccessAction_AesCopyWithImpl<$Res>
+    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_Aes>
+    implements _$$SuccessAction_AesCopyWith<$Res> {
+  __$$SuccessAction_AesCopyWithImpl(
+      _$SuccessAction_Aes _value, $Res Function(_$SuccessAction_Aes) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(_$SuccessAction_Aes(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as AesSuccessActionData,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessAction_Aes implements SuccessAction_Aes {
+  const _$SuccessAction_Aes(this.field0);
+
+  @override
+  final AesSuccessActionData field0;
+
+  @override
+  String toString() {
+    return 'SuccessAction.aes(field0: $field0)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessAction_Aes &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessAction_AesCopyWith<_$SuccessAction_Aes> get copyWith =>
+      __$$SuccessAction_AesCopyWithImpl<_$SuccessAction_Aes>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(AesSuccessActionData field0) aes,
+    required TResult Function(MessageSuccessActionData field0) message,
+    required TResult Function(UrlSuccessActionData field0) url,
+  }) {
+    return aes(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(AesSuccessActionData field0)? aes,
+    TResult? Function(MessageSuccessActionData field0)? message,
+    TResult? Function(UrlSuccessActionData field0)? url,
+  }) {
+    return aes?.call(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(AesSuccessActionData field0)? aes,
+    TResult Function(MessageSuccessActionData field0)? message,
+    TResult Function(UrlSuccessActionData field0)? url,
+    required TResult orElse(),
+  }) {
+    if (aes != null) {
+      return aes(field0);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SuccessAction_Aes value) aes,
+    required TResult Function(SuccessAction_Message value) message,
+    required TResult Function(SuccessAction_Url value) url,
+  }) {
+    return aes(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SuccessAction_Aes value)? aes,
+    TResult? Function(SuccessAction_Message value)? message,
+    TResult? Function(SuccessAction_Url value)? url,
+  }) {
+    return aes?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SuccessAction_Aes value)? aes,
+    TResult Function(SuccessAction_Message value)? message,
+    TResult Function(SuccessAction_Url value)? url,
+    required TResult orElse(),
+  }) {
+    if (aes != null) {
+      return aes(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class SuccessAction_Aes implements SuccessAction {
+  const factory SuccessAction_Aes(final AesSuccessActionData field0) =
+      _$SuccessAction_Aes;
+
+  @override
+  AesSuccessActionData get field0;
+  @JsonKey(ignore: true)
+  _$$SuccessAction_AesCopyWith<_$SuccessAction_Aes> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -3427,6 +3574,7 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(AesSuccessActionData field0) aes,
     required TResult Function(MessageSuccessActionData field0) message,
     required TResult Function(UrlSuccessActionData field0) url,
   }) {
@@ -3436,6 +3584,7 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(AesSuccessActionData field0)? aes,
     TResult? Function(MessageSuccessActionData field0)? message,
     TResult? Function(UrlSuccessActionData field0)? url,
   }) {
@@ -3445,6 +3594,7 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(AesSuccessActionData field0)? aes,
     TResult Function(MessageSuccessActionData field0)? message,
     TResult Function(UrlSuccessActionData field0)? url,
     required TResult orElse(),
@@ -3458,6 +3608,7 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(SuccessAction_Aes value) aes,
     required TResult Function(SuccessAction_Message value) message,
     required TResult Function(SuccessAction_Url value) url,
   }) {
@@ -3467,6 +3618,7 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SuccessAction_Aes value)? aes,
     TResult? Function(SuccessAction_Message value)? message,
     TResult? Function(SuccessAction_Url value)? url,
   }) {
@@ -3476,6 +3628,7 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(SuccessAction_Aes value)? aes,
     TResult Function(SuccessAction_Message value)? message,
     TResult Function(SuccessAction_Url value)? url,
     required TResult orElse(),
@@ -3562,6 +3715,7 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
+    required TResult Function(AesSuccessActionData field0) aes,
     required TResult Function(MessageSuccessActionData field0) message,
     required TResult Function(UrlSuccessActionData field0) url,
   }) {
@@ -3571,6 +3725,7 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(AesSuccessActionData field0)? aes,
     TResult? Function(MessageSuccessActionData field0)? message,
     TResult? Function(UrlSuccessActionData field0)? url,
   }) {
@@ -3580,6 +3735,7 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
+    TResult Function(AesSuccessActionData field0)? aes,
     TResult Function(MessageSuccessActionData field0)? message,
     TResult Function(UrlSuccessActionData field0)? url,
     required TResult orElse(),
@@ -3593,6 +3749,7 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
+    required TResult Function(SuccessAction_Aes value) aes,
     required TResult Function(SuccessAction_Message value) message,
     required TResult Function(SuccessAction_Url value) url,
   }) {
@@ -3602,6 +3759,7 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(SuccessAction_Aes value)? aes,
     TResult? Function(SuccessAction_Message value)? message,
     TResult? Function(SuccessAction_Url value)? url,
   }) {
@@ -3611,6 +3769,7 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
+    TResult Function(SuccessAction_Aes value)? aes,
     TResult Function(SuccessAction_Message value)? message,
     TResult Function(SuccessAction_Url value)? url,
     required TResult orElse(),

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -2292,19 +2292,19 @@ mixin _$LnUrlPayResult {
   Object? get data => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(SuccessAction? data) endpointSuccess,
+    required TResult Function(SuccessActionProcessed? data) endpointSuccess,
     required TResult Function(LnUrlErrorData data) endpointError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction? data)? endpointSuccess,
+    TResult? Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult? Function(LnUrlErrorData data)? endpointError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(SuccessAction? data)? endpointSuccess,
+    TResult Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult Function(LnUrlErrorData data)? endpointError,
     required TResult orElse(),
   }) =>
@@ -2356,9 +2356,9 @@ abstract class _$$LnUrlPayResult_EndpointSuccessCopyWith<$Res> {
           $Res Function(_$LnUrlPayResult_EndpointSuccess) then) =
       __$$LnUrlPayResult_EndpointSuccessCopyWithImpl<$Res>;
   @useResult
-  $Res call({SuccessAction? data});
+  $Res call({SuccessActionProcessed? data});
 
-  $SuccessActionCopyWith<$Res>? get data;
+  $SuccessActionProcessedCopyWith<$Res>? get data;
 }
 
 /// @nodoc
@@ -2379,18 +2379,18 @@ class __$$LnUrlPayResult_EndpointSuccessCopyWithImpl<$Res>
       data: freezed == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
-              as SuccessAction?,
+              as SuccessActionProcessed?,
     ));
   }
 
   @override
   @pragma('vm:prefer-inline')
-  $SuccessActionCopyWith<$Res>? get data {
+  $SuccessActionProcessedCopyWith<$Res>? get data {
     if (_value.data == null) {
       return null;
     }
 
-    return $SuccessActionCopyWith<$Res>(_value.data!, (value) {
+    return $SuccessActionProcessedCopyWith<$Res>(_value.data!, (value) {
       return _then(_value.copyWith(data: value));
     });
   }
@@ -2403,7 +2403,7 @@ class _$LnUrlPayResult_EndpointSuccess
   const _$LnUrlPayResult_EndpointSuccess({this.data});
 
   @override
-  final SuccessAction? data;
+  final SuccessActionProcessed? data;
 
   @override
   String toString() {
@@ -2431,7 +2431,7 @@ class _$LnUrlPayResult_EndpointSuccess
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(SuccessAction? data) endpointSuccess,
+    required TResult Function(SuccessActionProcessed? data) endpointSuccess,
     required TResult Function(LnUrlErrorData data) endpointError,
   }) {
     return endpointSuccess(data);
@@ -2440,7 +2440,7 @@ class _$LnUrlPayResult_EndpointSuccess
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction? data)? endpointSuccess,
+    TResult? Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult? Function(LnUrlErrorData data)? endpointError,
   }) {
     return endpointSuccess?.call(data);
@@ -2449,7 +2449,7 @@ class _$LnUrlPayResult_EndpointSuccess
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(SuccessAction? data)? endpointSuccess,
+    TResult Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult Function(LnUrlErrorData data)? endpointError,
     required TResult orElse(),
   }) {
@@ -2493,11 +2493,11 @@ class _$LnUrlPayResult_EndpointSuccess
 }
 
 abstract class LnUrlPayResult_EndpointSuccess implements LnUrlPayResult {
-  const factory LnUrlPayResult_EndpointSuccess({final SuccessAction? data}) =
-      _$LnUrlPayResult_EndpointSuccess;
+  const factory LnUrlPayResult_EndpointSuccess(
+      {final SuccessActionProcessed? data}) = _$LnUrlPayResult_EndpointSuccess;
 
   @override
-  SuccessAction? get data;
+  SuccessActionProcessed? get data;
   @JsonKey(ignore: true)
   _$$LnUrlPayResult_EndpointSuccessCopyWith<_$LnUrlPayResult_EndpointSuccess>
       get copyWith => throw _privateConstructorUsedError;
@@ -2570,7 +2570,7 @@ class _$LnUrlPayResult_EndpointError implements LnUrlPayResult_EndpointError {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(SuccessAction? data) endpointSuccess,
+    required TResult Function(SuccessActionProcessed? data) endpointSuccess,
     required TResult Function(LnUrlErrorData data) endpointError,
   }) {
     return endpointError(data);
@@ -2579,7 +2579,7 @@ class _$LnUrlPayResult_EndpointError implements LnUrlPayResult_EndpointError {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction? data)? endpointSuccess,
+    TResult? Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult? Function(LnUrlErrorData data)? endpointError,
   }) {
     return endpointError?.call(data);
@@ -2588,7 +2588,7 @@ class _$LnUrlPayResult_EndpointError implements LnUrlPayResult_EndpointError {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(SuccessAction? data)? endpointSuccess,
+    TResult Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult Function(LnUrlErrorData data)? endpointError,
     required TResult orElse(),
   }) {
@@ -3302,65 +3302,66 @@ abstract class PaymentDetails_ClosedChannel implements PaymentDetails {
 }
 
 /// @nodoc
-mixin _$SuccessAction {
-  Object get field0 => throw _privateConstructorUsedError;
+mixin _$SuccessActionProcessed {
+  Object get data => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $SuccessActionCopyWith<$Res> {
-  factory $SuccessActionCopyWith(
-          SuccessAction value, $Res Function(SuccessAction) then) =
-      _$SuccessActionCopyWithImpl<$Res, SuccessAction>;
+abstract class $SuccessActionProcessedCopyWith<$Res> {
+  factory $SuccessActionProcessedCopyWith(SuccessActionProcessed value,
+          $Res Function(SuccessActionProcessed) then) =
+      _$SuccessActionProcessedCopyWithImpl<$Res, SuccessActionProcessed>;
 }
 
 /// @nodoc
-class _$SuccessActionCopyWithImpl<$Res, $Val extends SuccessAction>
-    implements $SuccessActionCopyWith<$Res> {
-  _$SuccessActionCopyWithImpl(this._value, this._then);
+class _$SuccessActionProcessedCopyWithImpl<$Res,
+        $Val extends SuccessActionProcessed>
+    implements $SuccessActionProcessedCopyWith<$Res> {
+  _$SuccessActionProcessedCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
@@ -3369,96 +3370,100 @@ class _$SuccessActionCopyWithImpl<$Res, $Val extends SuccessAction>
 }
 
 /// @nodoc
-abstract class _$$SuccessAction_AesCopyWith<$Res> {
-  factory _$$SuccessAction_AesCopyWith(
-          _$SuccessAction_Aes value, $Res Function(_$SuccessAction_Aes) then) =
-      __$$SuccessAction_AesCopyWithImpl<$Res>;
+abstract class _$$SuccessActionProcessed_AesCopyWith<$Res> {
+  factory _$$SuccessActionProcessed_AesCopyWith(
+          _$SuccessActionProcessed_Aes value,
+          $Res Function(_$SuccessActionProcessed_Aes) then) =
+      __$$SuccessActionProcessed_AesCopyWithImpl<$Res>;
   @useResult
-  $Res call({AesSuccessActionData field0});
+  $Res call({AesSuccessActionDataDecrypted data});
 }
 
 /// @nodoc
-class __$$SuccessAction_AesCopyWithImpl<$Res>
-    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_Aes>
-    implements _$$SuccessAction_AesCopyWith<$Res> {
-  __$$SuccessAction_AesCopyWithImpl(
-      _$SuccessAction_Aes _value, $Res Function(_$SuccessAction_Aes) _then)
+class __$$SuccessActionProcessed_AesCopyWithImpl<$Res>
+    extends _$SuccessActionProcessedCopyWithImpl<$Res,
+        _$SuccessActionProcessed_Aes>
+    implements _$$SuccessActionProcessed_AesCopyWith<$Res> {
+  __$$SuccessActionProcessed_AesCopyWithImpl(
+      _$SuccessActionProcessed_Aes _value,
+      $Res Function(_$SuccessActionProcessed_Aes) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? field0 = null,
+    Object? data = null,
   }) {
-    return _then(_$SuccessAction_Aes(
-      null == field0
-          ? _value.field0
-          : field0 // ignore: cast_nullable_to_non_nullable
-              as AesSuccessActionData,
+    return _then(_$SuccessActionProcessed_Aes(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as AesSuccessActionDataDecrypted,
     ));
   }
 }
 
 /// @nodoc
 
-class _$SuccessAction_Aes implements SuccessAction_Aes {
-  const _$SuccessAction_Aes(this.field0);
+class _$SuccessActionProcessed_Aes implements SuccessActionProcessed_Aes {
+  const _$SuccessActionProcessed_Aes({required this.data});
 
   @override
-  final AesSuccessActionData field0;
+  final AesSuccessActionDataDecrypted data;
 
   @override
   String toString() {
-    return 'SuccessAction.aes(field0: $field0)';
+    return 'SuccessActionProcessed.aes(data: $data)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SuccessAction_Aes &&
-            (identical(other.field0, field0) || other.field0 == field0));
+            other is _$SuccessActionProcessed_Aes &&
+            (identical(other.data, data) || other.data == data));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, field0);
+  int get hashCode => Object.hash(runtimeType, data);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuccessAction_AesCopyWith<_$SuccessAction_Aes> get copyWith =>
-      __$$SuccessAction_AesCopyWithImpl<_$SuccessAction_Aes>(this, _$identity);
+  _$$SuccessActionProcessed_AesCopyWith<_$SuccessActionProcessed_Aes>
+      get copyWith => __$$SuccessActionProcessed_AesCopyWithImpl<
+          _$SuccessActionProcessed_Aes>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) {
-    return aes(field0);
+    return aes(data);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) {
-    return aes?.call(field0);
+    return aes?.call(data);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) {
     if (aes != null) {
-      return aes(field0);
+      return aes(data);
     }
     return orElse();
   }
@@ -3466,9 +3471,9 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) {
     return aes(this);
   }
@@ -3476,9 +3481,9 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) {
     return aes?.call(this);
   }
@@ -3486,9 +3491,9 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) {
     if (aes != null) {
@@ -3498,43 +3503,47 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   }
 }
 
-abstract class SuccessAction_Aes implements SuccessAction {
-  const factory SuccessAction_Aes(final AesSuccessActionData field0) =
-      _$SuccessAction_Aes;
+abstract class SuccessActionProcessed_Aes implements SuccessActionProcessed {
+  const factory SuccessActionProcessed_Aes(
+          {required final AesSuccessActionDataDecrypted data}) =
+      _$SuccessActionProcessed_Aes;
 
   @override
-  AesSuccessActionData get field0;
+  AesSuccessActionDataDecrypted get data;
   @JsonKey(ignore: true)
-  _$$SuccessAction_AesCopyWith<_$SuccessAction_Aes> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuccessActionProcessed_AesCopyWith<_$SuccessActionProcessed_Aes>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$SuccessAction_MessageCopyWith<$Res> {
-  factory _$$SuccessAction_MessageCopyWith(_$SuccessAction_Message value,
-          $Res Function(_$SuccessAction_Message) then) =
-      __$$SuccessAction_MessageCopyWithImpl<$Res>;
+abstract class _$$SuccessActionProcessed_MessageCopyWith<$Res> {
+  factory _$$SuccessActionProcessed_MessageCopyWith(
+          _$SuccessActionProcessed_Message value,
+          $Res Function(_$SuccessActionProcessed_Message) then) =
+      __$$SuccessActionProcessed_MessageCopyWithImpl<$Res>;
   @useResult
-  $Res call({MessageSuccessActionData field0});
+  $Res call({MessageSuccessActionData data});
 }
 
 /// @nodoc
-class __$$SuccessAction_MessageCopyWithImpl<$Res>
-    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_Message>
-    implements _$$SuccessAction_MessageCopyWith<$Res> {
-  __$$SuccessAction_MessageCopyWithImpl(_$SuccessAction_Message _value,
-      $Res Function(_$SuccessAction_Message) _then)
+class __$$SuccessActionProcessed_MessageCopyWithImpl<$Res>
+    extends _$SuccessActionProcessedCopyWithImpl<$Res,
+        _$SuccessActionProcessed_Message>
+    implements _$$SuccessActionProcessed_MessageCopyWith<$Res> {
+  __$$SuccessActionProcessed_MessageCopyWithImpl(
+      _$SuccessActionProcessed_Message _value,
+      $Res Function(_$SuccessActionProcessed_Message) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? field0 = null,
+    Object? data = null,
   }) {
-    return _then(_$SuccessAction_Message(
-      null == field0
-          ? _value.field0
-          : field0 // ignore: cast_nullable_to_non_nullable
+    return _then(_$SuccessActionProcessed_Message(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
               as MessageSuccessActionData,
     ));
   }
@@ -3542,65 +3551,66 @@ class __$$SuccessAction_MessageCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SuccessAction_Message implements SuccessAction_Message {
-  const _$SuccessAction_Message(this.field0);
+class _$SuccessActionProcessed_Message
+    implements SuccessActionProcessed_Message {
+  const _$SuccessActionProcessed_Message({required this.data});
 
   @override
-  final MessageSuccessActionData field0;
+  final MessageSuccessActionData data;
 
   @override
   String toString() {
-    return 'SuccessAction.message(field0: $field0)';
+    return 'SuccessActionProcessed.message(data: $data)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SuccessAction_Message &&
-            (identical(other.field0, field0) || other.field0 == field0));
+            other is _$SuccessActionProcessed_Message &&
+            (identical(other.data, data) || other.data == data));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, field0);
+  int get hashCode => Object.hash(runtimeType, data);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuccessAction_MessageCopyWith<_$SuccessAction_Message> get copyWith =>
-      __$$SuccessAction_MessageCopyWithImpl<_$SuccessAction_Message>(
-          this, _$identity);
+  _$$SuccessActionProcessed_MessageCopyWith<_$SuccessActionProcessed_Message>
+      get copyWith => __$$SuccessActionProcessed_MessageCopyWithImpl<
+          _$SuccessActionProcessed_Message>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) {
-    return message(field0);
+    return message(data);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) {
-    return message?.call(field0);
+    return message?.call(data);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) {
     if (message != null) {
-      return message(field0);
+      return message(data);
     }
     return orElse();
   }
@@ -3608,9 +3618,9 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) {
     return message(this);
   }
@@ -3618,9 +3628,9 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) {
     return message?.call(this);
   }
@@ -3628,9 +3638,9 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) {
     if (message != null) {
@@ -3640,43 +3650,48 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   }
 }
 
-abstract class SuccessAction_Message implements SuccessAction {
-  const factory SuccessAction_Message(final MessageSuccessActionData field0) =
-      _$SuccessAction_Message;
+abstract class SuccessActionProcessed_Message
+    implements SuccessActionProcessed {
+  const factory SuccessActionProcessed_Message(
+          {required final MessageSuccessActionData data}) =
+      _$SuccessActionProcessed_Message;
 
   @override
-  MessageSuccessActionData get field0;
+  MessageSuccessActionData get data;
   @JsonKey(ignore: true)
-  _$$SuccessAction_MessageCopyWith<_$SuccessAction_Message> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuccessActionProcessed_MessageCopyWith<_$SuccessActionProcessed_Message>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$SuccessAction_UrlCopyWith<$Res> {
-  factory _$$SuccessAction_UrlCopyWith(
-          _$SuccessAction_Url value, $Res Function(_$SuccessAction_Url) then) =
-      __$$SuccessAction_UrlCopyWithImpl<$Res>;
+abstract class _$$SuccessActionProcessed_UrlCopyWith<$Res> {
+  factory _$$SuccessActionProcessed_UrlCopyWith(
+          _$SuccessActionProcessed_Url value,
+          $Res Function(_$SuccessActionProcessed_Url) then) =
+      __$$SuccessActionProcessed_UrlCopyWithImpl<$Res>;
   @useResult
-  $Res call({UrlSuccessActionData field0});
+  $Res call({UrlSuccessActionData data});
 }
 
 /// @nodoc
-class __$$SuccessAction_UrlCopyWithImpl<$Res>
-    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_Url>
-    implements _$$SuccessAction_UrlCopyWith<$Res> {
-  __$$SuccessAction_UrlCopyWithImpl(
-      _$SuccessAction_Url _value, $Res Function(_$SuccessAction_Url) _then)
+class __$$SuccessActionProcessed_UrlCopyWithImpl<$Res>
+    extends _$SuccessActionProcessedCopyWithImpl<$Res,
+        _$SuccessActionProcessed_Url>
+    implements _$$SuccessActionProcessed_UrlCopyWith<$Res> {
+  __$$SuccessActionProcessed_UrlCopyWithImpl(
+      _$SuccessActionProcessed_Url _value,
+      $Res Function(_$SuccessActionProcessed_Url) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? field0 = null,
+    Object? data = null,
   }) {
-    return _then(_$SuccessAction_Url(
-      null == field0
-          ? _value.field0
-          : field0 // ignore: cast_nullable_to_non_nullable
+    return _then(_$SuccessActionProcessed_Url(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
               as UrlSuccessActionData,
     ));
   }
@@ -3684,64 +3699,65 @@ class __$$SuccessAction_UrlCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SuccessAction_Url implements SuccessAction_Url {
-  const _$SuccessAction_Url(this.field0);
+class _$SuccessActionProcessed_Url implements SuccessActionProcessed_Url {
+  const _$SuccessActionProcessed_Url({required this.data});
 
   @override
-  final UrlSuccessActionData field0;
+  final UrlSuccessActionData data;
 
   @override
   String toString() {
-    return 'SuccessAction.url(field0: $field0)';
+    return 'SuccessActionProcessed.url(data: $data)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SuccessAction_Url &&
-            (identical(other.field0, field0) || other.field0 == field0));
+            other is _$SuccessActionProcessed_Url &&
+            (identical(other.data, data) || other.data == data));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, field0);
+  int get hashCode => Object.hash(runtimeType, data);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuccessAction_UrlCopyWith<_$SuccessAction_Url> get copyWith =>
-      __$$SuccessAction_UrlCopyWithImpl<_$SuccessAction_Url>(this, _$identity);
+  _$$SuccessActionProcessed_UrlCopyWith<_$SuccessActionProcessed_Url>
+      get copyWith => __$$SuccessActionProcessed_UrlCopyWithImpl<
+          _$SuccessActionProcessed_Url>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) {
-    return url(field0);
+    return url(data);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) {
-    return url?.call(field0);
+    return url?.call(data);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) {
     if (url != null) {
-      return url(field0);
+      return url(data);
     }
     return orElse();
   }
@@ -3749,9 +3765,9 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) {
     return url(this);
   }
@@ -3759,9 +3775,9 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) {
     return url?.call(this);
   }
@@ -3769,9 +3785,9 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) {
     if (url != null) {
@@ -3781,13 +3797,14 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   }
 }
 
-abstract class SuccessAction_Url implements SuccessAction {
-  const factory SuccessAction_Url(final UrlSuccessActionData field0) =
-      _$SuccessAction_Url;
+abstract class SuccessActionProcessed_Url implements SuccessActionProcessed {
+  const factory SuccessActionProcessed_Url(
+          {required final UrlSuccessActionData data}) =
+      _$SuccessActionProcessed_Url;
 
   @override
-  UrlSuccessActionData get field0;
+  UrlSuccessActionData get data;
   @JsonKey(ignore: true)
-  _$$SuccessAction_UrlCopyWith<_$SuccessAction_Url> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuccessActionProcessed_UrlCopyWith<_$SuccessActionProcessed_Url>
+      get copyWith => throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
Fixes #82

Unlike other success actions, which can be fully used as soon as we get them, this one can only be decrypted once the LNURL-pay invoice is paid. The preimage is the decryption key.