### PR TITLE
CLI: Print bolt11 as QR to console on `receive_payment`

### DIFF
--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "hex",
  "log",
  "once_cell",
+ "qrcode-rs",
  "rustyline",
  "serde",
  "serde_json",
@@ -2196,6 +2197,12 @@ checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
  "prost 0.11.8",
 ]
+
+[[package]]
+name = "qrcode-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61095296b64ff214ce25eb3c5de8e804833ed8deb7a73dd5d2c68850b8ef671"
 
 [[package]]
 name = "querystring"

--- a/tools/sdk-cli/Cargo.toml
+++ b/tools/sdk-cli/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "*"
 hex = "*"
 log = "*"
 once_cell = "*"
+qrcode-rs = { version = "0.1", default-features = false }
 rustyline = "10.0.0"
 serde_json = "1.0"
 tiny-bip39 = "*"

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -139,9 +139,11 @@ pub(crate) async fn handle_command(
             amount,
             description,
         } => {
-            let res = sdk()?.receive_payment(amount, description).await?;
-            info!("{:?}", res);
-            Ok(build_qr_text(&res.bolt11))
+            let invoice = sdk()?.receive_payment(amount, description).await?;
+            let mut result = serde_json::to_string(&invoice)?;
+            result.push('\n');
+            result.push_str(&build_qr_text(&invoice.bolt11));
+            Ok(result)
         }
         Commands::SendPayment { bolt11, amount } => {
             let payment = sdk()?.send_payment(bolt11, amount).await?;


### PR DESCRIPTION
In addition to printing the `LNInvoice`, `receive_payment` now also prints the BOLT11 as a QR code in the console.