### PR TITLE
Lazy connection to greenlight to improve startup time

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -126,11 +126,14 @@ impl BreezServices {
         seed: Vec<u8>,
         event_listener: Box<dyn EventListener>,
     ) -> Result<Arc<BreezServices>> {
+        let start = Instant::now();
         let services = BreezServicesBuilder::new(config)
             .seed(seed)
             .build(Some(event_listener))
             .await?;
         services.start().await?;
+        let connect_duration = start.elapsed();
+        info!("SDK connected in: {:?}", connect_duration);
         Ok(services)
     }
 

--- a/libs/sdk-core/src/greenlight/backup_transport.rs
+++ b/libs/sdk-core/src/greenlight/backup_transport.rs
@@ -20,7 +20,7 @@ impl GLBackupTransport {
 impl BackupTransport for GLBackupTransport {
     async fn pull(&self) -> Result<Option<BackupState>> {
         let key = self.gl_key();
-        let mut c: node::ClnClient = self.inner.get_node_client();
+        let mut c: node::ClnClient = self.inner.get_node_client().await?;
         let response: pb::cln::ListdatastoreResponse = c
             .list_datastore(pb::cln::ListdatastoreRequest { key })
             .await?
@@ -39,7 +39,7 @@ impl BackupTransport for GLBackupTransport {
     async fn push(&self, version: Option<u64>, hex: Vec<u8>) -> Result<u64> {
         let key = self.gl_key();
         info!("set_value key = {:?} data length={:?}", key, hex.len());
-        let mut c: node::ClnClient = self.inner.get_node_client();
+        let mut c: node::ClnClient = self.inner.get_node_client().await?;
         let mut mode = pb::cln::datastore_request::DatastoreMode::MustCreate;
         if version.is_some() {
             mode = pb::cln::datastore_request::DatastoreMode::MustReplace;


### PR DESCRIPTION
This PR goes back to initiate greenlight connection lazily.
Before this change an attempt to go lock free resulted in initiating the connection as part of the connect method which increased this method time and caused bad user experience: https://github.com/breez/c-breez/pull/596#issuecomment-1629726361

Re-adding the mutexes which solves this problem. We can get rid of the mutexes again when greenlight exposes lazy connection API but this doesn't seem to be urgent IMO.