### PR TITLE
Add Maven publishing for Android bindings

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,0 +1,38 @@
+name: Publish Breez SDK to Breez Maven Repository
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'breez-sdk repo release (MAJOR.MINOR.PATCH)'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install required dependencies
+        run: |
+          brew install protobuf
+          cargo install --version 0.22.0 uniffi_bindgen
+          cargo install cargo-ndk
+      - name: Checkout breez-sdk repo
+        uses: actions/checkout@v3
+        with:
+          path: build
+          ref: ${{ inputs.version }}
+      - name: Build local Android project
+        working-directory: build/libs/sdk-bindings
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.REPO_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          sudo chmod 600 ~/.ssh/id_rsa
+          ssh-add ~/.ssh/id_rsa
+          make init
+          make bindings-android
+      - name: Publish to Breez Maven Repository
+        working-directory: build/libs/sdk-bindings/bindings-android
+        run: |
+          ./gradlew publish -PbreezReposiliteUsername=${{ secrets.BREEZ_MVN_USERNAME }} -PbreezReposilitePassword=${{ secrets.BREEZ_MVN_PASSWORD }} -PlibraryVersion=${{ inputs.version }}

--- a/libs/sdk-bindings/README.md
+++ b/libs/sdk-bindings/README.md
@@ -45,7 +45,31 @@ make bindings-swift
 
 ### Kotlin
 
-### Libraries and Bindings
+For most users, we recommend integrating the Breez SDK as Gradle dependency from [our Maven repository](https://mvn.breez.technology/releases).
+
+To do so, add the following to your Gradle dependencies:
+
+``` groovy
+repositories {
+  maven {
+      url("https://mvn.breez.technology/releases")
+  }
+}
+
+dependencies {
+  implementation("breez_sdk:bindings-android:<version>")
+}
+```
+
+You can then import and use the Breez SDK in your app:
+
+``` kotlin
+import breez_sdk.*
+```
+
+If you want to compile from source or need more options, read on.
+
+#### Libraries and Bindings
 
 This command will build libraries for different platforms in `../target/` and copy them to `ffi/kotlin/jniLibs`.
 In addition it will generate Kotlin bindings in `ffi/kotlin/breez-sdk`.
@@ -54,7 +78,7 @@ In addition it will generate Kotlin bindings in `ffi/kotlin/breez-sdk`.
 make kotlin
 ```
 
-### Android Archive (AAR)
+#### Android Archive (AAR)
 
 This command will build an AAR file in `ffi/android/lib-release.aar`:
 
@@ -63,6 +87,23 @@ make bindings-android
 ```
 
 See [Add your AAR or JAR as a dependency](https://developer.android.com/studio/projects/android-library#psd-add-aar-jar-dependency) in Android's docs for more information on how to integrate such an archive into your project.
+
+#### Known Issues
+
+The Kotlin bindings for the Breez SDK rely on [JNA](https://github.com/java-native-access/jna) to call native methods. JNA 5.7 or greater is required. Depending on the JVM version you use, you might not have the JNA dependency in your classpath. The exception thrown will be something like:
+
+```
+class file for com.sun.jna.Pointer not found
+```
+
+The solution is to add JNA as a dependency:
+
+```
+dependencies {
+    // ...
+    implementation "net.java.dev.jna:jna:5.7.0@aar"
+}
+```
 
 ### C#
 

--- a/libs/sdk-bindings/bindings-android/.gitignore
+++ b/libs/sdk-bindings/bindings-android/.gitignore
@@ -45,4 +45,4 @@ gen-external-apklibs
 # End of https://www.toptal.com/developers/gitignore/api/android
 
 lib/src/main/jniLibs/
-lib/src/main/kotlin/
+lib/src/main/kotlin/breez_sdk

--- a/libs/sdk-bindings/bindings-android/gradle.properties
+++ b/libs/sdk-bindings/bindings-android/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.0.1

--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android") version "1.6.10"
+    id("maven-publish")
 }
 
 repositories {
@@ -23,6 +24,12 @@ android {
             proguardFiles(file("proguard-android-optimize.txt"), file("proguard-rules.pro"))
         }
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
@@ -30,4 +37,47 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("androidx.appcompat:appcompat:1.4.0")
     implementation("androidx.core:core-ktx:1.7.0")
+}
+
+val libraryVersion: String by project
+
+afterEvaluate {
+    publishing {
+        repositories {
+            maven {
+                name = "breezReposilite"
+                url = uri("https://mvn.breez.technology/releases")
+                credentials(PasswordCredentials::class)
+                authentication {
+                    create<BasicAuthentication>("basic")
+                }
+            }
+        }
+        publications {
+            create<MavenPublication>("maven") {
+                groupId = "breez_sdk"
+                artifactId = "bindings-android"
+                version = libraryVersion
+
+                from(components["release"])
+
+                pom {
+                    name.set("breez-sdk")
+                    description.set("The Breez SDK enables mobile developers to integrate Lightning and bitcoin payments into their apps with a very shallow learning curve.")
+                    url.set("https://breez.technology")
+                    licenses {
+                        license {
+                            name.set("MIT")
+                            url.set("https://github.com/breez/breez-sdk/blob/main/LICENSE")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:github.com/breez/breez-sdk-ffi.git")
+                        developerConnection.set("scm:git:ssh://github.com/breez/breez-sdk.git")
+                        url.set("https://github.com/breez/breez-sdk")
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds a GitHub workflow that publishes the Breez SDK Android bindings to the [Breez Maven repository](https://mvn.breez.technology).

- 💡 I haven't yet been able to run the workflow file. I think it needs to be on `main` first before it can be run. If it doesn't work, I'll open a second PR to fix it.
- ⚠️  We still need to add the repository credentials as GitHub secrets.
- ❓ Should we [sign](https://docs.gradle.org/current/userguide/signing_plugin.html) the releases in our repo?

## Usage

With this setup, integrating the Breez SDK into your Android app will be as simple as adding the Breez repo to your `build.gradle`:

```  groovy
repositories {
  // ...
  maven {
    url("https://mvn.breez.technology/releases")
  }
}
```

then adding the Breez SDK as dependency:

``` groovy
dependencies {
  // ...
  implementation 'breez_sdk:bindings-android:<version>'
}
```

and finally using the Breez SDK:

``` kotlin
import breez_sdk.*

var seed = mnemonicToSeed("(...)");
```