### PR TITLE
Remove unexpected file from gitignore

### DIFF
--- a/libs/sdk-bindings/bindings-android/.gitignore
+++ b/libs/sdk-bindings/bindings-android/.gitignore
@@ -46,4 +46,3 @@ gen-external-apklibs
 
 lib/src/main/jniLibs/
 lib/src/main/kotlin/breez_sdk
-lib/src/main/kotlin/breez_sdk.kt


### PR DESCRIPTION
Removes a file that is not expected to ever be generated but will cause problems if it is there for some reason from the gititnore. That way one can immediately see that something changed. See [this discussion](https://breez-tech.slack.com/archives/C03D0DVDDQU/p1685974506226449) for more context.