### PR TITLE
Adapt fee settings

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -437,7 +437,7 @@ impl NodeAPI for Greenlight {
             exclude: vec![],
             maxfee: None,
             description,
-            exemptfee: None,
+            exemptfee: Some(gl_client::pb::cln::Amount { msat: 20000 }),
         };
         client.pay(request).await?.into_inner().try_into()
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -438,7 +438,7 @@ impl Config {
             payment_timeout_sec: 60,
             default_lsp_id: Some(String::from("03cea51f-b654-4fb0-8e82-eca137f236a0")),
             api_key: Some(api_key),
-            maxfee_percent: 0.5,
+            maxfee_percent: 1.0,
             node_config,
         }
     }


### PR DESCRIPTION
This PR make the default fee settings a bit more relaxed and match breez mobile.
It uses 1% as maximum with exempt fee of 20 sats.
These new settings should allow payments to Alby pass through.

fixes https://github.com/breez/c-breez/issues/599