### PR TITLE
Store LNURL metadata in extra payment info table

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -140,6 +140,7 @@ dictionary LnPaymentDetails {
     boolean keysend;
     string bolt11;
     SuccessActionProcessed? lnurl_success_action;
+    string? lnurl_metadata;
     string? ln_address;
 };
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -271,6 +271,7 @@ impl BreezServices {
                 self.persister.insert_lnurl_payment_external_info(
                     &details.payment_hash,
                     maybe_sa_processed.as_ref(),
+                    Some(req_data.metadata_str),
                     req_data.ln_address,
                 )?;
 
@@ -1075,6 +1076,7 @@ pub(crate) mod tests {
 
         let dummy_node_state = get_dummy_node_state();
 
+        let lnurl_metadata = "{'key': 'sample-metadata-val'}";
         let test_ln_address = "test@ln-address.com";
         let sa = SuccessActionProcessed::Message {
             data: MessageSuccessActionData {
@@ -1101,6 +1103,7 @@ pub(crate) mod tests {
                         keysend: false,
                         bolt11: "1111".to_string(),
                         lnurl_success_action: None,
+                        lnurl_metadata: None,
                         ln_address: None,
                     },
                 },
@@ -1122,6 +1125,7 @@ pub(crate) mod tests {
                         keysend: false,
                         bolt11: "123".to_string(),
                         lnurl_success_action: Some(sa.clone()),
+                        lnurl_metadata: Some(lnurl_metadata.to_string()),
                         ln_address: Some(test_ln_address.to_string()),
                     },
                 },
@@ -1136,6 +1140,7 @@ pub(crate) mod tests {
         persister.insert_lnurl_payment_external_info(
             payment_hash_with_lnurl_success_action,
             Some(&sa),
+            Some(lnurl_metadata.to_string()),
             Some(test_ln_address.to_string()),
         )?;
 

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -783,6 +783,7 @@ impl support::IntoDart for LnPaymentDetails {
             self.bolt11.into_dart(),
             self.lnurl_success_action.into_dart(),
             self.ln_address.into_dart(),
+            self.lnurl_metadata.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/greenlight.rs
+++ b/libs/sdk-core/src/greenlight.rs
@@ -554,7 +554,7 @@ impl TryFrom<OffChainPayment> for crate::models::Payment {
                     keysend: false,
                     bolt11: p.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
-                    lnurl_metadata: None, // For received payments, this is None
+                    lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                 },
             },
@@ -588,7 +588,7 @@ impl TryFrom<pb::Invoice> for crate::models::Payment {
                     keysend: false,
                     bolt11: invoice.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
-                    lnurl_metadata: None, // For received payments, this is None
+                    lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                 },
             },

--- a/libs/sdk-core/src/greenlight.rs
+++ b/libs/sdk-core/src/greenlight.rs
@@ -554,6 +554,7 @@ impl TryFrom<OffChainPayment> for crate::models::Payment {
                     keysend: false,
                     bolt11: p.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
+                    lnurl_metadata: None, // For received payments, this is None
                     ln_address: None,
                 },
             },
@@ -587,6 +588,7 @@ impl TryFrom<pb::Invoice> for crate::models::Payment {
                     keysend: false,
                     bolt11: invoice.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
+                    lnurl_metadata: None, // For received payments, this is None
                     ln_address: None,
                 },
             },
@@ -623,6 +625,7 @@ impl TryFrom<pb::Payment> for crate::models::Payment {
                     keysend: payment.bolt11.is_empty(),
                     bolt11: payment.bolt11,
                     lnurl_success_action: None,
+                    lnurl_metadata: None,
                     ln_address: None,
                 },
             },

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -304,6 +304,9 @@ pub struct LnPaymentDetails {
 
     /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address
     pub ln_address: Option<String>,
+
+    /// Only set for [PaymentType::Sent] payments where the receiver endpoint returned LNURL metadata
+    pub lnurl_metadata: Option<String>,
 }
 
 /// Represents the funds that were on the user side of the channel at the time it was closed.

--- a/libs/sdk-core/src/persist/db.rs
+++ b/libs/sdk-core/src/persist/db.rs
@@ -202,6 +202,9 @@ impl SqliteStorage {
             M::up("
              ALTER TABLE payments_external_info ADD COLUMN ln_address TEXT;
             "),
+            M::up("
+             ALTER TABLE payments_external_info ADD COLUMN lnurl_metadata TEXT;
+            "),
         ]);
 
         let mut conn = self.get_connection()?;

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -67,7 +67,12 @@ impl SqliteStorage {
         ",
         )?;
 
-        _ = prep_statement.execute((payment_hash, &lnurl_pay_success_action, lnurl_metadata, ln_address))?;
+        _ = prep_statement.execute((
+            payment_hash,
+            &lnurl_pay_success_action,
+            lnurl_metadata,
+            ln_address,
+        ))?;
 
         Ok(())
     }

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -870,6 +870,7 @@ mod tests {
                     keysend: false,
                     bolt11: "".to_string(),
                     lnurl_success_action: None,
+                    lnurl_metadata: None,
                     ln_address: None,
                 },
             },

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -498,6 +498,9 @@ class LnPaymentDetails {
   /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address
   final String? lnAddress;
 
+  /// Only set for [PaymentType::Sent] payments where the receiver endpoint returned LNURL metadata
+  final String? lnurlMetadata;
+
   LnPaymentDetails({
     required this.paymentHash,
     required this.label,
@@ -507,6 +510,7 @@ class LnPaymentDetails {
     required this.bolt11,
     this.lnurlSuccessAction,
     this.lnAddress,
+    this.lnurlMetadata,
   });
 }
 
@@ -1929,8 +1933,8 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LnPaymentDetails _wire2api_ln_payment_details(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 8)
-      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    if (arr.length != 9)
+      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return LnPaymentDetails(
       paymentHash: _wire2api_String(arr[0]),
       label: _wire2api_String(arr[1]),
@@ -1940,6 +1944,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       bolt11: _wire2api_String(arr[5]),
       lnurlSuccessAction: _wire2api_opt_success_action_processed(arr[6]),
       lnAddress: _wire2api_opt_String(arr[7]),
+      lnurlMetadata: _wire2api_opt_String(arr[8]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -202,6 +202,7 @@ fun readableMapOf(lnPaymentDetails: LnPaymentDetails): ReadableMap {
             "keysend" to lnPaymentDetails.keysend,
             "bolt11" to lnPaymentDetails.bolt11,
             "lnurlSuccessAction" to readableMapOf(lnPaymentDetails.lnurlSuccessAction),
+            "lnurlMetadata" to lnPaymentDetails.lnurlMetadata
             "lnAddress" to lnPaymentDetails.lnAddress
     )
 }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -187,6 +187,7 @@ class BreezSDKMapper {
             "keysend": lnPaymentDetails.keysend,
             "bolt11": lnPaymentDetails.bolt11,
             "lnurlSuccessAction": dictionaryOf(successActionProcessed: lnPaymentDetails.lnurlSuccessAction),
+            "lnurlMetadata": lnPaymentDetails.lnurlMetadata
             "lnAddress": lnPaymentDetails.lnAddress
         ]
     }

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -147,6 +147,7 @@ export type LnPaymentDetails = {
     keysend: boolean
     bolt11: string
     lnurlSuccessAction?: AesSuccessActionDataDecrypted | MessageSuccessActionData | UrlSuccessActionData
+    lnurlMetadata?: string
     lnAddress?: string
 }
 


### PR DESCRIPTION
Stores metadata, which can contain text, icons or other fields from the LNURL endpoint.