### PR TITLE
Allow user request/response for backup

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -425,7 +425,7 @@ interface BlockingBreezServices {
    BackupStatus backup_status();
 
    [Throws=SDKError]
-   void start_backup();
+   void backup();
 
    [Throws=SDKError]
    sequence<Payment> list_payments(PaymentTypeFilter filter, i64? from_timestamp, i64? to_timestamp);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -186,8 +186,9 @@ impl BlockingBreezServices {
         self.breez_services.backup_status().map_err(|e| e.into())
     }
 
-    pub fn start_backup(&self) -> Result<(), SDKError> {
-        self.breez_services.start_backup().map_err(|e| e.into())
+    pub fn backup(&self) -> Result<(), SDKError> {
+        rt().block_on(self.breez_services.backup())
+            .map_err(|e| e.into())
     }
 
     pub fn list_payments(

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -130,6 +130,7 @@ async fn start_threads(
     ])?;
 
     let backup_watcher = BackupWatcher::start(
+        breez_cloned.config.clone(),
         breez_services.backup_transport.clone(),
         breez_services.persister.clone(),
         backup_encryption_key.to_priv().to_bytes(),
@@ -181,6 +182,7 @@ async fn start_threads(
 
 /// BreezServices is a facade and the single entry point for the SDK.
 pub struct BreezServices {
+    config: Config,
     node_api: Arc<dyn NodeAPI>,
     lsp_api: Arc<dyn LspAPI>,
     fiat_api: Arc<dyn FiatAPI>,
@@ -1051,6 +1053,7 @@ impl BreezServicesBuilder {
 
         // Create the node services and it them statically
         let breez_services = Arc::new(BreezServices {
+            config: self.config.clone(),
             node_api: unwrapped_node_api.clone(),
             lsp_api: self.lsp_api.clone().unwrap_or_else(|| breez_server.clone()),
             fiat_api: self

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1,4 +1,4 @@
-use crate::backup::{BackupTransport, BackupWatcher};
+use crate::backup::{BackupRequest, BackupTransport, BackupWatcher};
 use crate::boltzswap::BoltzApi;
 use crate::chain::{ChainService, MempoolSpace, RecommendedFees};
 use crate::fiat::{FiatCurrency, Rate};
@@ -95,13 +95,19 @@ pub struct InvoicePaidDetails {
     pub bolt11: String,
 }
 
+#[derive(Clone, Debug)]
+struct SDKBackgroundController {
+    shutdown_handler: mpsc::Sender<()>,
+    backup_request_handler: mpsc::Sender<BackupRequest>,
+}
+
 /// Starts the BreezServices background threads.
 ///
 /// Internal method. Should only be used as part of [BreezServices::start]
 async fn start_threads(
     rt: &Runtime,
     breez_services: Arc<BreezServices>,
-) -> Result<mpsc::Sender<()>> {
+) -> Result<SDKBackgroundController> {
     // start the signer
     let (shutdown_signer_sender, signer_signer_receiver) = mpsc::channel(1);
     let signer_api = breez_services.clone();
@@ -114,17 +120,31 @@ async fn start_threads(
 
     let breez_cloned = breez_services.clone();
 
-    //restore backup state
-    if breez_cloned.persister.get_last_sync_version()?.is_none() {
-        debug!("No last sync version found, starting initial backup");
-        breez_cloned.start_backup()?;
-    }
-
     // sync with remote node state
     breez_cloned.sync().await?;
 
+    // create the backup encryption key
+    let backup_encryption_key = breez_services.node_api.derive_bip32_key(vec![
+        ChildNumber::from_hardened_idx(139)?,
+        ChildNumber::from(0),
+    ])?;
+
+    let backup_watcher = BackupWatcher::start(
+        breez_services.backup_transport.clone(),
+        breez_services.persister.clone(),
+        backup_encryption_key.to_priv().to_bytes(),
+    );
+
+    // Restore backup state and request backup on start if needed
+    let force_backup = breez_cloned.persister.get_last_sync_version()?.is_none();
+    let backup_request_handler = backup_watcher.request_handler();
+    backup_request_handler
+        .send(BackupRequest::new(force_backup))
+        .await
+        .map_err(|e| anyhow!("failed to send backup request {e}"))?;
+
     // create a shutdown channel (sender and receiver)
-    let (stop_sender, mut stop_receiver) = mpsc::channel(1);
+    let (shutdown_handler, mut shutdown_receiver) = mpsc::channel::<()>(1);
 
     // poll sdk events
     rt.spawn(async move {
@@ -132,7 +152,7 @@ async fn start_threads(
         let current_block: u32 = 0;
         loop {
             tokio::select! {
-              poll_result = poll_events(breez_services.clone(), current_block) => {
+              poll_result = poll_events(breez_services.clone(),&backup_watcher, current_block) => {
                match poll_result {
                 Ok(()) => {
                  return;
@@ -144,15 +164,19 @@ async fn start_threads(
                 }
                }
               },
-              _ = stop_receiver.recv() => {
+              _ = shutdown_receiver.recv() => {
                _ = shutdown_signer_sender.send(()).await;
                debug!("Received the signal to exit event polling loop");
                return;
-             }
             }
         }
+       }
     });
-    Ok(stop_sender)
+
+    Ok(SDKBackgroundController {
+        shutdown_handler,
+        backup_request_handler,
+    })
 }
 
 /// BreezServices is a facade and the single entry point for the SDK.
@@ -169,7 +193,7 @@ pub struct BreezServices {
     event_listener: Option<Box<dyn EventListener>>,
     //backup_watcher: BackupWatcher,
     backup_transport: Arc<dyn BackupTransport>,
-    shutdown_sender: Mutex<Option<mpsc::Sender<()>>>,
+    background_handler: Mutex<Option<SDKBackgroundController>>,
 }
 
 impl BreezServices {
@@ -209,24 +233,28 @@ impl BreezServices {
     /// It should be called only once when the app is started, regardless whether the app is sent to
     /// background and back.
     pub async fn start(runtime: &Runtime, breez_services: &Arc<BreezServices>) -> Result<()> {
-        let mut start_lock = breez_services.shutdown_sender.lock().await;
-        if start_lock.is_some() {
+        let mut handler_lock = breez_services.background_handler.lock().await;
+        if handler_lock.is_some() {
             return Err(anyhow!("start can only be called once"));
         }
-        let shutdown_handler = start_threads(runtime, breez_services.clone()).await?;
+        let background_handler = start_threads(runtime, breez_services.clone()).await?;
 
-        *start_lock = Some(shutdown_handler);
+        *handler_lock = Some(background_handler);
         Ok(())
     }
 
     /// Trigger the stopping of BreezServices background threads for this instance.
     pub async fn stop(&self) -> Result<()> {
-        let unlocked = self.shutdown_sender.lock().await;
-        if unlocked.is_none() {
+        let handler_lock = self.background_handler.lock().await;
+        if handler_lock.is_none() {
             return Err(anyhow!("node has not been started"));
         }
-        let sender = unlocked.as_ref().unwrap();
-        sender.send(()).await.map_err(anyhow::Error::msg)
+        let background_handler = handler_lock.as_ref().unwrap();
+        background_handler
+            .shutdown_handler
+            .send(())
+            .await
+            .map_err(anyhow::Error::msg)
     }
 
     /// Pay a bolt11 invoice
@@ -395,9 +423,8 @@ impl BreezServices {
         })
     }
 
-    /// Starts a backup process in the background
-    pub fn start_backup(&self) -> Result<()> {
-        self.persister.add_sync_request()
+    pub async fn backup(&self) -> Result<()> {
+        self.start_backup(true, true).await
     }
 
     /// List payments matching the given filters, as retrieved from persistent storage
@@ -711,27 +738,48 @@ impl BreezServices {
         };
         Ok(url)
     }
+
+    /// Starts a backup process in the background
+    async fn start_backup(&self, blocking: bool, force: bool) -> Result<()> {
+        let (on_complete, mut on_complete_receiver) = mpsc::channel::<Result<()>>(1);
+        let request = BackupRequest::with(on_complete, force);
+        self.background_controller()
+            .await?
+            .backup_request_handler
+            .send(request)
+            .await
+            .map_err(|e| anyhow!("failed to send backup request {e}"))?;
+
+        match blocking {
+            true => match on_complete_receiver.recv().await {
+                Some(res) => res,
+                None => Err(anyhow!("backup process failed to complete")),
+            },
+            false => Ok(()),
+        }
+    }
+
+    async fn background_controller(&self) -> Result<SDKBackgroundController> {
+        let handler_lock = self.background_handler.lock().await;
+        if handler_lock.is_none() {
+            return Err(anyhow!("node has not been started"));
+        }
+        Ok(handler_lock.clone().unwrap())
+    }
 }
 
-async fn poll_events(breez_services: Arc<BreezServices>, mut current_block: u32) -> Result<()> {
+async fn poll_events(
+    breez_services: Arc<BreezServices>,
+    backup_watcher: &BackupWatcher,
+    mut current_block: u32,
+) -> Result<()> {
     let mut interval = tokio::time::interval(Duration::from_secs(30));
     let mut invoice_stream = breez_services.node_api.stream_incoming_payments().await?;
     let mut log_stream = breez_services.node_api.stream_log_messages().await?;
 
-    // create the backup encryption key
-    let backup_encryption_key = breez_services.node_api.derive_bip32_key(vec![
-        ChildNumber::from_hardened_idx(139)?,
-        ChildNumber::from(0),
-    ])?;
-
-    let backup_watcher = BackupWatcher::start(
-        breez_services.backup_transport.clone(),
-        breez_services.persister.clone(),
-        backup_encryption_key.to_priv().to_bytes(),
-    );
     let mut backup_events_stream = backup_watcher.subscribe_events();
-
     loop {
+        error!("polling events");
         tokio::select! {
          backup_event = backup_events_stream.recv() => {
           if let Ok(e) = backup_event {
@@ -1020,7 +1068,7 @@ impl BreezServicesBuilder {
             payment_receiver,
             event_listener: listener,
             backup_transport: unwrapped_backup_transport.clone(),
-            shutdown_sender: Mutex::new(None),
+            background_handler: Mutex::new(None),
         });
 
         Ok(breez_services)

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -781,7 +781,6 @@ async fn poll_events(
 
     let mut backup_events_stream = backup_watcher.subscribe_events();
     loop {
-        error!("polling events");
         tokio::select! {
          backup_event = backup_events_stream.recv() => {
           if let Ok(e) = backup_event {

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -81,14 +81,6 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub(crate) fn add_sync_request(&self) -> Result<()> {
-        self.get_connection()?.execute(
-            " INSERT INTO sync_requests(changed_table) VALUES('user')",
-            [],
-        )?;
-        Ok(())
-    }
-
     pub(crate) fn import_remote_changes(&self, remote_storage: &SqliteStorage) -> Result<()> {
         let sync_data_file = remote_storage.sync_db_path();
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -583,14 +583,14 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun startBackup(promise: Promise) {
+    fun backup(promise: Promise) {
         executor.execute {
             try {
-                getBreezServices().startBackup()
+                getBreezServices().backup()
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling startBackup", e)
+                promise.reject(TAG, e.message ?: "Error calling backup", e)
             }
         }
     }

--- a/libs/sdk-react-native/example/App.js
+++ b/libs/sdk-react-native/example/App.js
@@ -26,7 +26,7 @@ import {
     registerNode,
     buyBitcoin,
     start,
-    startBackup,
+    backup,
     backupStatus
 } from "@breeztech/react-native-breez-sdk"
 import BuildConfig from "react-native-build-config"
@@ -135,7 +135,7 @@ const App = () => {
                 const buyBitcoinResult = await buyBitcoin(BuyBitcoinProvider.MOONPAY)
                 addLine("buyBitcoin", JSON.stringify(buyBitcoinResult))
                                                 
-                await startBackup();
+                await backup();
                 addLine("backupStatus", JSON.stringify( await backupStatus()));                
             }
         }

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -231,7 +231,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-        startBackup: (RCTPromiseResolveBlock)resolve
+        backup: (RCTPromiseResolveBlock)resolve
         rejecter: (RCTPromiseRejectBlock)reject
 )
 

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -537,15 +537,15 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
     
-    @objc(startBackup:rejecter:)
-    func startBackup(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+    @objc(backup:rejecter:)
+    func backup(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            try getBreezServices().startBackup()
+            try getBreezServices().backup()
             resolve(["status": "ok"])
         } catch SdkError.Error(let message) {
             reject(RNBreezSDK.TAG, message, nil)
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling startBackup", err)
+            reject(RNBreezSDK.TAG, "Error calling backup", err)
         }
     }
     

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -651,8 +651,8 @@ export const buyBitcoin = async (provider: BuyBitcoinProvider): Promise<string> 
     return response
 }
 
-export const startBackup = async (): Promise<void> => {
- await BreezSDK.startBackup() 
+export const backup = async (): Promise<void> => {
+ await BreezSDK.backup() 
 }
 
 export const backupStatus = async (): Promise<BackupStatus> => {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -327,8 +327,8 @@ pub(crate) async fn handle_command(
             Ok(format!("Here your {:?} url: {}", provider, res))
         }
         Commands::Backup {} => {
-            sdk()?.start_backup()?;
-            Ok("Backup started".into())
+            sdk().unwrap().backup().await?;
+            Ok("Backup completed succesfully".into())
         }
     }
 }


### PR DESCRIPTION
The initial version of the backup feature included the `start_backup` API method which started the backup process without waiting for completion and return the end result.
The user had to monitor the backup events (started, succeeded failed) in order to track the in progress operation.
The PR changes the following in order for the UX to be simpler:

1. change the `start_backup` to `backup` which now:
- Enque a backup request
- Wait for it to complete and return the result.
2. The `BackupWatcher` now monitors a request channel in addition to the sql hooks channel, so the user requests goes to that channel directly and not via the `sync_requests` table as before.  This allows the removal of `add_sync_request` method completely. 
3. I have noticed the use of temp directory fails in Android so the code was changed to use a temporary directory inside the sdk working dir.