### PR TITLE
Fix Jitpack build

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -45,7 +45,7 @@ publishing {
     repositories {
         maven {
             name = "breezReposilite"
-            url = uri("https://mvn.breez.technology/releases")
+            url = uri("https://mvn.breez.technology/snapshots")
             credentials(PasswordCredentials::class)
             authentication {
                 create<BasicAuthentication>("basic")

--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -45,7 +45,7 @@ publishing {
     repositories {
         maven {
             name = "breezReposilite"
-            url = uri("https://mvn.breez.technology/snapshots")
+            url = uri("https://mvn.breez.technology/releases")
             credentials(PasswordCredentials::class)
             authentication {
                 create<BasicAuthentication>("basic")

--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -116,6 +116,16 @@ x86_64-linux-android: $(SOURCES) ndk-home
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
 
 bindings-android: kotlin
+	# Manually add JNA native library (jnidispatch) to the packaged libraries.
+	# Due to an issue with Jitpack (https://github.com/jitpack/jitpack.io/issues/5752),
+	# the Android platform versions of jnidispatch is not included when installing the Breez SDK via Jitpack.
+	# This is because Jitpack seems to force the jar version of JNA which doesn't include the Android platform versions of the lib.
+	# We actually want the AAR version which does include them.
+	# Therefore we manually download and add the Android platform versions to the packaged native libraries.
+	# Make sure the downloaded JNA version matches the JNA dependency declared in: bindings-android/lib/build.gradke.kts
+	# When installing the Breez SDK from other package repositories this is not an issue since those allow for using the AAR version of JNA.
+	# Manually adding jnidispatch doesn't break those builds though since: "JNA falls back to extraction if the native library is not already installed"
+	# See https://github.com/java-native-access/jna/blob/master/www/GettingStarted.md#getting-started-with-jna
 	mkdir -p ffi/kotlin/jna
 	curl https://github.com/java-native-access/jna/archive/refs/tags/5.8.0.zip --location --output ffi/kotlin/jna/jna-5.8.0.zip
 	unzip ffi/kotlin/jna/jna-5.8.0.zip -d ffi/kotlin/jna/
@@ -123,6 +133,7 @@ bindings-android: kotlin
 	unzip -j ffi/kotlin/jna/jna-5.8.0/dist/android-armv7.jar libjnidispatch.so -d ffi/kotlin/jniLibs/armeabi-v7a
 	unzip -j ffi/kotlin/jna/jna-5.8.0/dist/android-x86-64.jar libjnidispatch.so -d ffi/kotlin/jniLibs/x86_64
 	unzip -j ffi/kotlin/jna/jna-5.8.0/dist/android-x86.jar libjnidispatch.so -d ffi/kotlin/jniLibs/x86
+	# End of JNA native library Jitpack fix.
 	cp -r ffi/kotlin/jniLibs bindings-android/lib/src/main
 	cp -r ffi/kotlin/breez_sdk bindings-android/lib/src/main/kotlin/
 	cd bindings-android && ./gradlew assemble

--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -116,6 +116,13 @@ x86_64-linux-android: $(SOURCES) ndk-home
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
 
 bindings-android: kotlin
+	mkdir -p ffi/kotlin/jna
+	curl https://github.com/java-native-access/jna/archive/refs/tags/5.8.0.zip --location --output ffi/kotlin/jna/jna-5.8.0.zip
+	unzip ffi/kotlin/jna/jna-5.8.0.zip -d ffi/kotlin/jna/
+	unzip -j ffi/kotlin/jna/jna-5.8.0/dist/android-aarch64.jar libjnidispatch.so -d ffi/kotlin/jniLibs/arm64-v8a
+	unzip -j ffi/kotlin/jna/jna-5.8.0/dist/android-armv7.jar libjnidispatch.so -d ffi/kotlin/jniLibs/armeabi-v7a
+	unzip -j ffi/kotlin/jna/jna-5.8.0/dist/android-x86-64.jar libjnidispatch.so -d ffi/kotlin/jniLibs/x86_64
+	unzip -j ffi/kotlin/jna/jna-5.8.0/dist/android-x86.jar libjnidispatch.so -d ffi/kotlin/jniLibs/x86
 	cp -r ffi/kotlin/jniLibs bindings-android/lib/src/main
 	cp -r ffi/kotlin/breez_sdk bindings-android/lib/src/main/kotlin/
 	cd bindings-android && ./gradlew assemble

--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -118,8 +118,8 @@ x86_64-linux-android: $(SOURCES) ndk-home
 bindings-android: kotlin
 	# Manually add JNA native library (jnidispatch) to the packaged libraries.
 	# Due to an issue with Jitpack (https://github.com/jitpack/jitpack.io/issues/5752),
-	# the Android platform versions of jnidispatch is not included when installing the Breez SDK via Jitpack.
-	# This is because Jitpack seems to force the jar version of JNA which doesn't include the Android platform versions of the lib.
+	# the Android platform versions of jnidispatch are not included when installing the Breez SDK via Jitpack.
+	# This is because Jitpack seems to force the JAR version of JNA which doesn't include the Android platform versions of the lib.
 	# We actually want the AAR version which does include them.
 	# Therefore we manually download and add the Android platform versions to the packaged native libraries.
 	# Make sure the downloaded JNA version matches the JNA dependency declared in: bindings-android/lib/build.gradke.kts


### PR DESCRIPTION
When we declare the JNA dependency in our Gradle project, we do it like so:

```
implementation("net.java.dev.jna:jna:5.8.0@aar")
```

Note the `@aar`. From my investigations, only the AAR version of JNA inlcudes the Android platform builds (aarch64, armv7, x86-64, x86) of the necessary `jnidispatch` native library.

But due what seems to be an [issue with Jitpack](https://github.com/jitpack/jitpack.io/issues/5752), the information about using the AAR instead of the JAR is dropped by Jitpack from our module definition file.

From what I can tell, that means that when using Jitpack, the JAR version of JNA will be used and therefore the versions of `jnidispatch` that are needed on the Android platform are missing. Therefore we get the following error when running Android apps:

```
(libjnidispatch.so) not found in resource path (.)
```

A solution to this (based on [this](https://stackoverflow.com/a/54663679/8034839) SO answer) is to manually download and include `jnidispatch` in the build. That way the necessary native libraries for the Android platform can be found. We already explicitly include `libc++_shared.so` so I think including `libjnidispatch.so` should be fine.

Size-wise, this adds about 400KB to the package.

When installing the Breez SDK from other package repositories (our custom one, GitHub), this is not an issue. There, the information to use the AAR version of JNA is kept and we don't run into the "libjnidispatch.so not found" issue. From my tests, manually including `jnidispatch` doesn't break builds installed from these repositories either. It doesn't seem to cause any duplicate symbols or other errors.

## How to Test

Add the Jitpack repository

```
repositories {
    ...
    maven { url 'https://jitpack.io' }
}
```

Then add the Breez SDK. The `c6f838bd89` is equivalent to the 0.1.3 release + this fix:

```
dependencies {
    implementation 'com.github.breez:breez-sdk:c6f838bd89'
}

```

## Why Jitpack

In React Native projects, Jitpack is a default repository. That means users don't need to manually add a repository when installing the Breez SDK plugin.