### PR TITLE
`connect_lsp`: Only connect to known LSPs from `list_lsps`

### DIFF
--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -206,7 +206,6 @@ impl BlockingBreezServices {
 
     pub fn connect_lsp(&self, lsp_id: String) -> SdkResult<()> {
         rt().block_on(self.breez_services.connect_lsp(lsp_id))
-            .map_err(|e| e.into())
     }
 
     /// Convenience method to look up LSP info based on current LSP ID

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -196,6 +196,7 @@ pub fn list_lsps() -> Result<Vec<LspInformation>> {
 /// See [BreezServices::connect_lsp]
 pub fn connect_lsp(lsp_id: String) -> Result<()> {
     block_on(async { get_breez_services()?.connect_lsp(lsp_id).await })
+        .map_err(anyhow::Error::new::<SdkError>)
 }
 
 /// See [BreezServices::fetch_lsp_info]

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -405,10 +405,17 @@ impl BreezServices {
     }
 
     /// Select the LSP to be used and provide inbound liquidity
-    pub async fn connect_lsp(&self, lsp_id: String) -> Result<()> {
-        self.persister.set_lsp_id(lsp_id)?;
-        self.sync().await?;
-        Ok(())
+    pub async fn connect_lsp(&self, lsp_id: String) -> SdkResult<()> {
+        match self.list_lsps().await?.iter().any(|lsp| lsp.id == lsp_id) {
+            true => {
+                self.persister.set_lsp_id(lsp_id)?;
+                self.sync().await?;
+                Ok(())
+            }
+            false => Err(SdkError::LspConnectFailed {
+                err: format!("Unknown LSP: {lsp_id}"),
+            }),
+        }
     }
 
     /// Get the current LSP's ID


### PR DESCRIPTION
Before connecting to the user-specified LSP, we check if the LSP ID is known.

Fixes #338