### PR TITLE
fix React Native example app

### DIFF
--- a/libs/sdk-react-native/example/README.md
+++ b/libs/sdk-react-native/example/README.md
@@ -8,7 +8,11 @@ or replace `INSERT_YOUR_BREEZ_API_KEY` in the following files:
 * `ios/Secrets.xconfig`
 
 ## Build
-First build the node modules in the example directory:
+Since the example app uses the Breez SDK react native plugin as a local file reference, you need to build the node_modules in the sdk-react-native directory:
+```
+yarn
+```
+Then build the node modules in the example directory:
 ```
 yarn
 ```

--- a/libs/sdk-react-native/example/android/app/build.gradle
+++ b/libs/sdk-react-native/example/android/app/build.gradle
@@ -261,7 +261,7 @@ android {
 }
 
 dependencies {
-    implementation project(':react-native-breez-sdk')
+    implementation project(':@breeztech_react-native-breez-sdk')
 
     implementation project(':react-native-build-config')
 

--- a/libs/sdk-react-native/example/android/settings.gradle
+++ b/libs/sdk-react-native/example/android/settings.gradle
@@ -3,8 +3,8 @@ apply from: file("../node_modules/@react-native-community/cli-platform-android/n
 include ':app'
 includeBuild('../node_modules/react-native-gradle-plugin')
 
-include ':react-native-breez-sdk'
-project(':react-native-breez-sdk').projectDir = new File(rootProject.projectDir, '../../android')
+include ':@breeztech_react-native-breez-sdk'
+project(':@breeztech_react-native-breez-sdk').projectDir = new File(rootProject.projectDir, '../node_modules/@breeztech/react-native-breez-sdk/android')
 
 include ':react-native-build-config'
 project(':react-native-build-config').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-build-config/android')


### PR DESCRIPTION
This PR fixes the example app to reference the react native plugin from the node_modules directory and not from the parent directory.
Updated the docs also to include a step that builds the parent directory node modules.