### PR TITLE
Fix iOS aarch64 target

### DIFF
--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -20,8 +20,7 @@ ios-universal: $(SOURCES)
 	mkdir -p ../target/ios-universal/release
 	cargo build --release --target aarch64-apple-ios ;\
 	cargo build --release --target x86_64-apple-ios ;\
-	cargo build --release --target aarch64-apple-ios-sim ;\
-	lipo -create -output ../target/ios-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a
+	lipo -create -output ../target/ios-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-ios/release/libbreez_sdk_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a
 
 darwin-universal: $(SOURCES)
 	mkdir -p ../target/darwin-universal/release

--- a/libs/sdk-react-native/package.json
+++ b/libs/sdk-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@breeztech/react-native-breez-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "React Native Breez SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Includes aarch64-apple-ios in the ios-universal target instead of aarch64-apple-ios-sim