### PR TITLE
Broadcast transaction error

### DIFF
--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -121,14 +121,19 @@ impl ChainService for MempoolSpace {
 
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String> {
         let client = reqwest::Client::new();
-        client
+        let txidOrError = client
             .post(format!("{}/api/tx", self.base_url))
             .body(hex::encode(tx))
             .send()
             .await?
             .text()
             .await
-            .map_err(anyhow::Error::msg)
+            .map_err(anyhow::Error::msg)?;
+        if txidOrError.contains("error") {
+            Err(anyhow::Error::msg(txidOrError))
+        } else {
+            Ok(txidOrError)
+        }
     }
 }
 #[cfg(test)]

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -121,7 +121,7 @@ impl ChainService for MempoolSpace {
 
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String> {
         let client = reqwest::Client::new();
-        let txidOrError = client
+        let txid_or_error = client
             .post(format!("{}/api/tx", self.base_url))
             .body(hex::encode(tx))
             .send()
@@ -129,10 +129,10 @@ impl ChainService for MempoolSpace {
             .text()
             .await
             .map_err(anyhow::Error::msg)?;
-        if txidOrError.contains("error") {
-            Err(anyhow::Error::msg(txidOrError))
+        if txid_or_error.contains("error") {
+            Err(anyhow::Error::msg(txid_or_error))
         } else {
-            Ok(txidOrError)
+            Ok(txid_or_error)
         }
     }
 }

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -659,6 +659,9 @@ fn create_refund_tx(
     let tx_weight = tx.strippedsize() as u32 * WITNESS_SCALE_FACTOR as u32
         + refund_witness_input_size * txins.len() as u32;
     let fees: u64 = (tx_weight * sat_per_vbyte / WITNESS_SCALE_FACTOR as u32) as u64;
+    if fees >= confirmed_amount {
+        return Err(anyhow!("insufficient funds to pay fees"));
+    }
     tx.output[0].value = confirmed_amount - fees;
 
     let scpt = Secp256k1::signing_only();

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -495,6 +495,7 @@ impl BTCReceiveSwap {
             script,
             sat_per_vbyte,
         )?;
+        info!("broadcasting refund tx {:?}", hex::encode(&refund_tx));
         let txid = self.chain_service.broadcast_transaction(refund_tx).await?;
 
         self.persister.update_swap_chain_info(

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -611,6 +611,8 @@ fn create_refund_tx(
         return Err(anyhow!("must have at least one input"));
     }
 
+    info!("creating refund tx sat_per_vbyte {}", sat_per_vbyte);
+
     let lock_time = utxos.confirmed.iter().fold(0, |accum, item| {
         let confirmed_height = item.block_height.unwrap();
         if accum >= confirmed_height + lock_delay {


### PR DESCRIPTION
This PR fixes the broadcast transaction in ChainService to properly parse the result and return error when needed.
Before this fix we assumed the HTTP API return non success status code (not 200) but it appears not to be the case.
Also some logs were added to better identify the refund tx and the used fees.