### PR TITLE
Split main database into two (main, sync)

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "tempfile",
  "tiny-bip39",
  "tokio",
  "tonic",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -33,6 +33,7 @@ rusqlite = { version = "0.28.0", features = [
     "serde_json",
     "bundled",
     "load_extension",
+    "backup",
 ] }
 rusqlite_migration = "*"
 reqwest = { version = "0.11", features = ["json"] }
@@ -51,6 +52,7 @@ once_cell = "*"
 openssl = { version = "0.10.42", features = ["vendored"] }
 strum = "0.24.1"
 strum_macros = "0.24.1"
+tempfile = "3"
 
 [dev-dependencies]
 mockito = "0.31.1"

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -792,12 +792,10 @@ impl BreezServicesBuilder {
         ));
 
         // The storage is implemented via sqlite.
-        let persister = self.persister.clone().unwrap_or_else(|| {
-            Arc::new(SqliteStorage::from_file(format!(
-                "{}/storage.sql",
-                self.config.working_dir
-            )))
-        });
+        let persister = self
+            .persister
+            .clone()
+            .unwrap_or_else(|| Arc::new(SqliteStorage::new(self.config.working_dir.clone())));
 
         persister.init().unwrap();
         let current_lsp_id = persister.get_lsp_id()?;

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -47,7 +47,7 @@ impl SqliteStorage {
 fn test_cached_items() {
     use crate::persist::test_utils;
 
-    let storage = SqliteStorage::from_file(test_utils::create_test_sql_file("cache".to_string()));
+    let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
 
     storage.init().unwrap();
     storage

--- a/libs/sdk-core/src/persist/channels.rs
+++ b/libs/sdk-core/src/persist/channels.rs
@@ -119,7 +119,7 @@ impl SqliteStorage {
 fn test_simple_sync_channels() {
     use crate::persist::test_utils;
 
-    let storage = SqliteStorage::from_file(test_utils::create_test_sql_file("cache".to_string()));
+    let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
 
     storage.init().unwrap();
     let channels = vec![
@@ -154,7 +154,7 @@ fn test_simple_sync_channels() {
 fn test_sync_closed_channels() {
     use crate::persist::test_utils;
 
-    let storage = SqliteStorage::from_file(test_utils::create_test_sql_file("cache".to_string()));
+    let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
 
     storage.init().unwrap();
     let channels = vec![

--- a/libs/sdk-core/src/persist/mod.rs
+++ b/libs/sdk-core/src/persist/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod db;
 pub(crate) mod migrations;
 pub(crate) mod settings;
 pub(crate) mod swap;
+pub(crate) mod sync;
 pub(crate) mod transactions;
 
 #[cfg(test)]

--- a/libs/sdk-core/src/persist/mod.rs
+++ b/libs/sdk-core/src/persist/mod.rs
@@ -4,21 +4,23 @@ pub(crate) mod db;
 pub(crate) mod migrations;
 pub(crate) mod settings;
 pub(crate) mod swap;
-pub(crate) mod sync;
 pub(crate) mod transactions;
 
 #[cfg(test)]
 mod test_utils {
+    use std::fs;
+
     use rand::Rng;
 
-    pub fn create_test_sql_file(suffix: String) -> String {
+    pub fn create_test_sql_dir() -> String {
         let mut tmp_file = std::env::temp_dir();
         let mut rng = rand::thread_rng();
-        tmp_file.push(format!("test_{}{}.sql", suffix, rng.gen::<u32>()));
+        tmp_file.push(rng.gen::<u32>().to_string());
         let path = tmp_file.as_path();
         if path.exists() {
             std::fs::remove_file(path).unwrap();
         }
+        fs::create_dir_all(&tmp_file).unwrap();
         let s = path.to_str().unwrap();
         String::from(s)
     }

--- a/libs/sdk-core/src/persist/settings.rs
+++ b/libs/sdk-core/src/persist/settings.rs
@@ -64,8 +64,7 @@ impl SqliteStorage {
 fn test_settings() {
     use crate::persist::test_utils;
 
-    let storage =
-        SqliteStorage::from_file(test_utils::create_test_sql_file("settings".to_string()));
+    let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
     storage.init().unwrap();
     storage
         .update_setting("key1".to_string(), "val1".to_string())

--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -10,7 +10,7 @@ impl SqliteStorage {
         let tx = con.transaction()?;
 
         tx.execute("
-         INSERT INTO swaps (
+         INSERT INTO sync.swaps (
            bitcoin_address, 
            created_at, 
            lock_height, 
@@ -116,7 +116,7 @@ impl SqliteStorage {
         refund_tx_id: String,
     ) -> Result<()> {
         self.get_connection()?.execute(
-            "INSERT INTO swap_refunds (bitcoin_address, refund_tx_id) VALUES(:bitcoin_address, :refund_tx_id)",
+            "INSERT INTO sync.swap_refunds (bitcoin_address, refund_tx_id) VALUES(:bitcoin_address, :refund_tx_id)",
             named_params! {
              ":bitcoin_address": bitcoin_address,
              ":refund_tx_id": refund_tx_id,
@@ -170,13 +170,13 @@ impl SqliteStorage {
              unconfirmed_sats as unconfirmed_sats,
              confirmed_sats as confirmed_sats,
              status as status,             
-             (SELECT json_group_array(refund_tx_id) FROM swap_refunds where bitcoin_address = swaps.bitcoin_address) as refund_tx_ids,
+             (SELECT json_group_array(refund_tx_id) FROM sync.swap_refunds as swap_refunds where bitcoin_address = swaps.bitcoin_address) as refund_tx_ids,
              unconfirmed_tx_ids as unconfirmed_tx_ids,
              confirmed_tx_ids as confirmed_tx_ids,
              last_redeem_error as last_redeem_error               
-            FROM swaps 
+            FROM sync.swaps as swaps
              LEFT JOIN swaps_info ON swaps.bitcoin_address = swaps_info.bitcoin_address
-             LEFT JOIN swap_refunds ON swaps.bitcoin_address = swap_refunds.bitcoin_address
+             LEFT JOIN sync.swap_refunds as swap_refunds ON swaps.bitcoin_address = swap_refunds.bitcoin_address
             WHERE {}
             ",
             where_clause
@@ -228,15 +228,23 @@ impl SqliteStorage {
     }
 
     fn sql_row_to_swap(&self, row: &Row) -> Result<SwapInfo, rusqlite::Error> {
-        let status: i32 = row.get("status")?;
+        let status: i32 = row
+            .get::<&str, Option<i32>>("status")?
+            .unwrap_or(SwapStatus::Initial as i32);
         let status: SwapStatus = status.try_into().map_or(SwapStatus::Initial, |v| v);
-        let refund_txs_raw: String = row.get("refund_tx_ids")?;
+        let refund_txs_raw: String = row
+            .get::<&str, Option<String>>("refund_tx_ids")?
+            .unwrap_or("[]".to_string());
         let refund_tx_ids: Vec<String> = serde_json::from_str(refund_txs_raw.as_str()).unwrap();
         // let t: Vec<String> =
         //     serde_json::from_value(refund_txs_raw).map_err(|e| FromSqlError::InvalidType)?;
 
-        let unconfirmed_tx_ids: StringArray = row.get("unconfirmed_tx_ids")?;
-        let confirmed_txs_raw: StringArray = row.get("confirmed_tx_ids")?;
+        let unconfirmed_tx_ids: StringArray = row
+            .get::<&str, Option<StringArray>>("unconfirmed_tx_ids")?
+            .unwrap_or(StringArray(vec![]));
+        let confirmed_txs_raw: StringArray = row
+            .get::<&str, Option<StringArray>>("confirmed_tx_ids")?
+            .unwrap_or(StringArray(vec![]));
         Ok(SwapInfo {
             bitcoin_address: row.get("bitcoin_address")?,
             created_at: row.get("created_at")?,
@@ -248,9 +256,15 @@ impl SqliteStorage {
             swapper_public_key: row.get("swapper_public_key")?,
             script: row.get("script")?,
             bolt11: row.get("bolt11")?,
-            paid_sats: row.get("paid_sats")?,
-            unconfirmed_sats: row.get("unconfirmed_sats")?,
-            confirmed_sats: row.get("confirmed_sats")?,
+            paid_sats: row
+                .get::<&str, Option<u32>>("paid_sats")?
+                .unwrap_or_default(),
+            unconfirmed_sats: row
+                .get::<&str, Option<u32>>("unconfirmed_sats")?
+                .unwrap_or_default(),
+            confirmed_sats: row
+                .get::<&str, Option<u32>>("confirmed_sats")?
+                .unwrap_or_default(),
             status,
             refund_tx_ids,
             unconfirmed_tx_ids: unconfirmed_tx_ids.0,

--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -287,7 +287,7 @@ fn test_swaps() -> Result<(), Box<dyn std::error::Error>> {
             .collect())
     }
 
-    let storage = SqliteStorage::from_file(test_utils::create_test_sql_file("swap".to_string()));
+    let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
 
     storage.init()?;
     let tested_swap_info = SwapInfo {

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -310,8 +310,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
             },
         },
     ];
-    let storage =
-        SqliteStorage::from_file(test_utils::create_test_sql_file("transactions".to_string()));
+    let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
     storage.init()?;
     storage.insert_payments(&txs)?;
     storage.insert_lnurl_payment_external_info(

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -57,7 +57,7 @@ impl SqliteStorage {
         let con = self.get_connection()?;
         let mut prep_statement = con.prepare(
             "
-         INSERT OR REPLACE INTO payments_external_info (
+         INSERT OR REPLACE INTO sync.payments_external_info (
            payment_id,
            lnurl_success_action,
            lnurl_metadata,
@@ -112,7 +112,7 @@ impl SqliteStorage {
              e.lnurl_metadata,
              e.ln_address
             FROM payments p
-            LEFT JOIN payments_external_info e
+            LEFT JOIN sync.payments_external_info e
             ON
              p.id = e.payment_id
             {where_clause} ORDER BY payment_time DESC
@@ -149,7 +149,7 @@ impl SqliteStorage {
                  e.lnurl_metadata,
                  e.ln_address
                 FROM payments p
-                LEFT JOIN payments_external_info e
+                LEFT JOIN sync.payments_external_info e
                 ON
                  p.id = e.payment_id
                 WHERE

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -398,7 +398,7 @@ impl BTCReceiveSwap {
         let payment = self
             .persister
             .get_payment_by_hash(&hex::encode(swap_info.payment_hash.clone()))?;
-        print!(
+        debug!(
             "found payment for hash {:?}, {:?}",
             &hex::encode(swap_info.payment_hash.clone()),
             payment

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -481,7 +481,7 @@ pub fn create_test_config() -> crate::models::Config {
 }
 
 pub fn create_test_persister(config: crate::models::Config) -> crate::persist::db::SqliteStorage {
-    crate::persist::db::SqliteStorage::new(config.working_dir.clone())
+    crate::persist::db::SqliteStorage::new(config.working_dir)
 }
 
 pub fn get_test_working_dir() -> String {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -481,8 +481,7 @@ pub fn create_test_config() -> crate::models::Config {
 }
 
 pub fn create_test_persister(config: crate::models::Config) -> crate::persist::db::SqliteStorage {
-    let storage_path = format!("{}/storage.sql", config.working_dir);
-    crate::persist::db::SqliteStorage::from_file(storage_path)
+    crate::persist::db::SqliteStorage::new(config.working_dir.clone())
 }
 
 pub fn get_test_working_dir() -> String {

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "tempfile",
  "tiny-bip39",
  "tokio",
  "tonic",
@@ -979,9 +980,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "1.71.1"
+version = "1.75.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08359c8042886dc6e3391d10bf96d80177a6ea091025174519da55a72d86aa25"
+checksum = "f29eab4bcef83a8266245c863fdbe5bce9180f17810b24d55b8ff7b358859ada"
 dependencies = [
  "allo-isolate",
  "anyhow",


### PR DESCRIPTION
This PR splits the main database into two databases.
storage.sql - the main database that contains mostly cache data.
sync_storage.sql - this database contains data that should sync across multiple apps.

We are using "ATTACH DATABASE" sqlite command to include the attach the sync database so we can use it in queries with the same sqlite connection.