### PR TITLE
Remove absolute maxfee config option.

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -37,8 +37,7 @@ dictionary Config {
     Network network;
     u32 payment_timeout_sec;
     string? default_lsp_id;
-    string? api_key;
-    u64? maxfee_sat;
+    string? api_key;    
     f64 maxfee_percent;
 };
 

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -329,7 +329,6 @@ impl Wire2Api<Config> for wire_Config {
             payment_timeout_sec: self.payment_timeout_sec.wire2api(),
             default_lsp_id: self.default_lsp_id.wire2api(),
             api_key: self.api_key.wire2api(),
-            maxfee_sat: self.maxfee_sat.wire2api(),
             maxfee_percent: self.maxfee_percent.wire2api(),
         }
     }
@@ -399,7 +398,6 @@ pub struct wire_Config {
     payment_timeout_sec: u32,
     default_lsp_id: *mut wire_uint_8_list,
     api_key: *mut wire_uint_8_list,
-    maxfee_sat: *mut u64,
     maxfee_percent: f64,
 }
 
@@ -470,7 +468,6 @@ impl NewWithNullPtr for wire_Config {
             payment_timeout_sec: Default::default(),
             default_lsp_id: core::ptr::null_mut(),
             api_key: core::ptr::null_mut(),
-            maxfee_sat: core::ptr::null_mut(),
             maxfee_percent: Default::default(),
         }
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -698,7 +698,6 @@ impl support::IntoDart for Config {
             self.payment_timeout_sec.into_dart(),
             self.default_lsp_id.into_dart(),
             self.api_key.into_dart(),
-            self.maxfee_sat.into_dart(),
             self.maxfee_percent.into_dart(),
         ]
         .into_dart()

--- a/libs/sdk-core/src/greenlight.rs
+++ b/libs/sdk-core/src/greenlight.rs
@@ -343,12 +343,7 @@ impl NodeAPI for Greenlight {
                 .map(|amt| Amount { unit: amt }),
             bolt11,
             timeout: self.sdk_config.payment_timeout_sec,
-            maxfee: self
-                .sdk_config
-                .maxfee_sat
-                .map(Unit::Satoshi)
-                .map(Some)
-                .map(|amt| Amount { unit: amt }),
+            maxfee: None,
             maxfeepercent: self.sdk_config.maxfee_percent,
         };
         client.pay(request).await?.into_inner().try_into()

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -131,7 +131,6 @@ pub struct Config {
     pub payment_timeout_sec: u32,
     pub default_lsp_id: Option<String>,
     pub api_key: Option<String>,
-    pub maxfee_sat: Option<u64>,
     pub maxfee_percent: f64,
 }
 
@@ -145,7 +144,6 @@ impl Config {
             payment_timeout_sec: 60,
             default_lsp_id: Some(String::from("03cea51f-b654-4fb0-8e82-eca137f236a0")),
             api_key: None,
-            maxfee_sat: None,
             maxfee_percent: 0.5,
         }
     }
@@ -160,7 +158,6 @@ impl Config {
             payment_timeout_sec: 60,
             default_lsp_id: Some(String::from("ea51d025-042d-456c-8325-63e430797481")),
             api_key: None,
-            maxfee_sat: None,
             maxfee_percent: 0.5,
         }
     }

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -22,7 +22,6 @@ typedef struct wire_Config {
   uint32_t payment_timeout_sec;
   struct wire_uint_8_list *default_lsp_id;
   struct wire_uint_8_list *api_key;
-  uint64_t *maxfee_sat;
   double maxfee_percent;
 } wire_Config;
 

--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -367,7 +367,6 @@ extension SDKConfig on Config {
     int? paymentTimeoutSec,
     String? defaultLspId,
     String? apiKey,
-    int? maxfeeSat,
     double? maxfeePercent,
   }) {
     return Config(
@@ -377,8 +376,7 @@ extension SDKConfig on Config {
       network: network ?? this.network,
       paymentTimeoutSec: paymentTimeoutSec ?? this.paymentTimeoutSec,
       defaultLspId: defaultLspId ?? this.defaultLspId,
-      apiKey: apiKey ?? this.apiKey,
-      maxfeeSat: maxfeeSat ?? this.maxfeeSat,
+      apiKey: apiKey ?? this.apiKey,      
       maxfeePercent: maxfeePercent ?? this.maxfeePercent,
     );
   }

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -300,7 +300,6 @@ class Config {
   final int paymentTimeoutSec;
   final String? defaultLspId;
   final String? apiKey;
-  final int? maxfeeSat;
   final double maxfeePercent;
 
   const Config({
@@ -311,7 +310,6 @@ class Config {
     required this.paymentTimeoutSec,
     this.defaultLspId,
     this.apiKey,
-    this.maxfeeSat,
     required this.maxfeePercent,
   });
 }
@@ -1708,7 +1706,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   Config _wire2api_config(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 9) throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return Config(
       breezserver: _wire2api_String(arr[0]),
       mempoolspaceUrl: _wire2api_String(arr[1]),
@@ -1717,8 +1715,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       paymentTimeoutSec: _wire2api_u32(arr[4]),
       defaultLspId: _wire2api_opt_String(arr[5]),
       apiKey: _wire2api_opt_String(arr[6]),
-      maxfeeSat: _wire2api_opt_box_autoadd_u64(arr[7]),
-      maxfeePercent: _wire2api_f64(arr[8]),
+      maxfeePercent: _wire2api_f64(arr[7]),
     );
   }
 
@@ -2453,7 +2450,6 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.payment_timeout_sec = api2wire_u32(apiObj.paymentTimeoutSec);
     wireObj.default_lsp_id = api2wire_opt_String(apiObj.defaultLspId);
     wireObj.api_key = api2wire_opt_String(apiObj.apiKey);
-    wireObj.maxfee_sat = api2wire_opt_box_autoadd_u64(apiObj.maxfeeSat);
     wireObj.maxfee_percent = api2wire_f64(apiObj.maxfeePercent);
   }
 
@@ -3223,8 +3219,6 @@ class wire_Config extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> default_lsp_id;
 
   external ffi.Pointer<wire_uint_8_list> api_key;
-
-  external ffi.Pointer<ffi.Uint64> maxfee_sat;
 
   @ffi.Double()
   external double maxfee_percent;

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -16,11 +16,10 @@ fun asConfig(config: ReadableMap): Config? {
     if (breezserver != null && mempoolspaceUrl != null && workingDir != null && network != null && hasNonNullKey(config, "paymentTimeoutSec") && hasNonNullKey(config, "maxfeePercent")) {
         var paymentTimeoutSec = config.getInt("paymentTimeoutSec")
         var defaultLspId = config.getString("defaultLspId")
-        var apiKey = config.getString("apiKey")
-        var maxfeeSat = if (hasNonNullKey(config, "maxfeeSat")) config.getInt("maxfeeSat") else null
+        var apiKey = config.getString("apiKey")        
         var maxfeePercent = config.getDouble("maxfeePercent")
 
-        return Config(breezserver, mempoolspaceUrl, workingDir, asNetwork(network), paymentTimeoutSec.toUInt(), defaultLspId, apiKey, maxfeeSat?.toULong(), maxfeePercent)
+        return Config(breezserver, mempoolspaceUrl, workingDir, asNetwork(network), paymentTimeoutSec.toUInt(), defaultLspId, apiKey, maxfeePercent)
     }
 
     return null
@@ -198,8 +197,7 @@ fun readableMapOf(config: Config): ReadableMap {
             "network" to config.network.name.lowercase(),
             "paymentTimeoutSec" to config.paymentTimeoutSec,
             "defaultLspId" to config.defaultLspId,
-            "apiKey" to config.apiKey,
-            "maxfeeSat" to config.maxfeeSat,
+            "apiKey" to config.apiKey,            
             "maxfeePercent" to config.maxfeePercent
     )
 }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -65,11 +65,10 @@ class BreezSDKMapper {
            let paymentTimeoutSec = config["paymentTimeoutSec"] as? UInt32,
            let maxfeePercent = config["maxfeePercent"] as? Double {
             let defaultLspId = config["defaultLspId"] as? String
-            let apiKey = config["apiKey"] as? String
-            let maxfeeSat = config["maxfeeSat"] as? UInt64
+            let apiKey = config["apiKey"] as? String            
             do {
                 var network = try asNetwork(network: networkStr)
-                return Config(breezserver: breezserver, mempoolspaceUrl: mempoolspaceUrl, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, defaultLspId: defaultLspId, apiKey: apiKey, maxfeeSat: maxfeeSat, maxfeePercent: maxfeePercent)
+                return Config(breezserver: breezserver, mempoolspaceUrl: mempoolspaceUrl, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, defaultLspId: defaultLspId, apiKey: apiKey, maxfeePercent: maxfeePercent)
             } catch {}
         }
         
@@ -167,8 +166,7 @@ class BreezSDKMapper {
             "network": valueOf(network: config.network),
             "paymentTimeoutSec": config.paymentTimeoutSec,
             "defaultLspId": config.defaultLspId,
-            "apiKey": config.apiKey,
-            "maxfeeSat": config.maxfeeSat,
+            "apiKey": config.apiKey,            
             "maxfeePercent": config.maxfeePercent
         ]
     }

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -9,13 +9,13 @@ const LINKING_ERROR =
 const BreezSDK = NativeModules.BreezSDK
     ? NativeModules.BreezSDK
     : new Proxy(
-        {},
-        {
-            get() {
-                throw new Error(LINKING_ERROR)
-            }
-        }
-    )
+          {},
+          {
+              get() {
+                  throw new Error(LINKING_ERROR)
+              }
+          }
+      )
 
 const BreezSDKEmitter = new NativeEventEmitter(BreezSDK)
 
@@ -105,7 +105,6 @@ export type Config = {
     paymentTimeoutSec: number
     defaultLspId?: string
     apiKey?: string
-    maxfeeSat?: number
     maxfeePercent: number
 }
 
@@ -440,8 +439,8 @@ export const recoverNode = async (network: Network, seed: Uint8Array): Promise<G
 }
 
 export const defaultConfig = async (envType: EnvironmentType): Promise<Config> => {
-   const response = await BreezSDK.defaultConfig(envType)
-   return response as Config
+    const response = await BreezSDK.defaultConfig(envType)
+    return response as Config
 }
 
 export const initServices = async (config: Config, deviceKey: Uint8Array, deviceCert: Uint8Array, seed: Uint8Array): Promise<void> => {


### PR DESCRIPTION
This parameter doesn't make sense as part of global config as in lightning fees are proportional to the payment amount which is different in each payment.
After this omit we are left with `maxfee_percent` (relative fee) and we plan to add `exemptfee_sats` for small payments (https://lightning.readthedocs.io/lightning-pay.7.html)