### PR TITLE
Startup time optimization (phase 1)

### DIFF
--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -138,7 +138,7 @@ pub struct BlockingBreezServices {
 
 impl BlockingBreezServices {
     pub fn start(&self) -> Result<()> {
-        rt().block_on(async move { BreezServices::start(rt(), &self.breez_services).await })
+        rt().block_on(async move { self.breez_services.start().await })
     }
 
     pub fn stop(&self) -> Result<()> {

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -455,7 +455,7 @@ mod tests {
         let watcher = BackupWatcher::new(config, transport.clone(), persister, vec![0; 32]);
         let (quit_sender, receiver) = watch::channel(());
         watcher.start(receiver).await.unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         (quit_sender, watcher, transport)
     }
 
@@ -466,7 +466,7 @@ mod tests {
         expected_pushed: u32,
         expected_pulls: u32,
     ) {
-        let start = Instant::now() + Duration::from_millis(100000);
+        let start = Instant::now() + Duration::from_millis(20000);
         let mut interval = tokio::time::interval_at(start, Duration::from_secs(3));
         let mut events = vec![];
         loop {
@@ -529,7 +529,7 @@ mod tests {
                 .unwrap();
         });
         test_expected_backup_events(subscription, transport, expected_events, 2, 0).await;
-        quit_sender.send(()).unwrap();
+        _ = quit_sender.send(());
         quit_sender.closed().await;
     }
 
@@ -561,7 +561,7 @@ mod tests {
                 .unwrap();
         });
         test_expected_backup_events(subscription, transport, expected_events, 3, 1).await;
-        quit_sender.send(()).unwrap();
+        _ = quit_sender.send(());
         quit_sender.closed().await;
     }
 
@@ -626,7 +626,7 @@ mod tests {
         test_expected_backup_events(subscription, transport, expected_events, 3, 0).await;
         let history = persister.sync_versions_history().unwrap();
         assert_eq!(history.len(), 3);
-        quit_sender.send(()).unwrap();
+        _ = quit_sender.send(());
         quit_sender.closed().await;
     }
 
@@ -656,7 +656,7 @@ mod tests {
         test_expected_backup_events(subscription, transport, expected_events, 30, 0).await;
         let history = persister.sync_versions_history().unwrap();
         assert_eq!(history.len(), 20);
-        quit_sender.send(()).unwrap();
+        _ = quit_sender.send(());
         quit_sender.closed().await;
     }
 
@@ -681,7 +681,7 @@ mod tests {
         test_expected_backup_events(subscription, transport, expected_events, 1, 0).await;
         let history = watcher.persister.sync_versions_history().unwrap();
         assert_eq!(history.len(), 1);
-        quit_sender.send(()).unwrap();
+        _ = quit_sender.send(());
         quit_sender.closed().await;
     }
 
@@ -734,7 +734,7 @@ mod tests {
         test_expected_backup_events(main_subscription, transport, expected_events, 3, 1).await;
         let swaps = cloned_persister.list_swaps().unwrap();
         assert!(swaps.len() == 1);
-        quit_sender.send(()).unwrap();
+        _ = quit_sender.send(());
         quit_sender.closed().await;
     }
 

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -12,7 +12,6 @@ use std::{
     io::{Read, Write},
     path::Path,
     sync::Arc,
-    thread::JoinHandle,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tempfile::tempdir_in;
@@ -21,7 +20,7 @@ use tokio::{
     sync::{
         broadcast::{self, error::RecvError},
         mpsc::{self, Sender},
-        watch,
+        watch, Mutex,
     },
 };
 
@@ -30,6 +29,9 @@ pub(crate) struct BackupRequest {
     force: bool,
     on_complete: Option<mpsc::Sender<Result<()>>>,
 }
+
+unsafe impl Send for BackupRequest {}
+unsafe impl Sync for BackupRequest {}
 
 impl BackupRequest {
     pub(crate) fn new(force: bool) -> Self {
@@ -66,46 +68,64 @@ pub trait BackupTransport: Send + Sync {
 }
 
 pub(crate) struct BackupWatcher {
-    worker: BackupWorker,
-    thread_handle: Option<JoinHandle<()>>,
-    quit_sender: watch::Sender<()>,
-    trigger_backup: mpsc::Sender<BackupRequest>,
+    config: Config,
+    backup_request_sender: Mutex<Option<mpsc::Sender<BackupRequest>>>,
+    inner: Arc<dyn BackupTransport>,
+    persister: Arc<SqliteStorage>,
+    encryption_key: Vec<u8>,
+    events_notifier: broadcast::Sender<BreezEvent>,
 }
 
 /// watches for sync requests and syncs the sdk state when a request is detected.
 impl BackupWatcher {
-    pub(crate) fn start(
+    pub(crate) fn new(
         config: Config,
         inner: Arc<dyn BackupTransport>,
         persister: Arc<SqliteStorage>,
         encryption_key: Vec<u8>,
     ) -> Self {
-        let (notifier, _) = broadcast::channel::<BreezEvent>(100);
-        let worker = BackupWorker::new(
-            config.working_dir,
+        let (events_notifier, _) = broadcast::channel::<BreezEvent>(100);
+
+        Self {
+            config,
+            backup_request_sender: Mutex::new(None),
             inner,
             persister,
             encryption_key,
-            notifier,
+            events_notifier,
+        }
+    }
+
+    async fn set_request_sender(&self, sender: mpsc::Sender<BackupRequest>) {
+        let mut backup_request_sender = self.backup_request_sender.lock().await;
+        *backup_request_sender = Some(sender);
+    }
+
+    pub(crate) async fn start(&self, mut quit_receiver: watch::Receiver<()>) -> Result<()> {
+        let worker = BackupWorker::new(
+            self.config.working_dir.clone(),
+            self.inner.clone(),
+            self.persister.clone(),
+            self.encryption_key.clone(),
+            self.events_notifier.clone(),
         );
 
-        let (trigger_backup, mut trigger_backup_receiver) = mpsc::channel::<BackupRequest>(100);
+        let mut hooks_subscription = self.persister.subscribe_hooks();
+        let (backup_request_sender, mut backup_request_receiver) =
+            mpsc::channel::<BackupRequest>(100);
+        self.set_request_sender(backup_request_sender.clone()).await;
 
-        let (quit_sender, mut quit_receiver) = watch::channel::<()>(());
-        let mut hooks_subscription = worker.persister.subscribe_hooks();
-
-        let cloned_worker = worker.clone();
         let rt = Builder::new_current_thread().enable_all().build().unwrap();
-        let thread_handle = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             rt.block_on(async move {
                 loop {
                     tokio::select! {
 
                      // We listen to manual backup requests from the user
-                     request = trigger_backup_receiver.recv() => {
+                     request = backup_request_receiver.recv() => {
                       match request {
                        Some(request) => {
-                        match cloned_worker.sync(request.force).await {
+                        match worker.sync(request.force).await {
                          Ok(_) => {
                           if let Some(callback) = request.on_complete {
                            _ = callback.send(Ok(())).await;
@@ -132,14 +152,14 @@ impl BackupWatcher {
                              if table == "sync_requests"{
                               // we do want to wait a bit to allow for multiple sync requests to be inserted
                               tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                              if let Err(e) = cloned_worker.sync(false).await {
+                              if let Err(e) = worker.sync(false).await {
                                error!("Sync worker returned with error {e}");
                               }
                              }
                             }
                             // If we are lagging we want to trigger sync
                             Err(RecvError::Lagged(_)) => {
-                             if let Err(e) = cloned_worker.sync(false).await {
+                             if let Err(e) = worker.sync(false).await {
                               error!("Sync worker returned with error {e}");
                              }
                             }
@@ -158,36 +178,21 @@ impl BackupWatcher {
             });
         });
 
-        Self {
-            worker,
-            thread_handle: Some(thread_handle),
-            quit_sender,
-            trigger_backup,
-        }
+        Ok(())
     }
 
     pub(crate) fn subscribe_events(&self) -> broadcast::Receiver<BreezEvent> {
-        self.worker.events_notifier.subscribe()
+        self.events_notifier.subscribe()
     }
 
-    pub(crate) fn request_handler(&self) -> Sender<BackupRequest> {
-        self.trigger_backup.clone()
-    }
-
-    fn stop(&mut self) -> Result<()> {
-        self.quit_sender.send(())?;
-        match self.thread_handle.take() {
-            Some(handle) => handle
-                .join()
-                .map_err(|_| anyhow::Error::msg("failed to join backup thread")),
-            None => Ok(()),
-        }
-    }
-}
-
-impl Drop for BackupWatcher {
-    fn drop(&mut self) {
-        self.stop().unwrap();
+    pub(crate) async fn request_backup(&self, request: BackupRequest) -> Result<()> {
+        let request_handler = self.backup_request_sender.lock().await;
+        let h = request_handler.clone();
+        h.unwrap()
+            .send(request)
+            .await
+            .map_err(|_| anyhow::Error::msg("test"))?;
+        Ok(())
     }
 }
 
@@ -432,9 +437,8 @@ mod tests {
         test_utils::{create_test_config, create_test_persister, MockBackupTransport},
         BreezEvent, SwapInfo,
     };
-    use anyhow::anyhow;
     use std::{sync::Arc, vec};
-    use tokio::sync::{broadcast::Receiver, mpsc::Sender};
+    use tokio::sync::{broadcast::Receiver, watch};
     use tokio::{
         spawn,
         time::{Duration, Instant},
@@ -442,22 +446,17 @@ mod tests {
 
     use super::BackupWatcher;
 
-    async fn create_test_backup_watcher() -> (BackupWatcher, Arc<MockBackupTransport>) {
+    async fn create_test_backup_watcher(
+    ) -> (watch::Sender<()>, BackupWatcher, Arc<MockBackupTransport>) {
         let config = create_test_config();
         let persister = Arc::new(create_test_persister(config.clone()));
         persister.init().unwrap();
         let transport = Arc::new(MockBackupTransport::new());
-        let watcher = BackupWatcher::start(config, transport.clone(), persister, vec![0; 32]);
-        (watcher, transport)
-    }
-
-    async fn request_backup(sender: Sender<BackupRequest>) {
-        let request = BackupRequest::new(true);
-        sender
-            .send(request)
-            .await
-            .map_err(|e| anyhow!("Failed to send backup request: {e}"))
-            .unwrap();
+        let watcher = BackupWatcher::new(config, transport.clone(), persister, vec![0; 32]);
+        let (quit_sender, receiver) = watch::channel(());
+        watcher.start(receiver).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+        (quit_sender, watcher, transport)
     }
 
     async fn test_expected_backup_events(
@@ -498,14 +497,15 @@ mod tests {
     // Test start and drop
     #[tokio::test]
     async fn test_start() {
-        let watcher = create_test_backup_watcher();
-        drop(watcher);
+        let (quit_sender, _, _) = create_test_backup_watcher().await;
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     // Test two optimistic backups in a row
     #[tokio::test]
     async fn test_optimistic() {
-        let (watcher, transport) = create_test_backup_watcher().await;
+        let (quit_sender, watcher, transport) = create_test_backup_watcher().await;
         let subscription = watcher.subscribe_events();
         let expected_events = vec![
             BreezEvent::BackupStarted,
@@ -515,19 +515,28 @@ mod tests {
         ];
 
         let task_subscription = watcher.subscribe_events();
-        let request_handler = watcher.request_handler();
+        //let cloned_watcher = watcher.clone();
+        //let request_handler = watcher.request_handler().unwrap();
         tokio::spawn(async move {
-            request_backup(request_handler.clone()).await;
+            watcher
+                .request_backup(BackupRequest::new(true))
+                .await
+                .unwrap();
             wait_for_backup_success(task_subscription).await;
-            request_backup(request_handler).await;
+            watcher
+                .request_backup(BackupRequest::new(true))
+                .await
+                .unwrap();
         });
         test_expected_backup_events(subscription, transport, expected_events, 2, 0).await;
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     // Test case when remote backup is not available and we only push the local backup.
     #[tokio::test]
     async fn test_remote_not_exist() {
-        let (watcher, transport) = create_test_backup_watcher().await;
+        let (quit_sender, watcher, transport) = create_test_backup_watcher().await;
         let subscription = watcher.subscribe_events();
         let expected_events = vec![
             BreezEvent::BackupStarted,
@@ -536,23 +545,30 @@ mod tests {
             BreezEvent::BackupSucceeded,
         ];
 
-        let persister = watcher.worker.persister.clone();
-        let request_handler = watcher.request_handler();
+        let persister = watcher.persister.clone();
         let task_subscription = watcher.subscribe_events();
         tokio::spawn(async move {
             let subscription = task_subscription.resubscribe();
-            request_backup(request_handler.clone()).await;
+            watcher
+                .request_backup(BackupRequest::new(true))
+                .await
+                .unwrap();
             wait_for_backup_success(subscription).await;
             persister.set_last_sync_version(10, &vec![]).unwrap();
-            request_backup(request_handler.clone()).await;
+            watcher
+                .request_backup(BackupRequest::new(true))
+                .await
+                .unwrap();
         });
         test_expected_backup_events(subscription, transport, expected_events, 3, 1).await;
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     // Test case when remote backup is older than local backup so we need to pull it first.
     #[tokio::test]
     async fn test_local_newer_than_remote() {
-        let (watcher, transport) = create_test_backup_watcher().await;
+        let (quit_sender, watcher, transport) = create_test_backup_watcher().await;
         let subscription = watcher.subscribe_events();
         let expected_events = vec![
             BreezEvent::BackupStarted,
@@ -561,23 +577,30 @@ mod tests {
             BreezEvent::BackupSucceeded,
         ];
 
-        let persister = watcher.worker.persister.clone();
+        let persister = watcher.persister.clone();
         let task_subscription = watcher.subscribe_events();
-        let request_handler = watcher.request_handler();
         tokio::spawn(async move {
             let subscription = task_subscription.resubscribe();
-            request_backup(request_handler.clone()).await;
+            watcher
+                .request_backup(BackupRequest::new(true))
+                .await
+                .unwrap();
             wait_for_backup_success(subscription).await;
             persister.set_last_sync_version(10, &vec![]).unwrap();
-            request_backup(request_handler.clone()).await;
+            watcher
+                .request_backup(BackupRequest::new(true))
+                .await
+                .unwrap();
         });
         test_expected_backup_events(subscription, transport, expected_events, 3, 1).await;
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     // Test versions history table is pupulated correctly
     #[tokio::test]
     async fn test_versions_history() {
-        let (watcher, transport) = create_test_backup_watcher().await;
+        let (quit_sender, watcher, transport) = create_test_backup_watcher().await;
         let subscription = watcher.subscribe_events();
         let expected_events = vec![
             BreezEvent::BackupStarted,
@@ -589,23 +612,28 @@ mod tests {
         ];
 
         let task_subscription = watcher.subscribe_events();
-        let request_handler = watcher.request_handler();
+        let persister = watcher.persister.clone();
         tokio::spawn(async move {
             for _ in 0..3 {
                 let subscription = task_subscription.resubscribe();
-                request_backup(request_handler.clone()).await;
+                watcher
+                    .request_backup(BackupRequest::new(true))
+                    .await
+                    .unwrap();
                 wait_for_backup_success(subscription).await;
             }
         });
         test_expected_backup_events(subscription, transport, expected_events, 3, 0).await;
-        let history = watcher.worker.persister.sync_versions_history().unwrap();
+        let history = persister.sync_versions_history().unwrap();
         assert_eq!(history.len(), 3);
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     // Test versions history table is not bypassing the limit
     #[tokio::test]
     async fn test_limit_versions_history() {
-        let (watcher, transport) = create_test_backup_watcher().await;
+        let (quit_sender, watcher, transport) = create_test_backup_watcher().await;
         let subscription = watcher.subscribe_events();
         let mut expected_events = vec![];
         for _ in 0..30 {
@@ -614,23 +642,28 @@ mod tests {
         }
 
         let task_subscription = watcher.subscribe_events();
-        let request_handler = watcher.request_handler();
+        let persister = watcher.persister.clone();
         tokio::spawn(async move {
             for _ in 0..30 {
                 let subscription = task_subscription.resubscribe();
-                request_backup(request_handler.clone()).await;
+                watcher
+                    .request_backup(BackupRequest::new(true))
+                    .await
+                    .unwrap();
                 wait_for_backup_success(subscription).await;
             }
         });
         test_expected_backup_events(subscription, transport, expected_events, 30, 0).await;
-        let history = watcher.worker.persister.sync_versions_history().unwrap();
+        let history = persister.sync_versions_history().unwrap();
         assert_eq!(history.len(), 20);
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     // Test that the actualy triggers cause sync and we only sync once
     #[tokio::test]
     async fn test_sync_triggers() {
-        let (watcher, transport) = create_test_backup_watcher().await;
+        let (quit_sender, watcher, transport) = create_test_backup_watcher().await;
         let subscription = watcher.subscribe_events();
 
         let mut expected_events = vec![];
@@ -639,15 +672,17 @@ mod tests {
             expected_events.push(BreezEvent::BackupSucceeded);
         }
 
-        let persister = watcher.worker.persister.clone();
+        let persister = watcher.persister.clone();
         spawn(async move {
             // Add some data to the sync database to trigger sync
             populate_sync_table(persister.clone());
         });
 
         test_expected_backup_events(subscription, transport, expected_events, 1, 0).await;
-        let history = watcher.worker.persister.sync_versions_history().unwrap();
+        let history = watcher.persister.sync_versions_history().unwrap();
         assert_eq!(history.len(), 1);
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     // Test that we only sync once if we have multiple sync requests
@@ -660,8 +695,8 @@ mod tests {
     // 5. Check that remote changes were populated locally and we synced exactly twice.
     #[tokio::test]
     async fn test_trigger_during_sync() {
-        let (watcher, transport) = create_test_backup_watcher().await;
-        let persister = watcher.worker.persister.clone();
+        let (quit_sender, watcher, transport) = create_test_backup_watcher().await;
+        let persister = watcher.persister.clone();
 
         let mut expected_events = vec![];
         for _ in 0..2 {
@@ -672,7 +707,7 @@ mod tests {
         let main_subscription = watcher.subscribe_events();
         let task_subscription = watcher.subscribe_events();
         let task_subscription1 = task_subscription.resubscribe();
-        let request_handler = watcher.request_handler();
+        let cloned_persister = watcher.persister.clone();
         tokio::spawn(async move {
             // Add some data to the sync database and wait for backup to complete.
             populate_sync_table(persister.clone());
@@ -690,12 +725,17 @@ mod tests {
                         [],
                     )
                     .unwrap();
-            request_backup(request_handler).await;
+            watcher
+                .request_backup(BackupRequest::new(true))
+                .await
+                .unwrap();
             wait_for_backup_success(task_subscription2).await;
         });
         test_expected_backup_events(main_subscription, transport, expected_events, 3, 1).await;
-        let swaps = watcher.worker.persister.list_swaps().unwrap();
+        let swaps = cloned_persister.list_swaps().unwrap();
         assert!(swaps.len() == 1);
+        quit_sender.send(()).unwrap();
+        quit_sender.closed().await;
     }
 
     fn populate_sync_table(persister: Arc<SqliteStorage>) {

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -142,13 +142,11 @@ pub fn init_services(config: Config, seed: Vec<u8>, creds: GreenlightCredentials
 /// See [BreezServices::start]
 pub fn start_node() -> Result<()> {
     block_on(async {
-        BreezServices::start(
-            rt(),
-            BREEZ_SERVICES_INSTANCE
-                .get()
-                .ok_or_else(|| anyhow!("breez services instance was not initialized"))?,
-        )
-        .await
+        BREEZ_SERVICES_INSTANCE
+            .get()
+            .ok_or_else(|| anyhow!("breez services instance was not initialized"))?
+            .start()
+            .await
     })
 }
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -790,7 +790,7 @@ impl BreezServices {
         loop {
             if shutdown_receiver.has_changed().map_or(true, |c| c) {
                 return;
-            }
+            }            
             let invoice_stream_res = cloned.node_api.stream_incoming_payments().await;
             if let Ok(mut invoice_stream) = invoice_stream_res {
                 loop {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -164,7 +164,7 @@ impl BreezServices {
 
         *runtime_lock = Some(runtime);
         let start_duration = start.elapsed();
-        println!("SDK initialized in: {:?}", start_duration);
+        info!("SDK initialized in: {:?}", start_duration);
         Ok(())
     }
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -790,7 +790,7 @@ impl BreezServices {
         loop {
             if shutdown_receiver.has_changed().map_or(true, |c| c) {
                 return;
-            }            
+            }
             let invoice_stream_res = cloned.node_api.stream_incoming_payments().await;
             if let Ok(mut invoice_stream) = invoice_stream_res {
                 loop {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -38,9 +38,9 @@ use bitcoin::util::bip32::ChildNumber;
 use std::cmp::max;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, RwLock};
 use tokio::time::{sleep, Duration};
 use tonic::codegen::InterceptedService;
 use tonic::metadata::{Ascii, MetadataValue};
@@ -95,94 +95,9 @@ pub struct InvoicePaidDetails {
     pub bolt11: String,
 }
 
-#[derive(Clone, Debug)]
-struct SDKBackgroundController {
-    shutdown_handler: mpsc::Sender<()>,
-    backup_request_handler: mpsc::Sender<BackupRequest>,
-}
-
-/// Starts the BreezServices background threads.
-///
-/// Internal method. Should only be used as part of [BreezServices::start]
-async fn start_threads(
-    rt: &Runtime,
-    breez_services: Arc<BreezServices>,
-) -> Result<SDKBackgroundController> {
-    // start the signer
-    let (shutdown_signer_sender, signer_signer_receiver) = mpsc::channel(1);
-    let signer_api = breez_services.clone();
-    rt.spawn(async move {
-        signer_api
-            .node_api
-            .start_signer(signer_signer_receiver)
-            .await;
-    });
-
-    let breez_cloned = breez_services.clone();
-
-    // sync with remote node state
-    breez_cloned.sync().await?;
-
-    // create the backup encryption key
-    let backup_encryption_key = breez_services.node_api.derive_bip32_key(vec![
-        ChildNumber::from_hardened_idx(139)?,
-        ChildNumber::from(0),
-    ])?;
-
-    let backup_watcher = BackupWatcher::start(
-        breez_cloned.config.clone(),
-        breez_services.backup_transport.clone(),
-        breez_services.persister.clone(),
-        backup_encryption_key.to_priv().to_bytes(),
-    );
-
-    // Restore backup state and request backup on start if needed
-    let force_backup = breez_cloned.persister.get_last_sync_version()?.is_none();
-    let backup_request_handler = backup_watcher.request_handler();
-    backup_request_handler
-        .send(BackupRequest::new(force_backup))
-        .await
-        .map_err(|e| anyhow!("failed to send backup request {e}"))?;
-
-    // create a shutdown channel (sender and receiver)
-    let (shutdown_handler, mut shutdown_receiver) = mpsc::channel::<()>(1);
-
-    // poll sdk events
-    rt.spawn(async move {
-        // start the backup watcher
-        let current_block: u32 = 0;
-        loop {
-            tokio::select! {
-              poll_result = poll_events(breez_services.clone(),&backup_watcher, current_block) => {
-               match poll_result {
-                Ok(()) => {
-                 return;
-                },
-                Err(err) => {
-                 debug!("poll_events returned with error: {:?} waiting...", err);
-                 sleep(Duration::from_secs(1)).await;
-                 continue
-                }
-               }
-              },
-              _ = shutdown_receiver.recv() => {
-               _ = shutdown_signer_sender.send(()).await;
-               debug!("Received the signal to exit event polling loop");
-               return;
-            }
-        }
-       }
-    });
-
-    Ok(SDKBackgroundController {
-        shutdown_handler,
-        backup_request_handler,
-    })
-}
-
 /// BreezServices is a facade and the single entry point for the SDK.
 pub struct BreezServices {
-    config: Config,
+    runtime: Arc<RwLock<Option<tokio::runtime::Runtime>>>,
     node_api: Arc<dyn NodeAPI>,
     lsp_api: Arc<dyn LspAPI>,
     fiat_api: Arc<dyn FiatAPI>,
@@ -193,9 +108,9 @@ pub struct BreezServices {
     btc_receive_swapper: Arc<BTCReceiveSwap>,
     btc_send_swapper: Arc<BTCSendSwap>,
     event_listener: Option<Box<dyn EventListener>>,
-    //backup_watcher: BackupWatcher,
-    backup_transport: Arc<dyn BackupTransport>,
-    background_handler: Mutex<Option<SDKBackgroundController>>,
+    backup_watcher: Arc<BackupWatcher>,
+    shutdown_sender: watch::Sender<()>,
+    shutdown_receiver: watch::Receiver<()>,
 }
 
 impl BreezServices {
@@ -227,36 +142,47 @@ impl BreezServices {
             .await
     }
 
-    /// Starts the BreezServices background threads for this instance.
+    /// Starts the BreezServices background tasks for this instance.
     ///
     /// It should be called once right after creating [BreezServices], since it is essential for the
     /// communicating with the node.
     ///
     /// It should be called only once when the app is started, regardless whether the app is sent to
     /// background and back.
-    pub async fn start(runtime: &Runtime, breez_services: &Arc<BreezServices>) -> Result<()> {
-        let mut handler_lock = breez_services.background_handler.lock().await;
-        if handler_lock.is_some() {
-            return Err(anyhow!("start can only be called once"));
+    pub async fn start(self: &Arc<BreezServices>) -> Result<()> {
+        let start = Instant::now();
+        let mut runtime_lock = self.runtime.write().await;
+        if runtime_lock.is_some() {
+            return Err(anyhow!("SDK already connected "));
         }
-        let background_handler = start_threads(runtime, breez_services.clone()).await?;
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
 
-        *handler_lock = Some(background_handler);
+        self.start_background_tasks(&runtime).await?;
+
+        *runtime_lock = Some(runtime);
+        let start_duration = start.elapsed();
+        println!("SDK initialized in: {:?}", start_duration);
         Ok(())
     }
 
     /// Trigger the stopping of BreezServices background threads for this instance.
     pub async fn stop(&self) -> Result<()> {
-        let handler_lock = self.background_handler.lock().await;
-        if handler_lock.is_none() {
-            return Err(anyhow!("node has not been started"));
-        }
-        let background_handler = handler_lock.as_ref().unwrap();
-        background_handler
-            .shutdown_handler
-            .send(())
+        let runtime = self
+            .runtime
+            .write()
             .await
-            .map_err(anyhow::Error::msg)
+            .take()
+            .ok_or(anyhow!("SDK is not connected"))?;
+
+        // Stop the runtime.
+        self.shutdown_sender.send(()).map_err(anyhow::Error::msg)?;
+        tokio::task::spawn_blocking(move || runtime.shutdown_timeout(Duration::from_secs(5)))
+            .await
+            .unwrap();
+        Ok(())
     }
 
     /// Pay a bolt11 invoice
@@ -429,12 +355,7 @@ impl BreezServices {
     pub async fn backup(&self) -> Result<()> {
         let (on_complete, mut on_complete_receiver) = mpsc::channel::<Result<()>>(1);
         let request = BackupRequest::with(on_complete, true);
-        self.background_controller()
-            .await?
-            .backup_request_handler
-            .send(request)
-            .await
-            .map_err(|e| anyhow!("failed to send backup request {e}"))?;
+        self.backup_watcher.request_backup(request).await?;
 
         match on_complete_receiver.recv().await {
             Some(res) => res,
@@ -761,98 +682,234 @@ impl BreezServices {
         Ok(url)
     }
 
-    async fn background_controller(&self) -> Result<SDKBackgroundController> {
-        let handler_lock = self.background_handler.lock().await;
-        if handler_lock.is_none() {
-            return Err(anyhow!("node has not been started"));
+    /// Starts the BreezServices background threads.
+    ///
+    /// Internal method. Should only be used as part of [BreezServices::start]
+    async fn start_background_tasks(self: &Arc<BreezServices>, rt: &Runtime) -> Result<()> {
+        // start the signer
+        let (shutdown_signer_sender, signer_signer_receiver) = mpsc::channel(1);
+        self.start_signer(rt, signer_signer_receiver).await;
+
+        // start backup watcher
+        self.start_backup_watcher().await?;
+
+        //track backup events
+        self.track_backup_events(rt).await;
+
+        // track paid invoices
+        self.track_invoices(rt).await;
+
+        // track new blocks
+        self.track_new_blocks(rt).await;
+
+        // track logs
+        self.track_logs(rt).await;
+
+        // Stop signer on shutdown
+        let mut shutdown_receiver = self.shutdown_receiver.clone();
+        rt.spawn(async move {
+            // start the backup watcher
+            _ = shutdown_receiver.changed().await;
+            _ = shutdown_signer_sender.send(()).await;
+            debug!("Received the signal to exit event polling loop");
+        });
+
+        // Sync node state
+        let sync_breez_services = self.clone();
+        match sync_breez_services.node_info()? {
+            Some(_) => {
+                // In case it is not a first run we sync in background to start quickly.
+                rt.spawn(async move {
+                    // sync with remote node state
+                    _ = sync_breez_services.sync().await;
+                });
+            }
+            None => {
+                // In case it is a first run we sync in foreground to get the node state.
+                _ = sync_breez_services.sync().await;
+            }
         }
-        Ok(handler_lock.clone().unwrap())
+
+        Ok(())
     }
-}
 
-async fn poll_events(
-    breez_services: Arc<BreezServices>,
-    backup_watcher: &BackupWatcher,
-    mut current_block: u32,
-) -> Result<()> {
-    let mut interval = tokio::time::interval(Duration::from_secs(30));
-    let mut invoice_stream = breez_services.node_api.stream_incoming_payments().await?;
-    let mut log_stream = breez_services.node_api.stream_log_messages().await?;
+    async fn start_signer(
+        self: &Arc<BreezServices>,
+        rt: &Runtime,
+        shutdown_receiver: mpsc::Receiver<()>,
+    ) {
+        let signer_api = self.clone();
+        rt.spawn(async move {
+            signer_api.node_api.start_signer(shutdown_receiver).await;
+        });
+    }
 
-    let mut backup_events_stream = backup_watcher.subscribe_events();
-    loop {
-        tokio::select! {
-         backup_event = backup_events_stream.recv() => {
-          if let Ok(e) = backup_event {
-           if let Err(err) = breez_services.notify_event_listeners(e).await {
-               error!("error handling backup event: {:?}", err);
-           }
-          }
-          let backup_status = breez_services.backup_status();
-          info!("backup status: {:?}", backup_status);
-         },
-         // handle chain events
-         _ = interval.tick() => {
-          let tip_res = breez_services.chain_service.current_tip().await;
-          match tip_res {
-           Ok(next_block) => {
-            debug!("got tip {:?}", next_block);
-            if next_block > current_block {
-             _ = breez_services.sync().await;
-             _  = breez_services.on_event(BreezEvent::NewBlock{block: next_block}).await;
+    async fn start_backup_watcher(self: &Arc<BreezServices>) -> Result<()> {
+        self.backup_watcher
+            .start(self.shutdown_receiver.clone())
+            .await?;
+
+        // Restore backup state and request backup on start if needed
+        let force_backup = self.persister.get_last_sync_version()?.is_none();
+        self.backup_watcher
+            .request_backup(BackupRequest::new(force_backup))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn track_backup_events(self: &Arc<BreezServices>, rt: &Runtime) {
+        let cloned = self.clone();
+        rt.spawn(async move {
+            let mut events_stream = cloned.backup_watcher.subscribe_events();
+            let mut shutdown_receiver = cloned.shutdown_receiver.clone();
+            loop {
+                tokio::select! {
+                  backup_event = events_stream.recv() => {
+                   if let Ok(e) = backup_event {
+                    if let Err(err) = cloned.notify_event_listeners(e).await {
+                        error!("error handling backup event: {:?}", err);
+                    }
+                   }
+                   let backup_status = cloned.backup_status();
+                   info!("backup status: {:?}", backup_status);
+                  },
+                  _ = shutdown_receiver.changed() => {
+                   debug!("Backup watcher task completed");
+                   break;
+                 }
+                }
             }
-            current_block = next_block
-           },
-           Err(e) => {
-            error!("failed to fetch next block {}", e)
-           }
-          };
-         },
-         paid_invoice_res = invoice_stream.message() => {
-          match paid_invoice_res {
-           Ok(Some(i)) => {
-            debug!("invoice stream got new invoice");
-            if let Some(gl_client::pb::incoming_payment::Details::Offchain(p)) = i.details {
-             let payment: Option<crate::models::Payment> = p.clone().try_into().ok();
-             if payment.is_some() {
-              let res = breez_services.persister.insert_or_update_payments(&vec![payment.unwrap()]);
-              debug!("paid invoice was added to payments list {:?}", res);
+        });
+    }
+
+    async fn track_invoices(self: &Arc<BreezServices>, rt: &Runtime) {
+        let cloned = self.clone();
+        rt.spawn(async move {
+        let mut shutdown_receiver = cloned.shutdown_receiver.clone();
+        loop {
+            if shutdown_receiver.has_changed().map_or(true, |c| c) {
+                return;
+            }
+            let invoice_stream_res = cloned.node_api.stream_incoming_payments().await;
+            if let Ok(mut invoice_stream) = invoice_stream_res {
+                loop {
+                    tokio::select! {
+                            paid_invoice_res = invoice_stream.message() => {
+                                  match paid_invoice_res {
+                                      Ok(Some(i)) => {
+                                          debug!("invoice stream got new invoice");
+                                          if let Some(gl_client::pb::incoming_payment::Details::Offchain(p)) = i.details {
+                                              let payment: Option<crate::models::Payment> = p.clone().try_into().ok();
+                                              if payment.is_some() {
+                                                  let res = cloned
+                                                      .persister
+                                                      .insert_or_update_payments(&vec![payment.unwrap()]);
+                                                  debug!("paid invoice was added to payments list {:?}", res);
+                                              }
+                                              _ = cloned.on_event(BreezEvent::InvoicePaid {
+                                                  details: InvoicePaidDetails {
+                                                      payment_hash: hex::encode(p.payment_hash),
+                                                      bolt11: p.bolt11,
+                                                  },
+                                              }).await;
+                                          }
+                                      }
+                                      Ok(None) => {
+                                          debug!("invoice stream got None");
+                                          break;
+                                      }
+                                      Err(err) => {
+                                          debug!("invoice stream got error: {:?}", err);
+                                          break;
+                                      }
+                                  }
+                         }
+
+                         _ = shutdown_receiver.changed() => {
+                          debug!("Invoice tracking task has completed");
+                          return;
+                         }
+                    }
+                }
              }
-             _  = breez_services.on_event(BreezEvent::InvoicePaid{details: InvoicePaidDetails {
-                 payment_hash: hex::encode(p.payment_hash),
-                 bolt11: p.bolt11,
-             }}).await;
-             _ = breez_services.sync().await;
-            }
-           }
-           // stream is closed, renew it
-           Ok(None) => {
-            debug!("invoice stream closed, renewing");
-            invoice_stream = breez_services.node_api.stream_incoming_payments().await?;
-           }
-           Err(err) => {
-            debug!("failed to process incoming payment {:?}", err);
-            invoice_stream = breez_services.node_api.stream_incoming_payments().await?;
-           }
-          };
-        },
-         log_message_res = log_stream.message() => {
-          match log_message_res {
-           Ok(Some(l)) => {
-            debug!("node-logs: {}", l.line);
-           },
-           // stream is closed, renew it
-           Ok(None) => {
-            //debug!("log stream closed, renewing");
-            log_stream = breez_services.node_api.stream_log_messages().await?;
-           }
-           Err(err) => {
-            debug!("failed to process log entry {:?}", err);
-            log_stream = breez_services.node_api.stream_log_messages().await?;
-           }
-          };
-         }
+         sleep(Duration::from_secs(1)).await;
         }
+     });
+    }
+
+    async fn track_logs(self: &Arc<BreezServices>, rt: &Runtime) {
+        let cloned = self.clone();
+        rt.spawn(async move {
+            let mut shutdown_receiver = cloned.shutdown_receiver.clone();
+            loop {
+                if shutdown_receiver.has_changed().map_or(true, |c| c) {
+                    return;
+                }
+                let log_stream_res = cloned.node_api.stream_log_messages().await;
+                if let Ok(mut log_stream) = log_stream_res {
+                    loop {
+                        tokio::select! {
+                         log_message_res = log_stream.message() => {
+                          match log_message_res {
+                           Ok(Some(l)) => {
+                            debug!("node-logs: {}", l.line);
+                           },
+                           // stream is closed, renew it
+                           Ok(None) => {
+                            break;
+                           }
+                           Err(err) => {
+                            debug!("failed to process log entry {:?}", err);
+                            break;
+                           }
+                          };
+                         }
+
+                         _ = shutdown_receiver.changed() => {
+                          debug!("Track logs task has completed");
+                          return;
+                         }
+                        }
+                    }
+                }
+                sleep(Duration::from_secs(1)).await;
+            }
+        });
+    }
+
+    async fn track_new_blocks(self: &Arc<BreezServices>, rt: &Runtime) {
+        let cloned = self.clone();
+        rt.spawn(async move {
+            let mut current_block: u32 = 0;
+            let mut shutdown_receiver = cloned.shutdown_receiver.clone();
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                tokio::select! {
+                 _ = interval.tick() => {
+                  let tip_res = cloned.chain_service.current_tip().await;
+                  match tip_res {
+                   Ok(next_block) => {
+                    debug!("got tip {:?}", next_block);
+                    if next_block > current_block {
+                     _ = cloned.sync().await;
+                     _  = cloned.on_event(BreezEvent::NewBlock{block: next_block}).await;
+                    }
+                    current_block = next_block
+                   },
+                   Err(e) => {
+                    error!("failed to fetch next block {}", e)
+                   }
+                  };
+                 }
+
+                 _ = shutdown_receiver.changed() => {
+                  debug!("New blocks task has completed");
+                  return;
+                 }
+                }
+            }
+        });
     }
 }
 
@@ -1001,12 +1058,25 @@ impl BreezServicesBuilder {
                 backup_transport = Some(Arc::new(GLBackupTransport { inner: gl_arc }));
             }
         }
+
         if backup_transport.is_none() {
             return Err(anyhow!("state synchronizer should be provided"));
         }
 
         let unwrapped_node_api = node_api.unwrap();
         let unwrapped_backup_transport = backup_transport.unwrap();
+
+        // create the backup encryption key and then the backup watcher
+        let backup_encryption_key = unwrapped_node_api.derive_bip32_key(vec![
+            ChildNumber::from_hardened_idx(139)?,
+            ChildNumber::from(0),
+        ])?;
+        let backup_watcher = BackupWatcher::new(
+            self.config.clone(),
+            unwrapped_backup_transport.clone(),
+            persister.clone(),
+            backup_encryption_key.to_priv().to_bytes(),
+        );
 
         // breez_server provides both FiatAPI & LspAPI implementations
         let breez_server = Arc::new(BreezServer::new(
@@ -1050,9 +1120,12 @@ impl BreezServicesBuilder {
             unwrapped_node_api.clone(),
         ));
 
+        // create a shutdown channel (sender and receiver)
+        let (shutdown_sender, shutdown_receiver) = watch::channel::<()>(());
+
         // Create the node services and it them statically
         let breez_services = Arc::new(BreezServices {
-            config: self.config.clone(),
+            runtime: Arc::new(RwLock::new(None)),
             node_api: unwrapped_node_api.clone(),
             lsp_api: self.lsp_api.clone().unwrap_or_else(|| breez_server.clone()),
             fiat_api: self
@@ -1069,8 +1142,9 @@ impl BreezServicesBuilder {
             btc_send_swapper,
             payment_receiver,
             event_listener: listener,
-            backup_transport: unwrapped_backup_transport.clone(),
-            background_handler: Mutex::new(None),
+            backup_watcher: Arc::new(backup_watcher),
+            shutdown_sender,
+            shutdown_receiver,
         });
 
         Ok(breez_services)

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -31,7 +31,7 @@
 //!     )
 //!     .await?;
 //!
-//! BreezServices::start(rt(), &sdk).await?;
+//! sdk.start().await?;
 //! ```
 //!
 //! On initializing the SDK, the caller gets its [GreenlightCredentials]. These are used to interact

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -125,7 +125,7 @@ class RNBreezSDK: RCTEventEmitter {
     func defaultConfig(_ envType: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             var config = try BreezSDK.defaultConfig(envType: BreezSDKMapper.asEnvironmentType(envType: envType))
-            config.workingDir = RNBreezSDK.breezSdkDirectory.absoluteString
+            config.workingDir = RNBreezSDK.breezSdkDirectory.path
 
             resolve(BreezSDKMapper.dictionaryOf(config: config))
         } catch SdkError.Error(let message) {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -35,7 +35,7 @@ impl EventListener for CliEventListener {
     }
 }
 
-async fn init_sdk(config: Config, seed: &[u8], creds: &GreenlightCredentials) -> Result<()> {   
+async fn init_sdk(config: Config, seed: &[u8], creds: &GreenlightCredentials) -> Result<()> {
     let service = BreezServices::init_services(
         config,
         seed.to_vec(),

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -9,7 +9,7 @@ use breez_sdk_core::{
     parse, BreezEvent, BreezServices, EventListener, GreenlightCredentials, InputType::LnUrlPay,
     PaymentTypeFilter,
 };
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 use qrcode_rs::render::unicode;
 use qrcode_rs::{EcLevel, QrCode};
 use rustyline::Editor;
@@ -18,7 +18,6 @@ use crate::persist::CliPersistence;
 use crate::Commands;
 
 static BREEZ_SERVICES: OnceCell<Arc<BreezServices>> = OnceCell::new();
-static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| tokio::runtime::Runtime::new().unwrap());
 
 fn sdk() -> Result<Arc<BreezServices>> {
     BREEZ_SERVICES
@@ -26,10 +25,6 @@ fn sdk() -> Result<Arc<BreezServices>> {
         .ok_or("Breez Services not initialized")
         .map_err(|err| anyhow!(err))
         .cloned()
-}
-
-fn rt() -> &'static tokio::runtime::Runtime {
-    &RT
 }
 
 struct CliEventListener {}
@@ -40,7 +35,7 @@ impl EventListener for CliEventListener {
     }
 }
 
-async fn init_sdk(config: Config, seed: &[u8], creds: &GreenlightCredentials) -> Result<()> {
+async fn init_sdk(config: Config, seed: &[u8], creds: &GreenlightCredentials) -> Result<()> {   
     let service = BreezServices::init_services(
         config,
         seed.to_vec(),
@@ -50,10 +45,10 @@ async fn init_sdk(config: Config, seed: &[u8], creds: &GreenlightCredentials) ->
     .await?;
 
     BREEZ_SERVICES
-        .set(service)
+        .set(service.clone())
         .map_err(|_| anyhow!("Failed to set Breez Service"))?;
 
-    BreezServices::start(rt(), &sdk()?).await
+    service.start().await
 }
 
 pub(crate) async fn handle_command(


### PR DESCRIPTION
This PR addresses the startup time of the sdk in all three cases (init, register, recover).
A small changes to the rust interface was made:
instead of: 
`BreezServices::start(rt(), &sdk).await?`
we now use:
`sdk.start()await?`

The runtime is initiated inside the sdk which is cleaner and also allows cleaner shutdown on disconnecting.
The start method now uses tokio tasks to spin all king of polling in the background and make sure no connections/handshakes are blocking the flow anymore.

The startup of existing node was more than 5 seconds before and now it is less then 10 milliseconds.
registering new node and recover node results in 5 seconds but I believe we can make it 2-3 seconds in the next phase.
Sorry for the long diff.

