### PR TITLE
Add build step for Swift package

### DIFF
--- a/libs/sdk-bindings/README.md
+++ b/libs/sdk-bindings/README.md
@@ -20,17 +20,11 @@ make init
 ### Swift
 
 ```
-make swift-ios
+make bindings-swift
 ```
 
-This will generate all the artifacts needed to for an iOS app to start writing code that uses breez sdk in swift.
-All files are generated in the bindings/swift-ios folder.
-We also provides the same binding for mac os by running the following command:
-
-```
-make swift-darwin
-```
-The above will generate the artifacts in the ffi/swift-darwin folder.
+This will produce a fully configured Swift Package in `bindings-swift/`.
+See [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) in Apple's docs for more information on how to integrate such a package into your project.
 
 ### Kotlin
 ```

--- a/libs/sdk-bindings/bindings-swift/.gitignore
+++ b/libs/sdk-bindings/bindings-swift/.gitignore
@@ -1,0 +1,7 @@
+.swiftpm/
+.build/
+*.xcodeproj
+Sources/
+**/breez_sdkFFI.h
+**/breez_sdkFFI
+**/breez_sdkFFI.modulemap

--- a/libs/sdk-bindings/bindings-swift/Package.swift
+++ b/libs/sdk-bindings/bindings-swift/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "bindings-swift",
+    platforms: [
+        .macOS(.v12),
+        .iOS(.v15),
+    ],
+    products: [
+        .library(name: "BreezSDK", targets: ["breez_sdkFFI", "BreezSDK"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .binaryTarget(name: "breez_sdkFFI", path: "./breez_sdkFFI.xcframework"),
+        .target(name: "BreezSDK", dependencies: ["breez_sdkFFI"]),
+        .testTarget(name: "BreezSDKTests", dependencies: ["BreezSDK"]),
+    ]
+)

--- a/libs/sdk-bindings/bindings-swift/Tests/BreezSDKTests/BreezSDKTests.swift
+++ b/libs/sdk-bindings/bindings-swift/Tests/BreezSDKTests/BreezSDKTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import BreezSDK
+
+class SDKListener: EventListener {
+    func onEvent(e: BreezEvent) {
+        print("received event ", e);
+    }
+}
+
+final class BreezSDKTests: XCTestCase {
+    func testExample() throws {
+        let seedPhraseForTesting = "cruise clever syrup coil cute execute laundry general cover prevent law sheriff"
+        let seedForTesting = try mnemonicToSeed(phrase: seedPhraseForTesting)
+        let credentials = try recoverNode(network: Network.bitcoin, seed: seedForTesting)
+        
+        let sdkServices = try initServices(
+            config: BreezSDK.defaultConfig(envType: EnvironmentType.staging),
+            seed: seedForTesting,
+            creds: credentials,
+            listener: SDKListener()
+        )
+        
+        try sdkServices.start()
+        let nodeInfo = try sdkServices.nodeInfo()
+        
+        XCTAssertEqual(nodeInfo?.id, "0352a918bdba7d7a69893a7d52a449f3e6df8e15a0edcc7fe59060be70d6f416f0")
+    }
+}

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/Info.plist
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>macos-arm64_x86_64</string>
+			<key>LibraryPath</key>
+			<string>breez_sdkFFI.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>macos</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64_x86_64-simulator</string>
+			<key>LibraryPath</key>
+			<string>breez_sdkFFI.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>breez_sdkFFI.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Headers/breez_sdkFFI-umbrella.h
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Headers/breez_sdkFFI-umbrella.h
@@ -1,0 +1,1 @@
+#import "breez_sdkFFI.h"

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Modules/module.modulemap
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module breez_sdkFFI {
+  umbrella header "breez_sdkFFI-umbrella.h"
+
+  export *
+  module * { export * }
+}

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Headers/breez_sdkFFI-umbrella.h
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Headers/breez_sdkFFI-umbrella.h
@@ -1,0 +1,1 @@
+#import "breez_sdkFFI.h"

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Modules/module.modulemap
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module breez_sdkFFI {
+  umbrella header "breez_sdkFFI-umbrella.h"
+
+  export *
+  module * { export * }
+}

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Headers/breez_sdkFFI-umbrella.h
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Headers/breez_sdkFFI-umbrella.h
@@ -1,0 +1,1 @@
+#import "breez_sdkFFI.h"

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Modules/module.modulemap
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module breez_sdkFFI {
+  umbrella header "breez_sdkFFI-umbrella.h"
+
+  export *
+  module * { export * }
+}

--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -9,44 +9,37 @@ init:
 	rustup target add aarch64-apple-ios-sim
 	#rustup target add armv7-apple-ios armv7s-apple-ios i386-apple-ios ## deprecated
 	rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
-	@if [ $$(uname) == "Darwin" ] ; then cargo install cargo-lipo ; fi
 	cargo install cbindgen
 	cargo install cargo-ndk
 
 ## all: Compile iOS, Android
-all: swift-ios swift-darwin kotlin
+all: bindings-swift kotlin
 
 ios-universal: $(SOURCES)		
-	mkdir -p ../target/ios-simulator/release
+	mkdir -p ../target/ios-universal/release
 	cargo build --release --target aarch64-apple-ios ;\
 	cargo build --release --target x86_64-apple-ios ;\
 	cargo build --release --target aarch64-apple-ios-sim ;\
-	lipo -create -output ../target/ios-simulator/release/libbreez_sdk_bindings.a ../target/aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a
+	lipo -create -output ../target/ios-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a
 
 darwin-universal: $(SOURCES)
 	mkdir -p ../target/darwin-universal/release
-	cargo lipo --release --targets aarch64-apple-darwin		
-	cargo lipo --release --targets x86_64-apple-darwin		
-	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.dylib ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.dylib
+	cargo build --release --target aarch64-apple-darwin
+	cargo build --release --target x86_64-apple-darwin
+	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.a ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.a
 
-swift-ios: ios-universal
-	uniffi-bindgen generate src/breez_sdk.udl -l swift -o ffi/swift-ios
-	cp ../target/ios-simulator/release/libbreez_sdk_bindings.a ffi/swift-ios
-	cd ffi/swift-ios && "swiftc" "-emit-module" "-module-name" "breez_sdk_bindings"  "-Xcc" "-fmodule-map-file=$(CURRENT_DIR)/ffi/swift-ios/breez_sdkFFI.modulemap" "-I" "."  "-L" "." "-lbreez_sdk_bindings" breez_sdk.swift
-
-xcframework: swift-ios
-	mkdir -p ffi/xcframework
-	mkdir -p ffi/xcframework/build/include ffi/xcframework/build/lib/ios-simulator/release ffi/xcframework/build/lib/aarch64-apple-ios/release
-	cp -r ffi/swift-ios/breez_sdkFFI.h ffi/xcframework/build/include
-	cp ffi/swift-ios/breez_sdkFFI.modulemap ffi/xcframework/build/include/module.modulemap
-	cp ../target/ios-simulator/release/libbreez_sdk_bindings.a ffi/xcframework/build/lib/ios-simulator/release
-	cp ../target/aarch64-apple-ios/release/libbreez_sdk_bindings.a ffi/xcframework/build/lib/aarch64-apple-ios/release
-	xcodebuild -create-xcframework -library ffi/xcframework/build/lib/ios-simulator/release/libbreez_sdk_bindings.a -headers ffi/xcframework/build/include -library ffi/xcframework/build/lib/aarch64-apple-ios/release/libbreez_sdk_bindings.a -headers ffi/xcframework/build/include -output ffi/xcframework/breez_sdkFFI.xcframework
-
-swift-darwin: darwin-universal
-	uniffi-bindgen generate src/breez_sdk.udl -l swift -o ffi/swift-darwin
-	cp ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ffi/swift-darwin
-	cd ffi/swift-darwin && "swiftc" "-emit-module" "-module-name" "breez_sdk_bindings"  "-Xcc" "-fmodule-map-file=$(CURRENT_DIR)/ffi/swift-darwin/breez_sdkFFI.modulemap" "-I" "."  "-L" "." "-lbreez_sdk_bindings" breez_sdk.swift
+bindings-swift: ios-universal darwin-universal
+	mkdir -p bindings-swift/Sources/BreezSDK
+	uniffi-bindgen generate src/breez_sdk.udl --no-format --language swift --out-dir bindings-swift/Sources/BreezSDK
+	mv bindings-swift/Sources/BreezSDK/breez_sdk.swift bindings-swift/Sources/BreezSDK/BreezSDK.swift
+	cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Headers
+	cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Headers
+	cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Headers
+	cp ../target/aarch64-apple-ios/release/libbreez_sdk_bindings.a bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/breez_sdkFFI
+	cp ../target/ios-universal/release/libbreez_sdk_bindings.a bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/breez_sdkFFI
+	cp ../target/darwin-universal/release/libbreez_sdk_bindings.a bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/breez_sdkFFI
+	rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.h
+	rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.modulemap
 
 kotlin: android
 	uniffi-bindgen generate src/breez_sdk.udl --language kotlin -o ffi/kotlin 


### PR DESCRIPTION
Resolves #137.

This adds a build step to the Makefile in `libs/sdk-bindings` which will create a fully configured Swift package in `libs/sdk-bindings/bindings-swift`.

This package can then be added to any Xcode project by simply dropping the folder `bindigns-swift` folder into the project. It can also be used by other Swift packages as a local dependency. The approach is inspired by the way [bdk](https://github.com/bitcoindevkit/bdk-ffi/tree/master/bdk-swift) ships its Swift bindings.

Another cool thing that bdk does is automatically push a fully configured Swift package to a [separate repository](https://github.com/bitcoindevkit/bdk-swift) using GitHub Actions. It would be cool if we could do that to. That way the Breez SDK could be used without anyone needing to build it manually. Instead, people could just add the repo URL to their project and Xcode/SPM would do the rest.

I'd say we do this step by step, though. This PR only adds the build step to create a local Swift package. Imo, setting up and configuring the hosted package in a separate repo can be a follow up PR if we agree that it makes sense.

---

👉 I removed the old `swift-ios` and `swift-darwin` build steps. Let me know if I should add them back.