### PR TITLE
Support min iOS v14 on swift package

### DIFF
--- a/libs/sdk-bindings/bindings-swift/Package.swift
+++ b/libs/sdk-bindings/bindings-swift/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "bindings-swift",
     platforms: [
         .macOS(.v12),
-        .iOS(.v15),
+        .iOS(.v14),
     ],
     products: [
         .library(name: "BreezSDK", targets: ["breez_sdkFFI", "BreezSDK"]),


### PR DESCRIPTION
Hi, I am using breez-sdk on iOS as SPM dependency and it works like a charm.
It works good on iOS v14, too.

Following comments on https://github.com/breez/breez-sdk-swift/pull/6 , open PR to setup iOS v14 as min supported platform. Hoping there are no constrains.

thanks