### PR TITLE
Rustdoc: Make contact link clickable

### DIFF
--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -133,7 +133,7 @@
 //!
 //! ## API Key
 //!
-//! To get an API key in order to use the SDK, please contact Breez: https://breez.technology/#contact-us-form
+//! To get an API key in order to use the SDK, please contact Breez: <https://breez.technology/#contact-us-form>
 
 mod bridge_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 #[macro_use]


### PR DESCRIPTION
Small update to the rustdoc, to test if it's automatically generated with a merge on the `main` branch.