### PR TITLE
Associate lightning payments with original payment amount

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1252,6 +1252,9 @@ impl Receiver for PaymentReceiver {
             info!("Payment registered");
         }
 
+        // Make sure we save the large amount so we can deduce the fees later.
+        self.persister
+            .insert_open_cannel_payment_info(&parsed_invoice.payment_hash, amount_sats * 1000)?;
         // return the signed, converted invoice with hints
         Ok(parsed_invoice)
     }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1254,7 +1254,7 @@ impl Receiver for PaymentReceiver {
 
         // Make sure we save the large amount so we can deduce the fees later.
         self.persister
-            .insert_open_cannel_payment_info(&parsed_invoice.payment_hash, amount_sats * 1000)?;
+            .insert_open_channel_payment_info(&parsed_invoice.payment_hash, amount_sats * 1000)?;
         // return the signed, converted invoice with hints
         Ok(parsed_invoice)
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -259,13 +259,18 @@ impl NodeAPI for Greenlight {
             .collect();
 
         // Fetch closed channels from greenlight
-        let closed_channels = node_client
+        let closed_channels = match node_client
             .list_closed_channels(ListclosedchannelsRequest { id: None })
-            .await?
-            .into_inner();
+            .await
+        {
+            Ok(c) => c.into_inner().closedchannels,
+            Err(e) => {
+                error!("list closed channels error {:?}", e);
+                vec![]
+            }
+        };
 
         let forgotten_closed_channels: Result<Vec<Channel>> = closed_channels
-            .closedchannels
             .into_iter()
             .filter(|c| {
                 let hex_txid = hex::encode(c.funding_txid.clone());

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -423,6 +423,18 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
          data BLOB NOT NULL,
          created_at TEXT DEFAULT CURRENT_TIMESTAMP
         ) STRICT;
+       "       
+    ]
+}
+
+pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
+    vec![
+        "
+        CREATE TABLE IF NOT EXISTS open_channel_payment_info (
+         payment_hash TEXT PRIMARY KEY NOT NULL,
+         payer_amount_msat INTEGER NOT NULL
+        ) STRICT;
+
        ",
     ]
 }

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -91,6 +91,12 @@ impl SqliteStorage {
 
     pub(crate) fn import_remote_changes(&self, remote_storage: &SqliteStorage) -> Result<()> {
         let sync_data_file = remote_storage.sync_db_path();
+        match SqliteStorage::migrate_sync_db(sync_data_file.clone()) {
+            Ok(_) => {}
+            Err(e) => {
+                log::error!("Failed to migrate sync db, probably local db is older than remote, skipping migration: {}", e);
+            }
+        }
 
         let mut con = self.get_connection()?;
         let tx = con.transaction()?;
@@ -163,6 +169,18 @@ impl SqliteStorage {
             [],
         )?;
 
+        // sync remote swap_refunds table
+        tx.execute(
+            "
+        INSERT INTO sync.open_channel_payment_info
+         SELECT
+          payment_hash,
+          payer_amount_msat
+         FROM remote_sync.open_channel_payment_info
+         WHERE payment_hash NOT IN (SELECT payment_hash FROM sync.open_channel_payment_info);",
+            [],
+        )?;
+
         tx.commit()?;
         con.execute("DETACH DATABASE remote_sync", [])?;
 
@@ -212,6 +230,11 @@ fn test_sync() {
     let remote_storage = SqliteStorage::new(test_utils::create_test_sql_dir());
     remote_storage.init().unwrap();
     remote_storage.insert_swap(remote_swap_info).unwrap();
+
+    remote_storage
+        .insert_open_cannel_payment_info("123", 100000)
+        .unwrap();
+
     remote_storage
         .import_remote_changes(&local_storage)
         .unwrap();

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -232,7 +232,7 @@ fn test_sync() {
     remote_storage.insert_swap(remote_swap_info).unwrap();
 
     remote_storage
-        .insert_open_cannel_payment_info("123", 100000)
+        .insert_open_channel_payment_info("123", 100000)
         .unwrap();
 
     remote_storage

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -91,7 +91,7 @@ impl SqliteStorage {
     }
 
     /// Inserts payer amount for invoices that requries openning a channel.
-    pub fn insert_open_cannel_payment_info(
+    pub fn insert_open_channel_payment_info(
         &self,
         payment_hash: &str,
         payer_amount_msat: u64,
@@ -410,7 +410,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
 
-    storage.insert_open_cannel_payment_info("123", 150)?;
+    storage.insert_open_channel_payment_info("123", 150)?;
     let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;
     assert_eq!(retrieve_txs[0].fee_msat, 50);
 

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -90,6 +90,28 @@ impl SqliteStorage {
         Ok(())
     }
 
+    /// Inserts payer amount for invoices that requries openning a channel.
+    pub fn insert_open_cannel_payment_info(
+        &self,
+        payment_hash: &str,
+        payer_amount_msat: u64,
+    ) -> Result<()> {
+        let con = self.get_connection()?;
+        let mut prep_statement = con.prepare(
+            "
+        INSERT INTO sync.open_channel_payment_info (
+          payment_hash,
+          payer_amount_msat
+        )
+        VALUES (?1,?2)
+       ",
+        )?;
+
+        _ = prep_statement.execute((payment_hash, payer_amount_msat))?;
+
+        Ok(())
+    }
+
     pub fn last_payment_timestamp(&self) -> Result<i64> {
         self.get_connection()?
             .query_row("SELECT max(payment_time) FROM payments", [], |row| {
@@ -124,11 +146,15 @@ impl SqliteStorage {
              p.details,
              e.lnurl_success_action,
              e.lnurl_metadata,
-             e.ln_address
+             e.ln_address,
+             o.payer_amount_msat
             FROM payments p
             LEFT JOIN sync.payments_external_info e
             ON
              p.id = e.payment_id
+            LEFT JOIN sync.open_channel_payment_info o
+             ON
+              p.id = o.payment_hash
             {where_clause} ORDER BY payment_time DESC
           "
             )
@@ -163,11 +189,15 @@ impl SqliteStorage {
                  p.details,
                  e.lnurl_success_action,
                  e.lnurl_metadata,
-                 e.ln_address
+                 e.ln_address,
+                 o.payer_amount_msat
                 FROM payments p
                 LEFT JOIN sync.payments_external_info e
                 ON
                  p.id = e.payment_id
+                LEFT JOIN sync.open_channel_payment_info o
+                 ON
+                  p.id = o.payment_hash
                 WHERE
                  id = ?1",
                 [hash],
@@ -187,11 +217,12 @@ impl SqliteStorage {
 
     fn sql_row_to_payment(&self, row: &Row) -> Result<Payment, rusqlite::Error> {
         let payment_type_str: String = row.get(1)?;
+        let amount_msat = row.get(3)?;
         let mut payment = Payment {
             id: row.get(0)?,
             payment_type: PaymentType::from_str(payment_type_str.as_str()).unwrap(),
             payment_time: row.get(2)?,
-            amount_msat: row.get(3)?,
+            amount_msat,
             fee_msat: row.get(4)?,
             pending: row.get(5)?,
             description: row.get(6)?,
@@ -202,6 +233,12 @@ impl SqliteStorage {
             data.lnurl_success_action = row.get(8)?;
             data.lnurl_metadata = row.get(9)?;
             data.ln_address = row.get(10)?;
+        }
+
+        // In cae we have a record of the open channel fee, let's use it.
+        let payer_amount_msat: Option<u64> = row.get(11)?;
+        if let Some(payer_amount) = payer_amount_msat {
+            payment.fee_msat = payer_amount - amount_msat;
         }
 
         Ok(payment)
@@ -372,6 +409,10 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
     let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
+
+    storage.insert_open_cannel_payment_info("123", 150)?;
+    let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None)?;
+    assert_eq!(retrieve_txs[0].fee_msat, 50);
 
     Ok(())
 }


### PR DESCRIPTION
fixed https://github.com/breez/c-breez/issues/568
This PR fixes the `fee_msat` field in payments that required to open a channel.
In that case the fee is not a regular lightning payment but is calculated by:
`payer_amount - incomoing_amount`
For the sdk to be able to calculate this we need to associate the payer_amount with the payment hash.

`Sync changes`
The above association should be synced between devices/apps so a new table was added open_channel_payment_info.
The sync db migration are were split from the main db migration starting from this point and are running on sync as well.