### PR TITLE
Add parse command to CLI app

### DIFF
--- a/libs/sdk-bindings/tests/test_generated_bindings.rs
+++ b/libs/sdk-bindings/tests/test_generated_bindings.rs
@@ -22,7 +22,10 @@ fn test_csharp() {
 #[test]
 fn test_golang() {
     let output = Command::new("go")
-        .env("CGO_LDFLAGS", "-lbreez_sdk_bindings -L../../../ffi/golang -lm -ldl")
+        .env(
+            "CGO_LDFLAGS",
+            "-lbreez_sdk_bindings -L../../../ffi/golang -lm -ldl",
+        )
         .env("CGO_ENABLED", "1")
         .current_dir("tests/bindings/golang/")
         .arg("run")

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -336,7 +336,7 @@ fn lnurl_decode(encoded: &str) -> Result<(String, String, bool)> {
 }
 
 /// Different kinds of inputs supported by [parse], including any relevant details extracted from the input
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum InputType {
     /// # Supported standards
     ///
@@ -445,7 +445,7 @@ pub struct LnUrlErrorData {
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
 /// See https://github.com/lnurl/luds/blob/luds/06.md
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LnUrlPayRequestData {
     pub callback: String,
@@ -498,7 +498,7 @@ impl LnUrlPayRequestData {
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
 /// See https://github.com/lnurl/luds/blob/luds/03.md
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LnUrlWithdrawRequestData {
     pub callback: String,
@@ -527,7 +527,7 @@ impl LnUrlWithdrawRequestData {
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
 /// See https://github.com/lnurl/luds/blob/luds/04.md
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct LnUrlAuthRequestData {
     /// Hex encoded 32 bytes of challenge
     pub k1: String,
@@ -554,7 +554,7 @@ pub struct MetadataItem {
 }
 
 /// Wrapped in a [BitcoinAddress], this is the result of [parse] when given a plain or BIP-21 BTC address.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct BitcoinAddressData {
     pub address: String,
     pub network: crate::models::Network,

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -148,7 +148,7 @@ mod crypt;
 mod fiat;
 mod greenlight;
 mod grpc;
-mod input_parser;
+pub mod input_parser;
 mod invoice;
 mod lnurl;
 mod lsp;

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -182,7 +182,7 @@ pub struct GreenlightCredentials {
 }
 
 /// The different supported bitcoin networks
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub enum Network {
     /// Mainnet
     Bitcoin,

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -113,6 +113,10 @@ pub(crate) async fn handle_command(
             sdk()?.sync().await?;
             Ok("Sync finished succesfully".to_string())
         }
+        Commands::Parse { input } => parse(&input)
+            .await
+            .map(|res| serde_json::to_string_pretty(&res))?
+            .map_err(|e| e.into()),
         Commands::ReceivePayment {
             amount,
             description,

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -34,6 +34,12 @@ pub(crate) enum Commands {
     /// Sync local data with remote node
     Sync {},
 
+    /// Parse a generic string to get its type and relevant metadata
+    Parse {
+        /// Generic input (URL, LNURL, BIP-21 BTC Address, LN invoice, etc)
+        input: String,
+    },
+
     /// Generate a bolt11 invoice
     ReceivePayment { amount: u64, description: String },
 


### PR DESCRIPTION
Adds the `parse` command, exposing our input parser.

Sample outputs:

URL:
```
sdk> parse https://breez.technology/
{
  "Url": {
    "url": "https://breez.technology/"
  }
}
```

Withdraw:
```
sdk> parse lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHW6T5DPJ8YCTH8AEK2UMND9HKU0FCX5CNWEFKXUCRWDPJVYCRQVNZXCCNWCF38Y6XGDE5XPJK2CEHXE3R2EFHVVMXVENPX3JNQENZXPNXGDE58Q6NJVMZXFSN2DEN8YCRXEL24D0
{
  "LnUrlWithdraw": {
    "data": {
      "callback": "https://lnurl.fiatjaf.com/lnurl-withdraw/callback/8517e670742a002b617a194d740eec76b5e7c6ffa4e0fb0fd748593b2a573903",
      "k1": "a08120c8bcd9d521f7d1cc7d6c3fe136fcdca898e2ee3654e1af09370bf2c650",
      "defaultDescription": "sample withdraw",
      "minWithdrawable": 2000,
      "maxWithdrawable": 8000
    }
  }
}
```