### PR TITLE
Reuse greenlight connection

### DIFF
--- a/libs/sdk-core/src/greenlight/backup_transport.rs
+++ b/libs/sdk-core/src/greenlight/backup_transport.rs
@@ -20,7 +20,7 @@ impl GLBackupTransport {
 impl BackupTransport for GLBackupTransport {
     async fn pull(&self) -> Result<Option<BackupState>> {
         let key = self.gl_key();
-        let mut c: node::ClnClient = self.inner.get_node_client().await?;
+        let mut c: node::ClnClient = self.inner.get_node_client();
         let response: pb::cln::ListdatastoreResponse = c
             .list_datastore(pb::cln::ListdatastoreRequest { key })
             .await?
@@ -39,7 +39,7 @@ impl BackupTransport for GLBackupTransport {
     async fn push(&self, version: Option<u64>, hex: Vec<u8>) -> Result<u64> {
         let key = self.gl_key();
         info!("set_value key = {:?} data length={:?}", key, hex.len());
-        let mut c: node::ClnClient = self.inner.get_node_client().await?;
+        let mut c: node::ClnClient = self.inner.get_node_client();
         let mut mode = pb::cln::datastore_request::DatastoreMode::MustCreate;
         if version.is_some() {
             mode = pb::cln::datastore_request::DatastoreMode::MustReplace;


### PR DESCRIPTION
This replaces https://github.com/breez/breez-sdk/pull/273 with a lock free approach.
We now take advantage of the connect method of Greenlight to initiate both connections and pass them to the NodeAPI instance.
It turns out that tonic connections are only cloned properly under the same runtime they were created (had to learn that the hard way...)
Therefore, I had to change the code not to create our own runtime for the background tasks but use the current runtime. As a library this seems the right approach as we can't control under which runtime the sdk is used.
The relevant code for the connection reuse is here: https://github.com/breez/breez-sdk/compare/connect-api...gl-connection-reuse#diff-7466a53546c6cded460ef5502a9168b13cc930d94fdf7d0ea8166bb10c75fe7eR151
This plus the activated Greenlight proxy (constant node URI) results in a significant performance gain.