### PR TITLE
Add methods to NodeAPI for signmessage and checkmessage [issue #109]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
-libs/sdk-bindings/storage.sql
+libs/sdk-bindings/*.sql
 .DS_Store
 .idea/
 
 tools/sdk-cli/config.json
 libs/sdk-react-native/ios/breez_sdk.swift
 libs/sdk-react-native/ios/bindings-swift/**
+
+.envrc
+*.jar
 
 # Visual Studio Code
 .vscode/*

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "zbase32",
 ]
 
 [[package]]
@@ -915,7 +916,7 @@ dependencies = [
  "hkdf",
  "libsecp256k1",
  "rand",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "typenum",
 ]
 
@@ -1193,7 +1194,7 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 [[package]]
 name = "gl-client"
 version = "0.1.9"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=2eabad561ef8d0c42b3bf190a94c9fd9ae303eb6#2eabad561ef8d0c42b3bf190a94c9fd9ae303eb6"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=113cc28c938d4ed607a6e3fc4ab044a000d7e5e1#113cc28c938d4ed607a6e3fc4ab044a000d7e5e1"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -2653,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2899,7 +2900,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "rustc-hash",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -3773,6 +3774,12 @@ checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time 0.3.22",
 ]
+
+[[package]]
+name = "zbase32"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9079049688da5871a7558ddacb7f04958862c703e68258594cb7a862b5e33f"
 
 [[package]]
 name = "zeroize"

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -96,6 +96,24 @@ dictionary NodeState {
     u64 inbound_liquidity_msats;    
 };
 
+dictionary SignMessageRequest {
+    string message;
+};
+
+dictionary SignMessageResponse {
+    string signature;
+};
+
+dictionary CheckMessageRequest {
+    string message;
+    string pubkey;
+    string signature;
+};
+
+dictionary CheckMessageResponse {
+    boolean is_valid;
+};
+
 enum PaymentTypeFilter {
     "Sent",
     "Received",
@@ -433,6 +451,12 @@ interface BlockingBreezServices {
 
    [Throws=SdkError]
    NodeState node_info();
+
+   [Throws=SdkError]
+   SignMessageResponse sign_message(SignMessageRequest request);
+
+   [Throws=SdkError]
+   CheckMessageResponse check_message(CheckMessageRequest request);
 
    [Throws=SdkError]
    BackupStatus backup_status();

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -8,15 +8,16 @@ use breez_sdk_core::{
     error::*, mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
     parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BackupFailedData,
     BackupStatus, BitcoinAddressData, BreezEvent, BreezServices, BuyBitcoinProvider, ChannelState,
-    ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType, EventListener,
-    FeeratePreset, FiatCurrency, GreenlightCredentials, GreenlightNodeConfig, InputType,
-    InvoicePaidDetails, LNInvoice, LnPaymentDetails, LnUrlAuthRequestData, LnUrlCallbackStatus,
-    LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult, LnUrlWithdrawRequestData, LocaleOverrides,
-    LocalizedName, LogEntry, LspInformation, MessageSuccessActionData, MetadataItem, Network,
-    NodeConfig, NodeState, Payment, PaymentDetails, PaymentFailedData, PaymentType,
-    PaymentTypeFilter, Rate, RecommendedFees, ReverseSwapInfo, ReverseSwapPairInfo,
-    ReverseSwapStatus, RouteHint, RouteHintHop, SuccessActionProcessed, SwapInfo, SwapStatus,
-    Symbol, UnspentTransactionOutput, UrlSuccessActionData,
+    CheckMessageRequest, CheckMessageResponse, ClosedChannelPaymentDetails, Config, CurrencyInfo,
+    EnvironmentType, EventListener, FeeratePreset, FiatCurrency, GreenlightCredentials,
+    GreenlightNodeConfig, InputType, InvoicePaidDetails, LNInvoice, LnPaymentDetails,
+    LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult,
+    LnUrlWithdrawRequestData, LocaleOverrides, LocalizedName, LogEntry, LspInformation,
+    MessageSuccessActionData, MetadataItem, Network, NodeConfig, NodeState, Payment,
+    PaymentDetails, PaymentFailedData, PaymentType, PaymentTypeFilter, Rate, RecommendedFees,
+    ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
+    SignMessageRequest, SignMessageResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
+    UnspentTransactionOutput, UrlSuccessActionData,
 };
 
 static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| tokio::runtime::Runtime::new().unwrap());
@@ -123,6 +124,16 @@ impl BlockingBreezServices {
 
     pub fn node_info(&self) -> SdkResult<NodeState> {
         self.breez_services.node_info()
+    }
+
+    pub fn sign_message(&self, request: SignMessageRequest) -> SdkResult<SignMessageResponse> {
+        rt().block_on(self.breez_services.sign_message(request))
+            .map_err(|e| e.into())
+    }
+
+    pub fn check_message(&self, request: CheckMessageRequest) -> SdkResult<CheckMessageResponse> {
+        rt().block_on(self.breez_services.check_message(request))
+            .map_err(|e| e.into())
     }
 
     pub fn backup_status(&self) -> SdkResult<BackupStatus> {

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -16,11 +16,10 @@ hex = "*"
 # v0.3 requires bitcoin 0.30, but lightning v0.115 needs bitcoin 0.29, so we keep this at v0.2 which also uses bitcoin 0.29
 bip21 = "0.2"
 bitcoin = "0.29.2"
-# Note: private repo, might need git credentials helper to be setup
-# If so, see https://techexpertise.medium.com/storing-git-credentials-with-git-credential-helper-33d22a6b5ce7
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "2eabad561ef8d0c42b3bf190a94c9fd9ae303eb6" }
+], rev = "113cc28c938d4ed607a6e3fc4ab044a000d7e5e1" }
+zbase32 = "0.1.2"
 base64 = "0.13.0"
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
 ripemd = "*"

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -31,8 +31,9 @@ use crate::lnurl::pay::model::LnUrlPayResult;
 use crate::lsp::LspInformation;
 use crate::models::{Config, LogEntry, NodeState, Payment, PaymentTypeFilter, SwapInfo};
 use crate::{
-    BackupStatus, BuyBitcoinProvider, EnvironmentType, LnUrlCallbackStatus, NodeConfig,
-    ReverseSwapInfo, ReverseSwapPairInfo,
+    BackupStatus, BuyBitcoinProvider, CheckMessageRequest, CheckMessageResponse, EnvironmentType,
+    LnUrlCallbackStatus, NodeConfig, ReverseSwapInfo, ReverseSwapPairInfo, SignMessageRequest,
+    SignMessageResponse,
 };
 
 static BREEZ_SERVICES_INSTANCE: OnceCell<Arc<BreezServices>> = OnceCell::new();
@@ -87,6 +88,16 @@ pub fn disconnect() -> Result<()> {
             Some(s) => s.send(()).await.map_err(anyhow::Error::msg),
         }
     })
+}
+
+/// See [BreezServices::sign_message]
+pub fn sign_message(request: SignMessageRequest) -> Result<SignMessageResponse> {
+    block_on(async { get_breez_services()?.sign_message(request).await })
+}
+
+/// See [BreezServices::check_message]
+pub fn check_message(request: CheckMessageRequest) -> Result<CheckMessageResponse> {
+    block_on(async { get_breez_services()?.check_message(request).await })
 }
 
 /*  Breez Services Helper API's */

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -27,6 +27,16 @@ pub extern "C" fn wire_disconnect(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_sign_message(port_: i64, request: *mut wire_SignMessageRequest) {
+    wire_sign_message_impl(port_, request)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_check_message(port_: i64, request: *mut wire_CheckMessageRequest) {
+    wire_check_message_impl(port_, request)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_mnemonic_to_seed(port_: i64, phrase: *mut wire_uint_8_list) {
     wire_mnemonic_to_seed_impl(port_, phrase)
 }
@@ -252,6 +262,11 @@ pub extern "C" fn wire_execute_command(port_: i64, command: *mut wire_uint_8_lis
 // Section: allocate functions
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_check_message_request_0() -> *mut wire_CheckMessageRequest {
+    support::new_leak_box_ptr(wire_CheckMessageRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_config_0() -> *mut wire_Config {
     support::new_leak_box_ptr(wire_Config::new_with_null_ptr())
 }
@@ -293,6 +308,11 @@ pub extern "C" fn new_box_autoadd_node_config_0() -> *mut wire_NodeConfig {
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_sign_message_request_0() -> *mut wire_SignMessageRequest {
+    support::new_leak_box_ptr(wire_SignMessageRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_u64_0(value: u64) -> *mut u64 {
     support::new_leak_box_ptr(value)
 }
@@ -314,6 +334,12 @@ impl Wire2Api<String> for *mut wire_uint_8_list {
     fn wire2api(self) -> String {
         let vec: Vec<u8> = self.wire2api();
         String::from_utf8_lossy(&vec).into_owned()
+    }
+}
+impl Wire2Api<CheckMessageRequest> for *mut wire_CheckMessageRequest {
+    fn wire2api(self) -> CheckMessageRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<CheckMessageRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<Config> for *mut wire_Config {
@@ -363,12 +389,27 @@ impl Wire2Api<NodeConfig> for *mut wire_NodeConfig {
         Wire2Api::<NodeConfig>::wire2api(*wrap).into()
     }
 }
+impl Wire2Api<SignMessageRequest> for *mut wire_SignMessageRequest {
+    fn wire2api(self) -> SignMessageRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<SignMessageRequest>::wire2api(*wrap).into()
+    }
+}
 impl Wire2Api<u64> for *mut u64 {
     fn wire2api(self) -> u64 {
         unsafe { *support::box_from_leak_ptr(self) }
     }
 }
 
+impl Wire2Api<CheckMessageRequest> for wire_CheckMessageRequest {
+    fn wire2api(self) -> CheckMessageRequest {
+        CheckMessageRequest {
+            message: self.message.wire2api(),
+            pubkey: self.pubkey.wire2api(),
+            signature: self.signature.wire2api(),
+        }
+    }
+}
 impl Wire2Api<Config> for wire_Config {
     fn wire2api(self) -> Config {
         Config {
@@ -452,6 +493,14 @@ impl Wire2Api<NodeConfig> for wire_NodeConfig {
     }
 }
 
+impl Wire2Api<SignMessageRequest> for wire_SignMessageRequest {
+    fn wire2api(self) -> SignMessageRequest {
+        SignMessageRequest {
+            message: self.message.wire2api(),
+        }
+    }
+}
+
 impl Wire2Api<Vec<u8>> for *mut wire_uint_8_list {
     fn wire2api(self) -> Vec<u8> {
         unsafe {
@@ -461,6 +510,14 @@ impl Wire2Api<Vec<u8>> for *mut wire_uint_8_list {
     }
 }
 // Section: wire structs
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_CheckMessageRequest {
+    message: *mut wire_uint_8_list,
+    pubkey: *mut wire_uint_8_list,
+    signature: *mut wire_uint_8_list,
+}
 
 #[repr(C)]
 #[derive(Clone)]
@@ -523,6 +580,12 @@ pub struct wire_LnUrlWithdrawRequestData {
 
 #[repr(C)]
 #[derive(Clone)]
+pub struct wire_SignMessageRequest {
+    message: *mut wire_uint_8_list,
+}
+
+#[repr(C)]
+#[derive(Clone)]
 pub struct wire_uint_8_list {
     ptr: *mut u8,
     len: i32,
@@ -555,6 +618,22 @@ pub trait NewWithNullPtr {
 impl<T> NewWithNullPtr for *mut T {
     fn new_with_null_ptr() -> Self {
         std::ptr::null_mut()
+    }
+}
+
+impl NewWithNullPtr for wire_CheckMessageRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            message: core::ptr::null_mut(),
+            pubkey: core::ptr::null_mut(),
+            signature: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_CheckMessageRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -687,6 +766,20 @@ pub extern "C" fn inflate_NodeConfig_Greenlight() -> *mut NodeConfigKind {
             config: core::ptr::null_mut(),
         }),
     })
+}
+
+impl NewWithNullPtr for wire_SignMessageRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            message: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_SignMessageRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
 }
 
 // Section: sync execution mode utility

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -21,8 +21,12 @@ use std::sync::Arc;
 
 use crate::breez_services::BackupFailedData;
 use crate::breez_services::BreezEvent;
+use crate::breez_services::CheckMessageRequest;
+use crate::breez_services::CheckMessageResponse;
 use crate::breez_services::InvoicePaidDetails;
 use crate::breez_services::PaymentFailedData;
+use crate::breez_services::SignMessageRequest;
+use crate::breez_services::SignMessageResponse;
 use crate::chain::RecommendedFees;
 use crate::fiat::CurrencyInfo;
 use crate::fiat::FiatCurrency;
@@ -128,6 +132,38 @@ fn wire_disconnect_impl(port_: MessagePort) {
             mode: FfiCallMode::Normal,
         },
         move || move |task_callback| disconnect(),
+    )
+}
+fn wire_sign_message_impl(
+    port_: MessagePort,
+    request: impl Wire2Api<SignMessageRequest> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "sign_message",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_request = request.wire2api();
+            move |task_callback| sign_message(api_request)
+        },
+    )
+}
+fn wire_check_message_impl(
+    port_: MessagePort,
+    request: impl Wire2Api<CheckMessageRequest> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "check_message",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_request = request.wire2api();
+            move |task_callback| check_message(api_request)
+        },
     )
 }
 fn wire_mnemonic_to_seed_impl(port_: MessagePort, phrase: impl Wire2Api<String> + UnwindSafe) {
@@ -684,6 +720,7 @@ impl Wire2Api<PaymentTypeFilter> for i32 {
         }
     }
 }
+
 impl Wire2Api<u16> for u16 {
     fn wire2api(self) -> u16 {
         self
@@ -774,6 +811,13 @@ impl support::IntoDart for ChannelState {
     }
 }
 impl support::IntoDartExceptPrimitive for ChannelState {}
+impl support::IntoDart for CheckMessageResponse {
+    fn into_dart(self) -> support::DartAbi {
+        vec![self.is_valid.into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for CheckMessageResponse {}
+
 impl support::IntoDart for ClosedChannelPaymentDetails {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -1207,6 +1251,13 @@ impl support::IntoDart for RouteHintHop {
     }
 }
 impl support::IntoDartExceptPrimitive for RouteHintHop {}
+
+impl support::IntoDart for SignMessageResponse {
+    fn into_dart(self) -> support::DartAbi {
+        vec![self.signature.into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for SignMessageResponse {}
 
 impl support::IntoDart for SuccessActionProcessed {
     fn into_dart(self) -> support::DartAbi {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -6,6 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{anyhow, Result};
 use bitcoin::bech32::{u5, ToBase32};
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
 use ecies::utils::{aes_decrypt, aes_encrypt};
@@ -23,6 +24,7 @@ use gl_client::scheduler::Scheduler;
 use gl_client::signer::Signer;
 use gl_client::tls::TlsConfig;
 use gl_client::{node, pb, utils};
+use lightning::util::message_signing::verify;
 use lightning_invoice::{RawInvoice, SignedRawInvoice};
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
@@ -510,6 +512,18 @@ impl NodeAPI for Greenlight {
         let connect_req = pb::ConnectRequest { node_id, addr };
         client.connect_peer(connect_req).await?;
         Ok(())
+    }
+
+    async fn sign_message(&self, message: &str) -> Result<String> {
+        let (sig, recovery_id) = self.signer.sign_message(message.as_bytes().to_vec())?;
+        let mut complete_signature = vec![31 + recovery_id];
+        complete_signature.extend_from_slice(&sig);
+        Ok(zbase32::encode_full_bytes(&complete_signature))
+    }
+
+    async fn check_message(&self, message: &str, pubkey: &str, signature: &str) -> Result<bool> {
+        let pk = PublicKey::from_str(pubkey)?;
+        Ok(verify(message.as_bytes(), signature, &pk))
     }
 
     fn sign_invoice(&self, invoice: RawInvoice) -> Result<String> {

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -173,8 +173,9 @@ mod swap;
 mod test_utils;
 
 pub use breez_services::{
-    mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, EventListener,
-    InvoicePaidDetails, PaymentFailedData,
+    mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, CheckMessageRequest,
+    CheckMessageResponse, EventListener, InvoicePaidDetails, PaymentFailedData, SignMessageRequest,
+    SignMessageResponse,
 };
 pub use chain::RecommendedFees;
 pub use fiat::{CurrencyInfo, FiatCurrency, LocaleOverrides, LocalizedName, Rate, Symbol};

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -67,6 +67,8 @@ pub trait NodeAPI: Send + Sync {
     async fn stream_incoming_payments(&self) -> Result<Streaming<gl_client::pb::IncomingPayment>>;
     async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>>;
     async fn execute_command(&self, command: String) -> Result<String>;
+    async fn sign_message(&self, message: &str) -> Result<String>;
+    async fn check_message(&self, message: &str, pubkey: &str, signature: &str) -> Result<bool>;
 
     /// Gets the private key at the path specified
     fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> Result<ExtendedPrivKey>;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -326,6 +326,14 @@ impl NodeAPI for MockNodeAPI {
         Ok(())
     }
 
+    async fn sign_message(&self, _message: &str) -> Result<String> {
+        Ok("".to_string())
+    }
+
+    async fn check_message(&self, _message: &str, _pubkey: &str, _signature: &str) -> Result<bool> {
+        Ok(true)
+    }
+
     fn sign_invoice(&self, invoice: RawInvoice) -> Result<String> {
         Ok(sign_invoice(invoice))
     }

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -49,6 +49,16 @@ typedef struct wire_Config {
   struct wire_NodeConfig node_config;
 } wire_Config;
 
+typedef struct wire_SignMessageRequest {
+  struct wire_uint_8_list *message;
+} wire_SignMessageRequest;
+
+typedef struct wire_CheckMessageRequest {
+  struct wire_uint_8_list *message;
+  struct wire_uint_8_list *pubkey;
+  struct wire_uint_8_list *signature;
+} wire_CheckMessageRequest;
+
 typedef struct wire_LnUrlPayRequestData {
   struct wire_uint_8_list *callback;
   uint64_t min_sendable;
@@ -95,6 +105,10 @@ void wire_sync(int64_t port_);
 void wire_node_info(int64_t port_);
 
 void wire_disconnect(int64_t port_);
+
+void wire_sign_message(int64_t port_, struct wire_SignMessageRequest *request);
+
+void wire_check_message(int64_t port_, struct wire_CheckMessageRequest *request);
 
 void wire_mnemonic_to_seed(int64_t port_, struct wire_uint_8_list *phrase);
 
@@ -189,6 +203,8 @@ void wire_recommended_fees(int64_t port_);
 
 void wire_execute_command(int64_t port_, struct wire_uint_8_list *command);
 
+struct wire_CheckMessageRequest *new_box_autoadd_check_message_request_0(void);
+
 struct wire_Config *new_box_autoadd_config_0(void);
 
 struct wire_GreenlightCredentials *new_box_autoadd_greenlight_credentials_0(void);
@@ -205,6 +221,8 @@ struct wire_LnUrlWithdrawRequestData *new_box_autoadd_ln_url_withdraw_request_da
 
 struct wire_NodeConfig *new_box_autoadd_node_config_0(void);
 
+struct wire_SignMessageRequest *new_box_autoadd_sign_message_request_0(void);
+
 uint64_t *new_box_autoadd_u64_0(uint64_t value);
 
 struct wire_uint_8_list *new_uint_8_list_0(int32_t len);
@@ -220,6 +238,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_sync);
     dummy_var ^= ((int64_t) (void*) wire_node_info);
     dummy_var ^= ((int64_t) (void*) wire_disconnect);
+    dummy_var ^= ((int64_t) (void*) wire_sign_message);
+    dummy_var ^= ((int64_t) (void*) wire_check_message);
     dummy_var ^= ((int64_t) (void*) wire_mnemonic_to_seed);
     dummy_var ^= ((int64_t) (void*) wire_default_config);
     dummy_var ^= ((int64_t) (void*) wire_breez_events_stream);
@@ -254,6 +274,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_fetch_reverse_swap_fees);
     dummy_var ^= ((int64_t) (void*) wire_recommended_fees);
     dummy_var ^= ((int64_t) (void*) wire_execute_command);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_check_message_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_config_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_credentials_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_node_config_0);
@@ -262,6 +283,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_pay_request_data_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_withdraw_request_data_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_node_config_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_sign_message_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_u64_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
     dummy_var ^= ((int64_t) (void*) inflate_NodeConfig_Greenlight);

--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -14,12 +14,14 @@ class BreezSDK {
 
   /* Streams */
   /// Listen to paid Invoice events
-  final StreamController<InvoicePaidDetails> _invoicePaidStream = BehaviorSubject<InvoicePaidDetails>();
+  final StreamController<InvoicePaidDetails> _invoicePaidStream =
+      BehaviorSubject<InvoicePaidDetails>();
 
   Stream<InvoicePaidDetails> get invoicePaidStream => _invoicePaidStream.stream;
 
   /// Listen to payment results
-  final StreamController<Payment> _paymentResultStream = BehaviorSubject<Payment>();
+  final StreamController<Payment> _paymentResultStream =
+      BehaviorSubject<Payment>();
 
   Stream<Payment> get paymentResultStream => _paymentResultStream.stream;
 
@@ -58,7 +60,8 @@ class BreezSDK {
   /* Breez Services API's & Streams*/
 
   /// Listen to node state
-  final StreamController<NodeState?> nodeStateController = BehaviorSubject<NodeState?>();
+  final StreamController<NodeState?> nodeStateController =
+      BehaviorSubject<NodeState?>();
 
   Stream<NodeState?> get nodeStateStream => nodeStateController.stream;
 
@@ -105,7 +108,8 @@ class BreezSDK {
   /// Attempts to convert the phrase to a mnemonic, then to a seed.
   ///
   /// If the phrase is not a valid mnemonic, an error is returned.
-  Future<Uint8List> mnemonicToSeed(String phrase) async => await _lnToolkit.mnemonicToSeed(phrase: phrase);
+  Future<Uint8List> mnemonicToSeed(String phrase) async =>
+      await _lnToolkit.mnemonicToSeed(phrase: phrase);
 
   /// Get the full default config for a specific environment type
   Future<Config> defaultConfig({
@@ -118,6 +122,22 @@ class BreezSDK {
       apiKey: apiKey,
       nodeConfig: nodeConfig,
     );
+  }
+
+  /// Sign given message with the private key of the node id. Returns a zbase
+  /// encoded signature.
+  Future<SignMessageResponse> signMessage({
+    required SignMessageRequest request,
+  }) {
+    return _lnToolkit.signMessage(request: request);
+  }
+
+  /// Check whether given message was signed by the private key or the given
+  /// pubkey and the signature (zbase encoded) is valid.
+  Future<CheckMessageResponse> checkMessage({
+    required CheckMessageRequest request,
+  }) {
+    return _lnToolkit.checkMessage(request: request);
   }
 
   /* LSP API's */
@@ -134,7 +154,8 @@ class BreezSDK {
   Future<String?> lspId() async => await _lnToolkit.lspId();
 
   /// Convenience method to look up LSP info
-  Future<LspInformation?> fetchLspInfo(String lspId) async => await _lnToolkit.fetchLspInfo(id: lspId);
+  Future<LspInformation?> fetchLspInfo(String lspId) async =>
+      await _lnToolkit.fetchLspInfo(id: lspId);
 
   /// close all channels with the current lsp
   Future closeLspChannels() async => await _lnToolkit.closeLspChannels();
@@ -142,7 +163,8 @@ class BreezSDK {
   /* Backup API's & Streams*/
 
   // Listen to backup results
-  final StreamController<BreezEvent?> _backupStreamController = BehaviorSubject<BreezEvent?>();
+  final StreamController<BreezEvent?> _backupStreamController =
+      BehaviorSubject<BreezEvent?>();
 
   Stream<BreezEvent?> get backupStream => _backupStreamController.stream;
 
@@ -155,15 +177,18 @@ class BreezSDK {
   /* Parse API's */
 
   /// Parse a BOLT11 payment request and return a structure contains the parsed fields.
-  Future<LNInvoice> parseInvoice(String invoice) async => await _lnToolkit.parseInvoice(invoice: invoice);
+  Future<LNInvoice> parseInvoice(String invoice) async =>
+      await _lnToolkit.parseInvoice(invoice: invoice);
 
   /// Parses generic user input, typically pasted from clipboard or scanned from a QR.
-  Future<InputType> parseInput({required String input}) async => await _lnToolkit.parseInput(input: input);
+  Future<InputType> parseInput({required String input}) async =>
+      await _lnToolkit.parseInput(input: input);
 
   /* Payment API's & Streams*/
 
   /// Listen to payment list
-  final StreamController<List<Payment>> paymentsController = BehaviorSubject<List<Payment>>();
+  final StreamController<List<Payment>> paymentsController =
+      BehaviorSubject<List<Payment>>();
 
   Stream<List<Payment>> get paymentsStream => paymentsController.stream;
 
@@ -301,7 +326,8 @@ class BreezSDK {
   }
 
   /// List all available fiat currencies
-  Future<List<FiatCurrency>> listFiatCurrencies() async => await _lnToolkit.listFiatCurrencies();
+  Future<List<FiatCurrency>> listFiatCurrencies() async =>
+      await _lnToolkit.listFiatCurrencies();
 
   /* On-Chain Swap API's */
 
@@ -323,7 +349,8 @@ class BreezSDK {
   Future<SwapInfo> receiveOnchain() async => await _lnToolkit.receiveOnchain();
 
   /// Generates an url that can be used by a third part provider to buy Bitcoin with fiat currency
-  Future<String> buyBitcoin(BuyBitcoinProvider provider) => _lnToolkit.buyBitcoin(provider: provider);
+  Future<String> buyBitcoin(BuyBitcoinProvider provider) =>
+      _lnToolkit.buyBitcoin(provider: provider);
 
   /// Withdraw on-chain funds in the wallet to an external btc address
   Future sweep({
@@ -340,7 +367,8 @@ class BreezSDK {
   /* Refundables API's */
 
   /// list non-completed expired swaps that should be refunded by calling refund()
-  Future<List<SwapInfo>> listRefundables() async => await _lnToolkit.listRefundables();
+  Future<List<SwapInfo>> listRefundables() async =>
+      await _lnToolkit.listRefundables();
 
   /// Construct and broadcast a refund transaction for a failed/expired swap
   Future<String> refund({
@@ -360,12 +388,14 @@ class BreezSDK {
   Future<SwapInfo?> inProgressSwap() async => await _lnToolkit.inProgressSwap();
 
   /// Returns the blocking [ReverseSwapInfo]s that are in progress
-  Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async => _lnToolkit.inProgressReverseSwaps();
+  Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async =>
+      _lnToolkit.inProgressReverseSwaps();
 
   /* Swap Fee API's */
 
   /// Lookup the most recent reverse swap pair info using the Boltz API
-  Future<ReverseSwapPairInfo> fetchReverseSwapFees() async => _lnToolkit.fetchReverseSwapFees();
+  Future<ReverseSwapPairInfo> fetchReverseSwapFees() async =>
+      _lnToolkit.fetchReverseSwapFees();
 
   /// Fetches the current recommended fees
   Future<RecommendedFees> recommendedFees() => _lnToolkit.recommendedFees();

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -39,6 +39,16 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kDisconnectConstMeta;
 
+  /// See [BreezServices::sign_message]
+  Future<SignMessageResponse> signMessage({required SignMessageRequest request, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kSignMessageConstMeta;
+
+  /// See [BreezServices::check_message]
+  Future<CheckMessageResponse> checkMessage({required CheckMessageRequest request, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kCheckMessageConstMeta;
+
   /// See [breez_services::mnemonic_to_seed]
   Future<Uint8List> mnemonicToSeed({required String phrase, dynamic hint});
 
@@ -319,6 +329,35 @@ enum ChannelState {
   Opened,
   PendingClose,
   Closed,
+}
+
+/// Request to check a message was signed by a specific node id.
+class CheckMessageRequest {
+  /// The message that was signed.
+  final String message;
+
+  /// The public key of the node that signed the message.
+  final String pubkey;
+
+  /// The zbase encoded signature to verify.
+  final String signature;
+
+  const CheckMessageRequest({
+    required this.message,
+    required this.pubkey,
+    required this.signature,
+  });
+}
+
+/// Response to a [CheckMessageRequest]
+class CheckMessageResponse {
+  /// Boolean value indicating whether the signature covers the message and
+  /// was signed by the given pubkey.
+  final bool isValid;
+
+  const CheckMessageResponse({
+    required this.isValid,
+  });
 }
 
 /// Represents the funds that were on the user side of the channel at the time it was closed.
@@ -998,6 +1037,27 @@ class RouteHintHop {
   });
 }
 
+/// Request to sign a message with the node's private key.
+class SignMessageRequest {
+  /// The message to be signed by the node's private key.
+  final String message;
+
+  const SignMessageRequest({
+    required this.message,
+  });
+}
+
+/// Response to a [SignMessageRequest].
+class SignMessageResponse {
+  /// The signature that covers the message of SignMessageRequest. Zbase
+  /// encoded.
+  final String signature;
+
+  const SignMessageResponse({
+    required this.signature,
+  });
+}
+
 @freezed
 class SuccessActionProcessed with _$SuccessActionProcessed {
   /// See [SuccessAction::Aes] for received payload
@@ -1209,6 +1269,38 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kDisconnectConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "disconnect",
         argNames: [],
+      );
+
+  Future<SignMessageResponse> signMessage({required SignMessageRequest request, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_sign_message_request(request);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_sign_message(port_, arg0),
+      parseSuccessData: _wire2api_sign_message_response,
+      constMeta: kSignMessageConstMeta,
+      argValues: [request],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kSignMessageConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "sign_message",
+        argNames: ["request"],
+      );
+
+  Future<CheckMessageResponse> checkMessage({required CheckMessageRequest request, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_check_message_request(request);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_check_message(port_, arg0),
+      parseSuccessData: _wire2api_check_message_response,
+      constMeta: kCheckMessageConstMeta,
+      argValues: [request],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kCheckMessageConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "check_message",
+        argNames: ["request"],
       );
 
   Future<Uint8List> mnemonicToSeed({required String phrase, dynamic hint}) {
@@ -1961,6 +2053,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return ChannelState.values[raw as int];
   }
 
+  CheckMessageResponse _wire2api_check_message_response(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return CheckMessageResponse(
+      isValid: _wire2api_bool(arr[0]),
+    );
+  }
+
   ClosedChannelPaymentDetails _wire2api_closed_channel_payment_details(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
@@ -2496,6 +2596,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     );
   }
 
+  SignMessageResponse _wire2api_sign_message_response(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return SignMessageResponse(
+      signature: _wire2api_String(arr[0]),
+    );
+  }
+
   SuccessActionProcessed _wire2api_success_action_processed(dynamic raw) {
     switch (raw[0]) {
       case 0:
@@ -2664,6 +2772,13 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_CheckMessageRequest> api2wire_box_autoadd_check_message_request(CheckMessageRequest raw) {
+    final ptr = inner.new_box_autoadd_check_message_request_0();
+    _api_fill_to_wire_check_message_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_Config> api2wire_box_autoadd_config(Config raw) {
     final ptr = inner.new_box_autoadd_config_0();
     _api_fill_to_wire_config(raw, ptr.ref);
@@ -2723,6 +2838,13 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_SignMessageRequest> api2wire_box_autoadd_sign_message_request(SignMessageRequest raw) {
+    final ptr = inner.new_box_autoadd_sign_message_request_0();
+    _api_fill_to_wire_sign_message_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<ffi.Uint64> api2wire_box_autoadd_u64(int raw) {
     return inner.new_box_autoadd_u64_0(api2wire_u64(raw));
   }
@@ -2768,6 +2890,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
 // Section: api_fill_to_wire
 
+  void _api_fill_to_wire_box_autoadd_check_message_request(
+      CheckMessageRequest apiObj, ffi.Pointer<wire_CheckMessageRequest> wireObj) {
+    _api_fill_to_wire_check_message_request(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_config(Config apiObj, ffi.Pointer<wire_Config> wireObj) {
     _api_fill_to_wire_config(apiObj, wireObj.ref);
   }
@@ -2799,6 +2926,17 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_box_autoadd_node_config(NodeConfig apiObj, ffi.Pointer<wire_NodeConfig> wireObj) {
     _api_fill_to_wire_node_config(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_box_autoadd_sign_message_request(
+      SignMessageRequest apiObj, ffi.Pointer<wire_SignMessageRequest> wireObj) {
+    _api_fill_to_wire_sign_message_request(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_check_message_request(CheckMessageRequest apiObj, wire_CheckMessageRequest wireObj) {
+    wireObj.message = api2wire_String(apiObj.message);
+    wireObj.pubkey = api2wire_String(apiObj.pubkey);
+    wireObj.signature = api2wire_String(apiObj.signature);
   }
 
   void _api_fill_to_wire_config(Config apiObj, wire_Config wireObj) {
@@ -2866,6 +3004,10 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_opt_box_autoadd_greenlight_credentials(
       GreenlightCredentials? apiObj, ffi.Pointer<wire_GreenlightCredentials> wireObj) {
     if (apiObj != null) _api_fill_to_wire_box_autoadd_greenlight_credentials(apiObj, wireObj);
+  }
+
+  void _api_fill_to_wire_sign_message_request(SignMessageRequest apiObj, wire_SignMessageRequest wireObj) {
+    wireObj.message = api2wire_String(apiObj.message);
   }
 }
 
@@ -3017,6 +3159,38 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_disconnectPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_disconnect');
   late final _wire_disconnect = _wire_disconnectPtr.asFunction<void Function(int)>();
+
+  void wire_sign_message(
+    int port_,
+    ffi.Pointer<wire_SignMessageRequest> request,
+  ) {
+    return _wire_sign_message(
+      port_,
+      request,
+    );
+  }
+
+  late final _wire_sign_messagePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SignMessageRequest>)>>(
+          'wire_sign_message');
+  late final _wire_sign_message =
+      _wire_sign_messagePtr.asFunction<void Function(int, ffi.Pointer<wire_SignMessageRequest>)>();
+
+  void wire_check_message(
+    int port_,
+    ffi.Pointer<wire_CheckMessageRequest> request,
+  ) {
+    return _wire_check_message(
+      port_,
+      request,
+    );
+  }
+
+  late final _wire_check_messagePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_CheckMessageRequest>)>>(
+          'wire_check_message');
+  late final _wire_check_message =
+      _wire_check_messagePtr.asFunction<void Function(int, ffi.Pointer<wire_CheckMessageRequest>)>();
 
   void wire_mnemonic_to_seed(
     int port_,
@@ -3540,6 +3714,16 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_execute_command =
       _wire_execute_commandPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
+  ffi.Pointer<wire_CheckMessageRequest> new_box_autoadd_check_message_request_0() {
+    return _new_box_autoadd_check_message_request_0();
+  }
+
+  late final _new_box_autoadd_check_message_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_CheckMessageRequest> Function()>>(
+          'new_box_autoadd_check_message_request_0');
+  late final _new_box_autoadd_check_message_request_0 = _new_box_autoadd_check_message_request_0Ptr
+      .asFunction<ffi.Pointer<wire_CheckMessageRequest> Function()>();
+
   ffi.Pointer<wire_Config> new_box_autoadd_config_0() {
     return _new_box_autoadd_config_0();
   }
@@ -3621,6 +3805,16 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Pointer<wire_NodeConfig> Function()>>('new_box_autoadd_node_config_0');
   late final _new_box_autoadd_node_config_0 =
       _new_box_autoadd_node_config_0Ptr.asFunction<ffi.Pointer<wire_NodeConfig> Function()>();
+
+  ffi.Pointer<wire_SignMessageRequest> new_box_autoadd_sign_message_request_0() {
+    return _new_box_autoadd_sign_message_request_0();
+  }
+
+  late final _new_box_autoadd_sign_message_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SignMessageRequest> Function()>>(
+          'new_box_autoadd_sign_message_request_0');
+  late final _new_box_autoadd_sign_message_request_0 = _new_box_autoadd_sign_message_request_0Ptr
+      .asFunction<ffi.Pointer<wire_SignMessageRequest> Function()>();
 
   ffi.Pointer<ffi.Uint64> new_box_autoadd_u64_0(
     int value,
@@ -3727,6 +3921,18 @@ class wire_Config extends ffi.Struct {
   external double maxfee_percent;
 
   external wire_NodeConfig node_config;
+}
+
+class wire_SignMessageRequest extends ffi.Struct {
+  external ffi.Pointer<wire_uint_8_list> message;
+}
+
+class wire_CheckMessageRequest extends ffi.Struct {
+  external ffi.Pointer<wire_uint_8_list> message;
+
+  external ffi.Pointer<wire_uint_8_list> pubkey;
+
+  external ffi.Pointer<wire_uint_8_list> signature;
 }
 
 class wire_LnUrlPayRequestData extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -82,6 +82,28 @@ fun asLnUrlWithdrawRequestData(reqData: ReadableMap): LnUrlWithdrawRequestData? 
     return null
 }
 
+fun asCheckMessageRequest(reqData: ReadableMap): CheckMessageRequest? {
+    val message = reqData.getString("message")
+    val signature = reqData.getString("signature")
+    val pubkey = reqData.getString("pubkey")
+
+    if (message != null && signature != null && pubkey != null) {
+        return CheckMessageRequest(message, pubkey, signature)
+    }
+
+    return null
+}
+
+fun asSignMessageRequest(reqData: ReadableMap): SignMessageRequest? {
+    val message = reqData.getString("message")
+
+    if (message != null) {
+        return SignMessageRequest(message)
+    }
+
+    return null
+}
+
 fun asPaymentTypeFilter(filter: String): PaymentTypeFilter {
     return PaymentTypeFilter.valueOf(filter.uppercase())
 }
@@ -612,4 +634,16 @@ fun readableMapOf(vararg values: Pair<String, *>): ReadableMap {
         pushToMap(map, key, value)
     }
     return map
+}
+
+fun readableMapOf(signMessageResponse: SignMessageResponse): ReadableMap {
+    return readableMapOf(
+            "signature" to signMessageResponse.signature
+    )
+}
+
+fun readableMapOf(checkMessageResponse: CheckMessageResponse): ReadableMap {
+    return readableMapOf(
+            "isValid" to checkMessageResponse.isValid
+    )
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -12,7 +12,6 @@ import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-
 class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
     private lateinit var executor: ExecutorService
     private var breezServices: BlockingBreezServices? = null
@@ -146,6 +145,44 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             }
         }
     }
+
+    @ReactMethod
+    fun signMessage(reqData: ReadableMap, promise: Promise) {
+        executor.execute {
+            val signMessageRequest = asSignMessageRequest(reqData)
+            if (signMessageRequest == null) {
+                 promise.reject(TAG, "Invalid reqData")
+            } else {
+                try {
+                    val response = getBreezServices().signMessage(signMessageRequest)
+                    promise.resolve(readableMapOf(response))
+                } catch (e: SdkException) {
+                    e.printStackTrace()
+                    promise.reject(e.javaClass.simpleName, e.message, e)
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun checkMessage(reqData: ReadableMap, promise: Promise) {
+        executor.execute {
+            val checkMessageRequest = asCheckMessageRequest(reqData)
+            if (checkMessageRequest == null) {
+                 promise.reject(TAG, "Invalid reqData")
+            } else {
+                try {
+                    val response = getBreezServices().checkMessage(checkMessageRequest)
+                    promise.resolve(readableMapOf(response))
+                } catch (e: SdkException) {
+                    e.printStackTrace()
+                    promise.reject(e.javaClass.simpleName, e.message, e)
+                }
+            }
+        }
+    }
+
+
 
     @ReactMethod
     fun sync(promise: Promise) {

--- a/libs/sdk-react-native/example/App.js
+++ b/libs/sdk-react-native/example/App.js
@@ -23,7 +23,9 @@ import {
     connect,
     buyBitcoin,
     backup,
-    backupStatus
+    backupStatus,
+    signMessage,
+    checkMessage
 } from "@breeztech/react-native-breez-sdk"
 import BuildConfig from "react-native-build-config"
 import { generateMnemonic } from "@dreson4/react-native-quick-bip39"
@@ -104,6 +106,16 @@ const App = () => {
 
                 const buyBitcoinResult = await buyBitcoin(BuyBitcoinProvider.MOONPAY)
                 addLine("buyBitcoin", JSON.stringify(buyBitcoinResult))
+
+                const signMessageResult = await signMessage({ message: "Hello world"})
+                addLine("signMessage: Hello World", JSON.stringify(signMessageResult))
+
+                const verifyMessageResult = await checkMessage({
+                    message: "Hello world",
+                    pubkey: nodeState.id,
+                    signature: signMessageResult.signature
+                })
+                addLine("verifyMessage:", JSON.stringify(verifyMessageResult))
 
                 await backup()
                 addLine("backupStatus", JSON.stringify(await backupStatus()))

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -110,6 +110,24 @@ class BreezSDKMapper {
         
         return nil
     }
+
+    static func asCheckMessageRequest(reqData: [String: Any?]) -> CheckMessageRequest? {
+        if let message = reqData["message"] as? String,
+           let signature = reqData["signature"] as? String,
+           let pubkey = reqData["pubkey"] as? String {
+            return CheckMessageRequest(message: message, pubkey: pubkey, signature: signature)
+        }
+
+        return nil
+    }
+
+     static func asSignMessageRequest(reqData: [String: Any?]) -> SignMessageRequest? {
+        if let message = reqData["message"] as? String {
+            return SignMessageRequest(message: message)
+        }
+
+        return nil
+    }
     
     static func asLnUrlAuthRequestData(reqData: [String: Any]) -> LnUrlAuthRequestData? {
         if let k1 = reqData["k1"] as? String,
@@ -199,6 +217,12 @@ class BreezSDKMapper {
             "amountSat": bitcoinAddressData.amountSat,
             "label": bitcoinAddressData.label,
             "message": bitcoinAddressData.message,
+        ]
+    }
+
+    static func dictionaryOf(checkMessageResponse: CheckMessageResponse) -> [String: Any] {
+        return [
+            "isValid": checkMessageResponse.isValid,
         ]
     }
     
@@ -506,6 +530,12 @@ class BreezSDKMapper {
             "cltvExpiryDelta": routeHintHop.cltvExpiryDelta,
             "htlcMinimumMsat": routeHintHop.htlcMinimumMsat,
             "htlcMaximumMsat": routeHintHop.htlcMaximumMsat
+        ]
+    }
+
+    static func dictionaryOf(signMessageResponse: SignMessageResponse) -> [String: Any] {
+        return [
+            "signature": signMessageResponse.signature,
         ]
     }
     

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -225,4 +225,16 @@ RCT_EXTERN_METHOD(
         rejecter: (RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(
+    signMessage: (NSDictionary*)reqData
+    resolver: (RCTPromiseResolveBlock)resolve
+    rejecter: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
+    checkMessage: (NSDictionary*)reqData
+    resolver: (RCTPromiseResolveBlock)resolve
+    rejecter: (RCTPromiseRejectBlock)reject
+)
+
 @end

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -111,6 +111,34 @@ class RNBreezSDK: RCTEventEmitter {
             rejectErr(err: SdkError.Generic(message:"Invalid config"), reject: reject)            
         }
     }
+
+    @objc(signMessage:resolver:rejecter:)
+    func signMessage(_ reqData:[String: Any], resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        if let signMessageRequest = BreezSDKMapper.asSignMessageRequest(reqData: reqData) {
+            do {
+                let signMessageResponse = try getBreezServices().signMessage(request: signMessageRequest)                
+                resolve(BreezSDKMapper.dictionaryOf(signMessageResponse: signMessageResponse))
+            } catch let err {
+                rejectErr(err: err, reject: reject)      
+            }
+        } else {            
+            rejectErr(err: SdkError.Generic(message:"Invalid reqData"), reject: reject)
+        }
+    }
+
+    @objc(checkMessage:resolver:rejecter:)
+    func checkMessage(_ reqData:[String: Any], resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        if let checkMessageRequest = BreezSDKMapper.asCheckMessageRequest(reqData: reqData) {
+            do {
+                let checkMessageResponse = try getBreezServices().checkMessage(request: checkMessageRequest)                
+                resolve(BreezSDKMapper.dictionaryOf(checkMessageResponse: checkMessageResponse))
+            } catch let err {
+                rejectErr(err: err, reject: reject)      
+            }
+        } else {            
+            rejectErr(err: SdkError.Generic(message:"Invalid reqData"), reject: reject)
+        }
+    }
     
     @objc(sync:rejecter:)
     func sync(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -415,6 +415,24 @@ export type BackupStatus = {
     lastBackupTime?: number
 }
 
+export type SignMessageRequest = {
+    message: string
+}
+
+export type SignMessageResponse = {
+    signature: string
+}
+
+export type CheckMessageRequest = {
+    message: string
+    pubkey: string
+    signature: string
+}
+
+export type CheckMessageResponse = {
+    isValid: boolean
+}
+
 const processEvent = (eventFn: EventFn) => {
     return (event: any) => {
         switch (event.type) {
@@ -513,6 +531,14 @@ export const defaultConfig = async (envType: EnvironmentType, apiKey: string, no
 export const connect = async (config: Config, seed: Uint8Array): Promise<void> => {
     config.nodeConfig = prepareNodeConfig(config.nodeConfig)
     await BreezSDK.connect(config, seed)
+}
+
+export const signMessage = async (request: SignMessageRequest): Promise<SignMessageResponse> => {
+    return await BreezSDK.signMessage(request)
+}
+
+export const checkMessage = async (request: CheckMessageRequest): Promise<CheckMessageResponse> => {
+    return await BreezSDK.checkMessage(request)
 }
 
 export const sync = async (): Promise<void> => {

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "zbase32",
 ]
 
 [[package]]
@@ -827,7 +828,7 @@ dependencies = [
  "hkdf",
  "libsecp256k1",
  "rand",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "typenum",
 ]
 
@@ -1076,7 +1077,7 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 [[package]]
 name = "gl-client"
 version = "0.1.9"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=2eabad561ef8d0c42b3bf190a94c9fd9ae303eb6#2eabad561ef8d0c42b3bf190a94c9fd9ae303eb6"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=113cc28c938d4ed607a6e3fc4ab044a000d7e5e1#113cc28c938d4ed607a6e3fc4ab044a000d7e5e1"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -2510,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2743,7 +2744,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "rustc-hash",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -3496,6 +3497,12 @@ checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time 0.3.21",
 ]
+
+[[package]]
+name = "zbase32"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9079049688da5871a7558ddacb7f04958862c703e68258594cb7a862b5e33f"
 
 [[package]]
 name = "zeroize"

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use anyhow::{anyhow, Error, Result};
 use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
-    parse, BreezEvent, BreezServices, EventListener, GreenlightCredentials, PaymentTypeFilter,
+    parse, BreezEvent, BreezServices, CheckMessageRequest, EventListener, GreenlightCredentials,
+    PaymentTypeFilter, SignMessageRequest,
 };
 use breez_sdk_core::{Config, GreenlightNodeConfig, NodeConfig};
 use once_cell::sync::OnceCell;
@@ -216,6 +217,24 @@ pub(crate) async fn handle_command(
                 .refund(swap_address, to_address, sat_per_vbyte)
                 .await?;
             Ok(format!("Refund tx: {}", res))
+        }
+        Commands::SignMessage { message } => {
+            let req = SignMessageRequest { message };
+            let res = sdk()?.sign_message(req).await?;
+            Ok(format!("Message signature: {}", res.signature))
+        }
+        Commands::CheckMessage {
+            message,
+            pubkey,
+            signature,
+        } => {
+            let req = CheckMessageRequest {
+                message,
+                pubkey,
+                signature,
+            };
+            let res = sdk()?.check_message(req).await?;
+            Ok(format!("Message was signed by node: {}", res.is_valid))
         }
         Commands::LnurlPay { lnurl } => match parse(&lnurl).await? {
             LnUrlPay { data: pd } => {

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -85,6 +85,16 @@ pub(crate) enum Commands {
     /// Send a spontaneous (keysend) payment
     SendSpontaneousPayment { node_id: String, amount: u64 },
 
+    /// Sign a message with the node's private key
+    SignMessage { message: String },
+
+    /// Verify a message with a node's public key
+    CheckMessage {
+        message: String,
+        pubkey: String,
+        signature: String,
+    },
+
     /// List all payments
     ListPayments {},
 


### PR DESCRIPTION
Early (partial) commit.

This commit augments the Breez SDK with message signing and verification facilities. Changes span across the Node API interface, its implementation (Greenlight), BreezServices and the UniFFI binding, with amendments in the FFI definition.

- Added sign_message() and check_message() methods to the NodeAPI trait and Greenlight.
- Added async calls for these methods in BreezServices.
- Exposed said calls via the UniFFI binding for FFI.
- Updated the FFI definition to mirror these additions.

Todo:

[ x] formatting
[ x] tests
[ ] etc.