### PR TITLE
Implement copyWith Config extension

### DIFF
--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -357,3 +357,27 @@ class BreezBridge {
     await listPayments();
   }
 }
+
+extension SDKConfig on Config {
+  Config copyWith(
+      {String? breezserver,
+      String? mempoolspaceUrl,
+      String? workingDir,
+      Network? network,
+      int? paymentTimeoutSec,
+      String? defaultLspId,
+      String? apiKey,
+      int? maxfeeSat,
+      double? maxfeepercent}) {
+    return Config(
+        breezserver: breezserver ?? this.breezserver,
+        mempoolspaceUrl: mempoolspaceUrl ?? this.mempoolspaceUrl,
+        workingDir: workingDir ?? this.workingDir,
+        network: network ?? this.network,
+        paymentTimeoutSec: paymentTimeoutSec ?? this.paymentTimeoutSec,
+        defaultLspId: defaultLspId ?? this.defaultLspId,
+        apiKey: apiKey ?? this.apiKey,
+        maxfeeSat: maxfeeSat ?? this.maxfeeSat,
+        maxfeepercent: maxfeepercent ?? this.maxfeepercent);
+  }
+}


### PR DESCRIPTION
Add copyWith extension to flutter SDK Config for easier usage of the default config. Instead of initialising all config field one now can write:

`sdk.defaultConfig().copyWith(workingDir:"/path")`
