### PR TITLE
Fix file permission to match GitHub Actions updates

### DIFF
--- a/.github/workflows/rustdoc-pages.yml
+++ b/.github/workflows/rustdoc-pages.yml
@@ -39,6 +39,15 @@ jobs:
           cd libs/sdk-core
           cargo doc --no-deps
 
+      # Set the right file permissions, based on https://github.com/actions/upload-pages-artifact#file-permissions
+      - name: Fix file permissions
+        shell: sh
+        run: |
+          chmod -c -R +rX "libs/target/doc" |
+          while read line; do
+              echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
All recent CI builds on `master` have been failing with

```
Current status: deployment_perms_error
Getting Pages deployment status...
Current status: deployment_perms_error
Getting Pages deployment status...
...
Current status: 
Error: Timeout reached, aborting!
Error: Timeout reached, aborting!
Canceling Pages deployment...
Canceled deployment with ID d0a0ecfda28ffb768cda2c0827fde39587692cc2
```

That is due to a recent change in Github Actions, which needs certain file permissions.

This PR sets those permissions.