### PR TITLE
Generate and publish rustdoc on main branch commits

### DIFF
--- a/.github/workflows/rustdoc-pages.yml
+++ b/.github/workflows/rustdoc-pages.yml
@@ -1,0 +1,54 @@
+# Publish rust docs built from the latest git main branch to a GitHub Pages site
+name: Publish rustdocs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build Docs
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Docs
+      - run: |
+          cd libs/sdk-core
+          cargo doc --no-deps
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload the entire doc folder
+          path: './target/doc'
+
+  deploy:
+    name: Deploy to Pages
+
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR adds a GH workflow that generates the rustdoc and publishes it to Github Pages, for every commit to the `main` branch.