### PR TITLE
Simplify version management

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "breez_sdk"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "breez-sdk-core",

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -11,6 +11,9 @@ members = [
   "sdk-bindings",
 ]
 
+[workspace.package]
+version = "0.1.2"
+
 [workspace.dependencies]
 uniffi = "0.23.0"
 uniffi_macros = "0.23.0"

--- a/libs/sdk-bindings/Cargo.toml
+++ b/libs/sdk-bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "breez_sdk"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "breez-sdk-core"
-version = "0.1.2"
 edition = "2021"
+version.workspace = true
 
 [lib]
 name = "breez_sdk_core"


### PR DESCRIPTION
Both packages of the workspace now derive their version from the workspace version.

The version in `libs/Cargo.toml` now defines the version of both `sdk-core` and `sdk-bindings`.