### PR TITLE
Use Breez SDK from Maven repository

### DIFF
--- a/libs/sdk-bindings/bindings-android/jitpack.yml
+++ b/libs/sdk-bindings/bindings-android/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk11
+before_install:
+  - cd libs/sdk-bindings/bindings-android

--- a/libs/sdk-react-native/android/build.gradle
+++ b/libs/sdk-react-native/android/build.gradle
@@ -56,14 +56,17 @@ repositories {
 
 allprojects {
     repositories {
+        maven {
+            url "https://mvn.breez.technology/releases"
+        }
         google()
     }
 }
 
 dependencies {
     //noinspection GradleDynamicVersion
+    implementation "breez_sdk:bindings-android:0.1.0"
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21"
     implementation("net.java.dev.jna:jna:5.6.0@aar")
-
 }


### PR DESCRIPTION
I would've assumed that this is all that needs to be done to make the Breez SDK available to the plugin without having a locally-built version on my machine. However, when I run the example app, I get the following error:

```
Could not determine the dependencies of task ':app:processDebugResources'.
> Could not resolve all task dependencies for configuration ':app:debugRuntimeClasspath'.
   > Could not find breez_sdk:bindings-android:0.1.0.
     Searched in the following locations:
       - file:/Users/daniel/Developer/bitcoin/breez-sdk/libs/sdk-react-native/example/node_modules/react-native/android/breez_sdk/bindings-android/0.1.0/bindings-android-0.1.0.pom
       - file:/Users/daniel/Developer/bitcoin/breez-sdk/libs/sdk-react-native/example/node_modules/jsc-android/dist/breez_sdk/bindings-android/0.1.0/bindings-android-0.1.0.pom
       - https://repo.maven.apache.org/maven2/breez_sdk/bindings-android/0.1.0/bindings-android-0.1.0.pom
       - https://dl.google.com/dl/android/maven2/breez_sdk/bindings-android/0.1.0/bindings-android-0.1.0.pom
       - https://www.jitpack.io/breez_sdk/bindings-android/0.1.0/bindings-android-0.1.0.pom
     Required by:
         project :app > project :@breeztech_react-native-breez-sdk
         project :app > project :breeztech_react-native-breez-sdk
```

👉 Somehow gradle is not seeing our repository and therefore doesn't find the Breez SDK.

What's interesting is that when I add our maven dependency to the example's project-level gradle file (`example/android/build.gradle`), everything works perfectly. But of course it would be nicer if the consumer or our RN plugin wouldn't have to do any change to their project.

I'm not sure why the repository declaration in the plugins gradle file is not seen. @dangeross do you have any ideas of why that could be? Is there some special configuration in the example project that prevents this?