### PR TITLE
Create swap address: add mandatory fee params arg

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -31,7 +31,7 @@ use crate::swap::BTCReceiveSwap;
 use crate::BuyBitcoinProvider::Moonpay;
 use crate::*;
 use crate::{BuyBitcoinProvider, LnUrlAuthRequestData, LnUrlWithdrawRequestData, PaymentResponse};
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use bip39::*;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::util::bip32::ChildNumber;
@@ -497,7 +497,7 @@ impl BreezServices {
             .choose_channel_opening_fees(opening_fee_params, false)?;
         let swap_info = self
             .btc_receive_swapper
-            .create_swap_address(channel_opening_fees)
+            .create_swap_address(channel_opening_fees.context("No channel opening fees provided")?)
             .await?;
         Ok(swap_info)
     }

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -131,7 +131,7 @@ impl BTCReceiveSwap {
     /// See [SwapInfo] for details.
     pub(crate) async fn create_swap_address(
         &self,
-        channel_opening_fees: Option<OpeningFeeParams>,
+        channel_opening_fees: OpeningFeeParams,
     ) -> Result<SwapInfo> {
         let node_state = self.persister.get_node_state()?;
         if node_state.is_none() {
@@ -193,7 +193,7 @@ impl BTCReceiveSwap {
             min_allowed_deposit: swap_reply.min_allowed_deposit,
             max_allowed_deposit: swap_reply.max_allowed_deposit,
             last_redeem_error: None,
-            channel_opening_fees,
+            channel_opening_fees: Some(channel_opening_fees),
         };
 
         // persist the address


### PR DESCRIPTION
Requre a mandatory `OpeningFeeParams` arg for `BTCReceiveSwap::create_swap_address`.

This can come either from the caller (as an arg to `receive_onchain` or can be looked-up from the LSP.