### PR TITLE
Update model to distinguish DB-stored struct vs Boltz-retrieved info struct

### DIFF
--- a/libs/sdk-core/src/boltzswap.rs
+++ b/libs/sdk-core/src/boltzswap.rs
@@ -12,7 +12,7 @@ use rand::random;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 
-use crate::models::ReverseSwapInfo;
+use crate::models::ReverseSwapPairInfo;
 use crate::reverseswap::CreateReverseSwapResponse;
 use crate::{ReverseSwap, ReverseSwapperAPI};
 
@@ -89,7 +89,7 @@ pub struct BoltzApi {}
 
 #[tonic::async_trait]
 impl ReverseSwapperAPI for BoltzApi {
-    async fn reverse_swap_info(&self) -> Result<ReverseSwapInfo> {
+    async fn reverse_swap_info(&self) -> Result<ReverseSwapPairInfo> {
         crate::boltzswap::reverse_swap_info().await
     }
 
@@ -129,7 +129,7 @@ impl ReverseSwapperAPI for BoltzApi {
     }
 }
 
-pub async fn reverse_swap_info() -> Result<ReverseSwapInfo> {
+pub async fn reverse_swap_info() -> Result<ReverseSwapPairInfo> {
     let pairs = reqwest::get(GET_PAIRS_ENDPOINT)
         .await?
         .json::<Pairs>()
@@ -139,7 +139,7 @@ pub async fn reverse_swap_info() -> Result<ReverseSwapInfo> {
         Some(btc_pair) => {
             println!("result: {}", serde_json::to_string_pretty(&btc_pair)?);
             let hash = String::from(&btc_pair.hash);
-            Ok(ReverseSwapInfo {
+            Ok(ReverseSwapPairInfo {
                 fees_hash: hash,
                 min: btc_pair.limits.minimal,
                 max: btc_pair.limits.maximal,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -18,12 +18,12 @@ use crate::lsp::LspInformation;
 use crate::models::{
     parse_short_channel_id, ChannelState, ClosedChannelPaymentDetails, Config, EnvironmentType,
     FiatAPI, GreenlightCredentials, LspAPI, Network, NodeAPI, NodeState, Payment, PaymentDetails,
-    PaymentType, PaymentTypeFilter, ReverseSwapInfo, ReverseSwapperAPI, SwapInfo, SwapperAPI,
+    PaymentType, PaymentTypeFilter, ReverseSwapPairInfo, ReverseSwapperAPI, SwapInfo, SwapperAPI,
 };
 use crate::persist::db::SqliteStorage;
 use crate::reverseswap::BTCSendSwap;
 use crate::swap::BTCReceiveSwap;
-use crate::{LnUrlWithdrawRequestData, ReverseSwap};
+use crate::{LnUrlWithdrawRequestData, ReverseSwapInfo};
 use anyhow::{anyhow, Result};
 use bip39::*;
 use std::cmp::max;
@@ -426,7 +426,7 @@ impl BreezServices {
         Ok(None)
     }
 
-    pub async fn reverse_swap_info(&self) -> Result<ReverseSwapInfo> {
+    pub async fn reverse_swap_info(&self) -> Result<ReverseSwapPairInfo> {
         self.btc_send_swapper
             .reverse_swapper_api
             .reverse_swap_info()
@@ -447,19 +447,16 @@ impl BreezServices {
         amount_sat: u64,
         onchain_recipient_address: String,
         pair_hash: String,
-    ) -> Result<ReverseSwap> {
+    ) -> Result<ReverseSwapInfo> {
         let routing_hop = self.lsp_info().await?;
-
-        let rev_swap = self
-            .btc_send_swapper
+        self.btc_send_swapper
             .create_reverse_swap(
                 amount_sat,
-                onchain_recipient_address,
+                onchain_recipient_address.clone(),
                 pair_hash,
                 routing_hop.pubkey,
             )
-            .await?;
-        Ok(rev_swap)
+            .await
     }
 
     /// list non-completed expired swaps that should be refunded bu calling [BreezServices::refund]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -107,14 +107,54 @@ pub trait SwapperAPI: Send + Sync {
     async fn complete_swap(&self, bolt11: String) -> Result<()>;
 }
 
+/// Details about the BTC/BTC reverse swap pair, at this point in time
+///
+/// Maps the result of https://docs.boltz.exchange/en/latest/api/#getting-pairs for the BTC/BTC pair
 #[derive(Clone, PartialEq, Debug)]
-pub struct ReverseSwapInfo {
+pub struct ReverseSwapPairInfo {
+    /// Minimum amount of sats a reverse swap is allowed to have on this endpoint
     pub min: u64,
+    /// Maximum amount of sats a reverse swap is allowed to have on this endpoint
     pub max: u64,
+    /// Hash of the pair info JSON
     pub fees_hash: String,
+    /// Percentage fee for the Boltz service
     pub fees_percentage: f64,
+    /// Estimated miner fees in sats for locking up funds
     pub fees_lockup: u64,
+    /// Estimated miner fees in sats for claiming funds
     pub fees_claim: u64,
+}
+
+/// Details of past or ongoing reverse swaps, as stored in the Breez local DB
+#[derive(Clone, Debug)]
+pub struct ReverseSwapInfo {
+    // static immutable data
+    pub claim_address: String,
+    pub lockup_address: String,
+
+    // dynamic data
+    pub status: ReverseSwapStatus,
+}
+
+/// The status of a reverse swap
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ReverseSwapStatus {
+    /// The reverse swap has been created. The HODL invoice is not yet paid.
+    Initial = 0,
+
+    /// The HODL invoice has been paid.
+    InvoicePaid = 1,
+
+    /// The lock transaction has 1 confirmation.
+    LockTxConfirmed = 2,
+
+    /// The claim transaction has 1 confirmation.
+    ClaimTxConfirmed = 3,
+
+    /// The blockchain reached [CreateReverseSwapResponse::timeout_block_height] before the reverse
+    /// swap completed
+    Cancelled = 4,
 }
 
 /// Information about a reverse swap that was just started with Boltz
@@ -127,7 +167,7 @@ pub struct ReverseSwap {
 /// Trait covering functionality involving swaps
 #[tonic::async_trait]
 pub trait ReverseSwapperAPI: Send + Sync {
-    async fn reverse_swap_info(&self) -> Result<ReverseSwapInfo>;
+    async fn reverse_swap_info(&self) -> Result<ReverseSwapPairInfo>;
 
     /// Creates a reverse submarine swap
     ///

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -1,19 +1,31 @@
 use std::sync::Arc;
 
 use crate::chain::{ChainService, MempoolSpace};
-use crate::models::{ReverseSwap, ReverseSwapperAPI};
+use crate::models::ReverseSwapperAPI;
+use crate::{ReverseSwapInfo, ReverseSwapStatus};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateReverseSwapResponse {
     id: String,
+
+    /// HODL invoice that has to be paid, for the Boltz service to lock up the funds
     invoice: String,
+
+    /// Redeem script from which the lock address is derived. Can be used to check that the Boltz
+    /// service didn't create an address without an HTLC.
     redeem_script: String,
+
+    /// Amount of sats which will be locked
     onchain_amount: u64,
-    timeout_block_height: u64,
-    lockup_address: String,
+
+    /// Block height at which the reverse swap will be considered cancelled
+    pub(crate) timeout_block_height: u64,
+
+    /// Address to which the funds will be locked
+    pub(crate) lockup_address: String,
 }
 
 /// This struct is responsible for sending to an onchain address using lightning payments.
@@ -49,9 +61,25 @@ impl BTCSendSwap {
         onchain_claim_address: String,
         pair_hash: String,
         routing_node: String,
-    ) -> Result<ReverseSwap> {
-        self.reverse_swapper_api
-            .create_reverse_swap(amount_sat, onchain_claim_address, pair_hash, routing_node)
-            .await
+    ) -> Result<ReverseSwapInfo> {
+        let rev_swap = self
+            .reverse_swapper_api
+            .create_reverse_swap(
+                amount_sat,
+                onchain_claim_address.clone(),
+                pair_hash,
+                routing_node,
+            )
+            .await?;
+
+        let rev_swap_info = ReverseSwapInfo {
+            lockup_address: rev_swap.response.lockup_address,
+            claim_address: onchain_claim_address,
+            status: ReverseSwapStatus::Initial,
+        };
+
+        // TODO persist
+
+        Ok(rev_swap_info)
     }
 }


### PR DESCRIPTION
Separate the two distinct structs:
- `ReverseSwapInfo` = the Breez view of a reverse swap (as stored in DB)
- `ReverseSwapPairInfo` = the Boltz reverse swap info for the BTC/BTC pair, containing point-in-time exchange rate and fees