### PR TITLE
Simplify fee params menu handling when it's empty

### DIFF
--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -63,22 +63,26 @@ impl LspInformation {
         Ok(info)
     }
 
+    /// Returns the channel opening fees, either the ones provided by the user (if any), or the ones from LSP.
+    ///
+    /// If the LSP fees are needed, the LSP is expected to have at least one dynamic fee entry in its menu,
+    /// otherwise this will result in an error.
     pub(crate) fn choose_channel_opening_fees(
         &self,
         maybe_user_supplied_fee_params: Option<OpeningFeeParams>,
         cheapest_or_longest: bool,
-    ) -> Result<Option<OpeningFeeParams>> {
+    ) -> Result<OpeningFeeParams> {
         match maybe_user_supplied_fee_params {
             // Validate given opening_fee_params and use it if possible
             Some(user_supplied_fees) => {
                 user_supplied_fees.validate()?;
-                Ok(Some(user_supplied_fees))
+                Ok(user_supplied_fees)
             }
             // We pick our own if None is supplied
             None => {
                 let menu = OpeningFeeParamsMenu::try_from(self.opening_fee_params_menu.clone())?;
                 match cheapest_or_longest {
-                    true => Ok(menu.get_cheapest_opening_fee_params()),
+                    true => menu.get_cheapest_opening_fee_params(),
                     false => menu.get_longest_valid_opening_fee_params(),
                 }
             }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -898,9 +898,6 @@ mod tests {
 
     #[test]
     fn test_ofp_menu_validation() -> Result<()> {
-        // Empty menu is invalid
-        assert!(OpeningFeeParamsMenu::try_from(vec![]).is_err());
-
         // Menu with one entry is valid
         OpeningFeeParamsMenu::try_from(vec![get_test_ofp(10, 12, true)])?;
 


### PR DESCRIPTION
- `OpeningFeeParamsMenu` validation accepts the case when it has no entries
- However, when we need channel opening fee params, and the user provided none, the fee lookup will result in an error