### PR TITLE
Fix GitHub Action syntax

### DIFF
--- a/.github/workflows/rustdoc-pages.yml
+++ b/.github/workflows/rustdoc-pages.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build Docs
-      - run: |
+        run: |
           cd libs/sdk-core
           cargo doc --no-deps
 


### PR DESCRIPTION
Fix a syntax typo that caused the CI to fail.