### PR TITLE
Use same network when changing invoice

### DIFF
--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -101,7 +101,7 @@ pub fn add_routing_hints(
         InvoiceDescription::Hash(_) => String::from(""),
     };
 
-    let mut invoice_builder = InvoiceBuilder::new(Currency::Bitcoin)
+    let mut invoice_builder = InvoiceBuilder::new(invoice.currency())
         .description(description)
         .payment_hash(*invoice.payment_hash())
         .timestamp(invoice.timestamp())

--- a/tools/sdk-cli/src/main.rs
+++ b/tools/sdk-cli/src/main.rs
@@ -13,7 +13,7 @@ use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use breez_sdk_core::InputType::LnUrlWithdraw;
 use breez_sdk_core::{
     parse, BreezEvent, BreezServices, EnvironmentType, EventListener, GreenlightCredentials,
-    InputType::LnUrlPay, LspInformation, Network, PaymentTypeFilter,
+    InputType::LnUrlPay, LspInformation, PaymentTypeFilter,
 };
 use env_logger::Env;
 use once_cell::sync::{Lazy, OnceCell};
@@ -138,8 +138,9 @@ async fn main() -> Result<()> {
                         save_config(config)?;
                     }
                     Some("register_node") => {
+                        let config = get_or_create_config()?.to_sdk_config();
                         let creds =
-                            BreezServices::register_node(Network::Bitcoin, seed.to_vec()).await?;
+                            BreezServices::register_node(config.network, seed.to_vec()).await?;
 
                         let res = init_sdk(&seed, &creds).await;
                         info!(
@@ -151,8 +152,9 @@ async fn main() -> Result<()> {
                         show_results(res);
                     }
                     Some("recover_node") => {
+                        let config = get_or_create_config()?.to_sdk_config();
                         let creds =
-                            BreezServices::recover_node(Network::Bitcoin, seed.to_vec()).await?;
+                            BreezServices::recover_node(config.network, seed.to_vec()).await?;
 
                         let res = init_sdk(&seed, &creds).await;
                         info!(


### PR DESCRIPTION
Although I don't see how we support other networks than mainnet soon in theory it might work if one implement all the external services (chain, swap in/out LSP) in the other network.
So for consistency this fixes two issues where the wrong network was used.