### PR TITLE
Update Swift bindings readme to include CocoaPod

### DIFF
--- a/libs/sdk-bindings/README.md
+++ b/libs/sdk-bindings/README.md
@@ -37,7 +37,7 @@ make swift-darwin
 #### Swift Package
 
 This command will produce a fully configured local Swift Package in `bindings-swift/`.
-See [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) in Apple's docs for more information on how to integrate such a package into your project. Note that for most users, we recommend using our official Swift package / CocoaPod. See [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift) for mor e information.
+See [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) in Apple's docs for more information on how to integrate such a package into your project. Note that for most users, we recommend using our official Swift package / CocoaPod. See [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift) for more information.
 
 ```
 make bindings-swift

--- a/libs/sdk-bindings/README.md
+++ b/libs/sdk-bindings/README.md
@@ -18,7 +18,7 @@ make init
 
 ### Swift
 
-For most users, we recommend using our official Swift package: [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift).
+For most users, we recommend using our official Swift package / CocoaPod. See here for installation instructions: [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift).
 
 If you want to compile from source or need more options, read on.
 
@@ -36,8 +36,8 @@ make swift-darwin
 
 #### Swift Package
 
-This command will produce a fully configured Swift Package in `bindings-swift/`.
-See [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) in Apple's docs for more information on how to integrate such a package into your project.
+This command will produce a fully configured local Swift Package in `bindings-swift/`.
+See [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) in Apple's docs for more information on how to integrate such a package into your project. Note that for most users, we recommend using our official Swift package / CocoaPod. See here for installation instructions: [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift).
 
 ```
 make bindings-swift

--- a/libs/sdk-bindings/README.md
+++ b/libs/sdk-bindings/README.md
@@ -18,7 +18,7 @@ make init
 
 ### Swift
 
-For most users, we recommend using our official Swift package / CocoaPod. See here for installation instructions: [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift).
+For most users, we recommend using our official Swift package / CocoaPod. See [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift) for more information.
 
 If you want to compile from source or need more options, read on.
 
@@ -37,7 +37,7 @@ make swift-darwin
 #### Swift Package
 
 This command will produce a fully configured local Swift Package in `bindings-swift/`.
-See [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) in Apple's docs for more information on how to integrate such a package into your project. Note that for most users, we recommend using our official Swift package / CocoaPod. See here for installation instructions: [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift).
+See [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) in Apple's docs for more information on how to integrate such a package into your project. Note that for most users, we recommend using our official Swift package / CocoaPod. See [breez/breez-sdk-swift](https://github.com/breez/breez-sdk-swift) for mor e information.
 
 ```
 make bindings-swift


### PR DESCRIPTION
Update Swift bindings readme to include info about our new CocoaPod (https://github.com/breez/breez-sdk-swift/pull/7).