### PR TITLE
Add swaps_Info and reverse_swaps_info on restore

### DIFF
--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -355,8 +355,9 @@ impl BackupWorker {
                 );
 
                 // Bidirectionaly sync the local and remote changes
-                self.persister.import_remote_changes(&remote_storage)?;
-                remote_storage.import_remote_changes(self.persister.as_ref())?;
+                self.persister
+                    .import_remote_changes(&remote_storage, true)?;
+                remote_storage.import_remote_changes(self.persister.as_ref(), false)?;
                 *last_sync_request_id = self.persister.get_last_sync_request()?.unwrap_or_default();
 
                 let mut hex = vec![];

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -1,6 +1,8 @@
+use crate::ReverseSwapStatus;
+
 use super::db::SqliteStorage;
 use anyhow::Result;
-use rusqlite::Row;
+use rusqlite::{named_params, Row};
 use std::path::Path;
 
 #[allow(dead_code)]
@@ -81,7 +83,11 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub(crate) fn import_remote_changes(&self, remote_storage: &SqliteStorage) -> Result<()> {
+    pub(crate) fn import_remote_changes(
+        &self,
+        remote_storage: &SqliteStorage,
+        to_local: bool,
+    ) -> Result<()> {
         let sync_data_file = remote_storage.sync_db_path();
         match SqliteStorage::migrate_sync_db(sync_data_file.clone()) {
             Ok(_) => {}
@@ -93,6 +99,28 @@ impl SqliteStorage {
         let mut con = self.get_connection()?;
         let tx = con.transaction()?;
         tx.execute("ATTACH DATABASE ? AS remote_sync;", [sync_data_file])?;
+
+        if to_local {
+            tx.execute(
+                "
+            INSERT OR IGNORE INTO swaps_info (bitcoin_address, unconfirmed_tx_ids, confirmed_tx_ids)
+                SELECT
+                    bitcoin_address, '[]', '[]'
+                FROM remote_sync.swaps;",
+                [],
+            )?;
+
+            tx.execute(
+                "
+            INSERT OR IGNORE INTO reverse_swaps_info (id, status)
+                SELECT
+                    id, :status
+                FROM remote_sync.reverse_swaps;",
+                named_params! {
+                    ":status": serde_json::to_value(ReverseSwapStatus::Initial)?
+                },
+            )?;
+        }
 
         // sync remote swaps table
         tx.execute(
@@ -228,10 +256,10 @@ fn test_sync() {
         .unwrap();
 
     remote_storage
-        .import_remote_changes(&local_storage)
+        .import_remote_changes(&local_storage, false)
         .unwrap();
     local_storage
-        .import_remote_changes(&remote_storage)
+        .import_remote_changes(&remote_storage, true)
         .unwrap();
 
     let mut local_swaps = local_storage.list_swaps().unwrap();


### PR DESCRIPTION
We missed reconstructing the cached tables on restore. We only need to add initial entries and on next sync they will be updated to the current state.