### PR TITLE
Enable rpath in profile settings

### DIFF
--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -3,6 +3,7 @@ lto = true
 opt-level = "z"
 codegen-units = 1
 panic = "abort"
+rpath = true
 
 [workspace]
 members = [

--- a/libs/sdk-bindings/tests/test_generated_bindings.rs
+++ b/libs/sdk-bindings/tests/test_generated_bindings.rs
@@ -25,7 +25,7 @@ fn test_golang() {
     let output = Command::new("go")
         .env(
             "CGO_LDFLAGS",
-            "-lbreez_sdk_bindings -L../../../ffi/golang -lm -ldl",
+            "-lbreez_sdk_bindings -L../../../ffi/golang -Wl,-rpath,../../../ffi/golang",
         )
         .env("CGO_ENABLED", "1")
         .current_dir("tests/bindings/golang/")


### PR DESCRIPTION
Set the rpath setting to true in the release profile to allow the runtime library search path to be passed to the linker. This enables the darwin libraries to be distributed in a Golang module and linked to at runtime using cgo.