### PR TITLE
flutter: add credentials to registerNode

### DIFF
--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -70,11 +70,15 @@ class BreezBridge {
     required Config config,
     required Network network,
     required Uint8List seed,
+    String? inviteCode,
+    GreenlightCredentials? registerCredentials,
   }) async {
     var creds = await _lnToolkit.registerNode(
       config: config,
       network: network,
       seed: seed,
+      inviteCode: inviteCode,
+      registerCredentials: registerCredentials,
     );
     await fetchNodeData();
     return creds;


### PR DESCRIPTION
Greenlight requires a single-use invite code to register a node now. Add the invite code as a parameter to the `registerNode` call, or Greenlight credentials.