### PR TITLE
Persist the lower amount invoice on the node

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -945,7 +945,7 @@ impl Receiver for PaymentReceiver {
         let amount_msats = amount_sats * 1000;
 
         let mut short_channel_id = parse_short_channel_id("1x0x0")?;
-        let mut destination_invoice_amount_sats = amount_msats;
+        let mut destination_invoice_amount_sats = amount_sats;
 
         // check if we need to open channel
         if node_state.inbound_liquidity_msats < amount_msats {
@@ -997,7 +997,7 @@ impl Receiver for PaymentReceiver {
         info!("Creating invoice on NodeAPI");
         let invoice = &self
             .node_api
-            .create_invoice(amount_sats, description, preimage)
+            .create_invoice(destination_invoice_amount_sats, description, preimage)
             .await?;
         info!("Invoice created {}", invoice.bolt11);
 


### PR DESCRIPTION
In order to support fee deduction by an LSP, the lower amount invoice has to be stored on the node, so greenlight is able to lookup the invoice and deduce whether a payload with a lower than expected amount is valid (because the LSP is allowed to take the fee that way).

This PR stores the lower amount on the node.
Note that the function `add_routing_hints` already replaces the amount, so the 'actual' amount that is sent to the sender is modified there.

This PR could give some backward compatibility issues. I'm not sure yet what happens if the fee is _not_ deducted when cln expects to receive the lower amount. Also, the entire integration flow is not working yet. That's why this PR is a draft. Relevant corresponding PRs are https://github.com/Blockstream/greenlight/pull/114 for Greenlight and https://github.com/breez/lspd/pull/55 for lspd.

