### PR TITLE
Add link to Rustdoc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The Breez SDK provides the following services:
 * Connecting to a new or existing node.
 
 Download our one pager [here](https://drive.google.com/file/d/1MBINTyEXX9tFLVXd3QoTUKLNWgjgWN2I/view?usp=drivesdk). 
+
+Browse the Breez SDK Rustdoc [here](https://breez.github.io/breez-sdk/breez_sdk_core/).
+
 ## Demo
 
 https://user-images.githubusercontent.com/31890660/208511040-989ff42c-ceb8-4a34-b2cb-a17a0a8c0150.mp4


### PR DESCRIPTION
Adds a link in the README to the (auto-generated) SDK Rustdoc.

With this setup, the docs are automatically generated and published with every commit to the SDK's `main` branch.

The new rustdoc link is: https://breez.github.io/breez-sdk/breez_sdk_core/

The old link  ( https://breez.github.io/breez-sdk-rustdoc/doc/breez_sdk_core/ )  was updated to auto-redirect to the new one.

---

Review notes

- New rustdoc generation + publishing handled in 1 file: https://github.com/breez/breez-sdk/blob/main/.github/workflows/rustdoc-pages.yml