### PR TITLE
update gl dependency

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -374,7 +374,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1998475af29ccfb7c761bb624a16e501fc321510366012bc9cce267bc134aedc"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin",
  "percent-encoding-rfc3986",
 ]
 
@@ -391,30 +391,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
- "bitcoin_hashes 0.11.0",
+ "bitcoin_hashes",
  "bitcoinconsensus",
  "secp256k1 0.24.3",
  "serde",
 ]
-
-[[package]]
-name = "bitcoin"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36f4c848f6bd9ff208128f08751135846cc23ae57d66ab10a22efff1c675f3c"
-dependencies = [
- "bech32",
- "bitcoin-private",
- "bitcoin_hashes 0.12.0",
- "hex_lit",
- "secp256k1 0.27.0",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -423,15 +404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
 ]
 
 [[package]]
@@ -480,7 +452,7 @@ dependencies = [
 [[package]]
 name = "bolt-derive"
 version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -495,7 +467,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bip21",
- "bitcoin 0.29.2",
+ "bitcoin",
  "cbc",
  "const_format",
  "ecies",
@@ -723,7 +695,7 @@ version = "0.1.3"
 source = "git+https://github.com/ElementsProject/lightning.git?branch=master#2d53707611e5c59a470dcad56ef1f0debb0d2ef0"
 dependencies = [
  "anyhow",
- "bitcoin 0.29.2",
+ "bitcoin",
  "hex",
  "log",
  "prost",
@@ -1216,12 +1188,12 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "gl-client"
-version = "0.1.6"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=9f2c038#9f2c038f0a944d32f8526bb9a0f8dd0edaea53ac"
+version = "0.1.8"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=0b1ffd9#0b1ffd98907eabb5e6dc6ce142b22f9728f60e68"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
- "bitcoin 0.30.0",
+ "bitcoin",
  "bytes",
  "chacha20poly1305",
  "cln-grpc",
@@ -1356,12 +1328,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "hkdf"
@@ -1677,7 +1643,7 @@ version = "0.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e009e1c0c21f66378b491bb40f548682138c63e09db6f3a05af59f8804bb9f4a"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin",
  "hex",
  "regex",
 ]
@@ -1689,8 +1655,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e44b0e2822c8811470137d2339fdfe67a699b3248bb1606d1d02eb6a1e9f0a"
 dependencies = [
  "bech32",
- "bitcoin 0.29.2",
- "bitcoin_hashes 0.11.0",
+ "bitcoin",
+ "bitcoin_hashes",
  "lightning",
  "num-traits",
  "secp256k1 0.24.3",
@@ -2494,7 +2460,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
- "bitcoin_hashes 0.11.0",
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys 0.6.1",
  "serde",
@@ -2506,16 +2472,6 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys 0.8.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
-dependencies = [
- "bitcoin_hashes 0.12.0",
  "secp256k1-sys 0.8.1",
 ]
 
@@ -3164,7 +3120,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8d7e67ea44d2f4df67df6c91e4c2d4e199b4f4950074ccc5cb141a3be60e01"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin",
  "log",
  "serde",
 ]
@@ -3373,11 +3329,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vls-core"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "anyhow",
  "backtrace",
- "bitcoin 0.29.2",
+ "bitcoin",
  "bolt-derive",
  "env_logger",
  "hashbrown 0.8.2",
@@ -3397,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "vls-persist"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "hex",
  "log",
@@ -3410,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "vls-protocol"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "as-any",
  "bolt-derive",
@@ -3424,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "vls-protocol-signer"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "bit-vec",
  "log",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -20,7 +20,7 @@ bitcoin = "0.29.2"
 # If so, see https://techexpertise.medium.com/storing-git-credentials-with-git-credential-helper-33d22a6b5ce7
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "9f2c038" }
+], rev = "0b1ffd9" }
 base64 = "0.13.0"
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
 ripemd = "*"

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "bolt-derive"
 version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1086,8 +1086,8 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "gl-client"
-version = "0.1.6"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=9f2c038#9f2c038f0a944d32f8526bb9a0f8dd0edaea53ac"
+version = "0.1.8"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=0b1ffd9#0b1ffd98907eabb5e6dc6ce142b22f9728f60e68"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -3099,7 +3099,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vls-core"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "vls-persist"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "hex",
  "log",
@@ -3136,7 +3136,7 @@ dependencies = [
 [[package]]
 name = "vls-protocol"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "as-any",
  "bolt-derive",
@@ -3150,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "vls-protocol-signer"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "bit-vec",
  "log",


### PR DESCRIPTION
updates the greenlight dependency to which contains a snapshot of [vls](https://gitlab.com/lightning-signer/validating-lightning-signer) pointing to [cdeckers fork](https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07).