### PR TITLE
Proper handle absolute and relative payments fee

### DIFF
--- a/libs/sdk-core/src/greenlight.rs
+++ b/libs/sdk-core/src/greenlight.rs
@@ -337,7 +337,7 @@ impl NodeAPI for Greenlight {
         let mut client = self.get_client().await?;
 
         // extract the amount we need to pay
-        let mut amount = amount_sats.clone();
+        let mut amount = amount_sats;
         if amount.is_none() {
             let invoice = parse_invoice(bolt11.as_str())?;
             amount = invoice.amount_msat.map(|amt| amt / 1000);


### PR DESCRIPTION
Here we fix the fee handling according to cln behavior.
It turns out that we can't pass both maxfeepercent and max_fee to the rpc call, only one of them (https://lightning.readthedocs.io/lightning-pay.7.html)

The strategy is in the case the user has configured max_fee we calculate the fees according to the percentage and if it exceeds the max_fee we will use the max_fee.
Otherwise we will use the percentage.

This is related to https://github.com/breez/c-breez/pull/544