### PR TITLE
Use cln client for sending payments

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -553,7 +553,7 @@ impl BreezServices {
             Some(p) => {
                 self.notify_event_listeners(BreezEvent::PaymentSucceed { details: p.clone() })
                     .await?;
-                return Ok(p);
+                Ok(p)
             }
             None => Err(anyhow!("payment not found")),
         }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -22,7 +22,7 @@ use crate::models::{
 };
 use crate::persist::db::SqliteStorage;
 use crate::swap::BTCReceiveSwap;
-use crate::{LnUrlAuthRequestData, LnUrlWithdrawRequestData};
+use crate::{LnUrlAuthRequestData, LnUrlWithdrawRequestData, PaymentResponse};
 use anyhow::{anyhow, Result};
 use bip39::*;
 use bitcoin_hashes::{sha256, Hash};
@@ -532,7 +532,7 @@ impl BreezServices {
         &self,
         node_id: String,
         invoice: Option<LNInvoice>,
-        payment_res: Result<Payment>,
+        payment_res: Result<PaymentResponse>,
     ) -> Result<Payment> {
         if payment_res.is_err() {
             self.notify_event_listeners(BreezEvent::PaymentFailed {
@@ -543,15 +543,20 @@ impl BreezServices {
                 },
             })
             .await?;
-            return payment_res;
+            return Err(payment_res.err().unwrap());
         }
         let payment = payment_res.unwrap();
         self.sync().await?;
-        self.notify_event_listeners(BreezEvent::PaymentSucceed {
-            details: payment.clone(),
-        })
-        .await?;
-        Ok(payment)
+
+        let p = self.persister.get_payment_by_hash(&payment.payment_hash)?;
+        match p {
+            Some(p) => {
+                self.notify_event_listeners(BreezEvent::PaymentSucceed { details: p.clone() })
+                    .await?;
+                return Ok(p);
+            }
+            None => Err(anyhow!("payment not found")),
+        }
     }
 
     async fn on_event(&self, e: BreezEvent) -> Result<()> {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -40,12 +40,12 @@ pub trait NodeAPI: Send + Sync {
         &self,
         bolt11: String,
         amount_sats: Option<u64>,
-    ) -> Result<crate::models::Payment>;
+    ) -> Result<crate::models::PaymentResponse>;
     async fn send_spontaneous_payment(
         &self,
         node_id: String,
         amount_sats: u64,
-    ) -> Result<crate::models::Payment>;
+    ) -> Result<crate::models::PaymentResponse>;
     async fn start(&self) -> Result<()>;
     async fn sweep(
         &self,
@@ -277,6 +277,16 @@ pub struct Payment {
     pub pending: bool,
     pub description: Option<String>,
     pub details: PaymentDetails,
+}
+
+/// Represents a payment response.
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+pub struct PaymentResponse {
+    pub payment_time: i64,
+    pub amount_msat: u64,
+    pub fee_msat: u64,
+    pub payment_hash: String,
+    pub payment_preimage: String,
 }
 
 /// Wrapper for the different types of payments


### PR DESCRIPTION
In order to get better control of the API we need to start using Cln gRPC client rather than Greenlight gRPC client.
Specifically here we want to use the exempt_fee that is exposed in Cln client and not in greenlight.