### PR TITLE
sdk-flutter: add desktop target

### DIFF
--- a/libs/sdk-flutter/makefile
+++ b/libs/sdk-flutter/makefile
@@ -29,6 +29,15 @@ android: $(SOURCES) flutter_rust_bridge
 	cp ../target/i686-linux-android/release/libbreez_sdk_core.so android/src/main/jniLibs/x86/libbreez_sdk_core.so
 	cp ../target/x86_64-linux-android/release/libbreez_sdk_core.so android/src/main/jniLibs/x86_64/libbreez_sdk_core.so
 
+## desktop: compiles for x86_64-unknown-linux-gnu by default, other targets can be specified
+## with the TARGET variable eg. make desktop TARGET=aarch64-unknown-linux-gnu
+TARGET ?= x86_64-unknown-linux-gnu
+.PHONY: desktop
+desktop: $(SOURCES) flutter_rust_bridge
+	cd ../sdk-core && make $(TARGET)
+	mkdir -p ./$(TARGET)
+	cp ../target/$(TARGET)/release/libbreez_sdk_core.so ./$(TARGET)/libbreez_sdk_core.so
+
 ## clean:
 .PHONY: clean
 clean:


### PR DESCRIPTION
This is primarily to make development (on the desktop) easier. 

The 4 Linux targets in `sdk-core` feel like a bit of an overkill but to be consistent I added `x86_64-unknown-linux-gnu` even though having a simple `linux` target would be my preference.