### PR TITLE
Fix RN parseInput response for LNURL-auth

### DIFF
--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -248,7 +248,12 @@ fun readableMapOf(lnPaymentDetails: LnPaymentDetails): ReadableMap {
 }
 
 fun readableMapOf(lnUrlAuthRequestData: LnUrlAuthRequestData): ReadableMap {
-    return readableMapOf("k1" to lnUrlAuthRequestData.k1)
+    return readableMapOf(
+            "k1" to lnUrlAuthRequestData.k1,
+            "action" to lnUrlAuthRequestData.action,
+            "domain" to lnUrlAuthRequestData.domain,
+            "url" to lnUrlAuthRequestData.url
+    )
 }
 
 fun readableMapOf(lnUrlErrorData: LnUrlErrorData): ReadableMap {


### PR DESCRIPTION
Add missing kotlin mappings of lnurl-auth parseInput response