### PR TITLE
Run rustdoc CI steps on macOS to simplify ssh key mgmt

### DIFF
--- a/.github/workflows/rustdoc-pages.yml
+++ b/.github/workflows/rustdoc-pages.yml
@@ -13,7 +13,8 @@ jobs:
   build:
     name: Build Docs
 
-    runs-on: ubuntu-latest
+    # Run on macOS because this auto-starts the ssh-agent, needed later for ssh-add
+    runs-on: macOS-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Run the CI steps on macOS, otherwise we'd have to explicitly start the `ssh-agent` before importing the ssh key.