### PR TITLE
Update pubspec flutter version

### DIFF
--- a/libs/sdk-flutter/pubspec.lock
+++ b/libs/sdk-flutter/pubspec.lock
@@ -767,5 +767,5 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.3.10"


### PR DESCRIPTION
I'm running the following version of flutter, and I got this pubspec update on my last build.

```
flutter --version                                                                                                                                                                                                                                                               ─╯
Flutter 3.7.0 • channel stable • https://github.com/flutter/flutter.git
Framework • revision b06b8b2710 (4 weeks ago) • 2023-01-23 16:55:55 -0800
Engine • revision b24591ed32
Tools • Dart 2.19.0 • DevTools 2.20.1
```