### PR TITLE
[WIP] Persist LNURL successAction in LnPaymentDetails

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -109,6 +109,27 @@ interface PaymentDetails {
     ClosedChannel(ClosedChannelPaymentDetails data);
 };
 
+dictionary AesSuccessActionDataDecrypted {
+    string description;
+    string plaintext;
+};
+
+dictionary MessageSuccessActionData {
+    string message;
+};
+
+dictionary UrlSuccessActionData {
+    string description;
+    string url;
+};
+
+[Enum]
+interface SuccessActionProcessed {
+    Aes(AesSuccessActionDataDecrypted data);
+    Message(MessageSuccessActionData data);
+    Url(UrlSuccessActionData data);
+};
+
 dictionary LnPaymentDetails {
     string payment_hash;
     string label;
@@ -116,6 +137,7 @@ dictionary LnPaymentDetails {
     string payment_preimage;
     boolean keysend;
     string bolt11;
+    SuccessActionProcessed? lnurl_success_action;
 };
 
 dictionary ClosedChannelPaymentDetails {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -4,14 +4,15 @@ use anyhow::{anyhow, Result};
 
 use breez_sdk_core::{
     mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
-    parse_invoice as sdk_parse_invoice, BitcoinAddressData, BreezEvent, BreezServices,
-    ChannelState, ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType,
-    EventListener, FeeratePreset, FiatCurrency, GreenlightCredentials, InputType,
+    parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BitcoinAddressData,
+    BreezEvent, BreezServices, ChannelState, ClosedChannelPaymentDetails, Config, CurrencyInfo,
+    EnvironmentType, EventListener, FeeratePreset, FiatCurrency, GreenlightCredentials, InputType,
     InvoicePaidDetails, LNInvoice, LnPaymentDetails, LnUrlAuthRequestData, LnUrlErrorData,
     LnUrlPayRequestData, LnUrlWithdrawCallbackStatus, LnUrlWithdrawRequestData, LocaleOverrides,
-    LocalizedName, LogEntry, LspInformation, MetadataItem, Network, NodeState, Payment,
-    PaymentDetails, PaymentType, PaymentTypeFilter, Rate, RecommendedFees, RouteHint, RouteHintHop,
-    SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput,
+    LocalizedName, LogEntry, LspInformation, MessageSuccessActionData, MetadataItem, Network,
+    NodeState, Payment, PaymentDetails, PaymentType, PaymentTypeFilter, Rate, RecommendedFees,
+    RouteHint, RouteHintHop, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
+    UnspentTransactionOutput, UrlSuccessActionData,
 };
 use log::Metadata;
 use log::Record;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -46,6 +46,7 @@ pub trait EventListener: Send + Sync {
 /// Event emitted by the SDK. To listen for and react to these events, use an [EventListener] when
 /// initializing the [BreezServices].
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum BreezEvent {
     /// Indicates that a new block has just been found
     NewBlock { block: u32 },
@@ -53,7 +54,7 @@ pub enum BreezEvent {
     InvoicePaid { details: InvoicePaidDetails },
     /// Indicates that the local SDK state has just been sync-ed with the remote components
     Synced,
-    /// Indicates that an outgoing payment has been completed succesfully
+    /// Indicates that an outgoing payment has been completed successfully
     PaymentSucceed { details: Payment },
     /// Indicates that an outgoing payment has been failed to complete
     PaymentFailed { error: String },
@@ -1130,7 +1131,7 @@ pub(crate) mod tests {
         let persister = Arc::new(create_test_persister(test_config.clone()));
         persister.init()?;
         persister.insert_payments(&dummy_transactions)?;
-        persister.insert_lnurl_success_action(&payment_hash_with_lnurl_success_action, &sa)?;
+        persister.insert_lnurl_success_action(payment_hash_with_lnurl_success_action, &sa)?;
 
         let mut builder = BreezServicesBuilder::new(test_config.clone());
         let breez_services = builder

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -781,6 +781,7 @@ impl support::IntoDart for LnPaymentDetails {
             self.payment_preimage.into_dart(),
             self.keysend.into_dart(),
             self.bolt11.into_dart(),
+            self.lnurl_success_action.into_dart(),
         ]
         .into_dart()
     }
@@ -1021,9 +1022,9 @@ impl support::IntoDartExceptPrimitive for RouteHintHop {}
 impl support::IntoDart for SuccessActionProcessed {
     fn into_dart(self) -> support::DartAbi {
         match self {
-            Self::Aes(field0) => vec![0.into_dart(), field0.into_dart()],
-            Self::Message(field0) => vec![1.into_dart(), field0.into_dart()],
-            Self::Url(field0) => vec![2.into_dart(), field0.into_dart()],
+            Self::Aes { data } => vec![0.into_dart(), data.into_dart()],
+            Self::Message { data } => vec![1.into_dart(), data.into_dart()],
+            Self::Url { data } => vec![2.into_dart(), data.into_dart()],
         }
         .into_dart()
     }

--- a/libs/sdk-core/src/greenlight.rs
+++ b/libs/sdk-core/src/greenlight.rs
@@ -527,7 +527,7 @@ async fn pull_transactions(
     Ok(transactions)
 }
 
-// construct a lightning transaction from an invoice
+/// Construct a lightning transaction from an invoice
 fn invoice_to_transaction(
     node_pubkey: String,
     invoice: pb::Invoice,
@@ -549,6 +549,7 @@ fn invoice_to_transaction(
                 payment_preimage: hex::encode(invoice.payment_preimage),
                 keysend: false,
                 bolt11: invoice.bolt11,
+                lnurl_success_action: None, // For received payments, this is None
             },
         },
     })
@@ -580,6 +581,7 @@ pub(crate) fn payment_to_transaction(payment: pb::Payment) -> Result<crate::mode
                 payment_preimage: hex::encode(payment.payment_preimage),
                 keysend: payment.bolt11.is_empty(),
                 bolt11: payment.bolt11,
+                lnurl_success_action: None,
             },
         },
     })

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -162,7 +162,7 @@ pub use input_parser::{
 };
 pub use invoice::{parse_invoice, LNInvoice, RouteHint, RouteHintHop};
 
-pub use lnurl::pay::model::LnUrlPayResult;
+pub use lnurl::pay::model::*;
 pub use lnurl::withdraw::model::LnUrlWithdrawCallbackStatus;
 pub use lsp::LspInformation;
 pub use models::*;

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -128,7 +128,7 @@ pub(crate) mod model {
 
     use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
     use anyhow::{anyhow, Result};
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     pub(crate) enum ValidatedCallbackResponse {
         EndpointSuccess { data: CallbackResponse },
@@ -176,7 +176,7 @@ pub(crate) mod model {
     }
 
     /// Wrapper for the decrypted [AesSuccessActionData] payload
-    #[derive(Deserialize, Debug)]
+    #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
     pub struct AesSuccessActionDataDecrypted {
         /// Contents description, up to 144 characters
         pub description: String,
@@ -185,12 +185,12 @@ pub(crate) mod model {
         pub plaintext: String,
     }
 
-    #[derive(Deserialize, Debug)]
+    #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
     pub struct MessageSuccessActionData {
         pub message: String,
     }
 
-    #[derive(Deserialize, Debug)]
+    #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
     pub struct UrlSuccessActionData {
         pub description: String,
         pub url: String,
@@ -199,18 +199,18 @@ pub(crate) mod model {
     /// [SuccessAction] where contents are ready to be consumed by the caller
     ///
     /// Contents are identical to [SuccessAction], except for AES where the ciphertext is decrypted.
-    #[derive(Deserialize, Debug)]
+    #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
     pub enum SuccessActionProcessed {
         /// See [SuccessAction::Aes] for received payload
         ///
         /// See [AesSuccessActionDataDecrypted] for decrypted payload
-        Aes(AesSuccessActionDataDecrypted),
+        Aes { data: AesSuccessActionDataDecrypted },
 
         /// See [SuccessAction::Message]
-        Message(MessageSuccessActionData),
+        Message { data: MessageSuccessActionData },
 
         /// See [SuccessAction::Url]
-        Url(UrlSuccessActionData),
+        Url { data: UrlSuccessActionData },
     }
 
     /// Supported success action types
@@ -482,6 +482,52 @@ mod tests {
         user_amount_sat: u64,
         error: Option<String>,
         pr: String,
+        sa_data: AesSuccessActionDataDecrypted,
+        iv_bytes: [u8; 16],
+        key_bytes: [u8; 32],
+    ) -> Result<Mock> {
+        let callback_url = build_pay_callback_url(user_amount_sat, &None, pay_req)?;
+        let url = reqwest::Url::parse(&callback_url)?;
+        let mockito_path: &str = &format!("{}?{}", url.path(), url.query().unwrap());
+
+        let iv_base64 = base64::encode(iv_bytes);
+        let cipertext = AesSuccessActionData::encrypt(&key_bytes, &iv_bytes, sa_data.plaintext)?;
+
+        let expected_payload = r#"
+{
+    "pr":"token-invoice",
+    "routes":[],
+    "successAction": {
+        "tag":"aes",
+        "description":"token-description",
+        "iv":"token-iv",
+        "ciphertext":"token-ciphertext"
+    }
+}
+        "#
+        .replace('\n', "")
+        .replace("token-iv", &iv_base64)
+        .replace("token-ciphertext", &cipertext)
+        .replace("token-description", &sa_data.description)
+        .replace("token-invoice", &pr);
+
+        let response_body = match error {
+            None => expected_payload,
+            Some(err_reason) => {
+                ["{\"status\": \"ERROR\", \"reason\": \"", &err_reason, "\"}"].join("")
+            }
+        };
+        Ok(mockito::mock("GET", mockito_path)
+            .with_body(response_body)
+            .create())
+    }
+
+    /// Mock an LNURL-pay endpoint that responds with a Success Action of type AES
+    fn mock_lnurl_pay_callback_endpoint_aes_success_action(
+        pay_req: &LnUrlPayRequestData,
+        user_amount_sat: u64,
+        error: Option<String>,
+        pr: String,
         plaintext: String,
         iv_bytes: [u8; 16],
         key_bytes: [u8; 32],
@@ -558,6 +604,117 @@ mod tests {
             &payreq,
             &req
         )
+        .is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lnurl_pay_validate_success_action_encrypt_decrypt() -> Result<()> {
+        // Simulate a preimage, which will be the AES key
+        let key = sha256::Hash::hash(&[0x42; 16]);
+        let key_bytes = key.as_inner();
+
+        let iv_bytes = [0x24; 16]; // 16 bytes = 24 chars
+        let iv_base64 = base64::encode(iv_bytes); // JCQkJCQkJCQkJCQkJCQkJA==
+
+        let plaintext = "hello world! this is my plaintext.";
+        let plaintext_bytes = plaintext.as_bytes();
+
+        // hex = 91239ab5d94369a18474ee58372c7d0fcee5e227903f671bfe19ef32f1cada804d10f0f006265289d936317343dbc0ca
+        // base64 = kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK
+        let ciphertext_bytes =
+            &hex::decode("91239ab5d94369a18474ee58372c7d0fcee5e227903f671bfe19ef32f1cada804d10f0f006265289d936317343dbc0ca")?;
+        let ciphertext_base64 = base64::encode(ciphertext_bytes);
+
+        // Encrypt raw (which returns raw bytes)
+        let res = Aes256CbcEnc::new_from_slices(key_bytes, &iv_bytes)?
+            .encrypt_padded_vec_mut::<Pkcs7>(plaintext_bytes);
+        assert_eq!(res[..], ciphertext_bytes[..]);
+
+        // Decrypt raw (which returns raw bytes)
+        let res = Aes256CbcDec::new_from_slices(key_bytes, &iv_bytes)?
+            .decrypt_padded_vec_mut::<Pkcs7>(&res)?;
+        assert_eq!(res[..], plaintext_bytes[..]);
+
+        // Encrypt via AesSuccessActionData helper method (which returns a base64 representation of the bytes)
+        let res = AesSuccessActionData::encrypt(key_bytes, &iv_bytes, plaintext.into())?;
+        assert_eq!(res, base64::encode(ciphertext_bytes));
+
+        // Decrypt via AesSuccessActionData instance method (which returns an UTF-8 string of the plaintext bytes)
+        let res = AesSuccessActionData {
+            description: "Test AES successData description".into(),
+            ciphertext: ciphertext_base64,
+            iv: iv_base64,
+        }
+        .decrypt(key_bytes)?;
+        assert_eq!(res.as_bytes(), plaintext_bytes);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lnurl_pay_validate_success_action_aes() -> Result<()> {
+        assert!(AesSuccessActionData {
+            description: "Test AES successData description".into(),
+            ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
+            iv: base64::encode([0xa; 16])
+        }
+        .validate()
+        .is_ok());
+
+        // Description longer than 144 chars
+        assert!(AesSuccessActionData {
+            description: rand_string(150),
+            ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
+            iv: base64::encode([0xa; 16])
+        }
+        .validate()
+        .is_err());
+
+        // IV size below 16 bytes (24 chars)
+        assert!(AesSuccessActionData {
+            description: "Test AES successData description".into(),
+            ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
+            iv: base64::encode([0xa; 10])
+        }
+        .validate()
+        .is_err());
+
+        // IV size above 16 bytes (24 chars)
+        assert!(AesSuccessActionData {
+            description: "Test AES successData description".into(),
+            ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
+            iv: base64::encode([0xa; 20])
+        }
+        .validate()
+        .is_err());
+
+        // IV is not base64 encoded (but fits length of 24 chars)
+        assert!(AesSuccessActionData {
+            description: "Test AES successData description".into(),
+            ciphertext: "kSOatdlDaaGEdO5YNyx9D87l4ieQP2cb/hnvMvHK2oBNEPDwBiZSidk2MXND28DK".into(),
+            iv: ",".repeat(24)
+        }
+        .validate()
+        .is_err());
+
+        // Ciphertext is not base64 encoded
+        assert!(AesSuccessActionData {
+            description: "Test AES successData description".into(),
+            ciphertext: ",".repeat(96),
+            iv: base64::encode([0xa; 16])
+        }
+        .validate()
+        .is_err());
+
+        // Ciphertext longer than 4KB
+        assert!(AesSuccessActionData {
+            description: "Test AES successData description".into(),
+            ciphertext: base64::encode(rand_string(5000)),
+            iv: base64::encode([0xa; 16])
+        }
+        .validate()
         .is_err());
 
         Ok(())
@@ -790,7 +947,7 @@ mod tests {
                 "Expected success action in callback, but none provided"
             )),
             LnUrlPayResult::EndpointSuccess {
-                data: Some(SuccessActionProcessed::Message(msg)),
+                data: Some(SuccessActionProcessed::Message { data: msg }),
             } => match msg.message {
                 s if s == "test msg" => Ok(()),
                 _ => Err(anyhow!("Unexpected success action message content")),
@@ -871,7 +1028,7 @@ mod tests {
             .await?
         {
             LnUrlPayResult::EndpointSuccess {
-                data: Some(SuccessActionProcessed::Url(url)),
+                data: Some(SuccessActionProcessed::Url { data: url }),
             } => {
                 if url.url == "https://localhost/test-url" && url.description == "test description"
                 {
@@ -889,7 +1046,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_lnurl_pay_aes_success_action() -> Result<()> {
-        let plaintext = "Hello, test plaintext";
+        // Expected fields in the AES payload
+        let description = "test description in AES payload".to_string();
+        let plaintext = "Hello, test plaintext".to_string();
+        let sa_data = AesSuccessActionDataDecrypted {
+            description: description.clone(),
+            plaintext: plaintext.clone(),
+        };
+        let sa = SuccessActionProcessed::Aes {
+            data: sa_data.clone(),
+        };
 
         // Generate preimage
         let preimage = sha256::Hash::hash(&rand_vec_u8(10));
@@ -907,12 +1073,14 @@ mod tests {
             user_amount_sat,
             None,
             bolt11.clone(),
-            plaintext.into(),
+            sa_data.clone(),
             rand::thread_rng().gen::<[u8; 16]>(),
             preimage.into_inner(),
         )?;
 
-        let model_payment = MockNodeAPI::add_dummy_payment_for(bolt11, Some(preimage)).await?;
+        let gl_payment = MockNodeAPI::add_dummy_payment_for(bolt11, Some(preimage)).await?;
+        let model_payment: crate::models::Payment =
+            crate::greenlight::payment_to_transaction(gl_payment.clone())?;
 
         let known_payments: Vec<crate::models::Payment> = vec![model_payment];
         let mock_breez_services =
@@ -922,11 +1090,11 @@ mod tests {
             .await?
         {
             LnUrlPayResult::EndpointSuccess {
-                data: Some(SuccessActionProcessed::Aes(aes_data)),
-            } => match aes_data.plaintext == plaintext {
+                data: Some(received_sa),
+            } => match received_sa == sa {
                 true => Ok(()),
                 false => Err(anyhow!(
-                    "Decrypted payload doesn't match original plaintext"
+                    "Decrypted payload and description doesn't match expected success action"
                 )),
             },
             LnUrlPayResult::EndpointSuccess { data: None } => Err(anyhow!(

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -11,6 +11,7 @@ use tonic::Streaming;
 
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentReply};
+use crate::lnurl::pay::model::SuccessActionProcessed;
 use crate::lsp::LspInformation;
 use crate::models::Network::*;
 
@@ -296,6 +297,10 @@ pub struct LnPaymentDetails {
     pub payment_preimage: String,
     pub keysend: bool,
     pub bolt11: String,
+
+    /// Only set for [PaymentType::Sent] payments that are part of a LNURL-pay workflow where
+    /// the endpoint returns a success action
+    pub lnurl_success_action: Option<SuccessActionProcessed>,
 }
 
 /// Represents the funds that were on the user side of the channel at the time it was closed.

--- a/libs/sdk-core/src/persist/db.rs
+++ b/libs/sdk-core/src/persist/db.rs
@@ -190,6 +190,15 @@ impl SqliteStorage {
              
              DROP TABLE old_swaps;            
             "),
+            M::up(
+                "
+             CREATE TABLE IF NOT EXISTS payments_external_info (
+              payment_id TEXT NOT NULL PRIMARY KEY,
+              lnurl_success_action TEXT,
+              FOREIGN KEY(payment_id) REFERENCES payments(id)
+             ) STRICT;
+            ",
+            ),
         ]);
 
         let mut conn = self.get_connection()?;

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -120,15 +120,21 @@ impl SqliteStorage {
             .query_row(
                 "
                 SELECT
-                 id, 
-                 payment_type, 
-                 payment_time, 
-                 amount_msat, 
-                 fee_msat, 
-                 pending, 
-                 description,
-                 details
-                FROM payments where id = ?1",
+                 p.id,
+                 p.payment_type,
+                 p.payment_time,
+                 p.amount_msat,
+                 p.fee_msat,
+                 p.pending,
+                 p.description,
+                 p.details,
+                 e.lnurl_success_action
+                FROM payments p
+                LEFT JOIN payments_external_info e
+                ON
+                 p.id = e.payment_id
+                WHERE
+                 id = ?1",
                 [hash],
                 |row| self.sql_row_to_payment(row),
             )

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -1,6 +1,6 @@
 use super::db::SqliteStorage;
-use crate::models::{Payment, PaymentDetails};
-use crate::models::{PaymentType, PaymentTypeFilter};
+use crate::lnurl::pay::model::SuccessActionProcessed;
+use crate::models::*;
 use anyhow::{anyhow, Result};
 use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput};
 use rusqlite::OptionalExtension;
@@ -8,9 +8,14 @@ use rusqlite::Row;
 use std::str::FromStr;
 
 impl SqliteStorage {
+    /// Inserts payments into the payments table.
+    ///
+    /// Note that, if a payment has details of type [LnPaymentDetails] which contain a [SuccessActionProcessed],
+    /// then the [LnPaymentDetails] will NOT be persisted. In that case, the [SuccessActionProcessed]
+    /// can be inserted separately via [SqliteStorage::insert_lnurl_success_action].
     pub fn insert_payments(&self, transactions: &[Payment]) -> Result<()> {
         let con = self.get_connection()?;
-        let mut prep_statment = con.prepare(
+        let mut prep_statement = con.prepare(
             "
          INSERT OR REPLACE INTO payments (
            id,
@@ -27,7 +32,7 @@ impl SqliteStorage {
         )?;
 
         for ln_tx in transactions {
-            _ = prep_statment.execute((
+            _ = prep_statement.execute((
                 &ln_tx.id,
                 &ln_tx.payment_type.to_string(),
                 &ln_tx.payment_time,
@@ -41,6 +46,27 @@ impl SqliteStorage {
         Ok(())
     }
 
+    pub fn insert_lnurl_success_action(
+        &self,
+        payment_hash: &str,
+        sa: &SuccessActionProcessed,
+    ) -> Result<()> {
+        let con = self.get_connection()?;
+        let mut prep_statement = con.prepare(
+            "
+         INSERT OR REPLACE INTO payments_external_info (
+           payment_id,
+           lnurl_success_action
+         )
+         VALUES (?1,?2)
+        ",
+        )?;
+
+        _ = prep_statement.execute((payment_hash, &sa))?;
+
+        Ok(())
+    }
+
     pub fn last_payment_timestamp(&self) -> Result<i64> {
         self.get_connection()?
             .query_row("SELECT max(payment_time) FROM payments", [], |row| {
@@ -49,6 +75,7 @@ impl SqliteStorage {
             .map_err(anyhow::Error::msg)
     }
 
+    /// Constructs [Payment] by joining data in the `payment` and `payments_external_info` tables
     pub fn list_payments(
         &self,
         type_filter: PaymentTypeFilter,
@@ -61,15 +88,19 @@ impl SqliteStorage {
             format!(
                 "
             SELECT 
-             id, 
-             payment_type, 
-             payment_time, 
-             amount_msat, 
-             fee_msat, 
-             pending, 
-             description,
-             details
-            FROM payments            
+             p.id,
+             p.payment_type,
+             p.payment_time,
+             p.amount_msat,
+             p.fee_msat,
+             p.pending,
+             p.description,
+             p.details,
+             e.lnurl_success_action
+            FROM payments p
+            LEFT JOIN payments_external_info e
+            ON
+             p.id = e.payment_id
             {where_clause} ORDER BY payment_time DESC
           "
             )
@@ -107,7 +138,7 @@ impl SqliteStorage {
 
     fn sql_row_to_payment(&self, row: &Row) -> Result<Payment, rusqlite::Error> {
         let payment_type_str: String = row.get(1)?;
-        Ok(Payment {
+        let mut payment = Payment {
             id: row.get(0)?,
             payment_type: PaymentType::from_str(payment_type_str.as_str()).unwrap(),
             payment_time: row.get(2)?,
@@ -116,7 +147,16 @@ impl SqliteStorage {
             pending: row.get(5)?,
             description: row.get(6)?,
             details: row.get(7)?,
-        })
+        };
+
+        match payment.details {
+            PaymentDetails::Ln { ref mut data } => {
+                data.lnurl_success_action = row.get(8)?;
+            }
+            _ => {}
+        }
+
+        Ok(payment)
     }
 }
 
@@ -170,14 +210,37 @@ impl ToSql for PaymentDetails {
     }
 }
 
+impl FromSql for SuccessActionProcessed {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        serde_json::from_str(value.as_str()?).map_err(|_| FromSqlError::InvalidType)
+    }
+}
+
+impl ToSql for SuccessActionProcessed {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(
+            serde_json::to_string(&self).map_err(|_| FromSqlError::InvalidType)?,
+        ))
+    }
+}
+
 #[test]
-fn test_ln_transactions() {
+fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
+    use crate::lnurl::pay::model::MessageSuccessActionData;
+    use crate::lnurl::pay::model::SuccessActionProcessed;
     use crate::models::{LnPaymentDetails, Payment, PaymentDetails};
     use crate::persist::test_utils;
 
+    let sa = SuccessActionProcessed::Message {
+        data: MessageSuccessActionData {
+            message: "test message".into(),
+        },
+    };
+
+    let payment_hash_with_lnurl_success_action = "123";
     let txs = [
         Payment {
-            id: "123".to_string(),
+            id: payment_hash_with_lnurl_success_action.to_string(),
             payment_type: PaymentType::Sent,
             payment_time: 1001,
             amount_msat: 100,
@@ -186,12 +249,13 @@ fn test_ln_transactions() {
             description: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
-                    payment_hash: "123".to_string(),
+                    payment_hash: payment_hash_with_lnurl_success_action.to_string(),
                     label: "label".to_string(),
                     destination_pubkey: "pubey".to_string(),
                     payment_preimage: "payment_preimage".to_string(),
                     keysend: true,
                     bolt11: "bolt11".to_string(),
+                    lnurl_success_action: Some(sa.clone()),
                 },
             },
         },
@@ -211,43 +275,42 @@ fn test_ln_transactions() {
                     payment_preimage: "payment_preimage".to_string(),
                     keysend: true,
                     bolt11: "bolt11".to_string(),
+                    lnurl_success_action: None,
                 },
             },
         },
     ];
     let storage =
         SqliteStorage::from_file(test_utils::create_test_sql_file("transactions".to_string()));
-    storage.init().unwrap();
-    storage.insert_payments(&txs).unwrap();
+    storage.init()?;
+    storage.insert_payments(&txs)?;
+    storage.insert_lnurl_success_action(&payment_hash_with_lnurl_success_action, &sa)?;
 
     // retrieve all
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::All, None, None)
-        .unwrap();
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
 
     //test only sent
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::Sent, None, None)
-        .unwrap();
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::Sent, None, None)?;
     assert_eq!(retrieve_txs.len(), 1);
     assert_eq!(retrieve_txs[0], txs[0]);
+    assert!(
+        matches!( &retrieve_txs[0].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_success_action, ..}} if lnurl_success_action == &Some(sa))
+    );
 
     //test only received
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::Received, None, None)
-        .unwrap();
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::Received, None, None)?;
     assert_eq!(retrieve_txs.len(), 1);
     assert_eq!(retrieve_txs[0], txs[1]);
 
-    let max_ts = storage.last_payment_timestamp().unwrap();
+    let max_ts = storage.last_payment_timestamp()?;
     assert_eq!(max_ts, 1001);
 
-    storage.insert_payments(&txs).unwrap();
-    let retrieve_txs = storage
-        .list_payments(PaymentTypeFilter::All, None, None)
-        .unwrap();
+    storage.insert_payments(&txs)?;
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
+
+    Ok(())
 }

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -155,11 +155,8 @@ impl SqliteStorage {
             details: row.get(7)?,
         };
 
-        match payment.details {
-            PaymentDetails::Ln { ref mut data } => {
-                data.lnurl_success_action = row.get(8)?;
-            }
-            _ => {}
+        if let PaymentDetails::Ln { ref mut data } = payment.details {
+            data.lnurl_success_action = row.get(8)?;
         }
 
         Ok(payment)
@@ -290,7 +287,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
         SqliteStorage::from_file(test_utils::create_test_sql_file("transactions".to_string()));
     storage.init()?;
     storage.insert_payments(&txs)?;
-    storage.insert_lnurl_success_action(&payment_hash_with_lnurl_success_action, &sa)?;
+    storage.insert_lnurl_success_action(payment_hash_with_lnurl_success_action, &sa)?;
 
     // retrieve all
     let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -869,6 +869,7 @@ mod tests {
                     payment_preimage: "111".to_string(),
                     keysend: false,
                     bolt11: "".to_string(),
+                    lnurl_success_action: None,
                 },
             },
         };

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -301,34 +301,6 @@ impl MockNodeAPI {
         Self::save_payment_for_future_sync_updates(gl_payment.clone()).await
     }
 
-    /// Include payment in the result of [MockNodeAPI::pull_changed].
-    async fn save_payment_for_future_sync_updates(
-        gl_payment: gl_client::pb::Payment,
-    ) -> Result<gl_client::pb::Payment> {
-        let mut cloud_payments = CLOUD_PAYMENTS.lock().await;
-
-        // Only store it if a payment with the same ID doesn't already exist
-        // This allows us to initialize a MockBreezServer with a list of known payments using
-        // breez_services::tests::breez_services_with(vec), but not replace them when
-        // send_payment is called in tests for those payments.
-        match cloud_payments
-            .iter()
-            .find(|p| p.payment_hash == gl_payment.payment_hash)
-        {
-            None => {
-                // If payment is not already known, add it to the list and return it
-                cloud_payments.push(gl_payment.clone());
-                Ok(gl_payment)
-            }
-            Some(p) => {
-                // If a payment already exists (by ID), then do not replace it and return it
-                // The existing version is returned, because that's initialized with the preimage
-                // on mock breez service init
-                Ok(p.clone())
-            }
-        }
-    }
-
     /// Adds a dummy payment with random attributes.
     pub(crate) async fn add_dummy_payment_rand() -> Result<Payment> {
         let preimage = sha256::Hash::hash(&rand_vec_u8(10));

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -276,7 +276,7 @@ class BreezEvent with _$BreezEvent {
   /// Indicates that the local SDK state has just been sync-ed with the remote components
   const factory BreezEvent.synced() = BreezEvent_Synced;
 
-  /// Indicates that an outgoing payment has been completed succesfully
+  /// Indicates that an outgoing payment has been completed successfully
   const factory BreezEvent.paymentSucceed({
     required Payment details,
   }) = BreezEvent_PaymentSucceed;
@@ -491,6 +491,10 @@ class LnPaymentDetails {
   final bool keysend;
   final String bolt11;
 
+  /// Only set for [PaymentType::Sent] payments that are part of a LNURL-pay workflow where
+  /// the endpoint returns a success action
+  final SuccessActionProcessed? lnurlSuccessAction;
+
   LnPaymentDetails({
     required this.paymentHash,
     required this.label,
@@ -498,6 +502,7 @@ class LnPaymentDetails {
     required this.paymentPreimage,
     required this.keysend,
     required this.bolt11,
+    this.lnurlSuccessAction,
   });
 }
 
@@ -823,19 +828,19 @@ class SuccessActionProcessed with _$SuccessActionProcessed {
   /// See [SuccessAction::Aes] for received payload
   ///
   /// See [AesSuccessActionDataDecrypted] for decrypted payload
-  const factory SuccessActionProcessed.aes(
-    AesSuccessActionDataDecrypted field0,
-  ) = SuccessActionProcessed_Aes;
+  const factory SuccessActionProcessed.aes({
+    required AesSuccessActionDataDecrypted data,
+  }) = SuccessActionProcessed_Aes;
 
   /// See [SuccessAction::Message]
-  const factory SuccessActionProcessed.message(
-    MessageSuccessActionData field0,
-  ) = SuccessActionProcessed_Message;
+  const factory SuccessActionProcessed.message({
+    required MessageSuccessActionData data,
+  }) = SuccessActionProcessed_Message;
 
   /// See [SuccessAction::Url]
-  const factory SuccessActionProcessed.url(
-    UrlSuccessActionData field0,
-  ) = SuccessActionProcessed_Url;
+  const factory SuccessActionProcessed.url({
+    required UrlSuccessActionData data,
+  }) = SuccessActionProcessed_Url;
 }
 
 /// Represents the details of an on-going swap.
@@ -1905,8 +1910,8 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LnPaymentDetails _wire2api_ln_payment_details(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return LnPaymentDetails(
       paymentHash: _wire2api_String(arr[0]),
       label: _wire2api_String(arr[1]),
@@ -1914,6 +1919,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       paymentPreimage: _wire2api_String(arr[3]),
       keysend: _wire2api_bool(arr[4]),
       bolt11: _wire2api_String(arr[5]),
+      lnurlSuccessAction: _wire2api_opt_success_action_processed(arr[6]),
     );
   }
 
@@ -2206,15 +2212,15 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     switch (raw[0]) {
       case 0:
         return SuccessActionProcessed_Aes(
-          _wire2api_box_autoadd_aes_success_action_data_decrypted(raw[1]),
+          data: _wire2api_box_autoadd_aes_success_action_data_decrypted(raw[1]),
         );
       case 1:
         return SuccessActionProcessed_Message(
-          _wire2api_box_autoadd_message_success_action_data(raw[1]),
+          data: _wire2api_box_autoadd_message_success_action_data(raw[1]),
         );
       case 2:
         return SuccessActionProcessed_Url(
-          _wire2api_box_autoadd_url_success_action_data(raw[1]),
+          data: _wire2api_box_autoadd_url_success_action_data(raw[1]),
         );
       default:
         throw Exception("unreachable");

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -2292,19 +2292,19 @@ mixin _$LnUrlPayResult {
   Object? get data => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(SuccessAction? data) endpointSuccess,
+    required TResult Function(SuccessActionProcessed? data) endpointSuccess,
     required TResult Function(LnUrlErrorData data) endpointError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction? data)? endpointSuccess,
+    TResult? Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult? Function(LnUrlErrorData data)? endpointError,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(SuccessAction? data)? endpointSuccess,
+    TResult Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult Function(LnUrlErrorData data)? endpointError,
     required TResult orElse(),
   }) =>
@@ -2356,9 +2356,9 @@ abstract class _$$LnUrlPayResult_EndpointSuccessCopyWith<$Res> {
           $Res Function(_$LnUrlPayResult_EndpointSuccess) then) =
       __$$LnUrlPayResult_EndpointSuccessCopyWithImpl<$Res>;
   @useResult
-  $Res call({SuccessAction? data});
+  $Res call({SuccessActionProcessed? data});
 
-  $SuccessActionCopyWith<$Res>? get data;
+  $SuccessActionProcessedCopyWith<$Res>? get data;
 }
 
 /// @nodoc
@@ -2379,18 +2379,18 @@ class __$$LnUrlPayResult_EndpointSuccessCopyWithImpl<$Res>
       data: freezed == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
-              as SuccessAction?,
+              as SuccessActionProcessed?,
     ));
   }
 
   @override
   @pragma('vm:prefer-inline')
-  $SuccessActionCopyWith<$Res>? get data {
+  $SuccessActionProcessedCopyWith<$Res>? get data {
     if (_value.data == null) {
       return null;
     }
 
-    return $SuccessActionCopyWith<$Res>(_value.data!, (value) {
+    return $SuccessActionProcessedCopyWith<$Res>(_value.data!, (value) {
       return _then(_value.copyWith(data: value));
     });
   }
@@ -2403,7 +2403,7 @@ class _$LnUrlPayResult_EndpointSuccess
   const _$LnUrlPayResult_EndpointSuccess({this.data});
 
   @override
-  final SuccessAction? data;
+  final SuccessActionProcessed? data;
 
   @override
   String toString() {
@@ -2431,7 +2431,7 @@ class _$LnUrlPayResult_EndpointSuccess
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(SuccessAction? data) endpointSuccess,
+    required TResult Function(SuccessActionProcessed? data) endpointSuccess,
     required TResult Function(LnUrlErrorData data) endpointError,
   }) {
     return endpointSuccess(data);
@@ -2440,7 +2440,7 @@ class _$LnUrlPayResult_EndpointSuccess
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction? data)? endpointSuccess,
+    TResult? Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult? Function(LnUrlErrorData data)? endpointError,
   }) {
     return endpointSuccess?.call(data);
@@ -2449,7 +2449,7 @@ class _$LnUrlPayResult_EndpointSuccess
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(SuccessAction? data)? endpointSuccess,
+    TResult Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult Function(LnUrlErrorData data)? endpointError,
     required TResult orElse(),
   }) {
@@ -2493,11 +2493,11 @@ class _$LnUrlPayResult_EndpointSuccess
 }
 
 abstract class LnUrlPayResult_EndpointSuccess implements LnUrlPayResult {
-  const factory LnUrlPayResult_EndpointSuccess({final SuccessAction? data}) =
-      _$LnUrlPayResult_EndpointSuccess;
+  const factory LnUrlPayResult_EndpointSuccess(
+      {final SuccessActionProcessed? data}) = _$LnUrlPayResult_EndpointSuccess;
 
   @override
-  SuccessAction? get data;
+  SuccessActionProcessed? get data;
   @JsonKey(ignore: true)
   _$$LnUrlPayResult_EndpointSuccessCopyWith<_$LnUrlPayResult_EndpointSuccess>
       get copyWith => throw _privateConstructorUsedError;
@@ -2570,7 +2570,7 @@ class _$LnUrlPayResult_EndpointError implements LnUrlPayResult_EndpointError {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(SuccessAction? data) endpointSuccess,
+    required TResult Function(SuccessActionProcessed? data) endpointSuccess,
     required TResult Function(LnUrlErrorData data) endpointError,
   }) {
     return endpointError(data);
@@ -2579,7 +2579,7 @@ class _$LnUrlPayResult_EndpointError implements LnUrlPayResult_EndpointError {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction? data)? endpointSuccess,
+    TResult? Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult? Function(LnUrlErrorData data)? endpointError,
   }) {
     return endpointError?.call(data);
@@ -2588,7 +2588,7 @@ class _$LnUrlPayResult_EndpointError implements LnUrlPayResult_EndpointError {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(SuccessAction? data)? endpointSuccess,
+    TResult Function(SuccessActionProcessed? data)? endpointSuccess,
     TResult Function(LnUrlErrorData data)? endpointError,
     required TResult orElse(),
   }) {
@@ -3302,65 +3302,66 @@ abstract class PaymentDetails_ClosedChannel implements PaymentDetails {
 }
 
 /// @nodoc
-mixin _$SuccessAction {
-  Object get field0 => throw _privateConstructorUsedError;
+mixin _$SuccessActionProcessed {
+  Object get data => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $SuccessActionCopyWith<$Res> {
-  factory $SuccessActionCopyWith(
-          SuccessAction value, $Res Function(SuccessAction) then) =
-      _$SuccessActionCopyWithImpl<$Res, SuccessAction>;
+abstract class $SuccessActionProcessedCopyWith<$Res> {
+  factory $SuccessActionProcessedCopyWith(SuccessActionProcessed value,
+          $Res Function(SuccessActionProcessed) then) =
+      _$SuccessActionProcessedCopyWithImpl<$Res, SuccessActionProcessed>;
 }
 
 /// @nodoc
-class _$SuccessActionCopyWithImpl<$Res, $Val extends SuccessAction>
-    implements $SuccessActionCopyWith<$Res> {
-  _$SuccessActionCopyWithImpl(this._value, this._then);
+class _$SuccessActionProcessedCopyWithImpl<$Res,
+        $Val extends SuccessActionProcessed>
+    implements $SuccessActionProcessedCopyWith<$Res> {
+  _$SuccessActionProcessedCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
@@ -3369,96 +3370,100 @@ class _$SuccessActionCopyWithImpl<$Res, $Val extends SuccessAction>
 }
 
 /// @nodoc
-abstract class _$$SuccessAction_AesCopyWith<$Res> {
-  factory _$$SuccessAction_AesCopyWith(
-          _$SuccessAction_Aes value, $Res Function(_$SuccessAction_Aes) then) =
-      __$$SuccessAction_AesCopyWithImpl<$Res>;
+abstract class _$$SuccessActionProcessed_AesCopyWith<$Res> {
+  factory _$$SuccessActionProcessed_AesCopyWith(
+          _$SuccessActionProcessed_Aes value,
+          $Res Function(_$SuccessActionProcessed_Aes) then) =
+      __$$SuccessActionProcessed_AesCopyWithImpl<$Res>;
   @useResult
-  $Res call({AesSuccessActionData field0});
+  $Res call({AesSuccessActionDataDecrypted data});
 }
 
 /// @nodoc
-class __$$SuccessAction_AesCopyWithImpl<$Res>
-    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_Aes>
-    implements _$$SuccessAction_AesCopyWith<$Res> {
-  __$$SuccessAction_AesCopyWithImpl(
-      _$SuccessAction_Aes _value, $Res Function(_$SuccessAction_Aes) _then)
+class __$$SuccessActionProcessed_AesCopyWithImpl<$Res>
+    extends _$SuccessActionProcessedCopyWithImpl<$Res,
+        _$SuccessActionProcessed_Aes>
+    implements _$$SuccessActionProcessed_AesCopyWith<$Res> {
+  __$$SuccessActionProcessed_AesCopyWithImpl(
+      _$SuccessActionProcessed_Aes _value,
+      $Res Function(_$SuccessActionProcessed_Aes) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? field0 = null,
+    Object? data = null,
   }) {
-    return _then(_$SuccessAction_Aes(
-      null == field0
-          ? _value.field0
-          : field0 // ignore: cast_nullable_to_non_nullable
-              as AesSuccessActionData,
+    return _then(_$SuccessActionProcessed_Aes(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as AesSuccessActionDataDecrypted,
     ));
   }
 }
 
 /// @nodoc
 
-class _$SuccessAction_Aes implements SuccessAction_Aes {
-  const _$SuccessAction_Aes(this.field0);
+class _$SuccessActionProcessed_Aes implements SuccessActionProcessed_Aes {
+  const _$SuccessActionProcessed_Aes({required this.data});
 
   @override
-  final AesSuccessActionData field0;
+  final AesSuccessActionDataDecrypted data;
 
   @override
   String toString() {
-    return 'SuccessAction.aes(field0: $field0)';
+    return 'SuccessActionProcessed.aes(data: $data)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SuccessAction_Aes &&
-            (identical(other.field0, field0) || other.field0 == field0));
+            other is _$SuccessActionProcessed_Aes &&
+            (identical(other.data, data) || other.data == data));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, field0);
+  int get hashCode => Object.hash(runtimeType, data);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuccessAction_AesCopyWith<_$SuccessAction_Aes> get copyWith =>
-      __$$SuccessAction_AesCopyWithImpl<_$SuccessAction_Aes>(this, _$identity);
+  _$$SuccessActionProcessed_AesCopyWith<_$SuccessActionProcessed_Aes>
+      get copyWith => __$$SuccessActionProcessed_AesCopyWithImpl<
+          _$SuccessActionProcessed_Aes>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) {
-    return aes(field0);
+    return aes(data);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) {
-    return aes?.call(field0);
+    return aes?.call(data);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) {
     if (aes != null) {
-      return aes(field0);
+      return aes(data);
     }
     return orElse();
   }
@@ -3466,9 +3471,9 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) {
     return aes(this);
   }
@@ -3476,9 +3481,9 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) {
     return aes?.call(this);
   }
@@ -3486,9 +3491,9 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) {
     if (aes != null) {
@@ -3498,43 +3503,47 @@ class _$SuccessAction_Aes implements SuccessAction_Aes {
   }
 }
 
-abstract class SuccessAction_Aes implements SuccessAction {
-  const factory SuccessAction_Aes(final AesSuccessActionData field0) =
-      _$SuccessAction_Aes;
+abstract class SuccessActionProcessed_Aes implements SuccessActionProcessed {
+  const factory SuccessActionProcessed_Aes(
+          {required final AesSuccessActionDataDecrypted data}) =
+      _$SuccessActionProcessed_Aes;
 
   @override
-  AesSuccessActionData get field0;
+  AesSuccessActionDataDecrypted get data;
   @JsonKey(ignore: true)
-  _$$SuccessAction_AesCopyWith<_$SuccessAction_Aes> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuccessActionProcessed_AesCopyWith<_$SuccessActionProcessed_Aes>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$SuccessAction_MessageCopyWith<$Res> {
-  factory _$$SuccessAction_MessageCopyWith(_$SuccessAction_Message value,
-          $Res Function(_$SuccessAction_Message) then) =
-      __$$SuccessAction_MessageCopyWithImpl<$Res>;
+abstract class _$$SuccessActionProcessed_MessageCopyWith<$Res> {
+  factory _$$SuccessActionProcessed_MessageCopyWith(
+          _$SuccessActionProcessed_Message value,
+          $Res Function(_$SuccessActionProcessed_Message) then) =
+      __$$SuccessActionProcessed_MessageCopyWithImpl<$Res>;
   @useResult
-  $Res call({MessageSuccessActionData field0});
+  $Res call({MessageSuccessActionData data});
 }
 
 /// @nodoc
-class __$$SuccessAction_MessageCopyWithImpl<$Res>
-    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_Message>
-    implements _$$SuccessAction_MessageCopyWith<$Res> {
-  __$$SuccessAction_MessageCopyWithImpl(_$SuccessAction_Message _value,
-      $Res Function(_$SuccessAction_Message) _then)
+class __$$SuccessActionProcessed_MessageCopyWithImpl<$Res>
+    extends _$SuccessActionProcessedCopyWithImpl<$Res,
+        _$SuccessActionProcessed_Message>
+    implements _$$SuccessActionProcessed_MessageCopyWith<$Res> {
+  __$$SuccessActionProcessed_MessageCopyWithImpl(
+      _$SuccessActionProcessed_Message _value,
+      $Res Function(_$SuccessActionProcessed_Message) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? field0 = null,
+    Object? data = null,
   }) {
-    return _then(_$SuccessAction_Message(
-      null == field0
-          ? _value.field0
-          : field0 // ignore: cast_nullable_to_non_nullable
+    return _then(_$SuccessActionProcessed_Message(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
               as MessageSuccessActionData,
     ));
   }
@@ -3542,65 +3551,66 @@ class __$$SuccessAction_MessageCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SuccessAction_Message implements SuccessAction_Message {
-  const _$SuccessAction_Message(this.field0);
+class _$SuccessActionProcessed_Message
+    implements SuccessActionProcessed_Message {
+  const _$SuccessActionProcessed_Message({required this.data});
 
   @override
-  final MessageSuccessActionData field0;
+  final MessageSuccessActionData data;
 
   @override
   String toString() {
-    return 'SuccessAction.message(field0: $field0)';
+    return 'SuccessActionProcessed.message(data: $data)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SuccessAction_Message &&
-            (identical(other.field0, field0) || other.field0 == field0));
+            other is _$SuccessActionProcessed_Message &&
+            (identical(other.data, data) || other.data == data));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, field0);
+  int get hashCode => Object.hash(runtimeType, data);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuccessAction_MessageCopyWith<_$SuccessAction_Message> get copyWith =>
-      __$$SuccessAction_MessageCopyWithImpl<_$SuccessAction_Message>(
-          this, _$identity);
+  _$$SuccessActionProcessed_MessageCopyWith<_$SuccessActionProcessed_Message>
+      get copyWith => __$$SuccessActionProcessed_MessageCopyWithImpl<
+          _$SuccessActionProcessed_Message>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) {
-    return message(field0);
+    return message(data);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) {
-    return message?.call(field0);
+    return message?.call(data);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) {
     if (message != null) {
-      return message(field0);
+      return message(data);
     }
     return orElse();
   }
@@ -3608,9 +3618,9 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) {
     return message(this);
   }
@@ -3618,9 +3628,9 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) {
     return message?.call(this);
   }
@@ -3628,9 +3638,9 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) {
     if (message != null) {
@@ -3640,43 +3650,48 @@ class _$SuccessAction_Message implements SuccessAction_Message {
   }
 }
 
-abstract class SuccessAction_Message implements SuccessAction {
-  const factory SuccessAction_Message(final MessageSuccessActionData field0) =
-      _$SuccessAction_Message;
+abstract class SuccessActionProcessed_Message
+    implements SuccessActionProcessed {
+  const factory SuccessActionProcessed_Message(
+          {required final MessageSuccessActionData data}) =
+      _$SuccessActionProcessed_Message;
 
   @override
-  MessageSuccessActionData get field0;
+  MessageSuccessActionData get data;
   @JsonKey(ignore: true)
-  _$$SuccessAction_MessageCopyWith<_$SuccessAction_Message> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuccessActionProcessed_MessageCopyWith<_$SuccessActionProcessed_Message>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$SuccessAction_UrlCopyWith<$Res> {
-  factory _$$SuccessAction_UrlCopyWith(
-          _$SuccessAction_Url value, $Res Function(_$SuccessAction_Url) then) =
-      __$$SuccessAction_UrlCopyWithImpl<$Res>;
+abstract class _$$SuccessActionProcessed_UrlCopyWith<$Res> {
+  factory _$$SuccessActionProcessed_UrlCopyWith(
+          _$SuccessActionProcessed_Url value,
+          $Res Function(_$SuccessActionProcessed_Url) then) =
+      __$$SuccessActionProcessed_UrlCopyWithImpl<$Res>;
   @useResult
-  $Res call({UrlSuccessActionData field0});
+  $Res call({UrlSuccessActionData data});
 }
 
 /// @nodoc
-class __$$SuccessAction_UrlCopyWithImpl<$Res>
-    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_Url>
-    implements _$$SuccessAction_UrlCopyWith<$Res> {
-  __$$SuccessAction_UrlCopyWithImpl(
-      _$SuccessAction_Url _value, $Res Function(_$SuccessAction_Url) _then)
+class __$$SuccessActionProcessed_UrlCopyWithImpl<$Res>
+    extends _$SuccessActionProcessedCopyWithImpl<$Res,
+        _$SuccessActionProcessed_Url>
+    implements _$$SuccessActionProcessed_UrlCopyWith<$Res> {
+  __$$SuccessActionProcessed_UrlCopyWithImpl(
+      _$SuccessActionProcessed_Url _value,
+      $Res Function(_$SuccessActionProcessed_Url) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? field0 = null,
+    Object? data = null,
   }) {
-    return _then(_$SuccessAction_Url(
-      null == field0
-          ? _value.field0
-          : field0 // ignore: cast_nullable_to_non_nullable
+    return _then(_$SuccessActionProcessed_Url(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
               as UrlSuccessActionData,
     ));
   }
@@ -3684,64 +3699,65 @@ class __$$SuccessAction_UrlCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SuccessAction_Url implements SuccessAction_Url {
-  const _$SuccessAction_Url(this.field0);
+class _$SuccessActionProcessed_Url implements SuccessActionProcessed_Url {
+  const _$SuccessActionProcessed_Url({required this.data});
 
   @override
-  final UrlSuccessActionData field0;
+  final UrlSuccessActionData data;
 
   @override
   String toString() {
-    return 'SuccessAction.url(field0: $field0)';
+    return 'SuccessActionProcessed.url(data: $data)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SuccessAction_Url &&
-            (identical(other.field0, field0) || other.field0 == field0));
+            other is _$SuccessActionProcessed_Url &&
+            (identical(other.data, data) || other.data == data));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, field0);
+  int get hashCode => Object.hash(runtimeType, data);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuccessAction_UrlCopyWith<_$SuccessAction_Url> get copyWith =>
-      __$$SuccessAction_UrlCopyWithImpl<_$SuccessAction_Url>(this, _$identity);
+  _$$SuccessActionProcessed_UrlCopyWith<_$SuccessActionProcessed_Url>
+      get copyWith => __$$SuccessActionProcessed_UrlCopyWithImpl<
+          _$SuccessActionProcessed_Url>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(AesSuccessActionData field0) aes,
-    required TResult Function(MessageSuccessActionData field0) message,
-    required TResult Function(UrlSuccessActionData field0) url,
+    required TResult Function(AesSuccessActionDataDecrypted data) aes,
+    required TResult Function(MessageSuccessActionData data) message,
+    required TResult Function(UrlSuccessActionData data) url,
   }) {
-    return url(field0);
+    return url(data);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(AesSuccessActionData field0)? aes,
-    TResult? Function(MessageSuccessActionData field0)? message,
-    TResult? Function(UrlSuccessActionData field0)? url,
+    TResult? Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult? Function(MessageSuccessActionData data)? message,
+    TResult? Function(UrlSuccessActionData data)? url,
   }) {
-    return url?.call(field0);
+    return url?.call(data);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(AesSuccessActionData field0)? aes,
-    TResult Function(MessageSuccessActionData field0)? message,
-    TResult Function(UrlSuccessActionData field0)? url,
+    TResult Function(AesSuccessActionDataDecrypted data)? aes,
+    TResult Function(MessageSuccessActionData data)? message,
+    TResult Function(UrlSuccessActionData data)? url,
     required TResult orElse(),
   }) {
     if (url != null) {
-      return url(field0);
+      return url(data);
     }
     return orElse();
   }
@@ -3749,9 +3765,9 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(SuccessAction_Aes value) aes,
-    required TResult Function(SuccessAction_Message value) message,
-    required TResult Function(SuccessAction_Url value) url,
+    required TResult Function(SuccessActionProcessed_Aes value) aes,
+    required TResult Function(SuccessActionProcessed_Message value) message,
+    required TResult Function(SuccessActionProcessed_Url value) url,
   }) {
     return url(this);
   }
@@ -3759,9 +3775,9 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(SuccessAction_Aes value)? aes,
-    TResult? Function(SuccessAction_Message value)? message,
-    TResult? Function(SuccessAction_Url value)? url,
+    TResult? Function(SuccessActionProcessed_Aes value)? aes,
+    TResult? Function(SuccessActionProcessed_Message value)? message,
+    TResult? Function(SuccessActionProcessed_Url value)? url,
   }) {
     return url?.call(this);
   }
@@ -3769,9 +3785,9 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   @override
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
-    TResult Function(SuccessAction_Aes value)? aes,
-    TResult Function(SuccessAction_Message value)? message,
-    TResult Function(SuccessAction_Url value)? url,
+    TResult Function(SuccessActionProcessed_Aes value)? aes,
+    TResult Function(SuccessActionProcessed_Message value)? message,
+    TResult Function(SuccessActionProcessed_Url value)? url,
     required TResult orElse(),
   }) {
     if (url != null) {
@@ -3781,13 +3797,14 @@ class _$SuccessAction_Url implements SuccessAction_Url {
   }
 }
 
-abstract class SuccessAction_Url implements SuccessAction {
-  const factory SuccessAction_Url(final UrlSuccessActionData field0) =
-      _$SuccessAction_Url;
+abstract class SuccessActionProcessed_Url implements SuccessActionProcessed {
+  const factory SuccessActionProcessed_Url(
+          {required final UrlSuccessActionData data}) =
+      _$SuccessActionProcessed_Url;
 
   @override
-  UrlSuccessActionData get field0;
+  UrlSuccessActionData get data;
   @JsonKey(ignore: true)
-  _$$SuccessAction_UrlCopyWith<_$SuccessAction_Url> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuccessActionProcessed_UrlCopyWith<_$SuccessActionProcessed_Url>
+      get copyWith => throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
This PR persists the LNURL successAction in the `LnPaymentDetails` as per https://github.com/breez/breez-sdk/pull/88#discussion_r1095486697 :

https://github.com/breez/breez-sdk/blob/9561894c9206a50d70c0d29c010628a7e93c28ef/libs/sdk-core/src/models.rs#L295-L297

However I don't think this is a viable solution because we don't have the successAction at the point where we want to set it:

https://github.com/breez/breez-sdk/blob/9561894c9206a50d70c0d29c010628a7e93c28ef/libs/sdk-core/src/breez_services.rs#L192-L198

The LNURL successAction is not passed as an arg to the service method `send_payment`.

The tests work because the `MockNodeAPI` has the entire payment structure in advance (incl. expected successAction). However the real `NodeAPI` has to handle it in the `send_payment`.

@roeierez should I add a separate service method `send_payment_lnurl` with an extra arg for `SuccessActionProcessed`?

Or is this general approach too fragile and we should look for a different approach?

---

P.S. In addition, the `udl` doesn't parse and I haven't figured out why, but that's a small issue.