### PR TITLE
Monitor refundable swaps until resolution.

### DIFF
--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -143,6 +143,22 @@ impl SqliteStorage {
         Ok(vec)
     }
 
+    pub(crate) fn list_swaps(&self) -> Result<Vec<SwapInfo>> {
+        let con = self.get_connection()?;
+        let mut stmt = con.prepare(
+            "
+           SELECT * FROM swaps        
+         ",
+        )?;
+
+        let vec: Vec<SwapInfo> = stmt
+            .query_map([], |row| self.sql_row_to_swap(row))?
+            .map(|i| i.unwrap())
+            .collect();
+
+        Ok(vec)
+    }
+
     fn sql_row_to_swap(&self, row: &Row) -> Result<SwapInfo, rusqlite::Error> {
         let status: i32 = row.get(13)?;
         let status: SwapStatus = status.try_into().map_or(SwapStatus::Initial, |v| v);

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -266,7 +266,7 @@ impl BTCReceiveSwap {
     pub fn list_monitored(&self) -> Result<Vec<SwapInfo>> {
         Ok(self
             .persister
-            .list_swaps_with_status(SwapStatus::Initial)?
+            .list_swaps()?
             .into_iter()
             .filter(SwapInfo::monitored)
             .collect())


### PR DESCRIPTION
This PR fixes an issue when we stop monitoring unconfirmed refunded addresses.
After this fix the swap address will be monitored until the refund tx is confirmed.