### PR TITLE
Add more data to PaymentFailed event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install dependencies
         run: |
           echo $ANDROID_NDK_HOME
-          cargo install cargo-ndk
+          cargo install cargo-ndk@2.12.2
           cargo install --version 0.22.0 uniffi_bindgen          
           brew install protobuf          
 

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -214,7 +214,7 @@ dictionary InvoicePaidDetails {
 dictionary PaymentFailedData {
     string error;
     string node_id;
-    LNInvoice? bolt11;
+    LNInvoice? invoice;
 };
 
 [Enum]

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -211,13 +211,19 @@ dictionary InvoicePaidDetails {
     string bolt11;
 };
 
+dictionary PaymentFailedData {
+    string error;
+    string node_id;
+    LNInvoice? bolt11;
+};
+
 [Enum]
 interface BreezEvent {
     NewBlock(u32 block);
     InvoicePaid(InvoicePaidDetails details);
     Synced();
     PaymentSucceed(Payment details);
-    PaymentFailed(string error);
+    PaymentFailed(PaymentFailedData details);
 };
 
 callback interface LogStream {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -11,8 +11,8 @@ use breez_sdk_core::{
     LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult, LnUrlWithdrawCallbackStatus,
     LnUrlWithdrawRequestData, LocaleOverrides, LocalizedName, LogEntry, LspInformation,
     MessageSuccessActionData, MetadataItem, Network, NodeState, Payment, PaymentDetails,
-    PaymentType, PaymentTypeFilter, Rate, RecommendedFees, RouteHint, RouteHintHop,
-    SuccessActionProcessed, SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput,
+    PaymentFailedData, PaymentType, PaymentTypeFilter, Rate, RecommendedFees, RouteHint,
+    RouteHintHop, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput,
     UrlSuccessActionData,
 };
 use log::Metadata;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -64,7 +64,7 @@ pub enum BreezEvent {
 pub struct PaymentFailedData {
     pub error: String,
     pub node_id: String,
-    pub bolt11: Option<LNInvoice>,
+    pub invoice: Option<LNInvoice>,
 }
 
 /// Details of an invoice that has been paid, included as payload in an emitted [BreezEvent]
@@ -531,7 +531,7 @@ impl BreezServices {
     async fn on_payment_completed(
         &self,
         node_id: String,
-        bolt11: Option<LNInvoice>,
+        invoice: Option<LNInvoice>,
         payment_res: Result<Payment>,
     ) -> Result<Payment> {
         if payment_res.is_err() {
@@ -539,7 +539,7 @@ impl BreezServices {
                 details: PaymentFailedData {
                     error: payment_res.as_ref().err().unwrap().to_string(),
                     node_id,
-                    bolt11,
+                    invoice,
                 },
             })
             .await?;

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -981,7 +981,7 @@ impl support::IntoDart for PaymentFailedData {
         vec![
             self.error.into_dart(),
             self.node_id.into_dart(),
-            self.bolt11.into_dart(),
+            self.invoice.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 use crate::breez_services::BreezEvent;
 use crate::breez_services::InvoicePaidDetails;
+use crate::breez_services::PaymentFailedData;
 use crate::chain::RecommendedFees;
 use crate::fiat::CurrencyInfo;
 use crate::fiat::FiatCurrency;
@@ -653,7 +654,7 @@ impl support::IntoDart for BreezEvent {
             Self::InvoicePaid { details } => vec![1.into_dart(), details.into_dart()],
             Self::Synced => vec![2.into_dart()],
             Self::PaymentSucceed { details } => vec![3.into_dart(), details.into_dart()],
-            Self::PaymentFailed { error } => vec![4.into_dart(), error.into_dart()],
+            Self::PaymentFailed { details } => vec![4.into_dart(), details.into_dart()],
         }
         .into_dart()
     }
@@ -975,6 +976,18 @@ impl support::IntoDart for PaymentDetails {
     }
 }
 impl support::IntoDartExceptPrimitive for PaymentDetails {}
+impl support::IntoDart for PaymentFailedData {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.error.into_dart(),
+            self.node_id.into_dart(),
+            self.bolt11.into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for PaymentFailedData {}
+
 impl support::IntoDart for PaymentType {
     fn into_dart(self) -> support::DartAbi {
         match self {

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use std::time::UNIX_EPOCH;
 
 /// Wrapper for a BOLT11 LN invoice
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LNInvoice {
     pub bolt11: String,
     pub payee_pubkey: String,
@@ -23,7 +23,7 @@ pub struct LNInvoice {
 }
 
 /// Details of a specific hop in a larger route hint
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct RouteHintHop {
     /// The node_id of the non-target end of the route
     pub src_node_id: String,
@@ -42,7 +42,7 @@ pub struct RouteHintHop {
 }
 
 /// A route hint for a LN payment
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct RouteHint {
     pub hops: Vec<RouteHintHop>,
 }

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -158,6 +158,7 @@ mod test_utils;
 
 pub use breez_services::{
     mnemonic_to_seed, BreezEvent, BreezServices, EventListener, InvoicePaidDetails,
+    PaymentFailedData,
 };
 pub use chain::RecommendedFees;
 pub use fiat::{CurrencyInfo, FiatCurrency, LocaleOverrides, LocalizedName, Rate, Symbol};

--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -50,7 +50,7 @@ class BreezBridge {
         _paymentResultStream.add(event.details);
       }
       if (event is BreezEvent_PaymentFailed) {
-        _paymentResultStream.addError(Exception(event.error));
+        _paymentResultStream.addError(Exception(event.details.error));
       }
     });
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -777,12 +777,12 @@ class PaymentDetails with _$PaymentDetails {
 class PaymentFailedData {
   final String error;
   final String nodeId;
-  final LNInvoice? bolt11;
+  final LNInvoice? invoice;
 
   PaymentFailedData({
     required this.error,
     required this.nodeId,
-    this.bolt11,
+    this.invoice,
   });
 }
 
@@ -2229,7 +2229,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return PaymentFailedData(
       error: _wire2api_String(arr[0]),
       nodeId: _wire2api_String(arr[1]),
-      bolt11: _wire2api_opt_box_autoadd_ln_invoice(arr[2]),
+      invoice: _wire2api_opt_box_autoadd_ln_invoice(arr[2]),
     );
   }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -283,7 +283,7 @@ class BreezEvent with _$BreezEvent {
 
   /// Indicates that an outgoing payment has been failed to complete
   const factory BreezEvent.paymentFailed({
-    required String error,
+    required PaymentFailedData details,
   }) = BreezEvent_PaymentFailed;
 }
 
@@ -772,6 +772,18 @@ class PaymentDetails with _$PaymentDetails {
   const factory PaymentDetails.closedChannel({
     required ClosedChannelPaymentDetails data,
   }) = PaymentDetails_ClosedChannel;
+}
+
+class PaymentFailedData {
+  final String error;
+  final String nodeId;
+  final LNInvoice? bolt11;
+
+  PaymentFailedData({
+    required this.error,
+    required this.nodeId,
+    this.bolt11,
+  });
 }
 
 /// Different types of supported payments
@@ -1710,6 +1722,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return _wire2api_payment(raw);
   }
 
+  PaymentFailedData _wire2api_box_autoadd_payment_failed_data(dynamic raw) {
+    return _wire2api_payment_failed_data(raw);
+  }
+
   SwapInfo _wire2api_box_autoadd_swap_info(dynamic raw) {
     return _wire2api_swap_info(raw);
   }
@@ -1749,7 +1765,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         );
       case 4:
         return BreezEvent_PaymentFailed(
-          error: _wire2api_String(raw[1]),
+          details: _wire2api_box_autoadd_payment_failed_data(raw[1]),
         );
       default:
         throw Exception("unreachable");
@@ -2135,6 +2151,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return raw == null ? null : _wire2api_box_autoadd_bool(raw);
   }
 
+  LNInvoice? _wire2api_opt_box_autoadd_ln_invoice(dynamic raw) {
+    return raw == null ? null : _wire2api_box_autoadd_ln_invoice(raw);
+  }
+
   LspInformation? _wire2api_opt_box_autoadd_lsp_information(dynamic raw) {
     return raw == null ? null : _wire2api_box_autoadd_lsp_information(raw);
   }
@@ -2200,6 +2220,17 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       default:
         throw Exception("unreachable");
     }
+  }
+
+  PaymentFailedData _wire2api_payment_failed_data(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return PaymentFailedData(
+      error: _wire2api_String(arr[0]),
+      nodeId: _wire2api_String(arr[1]),
+      bolt11: _wire2api_opt_box_autoadd_ln_invoice(arr[2]),
+    );
   }
 
   PaymentType _wire2api_payment_type(dynamic raw) {

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -22,7 +22,7 @@ mixin _$BreezEvent {
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
-    required TResult Function(String error) paymentFailed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -31,7 +31,7 @@ mixin _$BreezEvent {
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
-    TResult? Function(String error)? paymentFailed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -40,7 +40,7 @@ mixin _$BreezEvent {
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
-    TResult Function(String error)? paymentFailed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -161,7 +161,7 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
-    required TResult Function(String error) paymentFailed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
   }) {
     return newBlock(block);
   }
@@ -173,7 +173,7 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
-    TResult? Function(String error)? paymentFailed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
   }) {
     return newBlock?.call(block);
   }
@@ -185,7 +185,7 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
-    TResult Function(String error)? paymentFailed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
     required TResult orElse(),
   }) {
     if (newBlock != null) {
@@ -314,7 +314,7 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
-    required TResult Function(String error) paymentFailed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
   }) {
     return invoicePaid(details);
   }
@@ -326,7 +326,7 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
-    TResult? Function(String error)? paymentFailed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
   }) {
     return invoicePaid?.call(details);
   }
@@ -338,7 +338,7 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
-    TResult Function(String error)? paymentFailed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
     required TResult orElse(),
   }) {
     if (invoicePaid != null) {
@@ -440,7 +440,7 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
-    required TResult Function(String error) paymentFailed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
   }) {
     return synced();
   }
@@ -452,7 +452,7 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
-    TResult? Function(String error)? paymentFailed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
   }) {
     return synced?.call();
   }
@@ -464,7 +464,7 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
-    TResult Function(String error)? paymentFailed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
     required TResult orElse(),
   }) {
     if (synced != null) {
@@ -588,7 +588,7 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
-    required TResult Function(String error) paymentFailed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
   }) {
     return paymentSucceed(details);
   }
@@ -600,7 +600,7 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
-    TResult? Function(String error)? paymentFailed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
   }) {
     return paymentSucceed?.call(details);
   }
@@ -612,7 +612,7 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
-    TResult Function(String error)? paymentFailed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
     required TResult orElse(),
   }) {
     if (paymentSucceed != null) {
@@ -678,7 +678,7 @@ abstract class _$$BreezEvent_PaymentFailedCopyWith<$Res> {
           $Res Function(_$BreezEvent_PaymentFailed) then) =
       __$$BreezEvent_PaymentFailedCopyWithImpl<$Res>;
   @useResult
-  $Res call({String error});
+  $Res call({PaymentFailedData details});
 }
 
 /// @nodoc
@@ -692,13 +692,13 @@ class __$$BreezEvent_PaymentFailedCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? error = null,
+    Object? details = null,
   }) {
     return _then(_$BreezEvent_PaymentFailed(
-      error: null == error
-          ? _value.error
-          : error // ignore: cast_nullable_to_non_nullable
-              as String,
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as PaymentFailedData,
     ));
   }
 }
@@ -706,14 +706,14 @@ class __$$BreezEvent_PaymentFailedCopyWithImpl<$Res>
 /// @nodoc
 
 class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
-  const _$BreezEvent_PaymentFailed({required this.error});
+  const _$BreezEvent_PaymentFailed({required this.details});
 
   @override
-  final String error;
+  final PaymentFailedData details;
 
   @override
   String toString() {
-    return 'BreezEvent.paymentFailed(error: $error)';
+    return 'BreezEvent.paymentFailed(details: $details)';
   }
 
   @override
@@ -721,11 +721,11 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$BreezEvent_PaymentFailed &&
-            (identical(other.error, error) || other.error == error));
+            (identical(other.details, details) || other.details == details));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, error);
+  int get hashCode => Object.hash(runtimeType, details);
 
   @JsonKey(ignore: true)
   @override
@@ -742,9 +742,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
-    required TResult Function(String error) paymentFailed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
   }) {
-    return paymentFailed(error);
+    return paymentFailed(details);
   }
 
   @override
@@ -754,9 +754,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
-    TResult? Function(String error)? paymentFailed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
   }) {
-    return paymentFailed?.call(error);
+    return paymentFailed?.call(details);
   }
 
   @override
@@ -766,11 +766,11 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
-    TResult Function(String error)? paymentFailed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
     required TResult orElse(),
   }) {
     if (paymentFailed != null) {
-      return paymentFailed(error);
+      return paymentFailed(details);
     }
     return orElse();
   }
@@ -817,10 +817,10 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
 }
 
 abstract class BreezEvent_PaymentFailed implements BreezEvent {
-  const factory BreezEvent_PaymentFailed({required final String error}) =
-      _$BreezEvent_PaymentFailed;
+  const factory BreezEvent_PaymentFailed(
+      {required final PaymentFailedData details}) = _$BreezEvent_PaymentFailed;
 
-  String get error;
+  PaymentFailedData get details;
   @JsonKey(ignore: true)
   _$$BreezEvent_PaymentFailedCopyWith<_$BreezEvent_PaymentFailed>
       get copyWith => throw _privateConstructorUsedError;

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKListener.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKListener.kt
@@ -13,7 +13,7 @@ class BreezSDKListener(private val emitter: RCTDeviceEventEmitter): EventListene
         when (e) {
             is BreezEvent.InvoicePaid -> emitter.emit(emitterName, readableMapOf("type" to "invoicePaid", "data" to readableMapOf(e.details)))
             is BreezEvent.NewBlock -> emitter.emit(emitterName, readableMapOf("type" to "newBlock", "data" to e.block))
-            is BreezEvent.PaymentFailed -> emitter.emit(emitterName, readableMapOf("type" to "paymentFailed", "data" to e.error))
+            is BreezEvent.PaymentFailed -> emitter.emit(emitterName, readableMapOf("type" to "paymentFailed", "data" to readableMapOf(e.details)))
             is BreezEvent.PaymentSucceed -> emitter.emit(emitterName, readableMapOf("type" to "paymentSucceed", "data" to readableMapOf(e.details)))
             is BreezEvent.Synced -> emitter.emit(emitterName, readableMapOf("type" to "synced"))
         }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -193,7 +193,7 @@ fun readableMapOf(invoicePaidDetails: InvoicePaidDetails): ReadableMap {
 fun readableMapOf(paymentFailedData: PaymentFailedData): ReadableMap {
     return readableMapOf(
             "error" to paymentFailedData.error,
-            "bolt11" to if (paymentFailedData.bolt11 == null) null else readableMapOf(paymentFailedData.bolt11!!),
+            "bolt11" to if (paymentFailedData.invoice == null) null else readableMapOf(paymentFailedData.invoice!!),
             "nodeId" to paymentFailedData.nodeId
     )
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -190,6 +190,14 @@ fun readableMapOf(invoicePaidDetails: InvoicePaidDetails): ReadableMap {
     )
 }
 
+fun readableMapOf(paymentFailedData: PaymentFailedData): ReadableMap {
+    return readableMapOf(
+            "error" to paymentFailedData.error,
+            "bolt11" to readableMapOf(paymentFailedData.bolt11)
+            "nodeId" to paymentFailedData.node_id,
+    )
+}
+
 fun readableMapOf(lnInvoice: LnInvoice): ReadableMap {
     return readableMapOf(
             "bolt11" to lnInvoice.bolt11,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -193,8 +193,8 @@ fun readableMapOf(invoicePaidDetails: InvoicePaidDetails): ReadableMap {
 fun readableMapOf(paymentFailedData: PaymentFailedData): ReadableMap {
     return readableMapOf(
             "error" to paymentFailedData.error,
-            "bolt11" to readableMapOf(paymentFailedData.bolt11)
-            "nodeId" to paymentFailedData.node_id,
+            "bolt11" to if (paymentFailedData.bolt11 == null) null else readableMapOf(paymentFailedData.bolt11!!),
+            "nodeId" to paymentFailedData.nodeId
     )
 }
 

--- a/libs/sdk-react-native/ios/BreezSDKListener.swift
+++ b/libs/sdk-react-native/ios/BreezSDKListener.swift
@@ -23,11 +23,11 @@ class BreezSDKListener: NSObject, EventListener {
                                     "type": "newBlock",
                                     "data": block
                                    ])
-        case let .paymentFailed(error):
+        case let .paymentFailed(details):
             self.emitter.sendEvent(withName: BreezSDKListener.emitterName,
                                    body: [
                                     "type": "paymentFailed",
-                                    "data": error
+                                    "data": BreezSDKMapper.dictionaryOf(paymentFailedData: details)
                                    ])
         case let .paymentSucceed(details):
             self.emitter.sendEvent(withName: BreezSDKListener.emitterName,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -176,8 +176,8 @@ class BreezSDKMapper {
     static func dictionaryOf(paymentFailedData: PaymentFailedData) -> [String: Any?] {
         return [
             "error": paymentFailedData.error,
-            "bolt11": paymentFailedData.bolt11 == nil ? nil : dictionaryOf(lnInvoice: paymentFailedData.bolt111),
-            "nodeId": paymentFailedData.node_id
+            "bolt11": paymentFailedData.invoice == nil ? nil : dictionaryOf(lnInvoice: paymentFailedData.invoice!),
+            "nodeId": paymentFailedData.nodeId
         ]
     }
     

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -172,6 +172,14 @@ class BreezSDKMapper {
             "bolt11": invoicePaidDetails.bolt11
         ]
     }
+
+    static func dictionaryOf(paymentFailedData: PaymentFailedData) -> [String: Any?] {
+        return [
+            "error": paymentFailedData.error,
+            "bolt11": dictionaryOf(lnInvoice: paymentFailedData.bolt11),
+            "nodeId": paymentFailedData.node_id
+        ]
+    }
     
     static func dictionaryOf(lnInvoice: LnInvoice) -> [String: Any?] {
         return [

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -176,7 +176,7 @@ class BreezSDKMapper {
     static func dictionaryOf(paymentFailedData: PaymentFailedData) -> [String: Any?] {
         return [
             "error": paymentFailedData.error,
-            "bolt11": dictionaryOf(lnInvoice: paymentFailedData.bolt11),
+            "bolt11": paymentFailedData.bolt11 == nil ? nil : dictionaryOf(lnInvoice: paymentFailedData.bolt111),
             "nodeId": paymentFailedData.node_id
         ]
     }

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -117,6 +117,12 @@ export type InvoicePaidDetails = {
     bolt11: string
 }
 
+export type PaymentFailedData = {
+    error: string
+    bolt11?: LnInvoice
+    nodeId: string
+}
+
 export type LnInvoice = {
     bolt11: string
     payeePubkey: string
@@ -135,7 +141,7 @@ export type LogEntry = {
     level: string
 }
 
-export type EventData = InvoicePaidDetails | Payment | number | string
+export type EventData = InvoicePaidDetails | Payment | number | PaymentFailedData
 
 export type EventFn = (type: EventType, data?: EventData) => void
 
@@ -183,7 +189,6 @@ export type LnUrlWithdrawCallbackStatus = {
     status: string
     reason?: string
 }
-
 
 export type LnUrlWithdrawRequestData = {
     callback: string
@@ -334,7 +339,7 @@ function processEvent(eventFn: EventFn) {
             case EventType.NEW_BLOCK:
                 return eventFn(EventType.NEW_BLOCK, event.data)
             case EventType.PAYMENT_FAILED:
-                return eventFn(EventType.PAYMENT_FAILED, event.data)
+                return eventFn(EventType.PAYMENT_FAILED, event.data as PaymentFailedData)
             case EventType.PAYMENT_SUCCEED:
                 const payment = event.data as Payment
 
@@ -355,7 +360,7 @@ function processEvent(eventFn: EventFn) {
     }
 }
 
-function processSuccessActionProcessed (data: any): AesSuccessActionDataDecrypted | MessageSuccessActionData | UrlSuccessActionData | undefined {
+function processSuccessActionProcessed(data: any): AesSuccessActionDataDecrypted | MessageSuccessActionData | UrlSuccessActionData | undefined {
     switch (data.type) {
         case SuccessActionDataType.AES:
             return data as AesSuccessActionDataDecrypted
@@ -455,9 +460,7 @@ export async function receivePayment(amountSats: number, description: string): P
     return response as LnInvoice
 }
 
-export async function lnurlAuth(
-    reqData: LnUrlAuthRequestData
-): Promise<LnUrlAuthCallbackStatus> {
+export async function lnurlAuth(reqData: LnUrlAuthRequestData): Promise<LnUrlAuthCallbackStatus> {
     const response = await BreezSDK.lnurlAuth(reqData)
     return response as LnUrlAuthCallbackStatus
 }

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -119,7 +119,7 @@ export type InvoicePaidDetails = {
 
 export type PaymentFailedData = {
     error: string
-    bolt11?: LnInvoice
+    invoice?: LnInvoice
     nodeId: string
 }
 


### PR DESCRIPTION
This PR adds the following data to the payment failed event:
1. Node ID
2. Optional parsed bolt11 invoice.

fixed #143 