### PR TITLE
Implement multi-app sync

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -479,6 +479,7 @@ dependencies = [
  "lightning",
  "lightning-invoice",
  "log",
+ "miniz_oxide 0.7.1",
  "mockito",
  "once_cell",
  "openssl",
@@ -1723,6 +1724,15 @@ name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -232,6 +232,11 @@ interface BreezEvent {
     BackupFailed(BackupFailedData details);
 };
 
+dictionary BackupStatus {
+    boolean backed_up;
+    u64? last_backup_time;
+};
+
 callback interface LogStream {
     void log(LogEntry l);
 };
@@ -415,6 +420,12 @@ interface BlockingBreezServices {
 
    [Throws=SDKError]
    NodeState? node_info();
+
+   [Throws=SDKError]
+   BackupStatus backup_status();
+
+   [Throws=SDKError]
+   void start_backup();
 
    [Throws=SDKError]
    sequence<Payment> list_payments(PaymentTypeFilter filter, i64? from_timestamp, i64? to_timestamp);

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -216,6 +216,10 @@ dictionary PaymentFailedData {
     LNInvoice? invoice;
 };
 
+dictionary BackupFailedData {
+    string error;    
+};
+
 [Enum]
 interface BreezEvent {
     NewBlock(u32 block);
@@ -223,6 +227,9 @@ interface BreezEvent {
     Synced();
     PaymentSucceed(Payment details);
     PaymentFailed(PaymentFailedData details);
+    BackupStarted();
+    BackupSucceeded(); 
+    BackupFailed(BackupFailedData details);
 };
 
 callback interface LogStream {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use breez_sdk_core::{
     mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
     parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BackupFailedData,
-    BitcoinAddressData, BreezEvent, BreezServices, BuyBitcoinProvider, ChannelState,
+    BackupStatus, BitcoinAddressData, BreezEvent, BreezServices, BuyBitcoinProvider, ChannelState,
     ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType, EventListener,
     FeeratePreset, FiatCurrency, GreenlightCredentials, InputType, InvoicePaidDetails, LNInvoice,
     LnPaymentDetails, LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData,
@@ -180,6 +180,14 @@ impl BlockingBreezServices {
 
     pub fn node_info(&self) -> Result<Option<NodeState>, SDKError> {
         self.breez_services.node_info().map_err(|e| e.into())
+    }
+
+    pub fn backup_status(&self) -> Result<BackupStatus, SDKError> {
+        self.breez_services.backup_status().map_err(|e| e.into())
+    }
+
+    pub fn start_backup(&self) -> Result<(), SDKError> {
+        self.breez_services.start_backup().map_err(|e| e.into())
     }
 
     pub fn list_payments(

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -4,16 +4,17 @@ use anyhow::Result;
 
 use breez_sdk_core::{
     mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
-    parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BitcoinAddressData,
-    BreezEvent, BreezServices, BuyBitcoinProvider, ChannelState, ClosedChannelPaymentDetails,
-    Config, CurrencyInfo, EnvironmentType, EventListener, FeeratePreset, FiatCurrency,
-    GreenlightCredentials, InputType, InvoicePaidDetails, LNInvoice, LnPaymentDetails,
-    LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult,
-    LnUrlWithdrawRequestData, LocaleOverrides, LocalizedName, LogEntry, LspInformation,
-    MessageSuccessActionData, MetadataItem, Network, NodeState, Payment, PaymentDetails,
-    PaymentFailedData, PaymentType, PaymentTypeFilter, Rate, RecommendedFees, ReverseSwapInfo,
-    ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop, SuccessActionProcessed,
-    SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput, UrlSuccessActionData,
+    parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BackupFailedData,
+    BitcoinAddressData, BreezEvent, BreezServices, BuyBitcoinProvider, ChannelState,
+    ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType, EventListener,
+    FeeratePreset, FiatCurrency, GreenlightCredentials, InputType, InvoicePaidDetails, LNInvoice,
+    LnPaymentDetails, LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData,
+    LnUrlPayRequestData, LnUrlPayResult, LnUrlWithdrawRequestData, LocaleOverrides, LocalizedName,
+    LogEntry, LspInformation, MessageSuccessActionData, MetadataItem, Network, NodeState, Payment,
+    PaymentDetails, PaymentFailedData, PaymentType, PaymentTypeFilter, Rate, RecommendedFees,
+    ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
+    SuccessActionProcessed, SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput,
+    UrlSuccessActionData,
 };
 use log::LevelFilter;
 use log::Metadata;

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -34,6 +34,7 @@ rusqlite = { version = "0.28.0", features = [
     "bundled",
     "load_extension",
     "backup",
+    "hooks",
 ] }
 rusqlite_migration = "*"
 reqwest = { version = "0.11", features = ["json"] }
@@ -41,6 +42,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tonic = { version = "^0.8", features = [
     "tls",
+    "transport",
     "tls-roots",
     "tls-webpki-roots",
 ] }

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -56,6 +56,7 @@ strum = "0.24.1"
 strum_macros = "0.24.1"
 tempfile = "3"
 const_format = "*"
+miniz_oxide = "0.7.1"
 
 [dev-dependencies]
 futures = "0.3.28"

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -312,7 +312,7 @@ mod tests {
     use crate::{
         persist::db::SqliteStorage,
         test_utils::{create_test_config, create_test_persister, MockBackupTransport},
-        BreezEvent, ReverseSwapInfo, SwapInfo,
+        BreezEvent, FullReverseSwapInfo, SwapInfo,
     };
     use std::{sync::Arc, vec};
     use tokio::sync::broadcast::Receiver;
@@ -533,7 +533,7 @@ mod tests {
         tokio::spawn(async move {
             sleep(Duration::from_millis(20)).await;
             populate_sync_table(persister.clone());
-            sleep(Duration::from_millis(20)).await;
+            sleep(Duration::from_millis(1000)).await;
             persister
                 .get_connection()
                 .unwrap()
@@ -542,7 +542,6 @@ mod tests {
                     [],
                 )
                 .unwrap();
-            sleep(Duration::from_millis(100)).await;
             persister.set_last_sync_version(10, &vec![]).unwrap();
             persister.add_sync_request().unwrap();
         });
@@ -576,7 +575,7 @@ mod tests {
             max_allowed_deposit: 100,
             last_redeem_error: None,
         };
-        let rev_swap = ReverseSwapInfo {
+        let rev_swap = FullReverseSwapInfo {
             id: "1".into(),
             created_at_block_height: 10,
             preimage: vec![1],

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -592,7 +592,7 @@ mod tests {
             },
         };
 
-        persister.insert_swap(tested_swap_info.clone()).unwrap();
+        persister.insert_swap(tested_swap_info).unwrap();
         persister.insert_reverse_swap(&rev_swap).unwrap();
         persister
             .insert_lnurl_payment_external_info(

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1394,7 +1394,7 @@ pub(crate) mod tests {
             .fiat_api(Arc::new(MockBreezServer {}))
             .node_api(node_api)
             .persister(persister)
-            .backup_transport(Arc::new(MockBackupTransport {}))
+            .backup_transport(Arc::new(MockBackupTransport::new()))
             .build(None)
             .await?;
 
@@ -1548,7 +1548,7 @@ pub(crate) mod tests {
             .moonpay_api(Arc::new(MockBreezServer {}))
             .persister(persister)
             .node_api(node_api)
-            .backup_transport(Arc::new(MockBackupTransport {}))
+            .backup_transport(Arc::new(MockBackupTransport::new()))
             .build(None)
             .await
             .unwrap();

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -28,7 +28,6 @@ use crate::moonpay::MoonPayApi;
 use crate::persist::db::SqliteStorage;
 use crate::reverseswap::BTCSendSwap;
 use crate::swap::BTCReceiveSwap;
-use crate::sync_storage::{watch_and_sync, SyncTransport};
 use crate::BuyBitcoinProvider::Moonpay;
 use crate::*;
 use crate::{BuyBitcoinProvider, LnUrlAuthRequestData, LnUrlWithdrawRequestData, PaymentResponse};

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 // Section: imports
 
+use crate::breez_services::BackupFailedData;
 use crate::breez_services::BreezEvent;
 use crate::breez_services::InvoicePaidDetails;
 use crate::breez_services::PaymentFailedData;
@@ -737,6 +738,13 @@ impl support::IntoDart for AesSuccessActionDataDecrypted {
 }
 impl support::IntoDartExceptPrimitive for AesSuccessActionDataDecrypted {}
 
+impl support::IntoDart for BackupFailedData {
+    fn into_dart(self) -> support::DartAbi {
+        vec![self.error.into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for BackupFailedData {}
+
 impl support::IntoDart for BitcoinAddressData {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -759,6 +767,9 @@ impl support::IntoDart for BreezEvent {
             Self::Synced => vec![2.into_dart()],
             Self::PaymentSucceed { details } => vec![3.into_dart(), details.into_dart()],
             Self::PaymentFailed { details } => vec![4.into_dart(), details.into_dart()],
+            Self::BackupStarted => vec![5.into_dart()],
+            Self::BackupSucceeded => vec![6.into_dart()],
+            Self::BackupFailed { details } => vec![7.into_dart(), details.into_dart()],
         }
         .into_dart()
     }

--- a/libs/sdk-core/src/greenlight/backup_transport.rs
+++ b/libs/sdk-core/src/greenlight/backup_transport.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use gl_client::{node, pb};
 use std::sync::Arc;
 
-const BREEZ_SDK_DATASTORE_PATH: [&str; 2] = ["breez-sdk", "sync3"];
+const BREEZ_SDK_DATASTORE_PATH: [&str; 2] = ["breez-sdk", "backup"];
 
 pub(crate) struct GLBackupTransport {
     pub(crate) inner: Arc<Greenlight>,

--- a/libs/sdk-core/src/greenlight/mod.rs
+++ b/libs/sdk-core/src/greenlight/mod.rs
@@ -1,0 +1,4 @@
+mod node_api;
+mod state_sync;
+pub(crate) use node_api::Greenlight;
+pub(crate) use state_sync::GLSyncTransport;

--- a/libs/sdk-core/src/greenlight/mod.rs
+++ b/libs/sdk-core/src/greenlight/mod.rs
@@ -1,4 +1,4 @@
+mod backup_transport;
 mod node_api;
-mod state_sync;
+pub(crate) use backup_transport::GLBackupTransport;
 pub(crate) use node_api::Greenlight;
-pub(crate) use state_sync::GLSyncTransport;

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -208,6 +208,7 @@ impl NodeAPI for Greenlight {
 
     // implemenet pull changes from greenlight
     async fn pull_changed(&self, since_timestamp: i64) -> Result<SyncResponse> {
+        info!("pull changed since {}", since_timestamp);
         let mut client = self.get_client().await?;
 
         // list all peers

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -114,7 +114,7 @@ impl Greenlight {
         Ok(client)
     }
 
-    async fn get_node_client(&self) -> Result<node::ClnClient> {
+    pub(crate) async fn get_node_client(&self) -> Result<node::ClnClient> {
         let client: node::ClnClient = self
             .scheduler()
             .await?

--- a/libs/sdk-core/src/greenlight/state_sync.rs
+++ b/libs/sdk-core/src/greenlight/state_sync.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use gl_client::{node, pb};
 use std::sync::Arc;
 
-const BREEZ_SDK_DATASTORE_PATH: [&str; 2] = ["breez-sdk", "sync"];
+const BREEZ_SDK_DATASTORE_PATH: [&str; 2] = ["breez-sdk", "sync2"];
 
 pub(crate) struct GLSyncTransport {
     pub(crate) inner: Arc<Greenlight>,
@@ -26,10 +26,6 @@ impl SyncTransport for GLSyncTransport {
             .await?
             .into_inner();
         let store = response.datastore;
-        info!(
-            "pull remote storage succeeded = {:?}",
-            store[0].generation.unwrap()
-        );
         match store.len() {
             0 => Ok(None),
             1 => Ok(Some(SyncState {

--- a/libs/sdk-core/src/greenlight/state_sync.rs
+++ b/libs/sdk-core/src/greenlight/state_sync.rs
@@ -1,0 +1,63 @@
+use crate::sync_storage::{SyncState, SyncTransport};
+
+use super::node_api::Greenlight;
+use anyhow::{anyhow, Result};
+use gl_client::{node, pb};
+use std::sync::Arc;
+
+const BREEZ_SDK_DATASTORE_PATH: [&str; 2] = ["breez-sdk", "sync"];
+
+pub(crate) struct GLSyncTransport {
+    pub(crate) inner: Arc<Greenlight>,
+}
+
+impl GLSyncTransport {
+    fn gl_key(&self) -> Vec<String> {
+        BREEZ_SDK_DATASTORE_PATH.map(|s| s.into()).to_vec()
+    }
+}
+#[tonic::async_trait]
+impl SyncTransport for GLSyncTransport {
+    async fn pull(&self) -> Result<Option<SyncState>> {
+        let key = self.gl_key();
+        let mut c: node::ClnClient = self.inner.get_node_client().await?;
+        let response: pb::cln::ListdatastoreResponse = c
+            .list_datastore(pb::cln::ListdatastoreRequest { key })
+            .await?
+            .into_inner();
+        let store = response.datastore;
+        info!(
+            "pull remote storage succeeded = {:?}",
+            store[0].generation.unwrap()
+        );
+        match store.len() {
+            0 => Ok(None),
+            1 => Ok(Some(SyncState {
+                generation: store[0].generation.unwrap(),
+                data: store[0].clone().hex.unwrap(),
+            })),
+            _ => Err(anyhow!("get returned multiple values")),
+        }
+    }
+
+    async fn push(&self, version: Option<u64>, hex: Vec<u8>) -> Result<u64> {
+        let key = self.gl_key();
+        info!("set_value key = {:?} data length={:?}", key, hex.len());
+        let mut c: node::ClnClient = self.inner.get_node_client().await?;
+        let mut mode = pb::cln::datastore_request::DatastoreMode::MustCreate;
+        if version.is_some() {
+            mode = pb::cln::datastore_request::DatastoreMode::MustReplace;
+        }
+        let response = c
+            .datastore(pb::cln::DatastoreRequest {
+                key,
+                string: None,
+                hex: Some(hex),
+                generation: version,
+                mode: Some(mode.into()),
+            })
+            .await?
+            .into_inner();
+        Ok(response.generation.unwrap())
+    }
+}

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::time::UNIX_EPOCH;
 
 /// Wrapper for a BOLT11 LN invoice
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct LNInvoice {
     pub bolt11: String,
     pub payee_pubkey: String,

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -148,6 +148,7 @@ mod bridge_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not
 #[macro_use]
 extern crate log;
 
+mod backup;
 pub mod binding;
 mod boltzswap;
 mod breez_services;
@@ -165,13 +166,12 @@ mod moonpay;
 mod persist;
 mod reverseswap;
 mod swap;
-mod sync_storage;
 #[cfg(test)]
 mod test_utils;
 
 pub use breez_services::{
-    mnemonic_to_seed, BreezEvent, BreezServices, EventListener, InvoicePaidDetails,
-    PaymentFailedData,
+    mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, EventListener,
+    InvoicePaidDetails, PaymentFailedData,
 };
 pub use chain::RecommendedFees;
 pub use fiat::{CurrencyInfo, FiatCurrency, LocaleOverrides, LocalizedName, Rate, Symbol};

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -165,6 +165,7 @@ mod moonpay;
 mod persist;
 mod reverseswap;
 mod swap;
+mod sync_storage;
 #[cfg(test)]
 mod test_utils;
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -531,6 +531,12 @@ impl TryFrom<i32> for FeeratePreset {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct BackupStatus {
+    pub backed_up: bool,
+    pub last_backup_time: Option<u64>,
+}
+
 /// The node state of a Greenlight LN node running in the cloud
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct NodeState {

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -41,6 +41,19 @@ impl SqliteStorage {
             None => None,
         })
     }
+
+    pub fn set_last_backup_time(&self, t: u64) -> Result<()> {
+        self.update_cached_item("last_backup_time".to_string(), t.to_string())?;
+        Ok(())
+    }
+
+    pub fn get_last_backup_time(&self) -> Result<Option<u64>> {
+        let state_str = self.get_cached_item("last_backup_time".to_string())?;
+        Ok(match state_str {
+            Some(str) => str.as_str().parse::<u64>().ok(),
+            None => None,
+        })
+    }
 }
 
 #[test]

--- a/libs/sdk-core/src/persist/db.rs
+++ b/libs/sdk-core/src/persist/db.rs
@@ -48,7 +48,7 @@ impl SqliteStorage {
 
     pub(crate) fn hook_listeners(&self) -> Vec<Arc<dyn HookListener>> {
         let listeners = self.hook_listeners.lock().unwrap();
-        return listeners.clone();
+        listeners.clone()
     }
 
     pub(crate) fn init(&self) -> Result<()> {

--- a/libs/sdk-core/src/persist/db.rs
+++ b/libs/sdk-core/src/persist/db.rs
@@ -13,7 +13,7 @@ use tokio::sync::broadcast;
 /// modifications in the persistent storage.
 #[derive(Debug, Clone)]
 pub(crate) enum HookEvent {
-    Insert { table: String },
+    Insert {},
 }
 
 pub(crate) struct SqliteStorage {
@@ -58,9 +58,9 @@ impl SqliteStorage {
 
         // We want to notify any subscribers with hook events.
         let events_publisher = self.events_publisher.clone();
-        con.update_hook(Some(move |action, db: &str, tbl: &str, _| {
+        con.update_hook(Some(move |action, db: &str, _: &str, _| {
             if action == Action::SQLITE_INSERT && db == "sync" {
-                _ = events_publisher.send(HookEvent::Insert { table: tbl.into() });
+                _ = events_publisher.send(HookEvent::Insert {});
             }
         }));
 

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -383,5 +383,37 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
          status TEXT NOT NULL
         ) STRICT;
         ",
+
+        //sync & backup
+        "
+        CREATE TABLE IF NOT EXISTS sync.sync_requests (
+         id INTEGER PRIMARY KEY AUTOINCREMENT,
+         changed_table TEXT NOT NULL
+        ) STRICT;
+
+        CREATE TRIGGER sync.sync_requests_swaps 
+         AFTER INSERT ON swaps         
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('swaps');
+        END;
+
+        CREATE TRIGGER sync.sync_requests_swap_refunds 
+         AFTER INSERT ON swap_refunds        
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('swap_refunds');
+        END;
+
+        CREATE TRIGGER sync.sync_requests_reverse_swaps
+         AFTER INSERT ON reverse_swaps        
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('reverse_swaps');
+        END;
+
+        CREATE TRIGGER sync.sync_requests_payments_external_info
+         AFTER INSERT ON payments_external_info       
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('payments_external_info');
+        END;
+        ",       
     ]
 }

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -275,6 +275,7 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        "
        CREATE TABLE IF NOT EXISTS sync_versions (
         last_version INTEGER NOT NULL,
+        data BLOB NOT NULL,
         created_at TEXT DEFAULT CURRENT_TIMESTAMP
        ) STRICT;
        ",

--- a/libs/sdk-core/src/persist/mod.rs
+++ b/libs/sdk-core/src/persist/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod migrations;
 pub(crate) mod reverseswap;
 pub(crate) mod settings;
 pub(crate) mod swap;
+pub(crate) mod sync;
 pub(crate) mod transactions;
 
 #[cfg(test)]

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -43,6 +43,14 @@ impl SqliteStorage {
         Ok(())
     }
 
+    pub fn add_sync_request(&self) -> Result<()> {
+        self.get_connection()?.execute(
+            " INSERT INTO sync_requests(changed_table) VALUES('user')",
+            [],
+        )?;
+        Ok(())
+    }
+
     pub fn import_remote_changes(&self, remote_storage: &SqliteStorage) -> Result<()> {
         let sync_data_file = remote_storage.sync_db_path();
 

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -35,7 +35,7 @@ impl SqliteStorage {
         res.map_err(anyhow::Error::msg)
     }
 
-    pub fn delete_sync_requests_up_to(&self, request_id: u64) -> Result<()> {
+    pub(crate) fn delete_sync_requests_up_to(&self, request_id: u64) -> Result<()> {
         self.get_connection()?.execute(
             "DELETE FROM sync.sync_requests where id <= ?1",
             [request_id],
@@ -43,7 +43,7 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub fn add_sync_request(&self) -> Result<()> {
+    pub(crate) fn add_sync_request(&self) -> Result<()> {
         self.get_connection()?.execute(
             " INSERT INTO sync_requests(changed_table) VALUES('user')",
             [],
@@ -51,7 +51,7 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub fn import_remote_changes(&self, remote_storage: &SqliteStorage) -> Result<()> {
+    pub(crate) fn import_remote_changes(&self, remote_storage: &SqliteStorage) -> Result<()> {
         let sync_data_file = remote_storage.sync_db_path();
 
         let mut con = self.get_connection()?;

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -1,0 +1,133 @@
+use super::db::SqliteStorage;
+use anyhow::Result;
+use std::path::Path;
+
+impl SqliteStorage {
+    pub(crate) fn backup<P: AsRef<Path>>(&self, dst_path: P) -> Result<()> {
+        self.get_connection()?
+            .backup(rusqlite::DatabaseName::Attached("sync"), dst_path, None)
+            .map_err(anyhow::Error::msg)
+    }
+
+    pub fn get_last_sync_version(&self) -> Result<Option<u64>> {
+        let res: rusqlite::Result<Option<u64>> = self.get_connection()?.query_row(
+            "SELECT max(last_version) FROM sync_versions",
+            [],
+            |row| row.get::<usize, Option<u64>>(0),
+        );
+        res.map_err(anyhow::Error::msg)
+    }
+
+    pub fn set_last_sync_version(&self, last_version: u64) -> Result<()> {
+        self.get_connection()?.execute(
+            "INSERT OR REPLACE INTO sync_versions (last_version) VALUES (?1)",
+            [last_version],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_last_sync_request(&self) -> Result<Option<u64>> {
+        let res: rusqlite::Result<Option<u64>> =
+            self.get_connection()?
+                .query_row("SELECT max(id) FROM sync.sync_requests", [], |row| {
+                    row.get::<usize, Option<u64>>(0)
+                });
+        res.map_err(anyhow::Error::msg)
+    }
+
+    pub fn delete_sync_requests_up_to(&self, request_id: u64) -> Result<()> {
+        self.get_connection()?.execute(
+            "DELETE FROM sync.sync_requests where id <= ?1",
+            [request_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn import_remote_changes(&self, remote_storage: &SqliteStorage) -> Result<()> {
+        let sync_data_file = remote_storage.sync_db_path();
+
+        let mut con = self.get_connection()?;
+        let tx = con.transaction()?;
+        tx.execute(
+            "ATTACH DATABASE ? AS remote_sync;",
+            [sync_data_file.clone()],
+        )?;
+        tx.execute("insert into sync.swaps select * from remote_sync.swaps where bitcoin_address not in (select bitcoin_address from sync.swaps);", [])?;
+        tx.execute(
+            "insert into sync.swap_refunds select * from remote_sync.swap_refunds where bitcoin_address not in (select bitcoin_address from sync.swap_refunds);",
+            [],
+        )?;
+        tx.execute(
+            "insert into sync.payments_external_info select * from remote_sync.payments_external_info where payment_id not in (select payment_id from sync.payments_external_info);",
+            [],
+        )?;
+        tx.commit()?;
+        con.execute("DETACH DATABASE remote_sync", [])?;
+        Ok(())
+    }
+}
+
+#[test]
+fn test_sync() {
+    use crate::persist::test_utils;
+    let local_storage = SqliteStorage::new(test_utils::create_test_sql_dir());
+    local_storage.init().unwrap();
+
+    let local_swap_info = crate::SwapInfo {
+        bitcoin_address: String::from("1"),
+        created_at: 0,
+        lock_height: 100,
+        payment_hash: vec![1],
+        preimage: vec![2],
+        private_key: vec![3],
+        public_key: vec![4],
+        swapper_public_key: vec![5],
+        script: vec![5],
+        bolt11: None,
+        paid_sats: 0,
+        unconfirmed_sats: 0,
+        confirmed_sats: 0,
+        status: crate::models::SwapStatus::Initial,
+        refund_tx_ids: Vec::new(),
+        unconfirmed_tx_ids: Vec::new(),
+        confirmed_tx_ids: Vec::new(),
+        min_allowed_deposit: 0,
+        max_allowed_deposit: 100,
+        last_redeem_error: None,
+    };
+    local_storage.insert_swap(local_swap_info.clone()).unwrap();
+
+    let mut remote_swap_info = local_swap_info.clone();
+    remote_swap_info.bitcoin_address = "2".into();
+    remote_swap_info.script = vec![6];
+    remote_swap_info.swapper_public_key = vec![6];
+    remote_swap_info.public_key = vec![6];
+    remote_swap_info.preimage = vec![6];
+    remote_swap_info.payment_hash = vec![6];
+    remote_swap_info.private_key = vec![6];
+
+    let remote_storage = SqliteStorage::new(test_utils::create_test_sql_dir());
+    remote_storage.init().unwrap();
+    remote_storage
+        .insert_swap(remote_swap_info.clone())
+        .unwrap();
+    remote_storage
+        .import_remote_changes(&local_storage)
+        .unwrap();
+    local_storage
+        .import_remote_changes(&remote_storage)
+        .unwrap();
+
+    let mut local_swaps = local_storage.list_swaps().unwrap();
+    local_swaps.sort_by(|s1, s2| s1.bitcoin_address.cmp(&s2.bitcoin_address));
+
+    let mut remote_swaps = local_storage.list_swaps().unwrap();
+    remote_swaps.sort_by(|s1, s2| s1.bitcoin_address.cmp(&s2.bitcoin_address));
+
+    assert_eq!(local_swaps, remote_swaps);
+    assert_eq!(local_swaps.len(), 2);
+
+    local_storage.set_last_sync_version(10).unwrap();
+    let version = local_storage.get_last_sync_version().unwrap().unwrap();
+    assert_eq!(version, 10);
+}

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -102,7 +102,7 @@ fn test_sync() {
     };
     local_storage.insert_swap(local_swap_info.clone()).unwrap();
 
-    let mut remote_swap_info = local_swap_info.clone();
+    let mut remote_swap_info = local_swap_info;
     remote_swap_info.bitcoin_address = "2".into();
     remote_swap_info.script = vec![6];
     remote_swap_info.swapper_public_key = vec![6];
@@ -113,9 +113,7 @@ fn test_sync() {
 
     let remote_storage = SqliteStorage::new(test_utils::create_test_sql_dir());
     remote_storage.init().unwrap();
-    remote_storage
-        .insert_swap(remote_swap_info.clone())
-        .unwrap();
+    remote_storage.insert_swap(remote_swap_info).unwrap();
     remote_storage
         .import_remote_changes(&local_storage)
         .unwrap();

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -43,12 +43,7 @@ impl SqliteStorage {
     pub(crate) fn sync_versions_history(&self) -> Result<Vec<SyncVersion>> {
         let con = self.get_connection()?;
         let mut stmt = con.prepare(
-            format!(
-                "
-                 SELECT created_at, last_version, data FROM sync_versions ORDER BY created_at DESC;         
-                "
-            )
-            .as_str(),
+            "SELECT created_at, last_version, data FROM sync_versions ORDER BY created_at DESC;",
         )?;
 
         let vec: Vec<SyncVersion> = stmt

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -48,10 +48,7 @@ impl SqliteStorage {
 
         let mut con = self.get_connection()?;
         let tx = con.transaction()?;
-        tx.execute(
-            "ATTACH DATABASE ? AS remote_sync;",
-            [sync_data_file.clone()],
-        )?;
+        tx.execute("ATTACH DATABASE ? AS remote_sync;", [sync_data_file])?;
         tx.execute("insert into sync.swaps select * from remote_sync.swaps where bitcoin_address not in (select bitcoin_address from sync.swaps);", [])?;
         tx.execute(
             "insert into sync.swap_refunds select * from remote_sync.swap_refunds where bitcoin_address not in (select bitcoin_address from sync.swap_refunds);",

--- a/libs/sdk-core/src/sync_storage.rs
+++ b/libs/sdk-core/src/sync_storage.rs
@@ -1,0 +1,170 @@
+use crate::persist::db::{HookEvent, HookListener, SqliteStorage};
+use anyhow::{anyhow, Result};
+use std::{
+    env::temp_dir,
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+    sync::Arc,
+};
+use tempfile::tempdir_in;
+
+// SyncState is the sdk state that requiers syncing between multiple apps.
+/// It is just a blob of data marked with a specific version (generation).
+/// The generation signals for the local state if the remote state is newer,
+/// where in that case the local state should be updated with the remote state prior to pushing
+/// any local changes.
+pub struct SyncState {
+    pub generation: u64,
+    pub data: Vec<u8>,
+}
+
+/// SyncTransport is the interface for syncing the sdk state between multiple apps.
+#[tonic::async_trait]
+pub trait SyncTransport: Send + Sync {
+    async fn pull(&self) -> Result<Option<SyncState>>;
+    async fn push(&self, version: Option<u64>, data: Vec<u8>) -> Result<u64>;
+}
+
+/// watches for sync requests and syncs the sdk state when a request is detected.
+pub(crate) fn watch_and_sync(inner: Arc<dyn SyncTransport>, persister: Arc<SqliteStorage>) {
+    persister.add_hook_listener(Arc::new(SyncStorageListener {
+        inner: inner.clone(),
+        persister: persister.clone(),
+    }))
+}
+
+/// SyncStorageListener is a hook listener that syncs the sdk state when a sync request is detected.
+/// It listens to events on the sync_requests table and starts a sync when a new request is detected.
+struct SyncStorageListener {
+    inner: Arc<dyn SyncTransport>,
+    persister: Arc<SqliteStorage>,
+}
+
+impl HookListener for SyncStorageListener {
+    fn notify(&self, event: &HookEvent) {
+        match event {
+            HookEvent::Insert { table } => {
+                if table == "sync_requests" {
+                    let transport = self.inner.clone();
+                    let persister = self.persister.clone();
+                    info!("Sync request detected, starting sync");
+
+                    // spawn a new worker to sync the sdk state
+                    tokio::spawn(async move {
+                        if let Err(e) = SyncWorker::new(transport, persister).sync().await {
+                            error!("Failed to sync sdk state: {}", e);
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// SyncWorker is a worker that bidirectionaly syncs the sdk state.
+struct SyncWorker {
+    inner: Arc<dyn SyncTransport>,
+    persister: Arc<SqliteStorage>,
+}
+
+impl SyncWorker {
+    pub(crate) fn new(inner: Arc<dyn SyncTransport>, persister: Arc<SqliteStorage>) -> Self {
+        Self { inner, persister }
+    }
+    /// Syncs the sdk state with the remote state.
+    /// The process is done in 3 steps:
+    /// 1. Try to push the local state to the remote state using the current version (optimistic).
+    /// 2. If the push fails, sync the remote changes into the local changes including the remote newer version.
+    /// 3. Try to push the local state again with the new version.
+    async fn sync(&self) -> Result<()> {
+        // get the last local sync version and the last sync request id
+        let last_version = self.persister.get_last_sync_version()?;
+        let last_sync_request_id = self.persister.get_last_sync_request()?.unwrap_or_default();
+
+        // Backup the local sdk state
+        let local_storage_file = tempfile::NamedTempFile::new()?;
+        self.persister.backup(local_storage_file.path())?;
+        debug!(
+            "syncing storge, last_version = {:?}, file = {:?}",
+            last_version,
+            local_storage_file.path()
+        );
+
+        // read the backed up local data
+        let mut f = File::open(local_storage_file.path())?;
+        let mut data = vec![];
+        f.read_to_end(&mut data)?;
+
+        // Try to push with the current version, if no one else has pushed then we will succeed
+        let optimistic_sync = self.inner.push(last_version, data).await;
+
+        let sync_result = match optimistic_sync {
+            Ok(new_version) => {
+                info!("Optimistic sync succeeded, new version = {:?}", new_version);
+                Ok(new_version)
+            }
+            Err(e) => {
+                debug!(
+                    "Optimistic sync failed, trying to sync remote changes {}",
+                    e
+                );
+                // We need to sync remote changes and then retry the push
+                self.sync_remote_and_push().await
+            }
+        };
+
+        // In case we succeeded to push the local changes, we need to:
+        // 1. Delete the sync requests so.
+        // 2. Update the last sync version.
+        match sync_result {
+            Ok(new_version) => {
+                self.persister.set_last_sync_version(new_version)?;
+                self.persister
+                    .delete_sync_requests_up_to(last_sync_request_id)?;
+                info!("Sync succeeded");
+                Ok(())
+            }
+            Err(e) => {
+                error!("Sync failed: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    /// Syncs the remote changes into the local changes and then tries to push the local changes again.    
+    async fn sync_remote_and_push(&self) -> Result<u64> {
+        let remote_state = self.inner.pull().await?;
+        let tmp_dir = tempdir_in(temp_dir())?;
+        let remote_storage_path = tmp_dir.path();
+        let mut remote_storage_file = File::create(&remote_storage_path.join("sync_storage.sql"))?;
+        info!("remote_storage_path = {:?}", remote_storage_path);
+        match remote_state {
+            Some(state) => {
+                // Write the remote state to a file
+                remote_storage_file.write_all(&state.data[..])?;
+                remote_storage_file.flush()?;
+                let remote_storage = SqliteStorage::new(
+                    remote_storage_path
+                        .as_os_str()
+                        .to_str()
+                        .unwrap()
+                        .to_string(),
+                );
+
+                // Bidirectionaly sync the local and remote changes
+                self.persister.import_remote_changes(&remote_storage)?;
+                remote_storage.import_remote_changes(self.persister.as_ref())?;
+                let mut hex = vec![];
+                remote_storage_file =
+                    File::open(&Path::new(remote_storage_path).join("sync_storage.sql"))?;
+                remote_storage_file.read_to_end(&mut hex)?;
+
+                // Push the local changes again
+                let new_generation = self.inner.push(Some(state.generation), hex).await?;
+                Ok(new_generation)
+            }
+            None => Err(anyhow!("pull returned no values")),
+        }
+    }
+}

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -5,6 +5,7 @@ use bitcoin::secp256k1::ecdsa::RecoverableSignature;
 use bitcoin::secp256k1::{KeyPair, Message};
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
+use bitcoin::Network;
 use gl_client::pb::amount::Unit;
 use gl_client::pb::{
     Amount, CloseChannelResponse, CloseChannelType, Invoice, Peer, WithdrawResponse,
@@ -38,7 +39,7 @@ impl BackupTransport for MockBackupTransport {
     async fn pull(&self) -> Result<Option<BackupState>> {
         return Ok(None);
     }
-    async fn push(&self, version: Option<u64>, data: Vec<u8>) -> Result<u64> {
+    async fn push(&self, version: Option<u64>, _: Vec<u8>) -> Result<u64> {
         match version {
             Some(v) => Ok(v + 1),
             None => Ok(1),
@@ -304,7 +305,7 @@ impl NodeAPI for MockNodeAPI {
     }
 
     fn derive_bip32_key(&self, _path: Vec<ChildNumber>) -> Result<ExtendedPrivKey> {
-        Err(anyhow!("Not implemented"))
+        Ok(ExtendedPrivKey::new_master(Network::Bitcoin, &[])?)
     }
 }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -18,6 +18,7 @@ use rand::{random, Rng};
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 use tokio::sync::{mpsc, Mutex};
+use tokio::time::sleep;
 use tonic::Streaming;
 
 use crate::backup::{BackupState, BackupTransport};
@@ -37,9 +38,11 @@ pub struct MockBackupTransport {}
 #[tonic::async_trait]
 impl BackupTransport for MockBackupTransport {
     async fn pull(&self) -> Result<Option<BackupState>> {
+        sleep(Duration::from_millis(10)).await;
         return Ok(None);
     }
     async fn push(&self, version: Option<u64>, _: Vec<u8>) -> Result<u64> {
+        sleep(Duration::from_millis(10)).await;
         match version {
             Some(v) => Ok(v + 1),
             None => Ok(1),

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -27,8 +27,24 @@ use crate::lsp::LspInformation;
 use crate::models::{FiatAPI, LspAPI, NodeAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse};
 use crate::moonpay::MoonPayApi;
 use crate::swap::create_submarine_swap_script;
+use crate::sync_storage::{SyncState, SyncTransport};
 use crate::SwapInfo;
 use crate::{parse_invoice, Config, LNInvoice, PaymentResponse, RouteHint};
+
+pub struct MockSyncTransport {}
+
+#[tonic::async_trait]
+impl SyncTransport for MockSyncTransport {
+    async fn pull(&self) -> Result<Option<SyncState>> {
+        return Ok(None);
+    }
+    async fn push(&self, version: Option<u64>, data: Vec<u8>) -> Result<u64> {
+        match version {
+            Some(v) => Ok(v + 1),
+            None => Ok(1),
+        }
+    }
+}
 
 pub struct MockSwapperAPI {}
 
@@ -517,7 +533,9 @@ pub fn create_test_config() -> crate::models::Config {
     conf
 }
 
-pub fn create_test_persister(config: crate::models::Config) -> crate::persist::db::SqliteStorage {
+pub(crate) fn create_test_persister(
+    config: crate::models::Config,
+) -> crate::persist::db::SqliteStorage {
     crate::persist::db::SqliteStorage::new(config.working_dir)
 }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, SystemTime};
 use tokio::sync::{mpsc, Mutex};
 use tonic::Streaming;
 
+use crate::backup::{BackupState, BackupTransport};
 use crate::breez_services::Receiver;
 use crate::chain::{ChainService, OnchainTx, RecommendedFees};
 use crate::fiat::{FiatCurrency, Rate};
@@ -27,15 +28,14 @@ use crate::lsp::LspInformation;
 use crate::models::{FiatAPI, LspAPI, NodeAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse};
 use crate::moonpay::MoonPayApi;
 use crate::swap::create_submarine_swap_script;
-use crate::sync_storage::{SyncState, SyncTransport};
 use crate::SwapInfo;
 use crate::{parse_invoice, Config, LNInvoice, PaymentResponse, RouteHint};
 
-pub struct MockSyncTransport {}
+pub struct MockBackupTransport {}
 
 #[tonic::async_trait]
-impl SyncTransport for MockSyncTransport {
-    async fn pull(&self) -> Result<Option<SyncState>> {
+impl BackupTransport for MockBackupTransport {
+    async fn pull(&self) -> Result<Option<BackupState>> {
         return Ok(None);
     }
     async fn push(&self, version: Option<u64>, data: Vec<u8>) -> Result<u64> {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -65,7 +65,7 @@ impl BackupTransport for MockBackupTransport {
         let current_state = self.state.lock().unwrap();
 
         match current_state.clone() {
-            Some(state) => Ok(Some(state.clone())),
+            Some(state) => Ok(Some(state)),
             None => Ok(None),
         }
     }
@@ -74,7 +74,7 @@ impl BackupTransport for MockBackupTransport {
         let mut remote_version = self.remote_version.lock().unwrap();
         let mut numpushed = self.num_pushed.lock().unwrap();
         *numpushed += 1;
-        let t = *numpushed;
+
         if !remote_version.is_none() && *remote_version != version {
             return Err(anyhow!("version mismatch"));
         }

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -259,6 +259,14 @@ class AesSuccessActionDataDecrypted {
   });
 }
 
+class BackupFailedData {
+  final String error;
+
+  const BackupFailedData({
+    required this.error,
+  });
+}
+
 /// Wrapped in a [BitcoinAddress], this is the result of [parse] when given a plain or BIP-21 BTC address.
 class BitcoinAddressData {
   final String address;
@@ -300,6 +308,17 @@ class BreezEvent with _$BreezEvent {
   const factory BreezEvent.paymentFailed({
     required PaymentFailedData details,
   }) = BreezEvent_PaymentFailed;
+
+  /// Indicates that the backup process has just started
+  const factory BreezEvent.backupStarted() = BreezEvent_BackupStarted;
+
+  /// Indicates that the backup process has just finished successfully
+  const factory BreezEvent.backupSucceeded() = BreezEvent_BackupSucceeded;
+
+  /// Indicates that the backup process has just failed
+  const factory BreezEvent.backupFailed({
+    required BackupFailedData details,
+  }) = BreezEvent_BackupFailed;
 }
 
 /// Different providers will demand different behaviours when the user is trying to buy bitcoin.
@@ -1780,6 +1799,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     );
   }
 
+  BackupFailedData _wire2api_backup_failed_data(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return BackupFailedData(
+      error: _wire2api_String(arr[0]),
+    );
+  }
+
   BitcoinAddressData _wire2api_bitcoin_address_data(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
@@ -1798,6 +1825,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   AesSuccessActionDataDecrypted _wire2api_box_autoadd_aes_success_action_data_decrypted(dynamic raw) {
     return _wire2api_aes_success_action_data_decrypted(raw);
+  }
+
+  BackupFailedData _wire2api_box_autoadd_backup_failed_data(dynamic raw) {
+    return _wire2api_backup_failed_data(raw);
   }
 
   BitcoinAddressData _wire2api_box_autoadd_bitcoin_address_data(dynamic raw) {
@@ -1903,6 +1934,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       case 4:
         return BreezEvent_PaymentFailed(
           details: _wire2api_box_autoadd_payment_failed_data(raw[1]),
+        );
+      case 5:
+        return BreezEvent_BackupStarted();
+      case 6:
+        return BreezEvent_BackupSucceeded();
+      case 7:
+        return BreezEvent_BackupFailed(
+          details: _wire2api_box_autoadd_backup_failed_data(raw[1]),
         );
       default:
         throw Exception("unreachable");

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -23,6 +23,9 @@ mixin _$BreezEvent {
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -32,6 +35,9 @@ mixin _$BreezEvent {
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -41,6 +47,9 @@ mixin _$BreezEvent {
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -51,6 +60,9 @@ mixin _$BreezEvent {
     required TResult Function(BreezEvent_Synced value) synced,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -60,6 +72,9 @@ mixin _$BreezEvent {
     TResult? Function(BreezEvent_Synced value)? synced,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -69,6 +84,9 @@ mixin _$BreezEvent {
     TResult Function(BreezEvent_Synced value)? synced,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -158,6 +176,9 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
   }) {
     return newBlock(block);
   }
@@ -170,6 +191,9 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
   }) {
     return newBlock?.call(block);
   }
@@ -182,6 +206,9 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
     required TResult orElse(),
   }) {
     if (newBlock != null) {
@@ -198,6 +225,9 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     required TResult Function(BreezEvent_Synced value) synced,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
   }) {
     return newBlock(this);
   }
@@ -210,6 +240,9 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     TResult? Function(BreezEvent_Synced value)? synced,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
   }) {
     return newBlock?.call(this);
   }
@@ -222,6 +255,9 @@ class _$BreezEvent_NewBlock implements BreezEvent_NewBlock {
     TResult Function(BreezEvent_Synced value)? synced,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
     required TResult orElse(),
   }) {
     if (newBlock != null) {
@@ -308,6 +344,9 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
   }) {
     return invoicePaid(details);
   }
@@ -320,6 +359,9 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
   }) {
     return invoicePaid?.call(details);
   }
@@ -332,6 +374,9 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
     required TResult orElse(),
   }) {
     if (invoicePaid != null) {
@@ -348,6 +393,9 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     required TResult Function(BreezEvent_Synced value) synced,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
   }) {
     return invoicePaid(this);
   }
@@ -360,6 +408,9 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     TResult? Function(BreezEvent_Synced value)? synced,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
   }) {
     return invoicePaid?.call(this);
   }
@@ -372,6 +423,9 @@ class _$BreezEvent_InvoicePaid implements BreezEvent_InvoicePaid {
     TResult Function(BreezEvent_Synced value)? synced,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
     required TResult orElse(),
   }) {
     if (invoicePaid != null) {
@@ -430,6 +484,9 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
   }) {
     return synced();
   }
@@ -442,6 +499,9 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
   }) {
     return synced?.call();
   }
@@ -454,6 +514,9 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
     required TResult orElse(),
   }) {
     if (synced != null) {
@@ -470,6 +533,9 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     required TResult Function(BreezEvent_Synced value) synced,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
   }) {
     return synced(this);
   }
@@ -482,6 +548,9 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     TResult? Function(BreezEvent_Synced value)? synced,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
   }) {
     return synced?.call(this);
   }
@@ -494,6 +563,9 @@ class _$BreezEvent_Synced implements BreezEvent_Synced {
     TResult Function(BreezEvent_Synced value)? synced,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
     required TResult orElse(),
   }) {
     if (synced != null) {
@@ -576,6 +648,9 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
   }) {
     return paymentSucceed(details);
   }
@@ -588,6 +663,9 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
   }) {
     return paymentSucceed?.call(details);
   }
@@ -600,6 +678,9 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
     required TResult orElse(),
   }) {
     if (paymentSucceed != null) {
@@ -616,6 +697,9 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     required TResult Function(BreezEvent_Synced value) synced,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
   }) {
     return paymentSucceed(this);
   }
@@ -628,6 +712,9 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     TResult? Function(BreezEvent_Synced value)? synced,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
   }) {
     return paymentSucceed?.call(this);
   }
@@ -640,6 +727,9 @@ class _$BreezEvent_PaymentSucceed implements BreezEvent_PaymentSucceed {
     TResult Function(BreezEvent_Synced value)? synced,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
     required TResult orElse(),
   }) {
     if (paymentSucceed != null) {
@@ -727,6 +817,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     required TResult Function() synced,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
   }) {
     return paymentFailed(details);
   }
@@ -739,6 +832,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     TResult? Function()? synced,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
   }) {
     return paymentFailed?.call(details);
   }
@@ -751,6 +847,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     TResult Function()? synced,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
     required TResult orElse(),
   }) {
     if (paymentFailed != null) {
@@ -767,6 +866,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     required TResult Function(BreezEvent_Synced value) synced,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
   }) {
     return paymentFailed(this);
   }
@@ -779,6 +881,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     TResult? Function(BreezEvent_Synced value)? synced,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
   }) {
     return paymentFailed?.call(this);
   }
@@ -791,6 +896,9 @@ class _$BreezEvent_PaymentFailed implements BreezEvent_PaymentFailed {
     TResult Function(BreezEvent_Synced value)? synced,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
     required TResult orElse(),
   }) {
     if (paymentFailed != null) {
@@ -807,6 +915,452 @@ abstract class BreezEvent_PaymentFailed implements BreezEvent {
   PaymentFailedData get details;
   @JsonKey(ignore: true)
   _$$BreezEvent_PaymentFailedCopyWith<_$BreezEvent_PaymentFailed> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$BreezEvent_BackupStartedCopyWith<$Res> {
+  factory _$$BreezEvent_BackupStartedCopyWith(
+          _$BreezEvent_BackupStarted value, $Res Function(_$BreezEvent_BackupStarted) then) =
+      __$$BreezEvent_BackupStartedCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$BreezEvent_BackupStartedCopyWithImpl<$Res>
+    extends _$BreezEventCopyWithImpl<$Res, _$BreezEvent_BackupStarted>
+    implements _$$BreezEvent_BackupStartedCopyWith<$Res> {
+  __$$BreezEvent_BackupStartedCopyWithImpl(
+      _$BreezEvent_BackupStarted _value, $Res Function(_$BreezEvent_BackupStarted) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$BreezEvent_BackupStarted implements BreezEvent_BackupStarted {
+  const _$BreezEvent_BackupStarted();
+
+  @override
+  String toString() {
+    return 'BreezEvent.backupStarted()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$BreezEvent_BackupStarted);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int block) newBlock,
+    required TResult Function(InvoicePaidDetails details) invoicePaid,
+    required TResult Function() synced,
+    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
+  }) {
+    return backupStarted();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int block)? newBlock,
+    TResult? Function(InvoicePaidDetails details)? invoicePaid,
+    TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
+  }) {
+    return backupStarted?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int block)? newBlock,
+    TResult Function(InvoicePaidDetails details)? invoicePaid,
+    TResult Function()? synced,
+    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
+    required TResult orElse(),
+  }) {
+    if (backupStarted != null) {
+      return backupStarted();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(BreezEvent_NewBlock value) newBlock,
+    required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
+    required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
+    required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+  }) {
+    return backupStarted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(BreezEvent_NewBlock value)? newBlock,
+    TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+  }) {
+    return backupStarted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(BreezEvent_NewBlock value)? newBlock,
+    TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    required TResult orElse(),
+  }) {
+    if (backupStarted != null) {
+      return backupStarted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class BreezEvent_BackupStarted implements BreezEvent {
+  const factory BreezEvent_BackupStarted() = _$BreezEvent_BackupStarted;
+}
+
+/// @nodoc
+abstract class _$$BreezEvent_BackupSucceededCopyWith<$Res> {
+  factory _$$BreezEvent_BackupSucceededCopyWith(
+          _$BreezEvent_BackupSucceeded value, $Res Function(_$BreezEvent_BackupSucceeded) then) =
+      __$$BreezEvent_BackupSucceededCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$BreezEvent_BackupSucceededCopyWithImpl<$Res>
+    extends _$BreezEventCopyWithImpl<$Res, _$BreezEvent_BackupSucceeded>
+    implements _$$BreezEvent_BackupSucceededCopyWith<$Res> {
+  __$$BreezEvent_BackupSucceededCopyWithImpl(
+      _$BreezEvent_BackupSucceeded _value, $Res Function(_$BreezEvent_BackupSucceeded) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$BreezEvent_BackupSucceeded implements BreezEvent_BackupSucceeded {
+  const _$BreezEvent_BackupSucceeded();
+
+  @override
+  String toString() {
+    return 'BreezEvent.backupSucceeded()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$BreezEvent_BackupSucceeded);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int block) newBlock,
+    required TResult Function(InvoicePaidDetails details) invoicePaid,
+    required TResult Function() synced,
+    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
+  }) {
+    return backupSucceeded();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int block)? newBlock,
+    TResult? Function(InvoicePaidDetails details)? invoicePaid,
+    TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
+  }) {
+    return backupSucceeded?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int block)? newBlock,
+    TResult Function(InvoicePaidDetails details)? invoicePaid,
+    TResult Function()? synced,
+    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
+    required TResult orElse(),
+  }) {
+    if (backupSucceeded != null) {
+      return backupSucceeded();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(BreezEvent_NewBlock value) newBlock,
+    required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
+    required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
+    required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+  }) {
+    return backupSucceeded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(BreezEvent_NewBlock value)? newBlock,
+    TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+  }) {
+    return backupSucceeded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(BreezEvent_NewBlock value)? newBlock,
+    TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    required TResult orElse(),
+  }) {
+    if (backupSucceeded != null) {
+      return backupSucceeded(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class BreezEvent_BackupSucceeded implements BreezEvent {
+  const factory BreezEvent_BackupSucceeded() = _$BreezEvent_BackupSucceeded;
+}
+
+/// @nodoc
+abstract class _$$BreezEvent_BackupFailedCopyWith<$Res> {
+  factory _$$BreezEvent_BackupFailedCopyWith(
+          _$BreezEvent_BackupFailed value, $Res Function(_$BreezEvent_BackupFailed) then) =
+      __$$BreezEvent_BackupFailedCopyWithImpl<$Res>;
+  @useResult
+  $Res call({BackupFailedData details});
+}
+
+/// @nodoc
+class __$$BreezEvent_BackupFailedCopyWithImpl<$Res>
+    extends _$BreezEventCopyWithImpl<$Res, _$BreezEvent_BackupFailed>
+    implements _$$BreezEvent_BackupFailedCopyWith<$Res> {
+  __$$BreezEvent_BackupFailedCopyWithImpl(
+      _$BreezEvent_BackupFailed _value, $Res Function(_$BreezEvent_BackupFailed) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? details = null,
+  }) {
+    return _then(_$BreezEvent_BackupFailed(
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as BackupFailedData,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BreezEvent_BackupFailed implements BreezEvent_BackupFailed {
+  const _$BreezEvent_BackupFailed({required this.details});
+
+  @override
+  final BackupFailedData details;
+
+  @override
+  String toString() {
+    return 'BreezEvent.backupFailed(details: $details)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BreezEvent_BackupFailed &&
+            (identical(other.details, details) || other.details == details));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, details);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BreezEvent_BackupFailedCopyWith<_$BreezEvent_BackupFailed> get copyWith =>
+      __$$BreezEvent_BackupFailedCopyWithImpl<_$BreezEvent_BackupFailed>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int block) newBlock,
+    required TResult Function(InvoicePaidDetails details) invoicePaid,
+    required TResult Function() synced,
+    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
+  }) {
+    return backupFailed(details);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int block)? newBlock,
+    TResult? Function(InvoicePaidDetails details)? invoicePaid,
+    TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
+  }) {
+    return backupFailed?.call(details);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int block)? newBlock,
+    TResult Function(InvoicePaidDetails details)? invoicePaid,
+    TResult Function()? synced,
+    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
+    required TResult orElse(),
+  }) {
+    if (backupFailed != null) {
+      return backupFailed(details);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(BreezEvent_NewBlock value) newBlock,
+    required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
+    required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
+    required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+  }) {
+    return backupFailed(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(BreezEvent_NewBlock value)? newBlock,
+    TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+  }) {
+    return backupFailed?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(BreezEvent_NewBlock value)? newBlock,
+    TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    required TResult orElse(),
+  }) {
+    if (backupFailed != null) {
+      return backupFailed(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class BreezEvent_BackupFailed implements BreezEvent {
+  const factory BreezEvent_BackupFailed({required final BackupFailedData details}) =
+      _$BreezEvent_BackupFailed;
+
+  BackupFailedData get details;
+  @JsonKey(ignore: true)
+  _$$BreezEvent_BackupFailedCopyWith<_$BreezEvent_BackupFailed> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -427,6 +427,7 @@ dependencies = [
  "lightning",
  "lightning-invoice",
  "log",
+ "miniz_oxide 0.7.1",
  "once_cell",
  "openssl",
  "prost",
@@ -1605,6 +1606,15 @@ name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -326,6 +326,10 @@ pub(crate) async fn handle_command(
             let res = sdk()?.buy_bitcoin(provider.clone()).await?;
             Ok(format!("Here your {:?} url: {}", provider, res))
         }
+        Commands::Backup {} => {
+            sdk()?.start_backup()?;
+            Ok(format!("Backup started"))
+        }
     }
 }
 

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -328,7 +328,7 @@ pub(crate) async fn handle_command(
         }
         Commands::Backup {} => {
             sdk()?.start_backup()?;
-            Ok(format!("Backup started"))
+            Ok("Backup started".into())
         }
     }
 }

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -46,6 +46,9 @@ pub(crate) enum Commands {
     /// Sync local data with remote node
     Sync {},
 
+    /// Triggers a backup of the local data
+    Backup {},
+
     /// Parse a generic string to get its type and relevant metadata
     Parse {
         /// Generic input (URL, LNURL, BIP-21 BTC Address, LN invoice, etc)


### PR DESCRIPTION
This PR introduces multi app sync of the sdk state.
The data that requires sync is written to a different sqlite db (sync_storage.sql) that is attached to the main database.
Data there is immutable and only inserts are allowed which makes bidirectional syncing simple.
The sdk state that needs syncing represents by data and version. The version is used to detect stale local state that needs to pull updates from the remote state.

The process of syncing is as follows:
1. Triggers were added to every table that requires sync, the trigger insert a new record into the `sync_requests` table.
2. A sqlite hook is used to get notified with every insert to the sync_requests table, spawning a new sync worker.
3. The sync worker fetch the last sync request id and the current known sync state version and start the following process:

-  Try push the local changes to the remote (optimistic) with the current version
-  In case of failure, pull the remote changes, bidirectionally sync and try to push the updated remote.
-  Upon success, update the current sync version and delete the sync_requests up to the latest one.

Still missing:

- [x] Compress and encrypt the state before pushing
- [x] Adding API for fetching the backup status.
- [x] Allow initiating a backup programatically.