### PR TITLE
fix log stream

### DIFF
--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use breez_sdk_core::{
     mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
@@ -40,7 +40,7 @@ impl BindingLogger {
 impl log::Log for BindingLogger {
     fn enabled(&self, m: &Metadata) -> bool {
         // ignroe the internal uniffi log to prevent infinite loop.
-        return m.target().to_string() != "breez_sdk_bindings::uniffi_binding".to_string();
+        return *m.target() != *"breez_sdk_bindings::uniffi_binding";
     }
 
     fn log(&self, record: &Record) {

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.kts
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.kts
@@ -7,7 +7,14 @@ class SDKListener: breez_sdk.EventListener {
     }
 }
 
+class LogStreamListener: breez_sdk.LogStream { 
+    override fun log(l: breez_sdk.LogEntry) {
+        println(l.line);
+    }
+}
+
 try {
+    breez_sdk.setLogStream(LogStreamListener());
     var seed = breez_sdk.mnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
     var credentials = breez_sdk.recoverNode(breez_sdk.Network.BITCOIN, seed);
     var sdkServices = breez_sdk.initServices(breez_sdk.defaultConfig(breez_sdk.EnvironmentType.STAGING), seed, credentials, SDKListener());

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.swift
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.swift
@@ -7,7 +7,14 @@ class SDKListener: EventListener {
     }
 }
 
+class LogStreamListener: LogStream {
+    func log(l: LogEntry){
+      print(l.line);
+    }
+}
+
 do {
+    try setLogStream(logStream: LogStreamListener());
     let seed = try mnemonicToSeed(phrase: "cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
     let credentials = try recoverNode(network: Network.bitcoin, seed: seed);
     let sdkServices = try initServices(config: breez_sdk.defaultConfig(envType: EnvironmentType.staging), seed: seed, creds: credentials, listener: SDKListener());


### PR DESCRIPTION
This fixed #174 

Two fixes here:
1. Setting the filter level to trace (before it was Info and prevented from lower severity logs to be sent).
2. Prevent the internal uniffi logs from being added to the stream ( to prevent infinite loop with the callback).