### PR TITLE
Setup publishing of Android bindings to GitHub packages

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   publish-android:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Install dependencies
         run: |
@@ -37,6 +40,8 @@ jobs:
           make init
           make bindings-android
       - name: Publish artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd libs/sdk-bindings/bindings-android
           ./gradlew publish -PlibraryVersion=${{ inputs.version }} -PbreezReposiliteUsername=${{ secrets.BREEZ_MVN_USERNAME }} -PbreezReposilitePassword=${{ secrets.BREEZ_MVN_PASSWORD }}

--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -51,6 +51,14 @@ publishing {
                 create<BasicAuthentication>("basic")
             }
         }
+        maven {
+            name = "breezGitHubPackages"
+            url = uri("https://maven.pkg.github.com/breez/breez-sdk")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
     publications {
         create<MavenPublication>("maven") {


### PR DESCRIPTION
Sets up publishing of the Android bindings to [GitHub packages](https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-gradle).

I've done a [test run](https://github.com/breez/breez-sdk/actions/runs/5630034390) to [publish the 0.1.4 tag](https://github.com/breez/breez-sdk/packages/1906215) via CI and used the package in a sample Android project. ✅ 

@roeierez I haven't been able to test publishing to our custom repo _and_ GitHub packages side-by-side since the 0.1.4 release is already uploaded to our custom repo. I'd propose to do a 0.1.5 tag soon and test out the parallel publishing in "real live". I don't expect anything to go wrong (we're doing the [same thing as in the sample code from GitHub](https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-gradle#publishing-packages-to-the-maven-central-repository-and-github-packages) to publish to two repositories at the same time). But better to be safe than sorry.