### PR TITLE
Ignore reserved outputs for on-chain balance

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -64,6 +64,8 @@ dictionary UnspentTransactionOutput {
     u32 outnum;
     u64 amount_millisatoshi;
     string address;
+    boolean reserved;
+    u32 reserved_to_block;
 };
 
 dictionary NodeState {
@@ -77,7 +79,7 @@ dictionary NodeState {
     u64 max_single_payment_amount_msat;
     u64 max_chan_reserve_msats;
     sequence<string> connected_peers;
-    u64 inbound_liquidity_msats;
+    u64 inbound_liquidity_msats;    
 };
 
 enum PaymentTypeFilter {

--- a/libs/sdk-core/src/greenlight.rs
+++ b/libs/sdk-core/src/greenlight.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Result};
 use bitcoin::bech32::{u5, ToBase32};
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 use gl_client::pb::amount::Unit;
+
 use gl_client::pb::{
     Amount, CloseChannelRequest, CloseChannelResponse, Invoice, InvoiceRequest, InvoiceStatus,
     PayStatus, WithdrawResponse,
@@ -232,6 +233,9 @@ impl NodeAPI for Greenlight {
 
         // calculate onchain balance
         let onchain_balance = onchain_funds.iter().fold(0, |a, b| {
+            if b.reserved {
+                return a;
+            }
             a + amount_to_msat(&b.amount.clone().unwrap_or_default())
         });
 
@@ -251,6 +255,8 @@ impl NodeAPI for Greenlight {
                             .map(amount_to_msat)
                             .unwrap_or_default(),
                         address: list_funds_output.address.clone(),
+                        reserved: list_funds_output.reserved,
+                        reserved_to_block: list_funds_output.reserved_to_block,
                     })
             })
             .collect();

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -434,6 +434,10 @@ pub struct UnspentTransactionOutput {
     pub outnum: u32,
     pub amount_millisatoshi: u64,
     pub address: String,
+    #[serde(default)]
+    pub reserved: bool,
+    #[serde(default)]
+    pub reserved_to_block: u32,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Here we use this fix for greenlight (https://github.com/Blockstream/greenlight/issues/74) in order to ignore the reserved outputs.
A reserved output is one that is used in a current transaction that is still unconfirmed. This allow us to ignore it when calculating the on-chain balance allowing clients to get better user experience when sweeping from the wallet.
fixes https://github.com/breez/c-breez/issues/330