### PR TITLE
Use proper error code and message

### DIFF
--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -19,6 +19,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
 
     companion object {
         const val TAG = "RNBreezSDK"
+        const val GENERIC_CODE = "Generic"
     }
 
     override fun initialize() {
@@ -53,7 +54,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 val seed = mnemonicToSeed(mnemonic)
                 promise.resolve(readableArrayOf(seed))
             } catch (e: SdkException) {
-                promise.reject(TAG, e.message ?: "Error calling mnemonicToSeed", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -66,7 +67,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(inputType))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling parseInput", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -79,7 +80,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(lnInvoice))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling parseInvoice", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -94,7 +95,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             promise.resolve(readableMapOf("status" to "ok"))
         } catch (e: SdkException) {
             e.printStackTrace()
-            promise.reject(TAG, e.message ?: "Error calling setLogStream", e)
+            promise.reject(e.javaClass.simpleName, e.message, e)
         }
     }
 
@@ -104,7 +105,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             val nodeConfig = asNodeConfig(nodeConfigMap)
 
             if (nodeConfig == null) {
-                promise.reject(TAG, "Invalid nodeConfig")
+                promise.reject(GENERIC_CODE, "Invalid nodeConfig")
             } else {
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
 
@@ -119,7 +120,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             }
         } catch (e: SdkException) {
             e.printStackTrace()
-            promise.reject(TAG, e.message ?: "Error calling defaultConfig", e)
+            promise.reject(e.javaClass.simpleName, e.message, e)
         }
     }
 
@@ -132,7 +133,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         val configData = asConfig(config)
 
         if (configData == null) {
-            promise.reject(TAG, "Invalid config")
+            promise.reject(GENERIC_CODE, "Invalid config")
         } else {
             val emitter = reactApplicationContext.getJSModule(RCTDeviceEventEmitter::class.java)
 
@@ -141,7 +142,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling connect", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -154,7 +155,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling sync", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -167,7 +168,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling disconnect", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -181,7 +182,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(payment))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling sendPayment", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -194,7 +195,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(payment))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling sendSpontaneousPayment", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -207,7 +208,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(payment))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling receivePayment", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -218,14 +219,14 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             val lnUrlAuthRequestData = asLnUrlAuthRequestData(reqData)
 
             if (lnUrlAuthRequestData == null) {
-                promise.reject(TAG, "Invalid reqData")
+                promise.reject(GENERIC_CODE, "Invalid reqData")
             } else {
                 try {
                     val lnUrlCallbackStatus = getBreezServices().lnurlAuth(lnUrlAuthRequestData)
                     promise.resolve(readableMapOf(lnUrlCallbackStatus))
                 } catch (e: SdkException) {
                     e.printStackTrace()
-                    promise.reject(TAG, e.message ?: "Error calling lnurlAuth", e)
+                    promise.reject(e.javaClass.simpleName, e.message, e)
                 }
             }
         }
@@ -237,7 +238,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             val lnUrlPayRequestData = asLnUrlPayRequestData(reqData)
 
             if (lnUrlPayRequestData == null) {
-                promise.reject(TAG, "Invalid reqData")
+                promise.reject(GENERIC_CODE, "Invalid reqData")
             } else {
                 try {
                     val optionalComment = comment.takeUnless { it.isEmpty() }
@@ -245,7 +246,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     promise.resolve(readableMapOf(lnUrlPayResult))
                 } catch (e: SdkException) {
                     e.printStackTrace()
-                    promise.reject(TAG, e.message ?: "Error calling payLnurl", e)
+                    promise.reject(e.javaClass.simpleName, e.message, e)
                 }
             }
         }
@@ -257,7 +258,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             val lnUrlWithdrawRequestData = asLnUrlWithdrawRequestData(reqData)
 
             if (lnUrlWithdrawRequestData == null) {
-                promise.reject(TAG, "Invalid reqData")
+                promise.reject(GENERIC_CODE, "Invalid reqData")
             } else {
                 try {
                     val optionalDescription = description.takeUnless { it.isEmpty() }
@@ -265,7 +266,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     promise.resolve(readableMapOf(lnUrlCallbackStatus))
                 } catch (e: SdkException) {
                     e.printStackTrace()
-                    promise.reject(TAG, e.message ?: "Error calling withdrawLnurl", e)
+                    promise.reject(e.javaClass.simpleName, e.message, e)
                 }
             }
         }
@@ -279,7 +280,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(nodeState))                
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling nodeInfo", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -291,11 +292,11 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 getBreezServices().paymentByHash(hash)?.let {payment->
                     promise.resolve(readableMapOf(payment))
                 } ?: run {
-                    promise.reject(TAG, "No available payment")
+                    promise.reject(GENERIC_CODE, "No available payment")
                 }
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling paymentByHash", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -310,7 +311,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableArrayOf(payments))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling listPayments", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -323,7 +324,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling sweep", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -336,7 +337,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableArrayOf(rates))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling fetchFiatRates", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -349,7 +350,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableArrayOf(fiatCurrencies))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling listFiatCurrencies", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -362,7 +363,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableArrayOf(lsps))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling listLsps", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -375,7 +376,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling connectLsp", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -386,12 +387,12 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 getBreezServices().fetchLspInfo(lspId)?.let {lspInformation->
                     promise.resolve(readableMapOf(lspInformation))
-                } ?: run {
-                    promise.reject(TAG, "No available lsp info")
+                } ?: run {                    
+                    promise.reject(GENERIC_CODE, "No available lsp info")
                 }
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling fetchLspInfo", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -403,11 +404,11 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 getBreezServices().lspId()?.let {lspId->
                     promise.resolve(lspId)
                 } ?: run {
-                    promise.reject(TAG, "No available lsp id")
+                    promise.reject(GENERIC_CODE, "No available lsp id")
                 }
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling lspId", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -420,7 +421,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling closeLspChannels", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -433,7 +434,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(swapInfo))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling receiveOnchain", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -445,11 +446,11 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 getBreezServices().inProgressSwap()?.let {swapInfo->
                     promise.resolve(readableMapOf(swapInfo))
                 } ?: run {
-                    promise.reject(TAG, "No available in progress swap")
+                    promise.reject(GENERIC_CODE, "No available in progress swap")
                 }
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling inProgressSwap", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -462,7 +463,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableArrayOf(swapInfos))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling listRefundables", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -475,7 +476,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(result)
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling refund", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -488,7 +489,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(reverseSwapFees))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling fetchReverseSwapFees", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -501,7 +502,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableArrayOf(inProgressReverseSwaps))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling inProgressReverseSwaps", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -514,7 +515,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(response))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling sendOnchain", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -527,7 +528,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(result)
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling executeDevCommand", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -540,7 +541,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(fees))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling recommendedFees", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -554,7 +555,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(result)
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling buyBitcoin", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -567,7 +568,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling backup", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }
@@ -580,7 +581,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 promise.resolve(readableMapOf(status))
             } catch (e: SdkException) {
                 e.printStackTrace()
-                promise.reject(TAG, e.message ?: "Error calling backupStatus", e)
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -47,7 +47,7 @@ class RNBreezSDK: RCTEventEmitter {
             let seed = try BreezSDK.mnemonicToSeed(phrase: phrase)        
             resolve(seed)        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling mnemonicToSeed \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -57,7 +57,7 @@ class RNBreezSDK: RCTEventEmitter {
             let inputType = try BreezSDK.parseInput(s: input)            
             resolve(BreezSDKMapper.dictionaryOf(inputType: inputType))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling parseInput \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -67,7 +67,7 @@ class RNBreezSDK: RCTEventEmitter {
             let lnInvoice = try BreezSDK.parseInvoice(invoice: invoice)            
             resolve(BreezSDKMapper.dictionaryOf(lnInvoice: lnInvoice))
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling parseInvoice \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -77,7 +77,7 @@ class RNBreezSDK: RCTEventEmitter {
             try BreezSDK.setLogStream(logStream: BreezSDKLogStream(emitter: self))            
             resolve(["status": "ok"])        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling setLogStream \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -92,7 +92,7 @@ class RNBreezSDK: RCTEventEmitter {
                 reject(RNBreezSDK.TAG, "Invalid node config", nil)
             }        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling defaultConfig \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -105,10 +105,10 @@ class RNBreezSDK: RCTEventEmitter {
                 self.breezServices = try BreezSDK.connect(config: config, seed: seed, listener: BreezSDKListener(emitter: self))                
                 resolve(["status": "ok"])
             } catch let err {
-                reject(RNBreezSDK.TAG, "Error calling connect \(err)", err)
+                rejectErr(err: err, reject: reject)
             }
         } else {
-            reject(RNBreezSDK.TAG, "Invalid config", nil)
+            rejectErr(err: SdkError.Generic(message:"Invalid config"), reject: reject)            
         }
     }
     
@@ -118,7 +118,7 @@ class RNBreezSDK: RCTEventEmitter {
             try getBreezServices().sync()
             resolve(["status": "ok"])        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling sync \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
    }
     
@@ -128,7 +128,7 @@ class RNBreezSDK: RCTEventEmitter {
             try getBreezServices().disconnect()
             resolve(["status": "ok"])        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling disconnect \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -139,7 +139,7 @@ class RNBreezSDK: RCTEventEmitter {
             let payment = try getBreezServices().sendPayment(bolt11: bolt11, amountSats: optionalAmountSats)
             resolve(BreezSDKMapper.dictionaryOf(payment: payment))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling sendPayment \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -149,7 +149,7 @@ class RNBreezSDK: RCTEventEmitter {
             let payment = try getBreezServices().sendSpontaneousPayment(nodeId: nodeId, amountSats: amountSats)
             resolve(BreezSDKMapper.dictionaryOf(payment: payment))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling sendSpontaneousPayment \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -159,7 +159,7 @@ class RNBreezSDK: RCTEventEmitter {
             let lnInvoice = try getBreezServices().receivePayment(amountSats: amountSats, description: description)
             resolve(BreezSDKMapper.dictionaryOf(lnInvoice: lnInvoice))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling receivePayment \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -173,7 +173,7 @@ class RNBreezSDK: RCTEventEmitter {
                 reject(RNBreezSDK.TAG, "Error calling lnurlAuth \(err)", err)
             }
         } else {
-            reject(RNBreezSDK.TAG, "Invalid reqData", nil)
+            rejectErr(err: SdkError.Generic(message:"Invalid reqData"), reject: reject)            
         }
     }
     
@@ -188,7 +188,7 @@ class RNBreezSDK: RCTEventEmitter {
                 reject(RNBreezSDK.TAG, "Error calling payLnurl \(err)", err)
             }
         } else {
-            reject(RNBreezSDK.TAG, "Invalid reqData", nil)
+            rejectErr(err: SdkError.Generic(message:"Invalid reqData"), reject: reject)                        
         }
     }
     
@@ -200,10 +200,10 @@ class RNBreezSDK: RCTEventEmitter {
                 let lnUrlCallbackStatus = try getBreezServices().withdrawLnurl(reqData: lnUrlWithdrawRequestData, amountSats: amountSats, description: optionalDescription)                
                 resolve(BreezSDKMapper.dictionaryOf(lnUrlCallbackStatus: lnUrlCallbackStatus))
             } catch let err {
-                reject(RNBreezSDK.TAG, "Error calling withdrawLnurl \(err)", err)
+                rejectErr(err: err, reject: reject)      
             }
-        } else {
-            reject(RNBreezSDK.TAG, "Invalid reqData", nil)
+        } else {            
+            rejectErr(err: SdkError.Generic(message:"Invalid reqData"), reject: reject)
         }
     }
     
@@ -213,7 +213,7 @@ class RNBreezSDK: RCTEventEmitter {
             let nodeState = try getBreezServices().nodeInfo()
             resolve(BreezSDKMapper.dictionaryOf(nodeState: nodeState))                 
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling nodeInfo \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -223,10 +223,10 @@ class RNBreezSDK: RCTEventEmitter {
             if let payment = try getBreezServices().paymentByHash(hash: hash) {
                 resolve(BreezSDKMapper.dictionaryOf(payment: payment))
             } else {
-                reject(RNBreezSDK.TAG, "No available payment", nil)
+                rejectErr(err: SdkError.Generic(message: "No available payment"), reject: reject)
             }        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling paymentByHash \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
 
@@ -238,7 +238,7 @@ class RNBreezSDK: RCTEventEmitter {
             let payments = try getBreezServices().listPayments(filter: BreezSDKMapper.asPaymentTypeFilter(filter: filter), fromTimestamp: optionalFromTimestamp, toTimestamp: optionalToTimestamp)
             resolve(BreezSDKMapper.arrayOf(payments: payments))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling listPayments \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -248,7 +248,7 @@ class RNBreezSDK: RCTEventEmitter {
             try getBreezServices().sweep(toAddress: toAddress, feeRateSatsPerVbyte: feeRateSatsPerVbyte)
             resolve(["status": "ok"])        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling sweep \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -258,7 +258,7 @@ class RNBreezSDK: RCTEventEmitter {
             let rates = try getBreezServices().fetchFiatRates()
             resolve(BreezSDKMapper.arrayOf(rates: rates))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling fetchFiatRates \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -268,7 +268,7 @@ class RNBreezSDK: RCTEventEmitter {
             let fiatCurrencies = try getBreezServices().listFiatCurrencies()
             resolve(BreezSDKMapper.arrayOf(fiatCurrencies: fiatCurrencies))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling listFiatCurrencies \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -278,7 +278,7 @@ class RNBreezSDK: RCTEventEmitter {
             let lsps = try getBreezServices().listLsps()
             resolve(BreezSDKMapper.arrayOf(lsps: lsps))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling listLsps \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -288,7 +288,7 @@ class RNBreezSDK: RCTEventEmitter {
             try getBreezServices().connectLsp(lspId: lspId)
             resolve(["status": "ok"])        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling connectLsp \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -298,10 +298,10 @@ class RNBreezSDK: RCTEventEmitter {
             if let lspInformation = try getBreezServices().fetchLspInfo(lspId: lspId) {
                 resolve(BreezSDKMapper.dictionaryOf(lspInformation: lspInformation))
             } else {
-                reject(RNBreezSDK.TAG, "No available lsp info", nil)
+                rejectErr(err: SdkError.Generic(message: "No available lsp info"), reject: reject)
             }        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling fetchLspInfo \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -311,10 +311,10 @@ class RNBreezSDK: RCTEventEmitter {
             if let lspId = try getBreezServices().lspId() {
                 resolve(lspId)
             } else {
-                reject(RNBreezSDK.TAG, "No available lsp id", nil)
+                rejectErr(err: SdkError.Generic(message: "No available lsp id"), reject: reject)
             }        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling lspId \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -324,7 +324,7 @@ class RNBreezSDK: RCTEventEmitter {
             try getBreezServices().closeLspChannels()
             resolve(["status": "ok"])        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling closeLspChannels \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -334,7 +334,7 @@ class RNBreezSDK: RCTEventEmitter {
             let swapInfo = try getBreezServices().receiveOnchain()
             resolve(BreezSDKMapper.dictionaryOf(swapInfo: swapInfo))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling receiveOnchain \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -347,7 +347,7 @@ class RNBreezSDK: RCTEventEmitter {
                 reject(RNBreezSDK.TAG, "No available in progress swap", nil)
             }        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling inProgressSwap \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -357,7 +357,7 @@ class RNBreezSDK: RCTEventEmitter {
             let swapInfos = try getBreezServices().listRefundables()
             resolve(BreezSDKMapper.arrayOf(swapInfos: swapInfos))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling listRefundables \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -367,7 +367,7 @@ class RNBreezSDK: RCTEventEmitter {
             let result = try getBreezServices().refund(swapAddress: swapAddress, toAddress: toAddress, satPerVbyte: satPerVbyte)
             resolve(result)        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling refund \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
 
@@ -377,7 +377,7 @@ class RNBreezSDK: RCTEventEmitter {
             let fees = try getBreezServices().fetchReverseSwapFees()
             resolve(fees)        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling fetchReverseSwapFees \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
 
@@ -387,7 +387,7 @@ class RNBreezSDK: RCTEventEmitter {
             let swaps = try getBreezServices().inProgressReverseSwaps()
             resolve(BreezSDKMapper.arrayOf(reverseSwapInfos: swaps))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling inProgressReverseSwaps \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
 
@@ -397,7 +397,7 @@ class RNBreezSDK: RCTEventEmitter {
             let swapInfo = try getBreezServices().sendOnchain(amountSat: amountSat, onchainRecipientAddress: onchainRecipientAddress, pairHash: pairHash, satPerVbyte: satPerVbyte)
             resolve(BreezSDKMapper.dictionaryOf(reverseSwapInfo: swapInfo))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling sendOnchain \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -407,7 +407,7 @@ class RNBreezSDK: RCTEventEmitter {
             let result = try getBreezServices().executeDevCommand(command: command)
             resolve(result)        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling executeDevCommand \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -417,7 +417,7 @@ class RNBreezSDK: RCTEventEmitter {
             let fees = try getBreezServices().recommendedFees()
             resolve(BreezSDKMapper.dictionaryOf(recommendedFees: fees))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling recommendedFees \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
 
@@ -428,7 +428,7 @@ class RNBreezSDK: RCTEventEmitter {
             let result = try getBreezServices().buyBitcoin(provider: buyBitcoinProvider)
             resolve(result)        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling buyBitcoin \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -438,7 +438,7 @@ class RNBreezSDK: RCTEventEmitter {
             try getBreezServices().backup()
             resolve(["status": "ok"])        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling backup \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
     }
     
@@ -448,7 +448,17 @@ class RNBreezSDK: RCTEventEmitter {
             let status = try getBreezServices().backupStatus()
             resolve(BreezSDKMapper.dictionaryOf(backupStatus: status))        
         } catch let err {
-            reject(RNBreezSDK.TAG, "Error calling backupStatus \(err)", err)
+            rejectErr(err: err, reject: reject)
         }
+    }
+    
+    func rejectErr(err: Error, reject: @escaping RCTPromiseRejectBlock) {
+        var errorCode = "Generic"
+        if let sdkErr = err as? SdkError {
+            let mirror = Mirror(reflecting: sdkErr)
+            errorCode = mirror.children.first!.label!
+        }
+        reject(errorCode, "\(err)", err)
+        
     }
 }


### PR DESCRIPTION
Propagating the error code and message to the errors thrown from the native layer.
To make it generic reflection is used in both platform to extract the class name, e.g:
SdkError.Generic => Generic