### PR TITLE
Cache cargo crates and target dependency builds etc.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,12 @@ jobs:
           go-version: '1.19.9'                      
       - uses: actions/setup-python@v4      
       
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./libs -> target\n./tools/sdk-cli -> target"
+
       - name: install dependencies
         run: |
           cd libs/sdk-bindings


### PR DESCRIPTION
- Use the Swatinem/rust-cache@v2 to cache ~/.cargo
- Also cache libs/target and tools/sdk-cli/target

Workflow run now takes 13 minutes.