### PR TITLE
Grouped up Dart API's by concept

### DIFF
--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -24,7 +24,7 @@ use crate::chain::RecommendedFees;
 use crate::error::SdkError;
 use crate::fiat::{FiatCurrency, Rate};
 use crate::input_parser::{
-    InputType, LnUrlAuthRequestData, LnUrlPayRequestData, LnUrlWithdrawRequestData,
+    self, InputType, LnUrlAuthRequestData, LnUrlPayRequestData, LnUrlWithdrawRequestData,
 };
 use crate::invoice::{self, LNInvoice};
 use crate::lnurl::pay::model::LnUrlPayResult;
@@ -40,6 +40,325 @@ static BREEZ_SERVICES_SHUTDOWN: OnceCell<mpsc::Sender<()>> = OnceCell::new();
 static NOTIFICATION_STREAM: OnceCell<StreamSink<BreezEvent>> = OnceCell::new();
 static LOG_STREAM: OnceCell<StreamSink<LogEntry>> = OnceCell::new();
 static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| tokio::runtime::Runtime::new().unwrap());
+
+/*  Breez Services API's */
+
+/// See [BreezServices::connect]
+pub fn connect(config: Config, seed: Vec<u8>) -> Result<()> {
+    block_on(async move {
+        let breez_services =
+            BreezServices::connect(config, seed, Box::new(BindingEventListener {})).await?;
+        BREEZ_SERVICES_INSTANCE
+            .set(breez_services)
+            .map_err(|_| SdkError::InitFailed {
+                err: "static node services already set".into(),
+            })?;
+
+        Ok(())
+    })
+    .map_err(anyhow::Error::new::<SdkError>)
+}
+
+/// Check whether node service is initialized or not
+pub fn is_initialized() -> bool {
+    block_on(async { get_breez_services().is_ok() })
+}
+
+/// See [BreezServices::sync]
+pub fn sync() -> Result<()> {
+    block_on(async { get_breez_services()?.sync().await })
+}
+
+/// See [BreezServices::node_info]
+pub fn node_info() -> Result<NodeState> {
+    block_on(async {
+        get_breez_services()?
+            .node_info()
+            .map_err(anyhow::Error::new)
+    })
+}
+
+/// Cleanup node resources and stop the signer.
+pub fn disconnect() -> Result<()> {
+    block_on(async {
+        let shutdown_handler = BREEZ_SERVICES_SHUTDOWN.get();
+        match shutdown_handler {
+            None => Err(anyhow!("Background processing is not running")),
+            Some(s) => s.send(()).await.map_err(anyhow::Error::msg),
+        }
+    })
+}
+
+/*  Breez Services Helper API's */
+
+/// See [breez_services::mnemonic_to_seed]
+pub fn mnemonic_to_seed(phrase: String) -> Result<Vec<u8>> {
+    breez_services::mnemonic_to_seed(phrase)
+}
+
+/// See [BreezServices::default_config]
+pub fn default_config(
+    env_type: EnvironmentType,
+    api_key: String,
+    node_config: NodeConfig,
+) -> Config {
+    BreezServices::default_config(env_type, api_key, node_config)
+}
+
+/*  Stream API's */
+
+pub fn breez_events_stream(s: StreamSink<BreezEvent>) -> Result<()> {
+    NOTIFICATION_STREAM
+        .set(s)
+        .map_err(|_| anyhow!("events stream already created"))?;
+    Ok(())
+}
+
+pub fn breez_log_stream(s: StreamSink<LogEntry>) -> Result<()> {
+    LOG_STREAM
+        .set(s)
+        .map_err(|_| anyhow!("log stream already created"))?;
+    BindingLogger::init();
+    Ok(())
+}
+
+/*  LSP API's */
+
+/// See [BreezServices::list_lsps]
+pub fn list_lsps() -> Result<Vec<LspInformation>> {
+    block_on(async { get_breez_services()?.list_lsps().await }).map_err(anyhow::Error::new)
+}
+
+/// See [BreezServices::connect_lsp]
+pub fn connect_lsp(lsp_id: String) -> Result<()> {
+    block_on(async { get_breez_services()?.connect_lsp(lsp_id).await })
+        .map_err(anyhow::Error::new::<SdkError>)
+}
+
+/// See [BreezServices::lsp_id]
+pub fn lsp_id() -> Result<Option<String>> {
+    block_on(async { get_breez_services()?.lsp_id().await }).map_err(anyhow::Error::new)
+}
+
+/// See [BreezServices::fetch_lsp_info]
+pub fn fetch_lsp_info(id: String) -> Result<Option<LspInformation>> {
+    block_on(async { get_breez_services()?.fetch_lsp_info(id).await })
+}
+
+/// See [BreezServices::close_lsp_channels]
+pub fn close_lsp_channels() -> Result<()> {
+    block_on(async {
+        _ = get_breez_services()?.close_lsp_channels().await;
+        Ok(())
+    })
+}
+
+/*  Backup API's */
+
+/// See [BreezServices::backup]
+pub fn backup() -> Result<()> {
+    block_on(async { get_breez_services()?.backup().await })
+}
+
+/// See [BreezServices::backup_status]
+pub fn backup_status() -> Result<BackupStatus> {
+    get_breez_services()?.backup_status()
+}
+
+/*  Parse API's */
+
+pub fn parse_invoice(invoice: String) -> Result<LNInvoice> {
+    invoice::parse_invoice(&invoice)
+}
+
+pub fn parse_input(input: String) -> Result<InputType> {
+    block_on(async { input_parser::parse(&input).await })
+}
+
+/*  Payment API's */
+
+/// See [BreezServices::list_payments]
+pub fn list_payments(
+    filter: PaymentTypeFilter,
+    from_timestamp: Option<i64>,
+    to_timestamp: Option<i64>,
+) -> Result<Vec<Payment>> {
+    block_on(async {
+        get_breez_services()?
+            .list_payments(filter, from_timestamp, to_timestamp)
+            .await
+    })
+    .map_err(anyhow::Error::new)
+}
+
+/// See [BreezServices::list_payments]
+pub fn payment_by_hash(hash: String) -> Result<Option<Payment>> {
+    block_on(async { get_breez_services()?.payment_by_hash(hash).await })
+}
+
+/*  Lightning Payment API's */
+
+/// See [BreezServices::send_payment]
+pub fn send_payment(bolt11: String, amount_sats: Option<u64>) -> Result<Payment> {
+    block_on(async {
+        get_breez_services()?
+            .send_payment(bolt11, amount_sats)
+            .await
+    })
+}
+
+/// See [BreezServices::send_spontaneous_payment]
+pub fn send_spontaneous_payment(node_id: String, amount_sats: u64) -> Result<Payment> {
+    block_on(async {
+        get_breez_services()?
+            .send_spontaneous_payment(node_id, amount_sats)
+            .await
+    })
+}
+
+/// See [BreezServices::receive_payment]
+pub fn receive_payment(amount_sats: u64, description: String) -> Result<LNInvoice> {
+    block_on(async {
+        get_breez_services()?
+            .receive_payment(amount_sats, description.to_string())
+            .await
+    })
+    .map_err(anyhow::Error::new)
+}
+
+/*  LNURL API's */
+
+/// See [BreezServices::lnurl_pay]
+pub fn lnurl_pay(
+    user_amount_sat: u64,
+    comment: Option<String>,
+    req_data: LnUrlPayRequestData,
+) -> Result<LnUrlPayResult> {
+    block_on(async {
+        get_breez_services()?
+            .lnurl_pay(user_amount_sat, comment, req_data)
+            .await
+    })
+}
+
+/// See [BreezServices::lnurl_withdraw]
+pub fn lnurl_withdraw(
+    req_data: LnUrlWithdrawRequestData,
+    amount_sats: u64,
+    description: Option<String>,
+) -> Result<LnUrlCallbackStatus> {
+    block_on(async {
+        get_breez_services()?
+            .lnurl_withdraw(req_data, amount_sats, description)
+            .await
+    })
+}
+
+/// See [BreezServices::lnurl_auth]
+pub fn lnurl_auth(req_data: LnUrlAuthRequestData) -> Result<LnUrlCallbackStatus> {
+    block_on(async { get_breez_services()?.lnurl_auth(req_data).await })
+}
+
+/*  Fiat Currency API's */
+
+/// See [BreezServices::fetch_fiat_rates]
+pub fn fetch_fiat_rates() -> Result<Vec<Rate>> {
+    block_on(async { get_breez_services()?.fetch_fiat_rates().await })
+}
+
+/// See [BreezServices::list_fiat_currencies]
+pub fn list_fiat_currencies() -> Result<Vec<FiatCurrency>> {
+    block_on(async { get_breez_services()?.list_fiat_currencies().await })
+}
+
+/*  On-Chain Swap API's */
+
+/// See [BreezServices::send_onchain]
+pub fn send_onchain(
+    amount_sat: u64,
+    onchain_recipient_address: String,
+    pair_hash: String,
+    sat_per_vbyte: u64,
+) -> Result<ReverseSwapInfo> {
+    block_on(async {
+        get_breez_services()?
+            .send_onchain(
+                amount_sat,
+                onchain_recipient_address,
+                pair_hash,
+                sat_per_vbyte,
+            )
+            .await
+    })
+}
+
+/// See [BreezServices::receive_onchain]
+pub fn receive_onchain() -> Result<SwapInfo> {
+    block_on(async { get_breez_services()?.receive_onchain().await })
+}
+
+/// See [BreezServices::buy_bitcoin]
+pub fn buy_bitcoin(provider: BuyBitcoinProvider) -> Result<String> {
+    block_on(async { get_breez_services()?.buy_bitcoin(provider).await })
+}
+
+/// See [BreezServices::sweep]
+pub fn sweep(to_address: String, fee_rate_sats_per_vbyte: u64) -> Result<()> {
+    block_on(async {
+        get_breez_services()?
+            .sweep(to_address, fee_rate_sats_per_vbyte)
+            .await
+    })
+}
+
+/*  Refundables API's */
+
+/// See [BreezServices::list_refundables]
+pub fn list_refundables() -> Result<Vec<SwapInfo>> {
+    block_on(async { get_breez_services()?.list_refundables().await })
+}
+
+/// See [BreezServices::refund]
+pub fn refund(swap_address: String, to_address: String, sat_per_vbyte: u32) -> Result<String> {
+    block_on(async {
+        get_breez_services()?
+            .refund(swap_address, to_address, sat_per_vbyte)
+            .await
+    })
+}
+
+/*  In Progress Swap API's */
+
+/// See [BreezServices::in_progress_swap]
+pub fn in_progress_swap() -> Result<Option<SwapInfo>> {
+    block_on(async { get_breez_services()?.in_progress_swap().await })
+}
+
+/// See [BreezServices::in_progress_reverse_swaps]
+pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
+    block_on(async { get_breez_services()?.in_progress_reverse_swaps().await })
+}
+
+/*  Swap Fee API's */
+
+/// See [BreezServices::fetch_reverse_swap_fees]
+pub fn fetch_reverse_swap_fees() -> Result<ReverseSwapPairInfo> {
+    block_on(async { get_breez_services()?.fetch_reverse_swap_fees().await })
+}
+
+/// See [BreezServices::recommended_fees]
+pub fn recommended_fees() -> Result<RecommendedFees> {
+    block_on(async { get_breez_services()?.recommended_fees().await })
+}
+
+/*  CLI API's */
+
+/// See [BreezServices::execute_dev_command]
+pub fn execute_command(command: String) -> Result<String> {
+    block_on(async { get_breez_services()?.execute_dev_command(command).await })
+}
+
+/*  Binding Related Logic */
 
 struct BindingLogger;
 
@@ -78,226 +397,6 @@ impl EventListener for BindingEventListener {
     }
 }
 
-/// Check whether node service is initialized or not
-pub fn initialized() -> bool {
-    block_on(async { get_breez_services().is_ok() })
-}
-
-/// connect initializes the global NodeService, schedule the node to run in the cloud and
-/// run the signer. This must be called in order to start communicate with the node
-///
-/// # Arguments
-///
-/// * `config` - The sdk configuration
-/// * `seed` - The node private key
-///
-pub fn connect(config: Config, seed: Vec<u8>) -> Result<()> {
-    block_on(async move {
-        let breez_services =
-            BreezServices::connect(config, seed, Box::new(BindingEventListener {})).await?;
-        BREEZ_SERVICES_INSTANCE
-            .set(breez_services)
-            .map_err(|_| SdkError::InitFailed {
-                err: "static node services already set".into(),
-            })?;
-
-        Ok(())
-    })
-    .map_err(anyhow::Error::new::<SdkError>)
-}
-
-pub fn breez_events_stream(s: StreamSink<BreezEvent>) -> Result<()> {
-    NOTIFICATION_STREAM
-        .set(s)
-        .map_err(|_| anyhow!("events stream already created"))?;
-    Ok(())
-}
-
-pub fn breez_log_stream(s: StreamSink<LogEntry>) -> Result<()> {
-    LOG_STREAM
-        .set(s)
-        .map_err(|_| anyhow!("log stream already created"))?;
-    BindingLogger::init();
-    Ok(())
-}
-
-/// Cleanup node resources and stop the signer.
-pub fn disconnect() -> Result<()> {
-    block_on(async {
-        let shutdown_handler = BREEZ_SERVICES_SHUTDOWN.get();
-        match shutdown_handler {
-            None => Err(anyhow!("Background processing is not running")),
-            Some(s) => s.send(()).await.map_err(anyhow::Error::msg),
-        }
-    })
-}
-
-/// See [BreezServices::send_payment]
-pub fn send_payment(bolt11: String, amount_sats: Option<u64>) -> Result<Payment> {
-    block_on(async {
-        get_breez_services()?
-            .send_payment(bolt11, amount_sats)
-            .await
-    })
-}
-
-/// See [BreezServices::send_spontaneous_payment]
-pub fn send_spontaneous_payment(node_id: String, amount_sats: u64) -> Result<Payment> {
-    block_on(async {
-        get_breez_services()?
-            .send_spontaneous_payment(node_id, amount_sats)
-            .await
-    })
-}
-
-/// See [BreezServices::receive_payment]
-pub fn receive_payment(amount_sats: u64, description: String) -> Result<LNInvoice> {
-    block_on(async {
-        get_breez_services()?
-            .receive_payment(amount_sats, description.to_string())
-            .await
-    })
-    .map_err(anyhow::Error::new)
-}
-
-/// See [BreezServices::node_info]
-pub fn node_info() -> Result<NodeState> {
-    block_on(async {
-        get_breez_services()?
-            .node_info()
-            .map_err(anyhow::Error::new)
-    })
-}
-
-/// See [BreezServices::list_payments]
-pub fn list_payments(
-    filter: PaymentTypeFilter,
-    from_timestamp: Option<i64>,
-    to_timestamp: Option<i64>,
-) -> Result<Vec<Payment>> {
-    block_on(async {
-        get_breez_services()?
-            .list_payments(filter, from_timestamp, to_timestamp)
-            .await
-    })
-    .map_err(anyhow::Error::new)
-}
-
-/// See [BreezServices::list_payments]
-pub fn payment_by_hash(hash: String) -> Result<Option<Payment>> {
-    block_on(async { get_breez_services()?.payment_by_hash(hash).await })
-}
-
-/// See [BreezServices::list_lsps]
-pub fn list_lsps() -> Result<Vec<LspInformation>> {
-    block_on(async { get_breez_services()?.list_lsps().await }).map_err(anyhow::Error::new)
-}
-
-/// See [BreezServices::connect_lsp]
-pub fn connect_lsp(lsp_id: String) -> Result<()> {
-    block_on(async { get_breez_services()?.connect_lsp(lsp_id).await })
-        .map_err(anyhow::Error::new::<SdkError>)
-}
-
-/// See [BreezServices::fetch_lsp_info]
-pub fn fetch_lsp_info(id: String) -> Result<Option<LspInformation>> {
-    block_on(async { get_breez_services()?.fetch_lsp_info(id).await })
-}
-
-/// See [BreezServices::lsp_id]
-pub fn lsp_id() -> Result<Option<String>> {
-    block_on(async { get_breez_services()?.lsp_id().await }).map_err(anyhow::Error::new)
-}
-
-/// See [BreezServices::fetch_fiat_rates]
-pub fn fetch_fiat_rates() -> Result<Vec<Rate>> {
-    block_on(async { get_breez_services()?.fetch_fiat_rates().await })
-}
-
-/// See [BreezServices::list_fiat_currencies]
-pub fn list_fiat_currencies() -> Result<Vec<FiatCurrency>> {
-    block_on(async { get_breez_services()?.list_fiat_currencies().await })
-}
-
-/// See [BreezServices::close_lsp_channels]
-pub fn close_lsp_channels() -> Result<()> {
-    block_on(async {
-        _ = get_breez_services()?.close_lsp_channels().await;
-        Ok(())
-    })
-}
-
-/// See [BreezServices::sweep]
-pub fn sweep(to_address: String, fee_rate_sats_per_vbyte: u64) -> Result<()> {
-    block_on(async {
-        get_breez_services()?
-            .sweep(to_address, fee_rate_sats_per_vbyte)
-            .await
-    })
-}
-
-/// See [BreezServices::receive_onchain]
-pub fn receive_onchain() -> Result<SwapInfo> {
-    block_on(async { get_breez_services()?.receive_onchain().await })
-}
-
-/// See [BreezServices::in_progress_swap]
-pub fn in_progress_swap() -> Result<Option<SwapInfo>> {
-    block_on(async { get_breez_services()?.in_progress_swap().await })
-}
-
-/// See [BreezServices::list_refundables]
-pub fn list_refundables() -> Result<Vec<SwapInfo>> {
-    block_on(async { get_breez_services()?.list_refundables().await })
-}
-
-/// See [BreezServices::refund]
-pub fn refund(swap_address: String, to_address: String, sat_per_vbyte: u32) -> Result<String> {
-    block_on(async {
-        get_breez_services()?
-            .refund(swap_address, to_address, sat_per_vbyte)
-            .await
-    })
-}
-
-/// See [BreezServices::fetch_reverse_swap_fees]
-pub fn fetch_reverse_swap_fees() -> Result<ReverseSwapPairInfo> {
-    block_on(async { get_breez_services()?.fetch_reverse_swap_fees().await })
-}
-
-/// See [BreezServices::in_progress_reverse_swaps]
-pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
-    block_on(async { get_breez_services()?.in_progress_reverse_swaps().await })
-}
-
-/// See [BreezServices::send_onchain]
-pub fn send_onchain(
-    amount_sat: u64,
-    onchain_recipient_address: String,
-    pair_hash: String,
-    sat_per_vbyte: u64,
-) -> Result<ReverseSwapInfo> {
-    block_on(async {
-        get_breez_services()?
-            .send_onchain(
-                amount_sat,
-                onchain_recipient_address,
-                pair_hash,
-                sat_per_vbyte,
-            )
-            .await
-    })
-}
-
-/// See [BreezServices::execute_dev_command]
-pub fn execute_command(command: String) -> Result<String> {
-    block_on(async { get_breez_services()?.execute_dev_command(command).await })
-}
-
-pub fn sync() -> Result<()> {
-    block_on(async { get_breez_services()?.sync().await })
-}
-
 fn get_breez_services() -> Result<&'static BreezServices> {
     let n = BREEZ_SERVICES_INSTANCE.get();
     match n {
@@ -312,79 +411,4 @@ fn block_on<F: Future>(future: F) -> F::Output {
 
 pub(crate) fn rt() -> &'static tokio::runtime::Runtime {
     &RT
-}
-
-// These functions are exposed temporarily for integration purposes
-
-pub fn parse_invoice(invoice: String) -> Result<LNInvoice> {
-    invoice::parse_invoice(&invoice)
-}
-
-pub fn parse_input(input: String) -> Result<InputType> {
-    block_on(async { crate::input_parser::parse(&input).await })
-}
-
-/// See [BreezServices::lnurl_pay]
-pub fn lnurl_pay(
-    user_amount_sat: u64,
-    comment: Option<String>,
-    req_data: LnUrlPayRequestData,
-) -> Result<LnUrlPayResult> {
-    block_on(async {
-        get_breez_services()?
-            .lnurl_pay(user_amount_sat, comment, req_data)
-            .await
-    })
-}
-
-/// See [BreezServices::lnurl_withdraw]
-pub fn lnurl_withdraw(
-    req_data: LnUrlWithdrawRequestData,
-    amount_sats: u64,
-    description: Option<String>,
-) -> Result<LnUrlCallbackStatus> {
-    block_on(async {
-        get_breez_services()?
-            .lnurl_withdraw(req_data, amount_sats, description)
-            .await
-    })
-}
-
-/// See [BreezServices::lnurl_auth]
-pub fn lnurl_auth(req_data: LnUrlAuthRequestData) -> Result<LnUrlCallbackStatus> {
-    block_on(async { get_breez_services()?.lnurl_auth(req_data).await })
-}
-
-/// See [breez_services::mnemonic_to_seed]
-pub fn mnemonic_to_seed(phrase: String) -> Result<Vec<u8>> {
-    breez_services::mnemonic_to_seed(phrase)
-}
-
-/// See [BreezServices::recommended_fees]
-pub fn recommended_fees() -> Result<RecommendedFees> {
-    block_on(async { get_breez_services()?.recommended_fees().await })
-}
-
-/// See [BreezServices::default_config]
-pub fn default_config(
-    env_type: EnvironmentType,
-    api_key: String,
-    node_config: NodeConfig,
-) -> Config {
-    BreezServices::default_config(env_type, api_key, node_config)
-}
-
-/// See [BreezServices::buy_bitcoin]
-pub fn buy_bitcoin(provider: BuyBitcoinProvider) -> Result<String> {
-    block_on(async { get_breez_services()?.buy_bitcoin(provider).await })
-}
-
-/// See [BreezServices::backup]
-pub fn backup() -> Result<()> {
-    block_on(async { get_breez_services()?.backup().await })
-}
-
-/// See [BreezServices::backup_status]
-pub fn backup_status() -> Result<BackupStatus> {
-    get_breez_services()?.backup_status()
 }

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -2,13 +2,43 @@ use super::*;
 // Section: wire functions
 
 #[no_mangle]
-pub extern "C" fn wire_initialized(port_: i64) {
-    wire_initialized_impl(port_)
+pub extern "C" fn wire_connect(port_: i64, config: *mut wire_Config, seed: *mut wire_uint_8_list) {
+    wire_connect_impl(port_, config, seed)
 }
 
 #[no_mangle]
-pub extern "C" fn wire_connect(port_: i64, config: *mut wire_Config, seed: *mut wire_uint_8_list) {
-    wire_connect_impl(port_, config, seed)
+pub extern "C" fn wire_is_initialized(port_: i64) {
+    wire_is_initialized_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_sync(port_: i64) {
+    wire_sync_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_node_info(port_: i64) {
+    wire_node_info_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_disconnect(port_: i64) {
+    wire_disconnect_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_mnemonic_to_seed(port_: i64, phrase: *mut wire_uint_8_list) {
+    wire_mnemonic_to_seed_impl(port_, phrase)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_default_config(
+    port_: i64,
+    env_type: i32,
+    api_key: *mut wire_uint_8_list,
+    node_config: *mut wire_NodeConfig,
+) {
+    wire_default_config_impl(port_, env_type, api_key, node_config)
 }
 
 #[no_mangle]
@@ -22,8 +52,63 @@ pub extern "C" fn wire_breez_log_stream(port_: i64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_disconnect(port_: i64) {
-    wire_disconnect_impl(port_)
+pub extern "C" fn wire_list_lsps(port_: i64) {
+    wire_list_lsps_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_connect_lsp(port_: i64, lsp_id: *mut wire_uint_8_list) {
+    wire_connect_lsp_impl(port_, lsp_id)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_lsp_id(port_: i64) {
+    wire_lsp_id_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_fetch_lsp_info(port_: i64, id: *mut wire_uint_8_list) {
+    wire_fetch_lsp_info_impl(port_, id)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_close_lsp_channels(port_: i64) {
+    wire_close_lsp_channels_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_backup(port_: i64) {
+    wire_backup_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_backup_status(port_: i64) {
+    wire_backup_status_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_parse_invoice(port_: i64, invoice: *mut wire_uint_8_list) {
+    wire_parse_invoice_impl(port_, invoice)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_parse_input(port_: i64, input: *mut wire_uint_8_list) {
+    wire_parse_input_impl(port_, input)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_list_payments(
+    port_: i64,
+    filter: i32,
+    from_timestamp: *mut i64,
+    to_timestamp: *mut i64,
+) {
+    wire_list_payments_impl(port_, filter, from_timestamp, to_timestamp)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_payment_by_hash(port_: i64, hash: *mut wire_uint_8_list) {
+    wire_payment_by_hash_impl(port_, hash)
 }
 
 #[no_mangle]
@@ -54,142 +139,6 @@ pub extern "C" fn wire_receive_payment(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_node_info(port_: i64) {
-    wire_node_info_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_list_payments(
-    port_: i64,
-    filter: i32,
-    from_timestamp: *mut i64,
-    to_timestamp: *mut i64,
-) {
-    wire_list_payments_impl(port_, filter, from_timestamp, to_timestamp)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_payment_by_hash(port_: i64, hash: *mut wire_uint_8_list) {
-    wire_payment_by_hash_impl(port_, hash)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_list_lsps(port_: i64) {
-    wire_list_lsps_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_connect_lsp(port_: i64, lsp_id: *mut wire_uint_8_list) {
-    wire_connect_lsp_impl(port_, lsp_id)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_fetch_lsp_info(port_: i64, id: *mut wire_uint_8_list) {
-    wire_fetch_lsp_info_impl(port_, id)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_lsp_id(port_: i64) {
-    wire_lsp_id_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_fetch_fiat_rates(port_: i64) {
-    wire_fetch_fiat_rates_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_list_fiat_currencies(port_: i64) {
-    wire_list_fiat_currencies_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_close_lsp_channels(port_: i64) {
-    wire_close_lsp_channels_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_sweep(
-    port_: i64,
-    to_address: *mut wire_uint_8_list,
-    fee_rate_sats_per_vbyte: u64,
-) {
-    wire_sweep_impl(port_, to_address, fee_rate_sats_per_vbyte)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_receive_onchain(port_: i64) {
-    wire_receive_onchain_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_in_progress_swap(port_: i64) {
-    wire_in_progress_swap_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_list_refundables(port_: i64) {
-    wire_list_refundables_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_refund(
-    port_: i64,
-    swap_address: *mut wire_uint_8_list,
-    to_address: *mut wire_uint_8_list,
-    sat_per_vbyte: u32,
-) {
-    wire_refund_impl(port_, swap_address, to_address, sat_per_vbyte)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_fetch_reverse_swap_fees(port_: i64) {
-    wire_fetch_reverse_swap_fees_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
-    wire_in_progress_reverse_swaps_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_send_onchain(
-    port_: i64,
-    amount_sat: u64,
-    onchain_recipient_address: *mut wire_uint_8_list,
-    pair_hash: *mut wire_uint_8_list,
-    sat_per_vbyte: u64,
-) {
-    wire_send_onchain_impl(
-        port_,
-        amount_sat,
-        onchain_recipient_address,
-        pair_hash,
-        sat_per_vbyte,
-    )
-}
-
-#[no_mangle]
-pub extern "C" fn wire_execute_command(port_: i64, command: *mut wire_uint_8_list) {
-    wire_execute_command_impl(port_, command)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_sync(port_: i64) {
-    wire_sync_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_parse_invoice(port_: i64, invoice: *mut wire_uint_8_list) {
-    wire_parse_invoice_impl(port_, invoice)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_parse_input(port_: i64, input: *mut wire_uint_8_list) {
-    wire_parse_input_impl(port_, input)
-}
-
-#[no_mangle]
 pub extern "C" fn wire_lnurl_pay(
     port_: i64,
     user_amount_sat: u64,
@@ -215,23 +164,35 @@ pub extern "C" fn wire_lnurl_auth(port_: i64, req_data: *mut wire_LnUrlAuthReque
 }
 
 #[no_mangle]
-pub extern "C" fn wire_mnemonic_to_seed(port_: i64, phrase: *mut wire_uint_8_list) {
-    wire_mnemonic_to_seed_impl(port_, phrase)
+pub extern "C" fn wire_fetch_fiat_rates(port_: i64) {
+    wire_fetch_fiat_rates_impl(port_)
 }
 
 #[no_mangle]
-pub extern "C" fn wire_recommended_fees(port_: i64) {
-    wire_recommended_fees_impl(port_)
+pub extern "C" fn wire_list_fiat_currencies(port_: i64) {
+    wire_list_fiat_currencies_impl(port_)
 }
 
 #[no_mangle]
-pub extern "C" fn wire_default_config(
+pub extern "C" fn wire_send_onchain(
     port_: i64,
-    env_type: i32,
-    api_key: *mut wire_uint_8_list,
-    node_config: *mut wire_NodeConfig,
+    amount_sat: u64,
+    onchain_recipient_address: *mut wire_uint_8_list,
+    pair_hash: *mut wire_uint_8_list,
+    sat_per_vbyte: u64,
 ) {
-    wire_default_config_impl(port_, env_type, api_key, node_config)
+    wire_send_onchain_impl(
+        port_,
+        amount_sat,
+        onchain_recipient_address,
+        pair_hash,
+        sat_per_vbyte,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_receive_onchain(port_: i64) {
+    wire_receive_onchain_impl(port_)
 }
 
 #[no_mangle]
@@ -240,13 +201,52 @@ pub extern "C" fn wire_buy_bitcoin(port_: i64, provider: i32) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_backup(port_: i64) {
-    wire_backup_impl(port_)
+pub extern "C" fn wire_sweep(
+    port_: i64,
+    to_address: *mut wire_uint_8_list,
+    fee_rate_sats_per_vbyte: u64,
+) {
+    wire_sweep_impl(port_, to_address, fee_rate_sats_per_vbyte)
 }
 
 #[no_mangle]
-pub extern "C" fn wire_backup_status(port_: i64) {
-    wire_backup_status_impl(port_)
+pub extern "C" fn wire_list_refundables(port_: i64) {
+    wire_list_refundables_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_refund(
+    port_: i64,
+    swap_address: *mut wire_uint_8_list,
+    to_address: *mut wire_uint_8_list,
+    sat_per_vbyte: u32,
+) {
+    wire_refund_impl(port_, swap_address, to_address, sat_per_vbyte)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_in_progress_swap(port_: i64) {
+    wire_in_progress_swap_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
+    wire_in_progress_reverse_swaps_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_fetch_reverse_swap_fees(port_: i64) {
+    wire_fetch_reverse_swap_fees_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_recommended_fees(port_: i64) {
+    wire_recommended_fees_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_execute_command(port_: i64, command: *mut wire_uint_8_list) {
+    wire_execute_command_impl(port_, command)
 }
 
 // Section: allocate functions

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -72,16 +72,6 @@ use crate::models::UnspentTransactionOutput;
 
 // Section: wire functions
 
-fn wire_initialized_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "initialized",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| Ok(initialized()),
-    )
-}
 fn wire_connect_impl(
     port_: MessagePort,
     config: impl Wire2Api<Config> + UnwindSafe,
@@ -97,6 +87,79 @@ fn wire_connect_impl(
             let api_config = config.wire2api();
             let api_seed = seed.wire2api();
             move |task_callback| connect(api_config, api_seed)
+        },
+    )
+}
+fn wire_is_initialized_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "is_initialized",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| Ok(is_initialized()),
+    )
+}
+fn wire_sync_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "sync",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| sync(),
+    )
+}
+fn wire_node_info_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "node_info",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| node_info(),
+    )
+}
+fn wire_disconnect_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "disconnect",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| disconnect(),
+    )
+}
+fn wire_mnemonic_to_seed_impl(port_: MessagePort, phrase: impl Wire2Api<String> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "mnemonic_to_seed",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_phrase = phrase.wire2api();
+            move |task_callback| mnemonic_to_seed(api_phrase)
+        },
+    )
+}
+fn wire_default_config_impl(
+    port_: MessagePort,
+    env_type: impl Wire2Api<EnvironmentType> + UnwindSafe,
+    api_key: impl Wire2Api<String> + UnwindSafe,
+    node_config: impl Wire2Api<NodeConfig> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "default_config",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_env_type = env_type.wire2api();
+            let api_api_key = api_key.wire2api();
+            let api_node_config = node_config.wire2api();
+            move |task_callback| Ok(default_config(api_env_type, api_api_key, api_node_config))
         },
     )
 }
@@ -120,14 +183,139 @@ fn wire_breez_log_stream_impl(port_: MessagePort) {
         move || move |task_callback| breez_log_stream(task_callback.stream_sink()),
     )
 }
-fn wire_disconnect_impl(port_: MessagePort) {
+fn wire_list_lsps_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "disconnect",
+            debug_name: "list_lsps",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| disconnect(),
+        move || move |task_callback| list_lsps(),
+    )
+}
+fn wire_connect_lsp_impl(port_: MessagePort, lsp_id: impl Wire2Api<String> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "connect_lsp",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_lsp_id = lsp_id.wire2api();
+            move |task_callback| connect_lsp(api_lsp_id)
+        },
+    )
+}
+fn wire_lsp_id_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "lsp_id",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| lsp_id(),
+    )
+}
+fn wire_fetch_lsp_info_impl(port_: MessagePort, id: impl Wire2Api<String> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "fetch_lsp_info",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_id = id.wire2api();
+            move |task_callback| fetch_lsp_info(api_id)
+        },
+    )
+}
+fn wire_close_lsp_channels_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "close_lsp_channels",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| close_lsp_channels(),
+    )
+}
+fn wire_backup_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "backup",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| backup(),
+    )
+}
+fn wire_backup_status_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "backup_status",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| backup_status(),
+    )
+}
+fn wire_parse_invoice_impl(port_: MessagePort, invoice: impl Wire2Api<String> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "parse_invoice",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_invoice = invoice.wire2api();
+            move |task_callback| parse_invoice(api_invoice)
+        },
+    )
+}
+fn wire_parse_input_impl(port_: MessagePort, input: impl Wire2Api<String> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "parse_input",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_input = input.wire2api();
+            move |task_callback| parse_input(api_input)
+        },
+    )
+}
+fn wire_list_payments_impl(
+    port_: MessagePort,
+    filter: impl Wire2Api<PaymentTypeFilter> + UnwindSafe,
+    from_timestamp: impl Wire2Api<Option<i64>> + UnwindSafe,
+    to_timestamp: impl Wire2Api<Option<i64>> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "list_payments",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_filter = filter.wire2api();
+            let api_from_timestamp = from_timestamp.wire2api();
+            let api_to_timestamp = to_timestamp.wire2api();
+            move |task_callback| list_payments(api_filter, api_from_timestamp, api_to_timestamp)
+        },
+    )
+}
+fn wire_payment_by_hash_impl(port_: MessagePort, hash: impl Wire2Api<String> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "payment_by_hash",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_hash = hash.wire2api();
+            move |task_callback| payment_by_hash(api_hash)
+        },
     )
 }
 fn wire_send_payment_impl(
@@ -181,291 +369,6 @@ fn wire_receive_payment_impl(
             let api_amount_sats = amount_sats.wire2api();
             let api_description = description.wire2api();
             move |task_callback| receive_payment(api_amount_sats, api_description)
-        },
-    )
-}
-fn wire_node_info_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "node_info",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| node_info(),
-    )
-}
-fn wire_list_payments_impl(
-    port_: MessagePort,
-    filter: impl Wire2Api<PaymentTypeFilter> + UnwindSafe,
-    from_timestamp: impl Wire2Api<Option<i64>> + UnwindSafe,
-    to_timestamp: impl Wire2Api<Option<i64>> + UnwindSafe,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "list_payments",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_filter = filter.wire2api();
-            let api_from_timestamp = from_timestamp.wire2api();
-            let api_to_timestamp = to_timestamp.wire2api();
-            move |task_callback| list_payments(api_filter, api_from_timestamp, api_to_timestamp)
-        },
-    )
-}
-fn wire_payment_by_hash_impl(port_: MessagePort, hash: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "payment_by_hash",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_hash = hash.wire2api();
-            move |task_callback| payment_by_hash(api_hash)
-        },
-    )
-}
-fn wire_list_lsps_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "list_lsps",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| list_lsps(),
-    )
-}
-fn wire_connect_lsp_impl(port_: MessagePort, lsp_id: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "connect_lsp",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_lsp_id = lsp_id.wire2api();
-            move |task_callback| connect_lsp(api_lsp_id)
-        },
-    )
-}
-fn wire_fetch_lsp_info_impl(port_: MessagePort, id: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "fetch_lsp_info",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_id = id.wire2api();
-            move |task_callback| fetch_lsp_info(api_id)
-        },
-    )
-}
-fn wire_lsp_id_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "lsp_id",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| lsp_id(),
-    )
-}
-fn wire_fetch_fiat_rates_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "fetch_fiat_rates",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| fetch_fiat_rates(),
-    )
-}
-fn wire_list_fiat_currencies_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "list_fiat_currencies",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| list_fiat_currencies(),
-    )
-}
-fn wire_close_lsp_channels_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "close_lsp_channels",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| close_lsp_channels(),
-    )
-}
-fn wire_sweep_impl(
-    port_: MessagePort,
-    to_address: impl Wire2Api<String> + UnwindSafe,
-    fee_rate_sats_per_vbyte: impl Wire2Api<u64> + UnwindSafe,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "sweep",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_to_address = to_address.wire2api();
-            let api_fee_rate_sats_per_vbyte = fee_rate_sats_per_vbyte.wire2api();
-            move |task_callback| sweep(api_to_address, api_fee_rate_sats_per_vbyte)
-        },
-    )
-}
-fn wire_receive_onchain_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "receive_onchain",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| receive_onchain(),
-    )
-}
-fn wire_in_progress_swap_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "in_progress_swap",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| in_progress_swap(),
-    )
-}
-fn wire_list_refundables_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "list_refundables",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| list_refundables(),
-    )
-}
-fn wire_refund_impl(
-    port_: MessagePort,
-    swap_address: impl Wire2Api<String> + UnwindSafe,
-    to_address: impl Wire2Api<String> + UnwindSafe,
-    sat_per_vbyte: impl Wire2Api<u32> + UnwindSafe,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "refund",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_swap_address = swap_address.wire2api();
-            let api_to_address = to_address.wire2api();
-            let api_sat_per_vbyte = sat_per_vbyte.wire2api();
-            move |task_callback| refund(api_swap_address, api_to_address, api_sat_per_vbyte)
-        },
-    )
-}
-fn wire_fetch_reverse_swap_fees_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "fetch_reverse_swap_fees",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| fetch_reverse_swap_fees(),
-    )
-}
-fn wire_in_progress_reverse_swaps_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "in_progress_reverse_swaps",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| in_progress_reverse_swaps(),
-    )
-}
-fn wire_send_onchain_impl(
-    port_: MessagePort,
-    amount_sat: impl Wire2Api<u64> + UnwindSafe,
-    onchain_recipient_address: impl Wire2Api<String> + UnwindSafe,
-    pair_hash: impl Wire2Api<String> + UnwindSafe,
-    sat_per_vbyte: impl Wire2Api<u64> + UnwindSafe,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "send_onchain",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_amount_sat = amount_sat.wire2api();
-            let api_onchain_recipient_address = onchain_recipient_address.wire2api();
-            let api_pair_hash = pair_hash.wire2api();
-            let api_sat_per_vbyte = sat_per_vbyte.wire2api();
-            move |task_callback| {
-                send_onchain(
-                    api_amount_sat,
-                    api_onchain_recipient_address,
-                    api_pair_hash,
-                    api_sat_per_vbyte,
-                )
-            }
-        },
-    )
-}
-fn wire_execute_command_impl(port_: MessagePort, command: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "execute_command",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_command = command.wire2api();
-            move |task_callback| execute_command(api_command)
-        },
-    )
-}
-fn wire_sync_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "sync",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| sync(),
-    )
-}
-fn wire_parse_invoice_impl(port_: MessagePort, invoice: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "parse_invoice",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_invoice = invoice.wire2api();
-            move |task_callback| parse_invoice(api_invoice)
-        },
-    )
-}
-fn wire_parse_input_impl(port_: MessagePort, input: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "parse_input",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_input = input.wire2api();
-            move |task_callback| parse_input(api_input)
         },
     )
 }
@@ -525,47 +428,63 @@ fn wire_lnurl_auth_impl(
         },
     )
 }
-fn wire_mnemonic_to_seed_impl(port_: MessagePort, phrase: impl Wire2Api<String> + UnwindSafe) {
+fn wire_fetch_fiat_rates_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "mnemonic_to_seed",
+            debug_name: "fetch_fiat_rates",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || {
-            let api_phrase = phrase.wire2api();
-            move |task_callback| mnemonic_to_seed(api_phrase)
-        },
+        move || move |task_callback| fetch_fiat_rates(),
     )
 }
-fn wire_recommended_fees_impl(port_: MessagePort) {
+fn wire_list_fiat_currencies_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "recommended_fees",
+            debug_name: "list_fiat_currencies",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| recommended_fees(),
+        move || move |task_callback| list_fiat_currencies(),
     )
 }
-fn wire_default_config_impl(
+fn wire_send_onchain_impl(
     port_: MessagePort,
-    env_type: impl Wire2Api<EnvironmentType> + UnwindSafe,
-    api_key: impl Wire2Api<String> + UnwindSafe,
-    node_config: impl Wire2Api<NodeConfig> + UnwindSafe,
+    amount_sat: impl Wire2Api<u64> + UnwindSafe,
+    onchain_recipient_address: impl Wire2Api<String> + UnwindSafe,
+    pair_hash: impl Wire2Api<String> + UnwindSafe,
+    sat_per_vbyte: impl Wire2Api<u64> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "default_config",
+            debug_name: "send_onchain",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
         move || {
-            let api_env_type = env_type.wire2api();
-            let api_api_key = api_key.wire2api();
-            let api_node_config = node_config.wire2api();
-            move |task_callback| Ok(default_config(api_env_type, api_api_key, api_node_config))
+            let api_amount_sat = amount_sat.wire2api();
+            let api_onchain_recipient_address = onchain_recipient_address.wire2api();
+            let api_pair_hash = pair_hash.wire2api();
+            let api_sat_per_vbyte = sat_per_vbyte.wire2api();
+            move |task_callback| {
+                send_onchain(
+                    api_amount_sat,
+                    api_onchain_recipient_address,
+                    api_pair_hash,
+                    api_sat_per_vbyte,
+                )
+            }
         },
+    )
+}
+fn wire_receive_onchain_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "receive_onchain",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| receive_onchain(),
     )
 }
 fn wire_buy_bitcoin_impl(
@@ -584,24 +503,105 @@ fn wire_buy_bitcoin_impl(
         },
     )
 }
-fn wire_backup_impl(port_: MessagePort) {
+fn wire_sweep_impl(
+    port_: MessagePort,
+    to_address: impl Wire2Api<String> + UnwindSafe,
+    fee_rate_sats_per_vbyte: impl Wire2Api<u64> + UnwindSafe,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "backup",
+            debug_name: "sweep",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| backup(),
+        move || {
+            let api_to_address = to_address.wire2api();
+            let api_fee_rate_sats_per_vbyte = fee_rate_sats_per_vbyte.wire2api();
+            move |task_callback| sweep(api_to_address, api_fee_rate_sats_per_vbyte)
+        },
     )
 }
-fn wire_backup_status_impl(port_: MessagePort) {
+fn wire_list_refundables_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "backup_status",
+            debug_name: "list_refundables",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| backup_status(),
+        move || move |task_callback| list_refundables(),
+    )
+}
+fn wire_refund_impl(
+    port_: MessagePort,
+    swap_address: impl Wire2Api<String> + UnwindSafe,
+    to_address: impl Wire2Api<String> + UnwindSafe,
+    sat_per_vbyte: impl Wire2Api<u32> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "refund",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_swap_address = swap_address.wire2api();
+            let api_to_address = to_address.wire2api();
+            let api_sat_per_vbyte = sat_per_vbyte.wire2api();
+            move |task_callback| refund(api_swap_address, api_to_address, api_sat_per_vbyte)
+        },
+    )
+}
+fn wire_in_progress_swap_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "in_progress_swap",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| in_progress_swap(),
+    )
+}
+fn wire_in_progress_reverse_swaps_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "in_progress_reverse_swaps",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| in_progress_reverse_swaps(),
+    )
+}
+fn wire_fetch_reverse_swap_fees_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "fetch_reverse_swap_fees",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| fetch_reverse_swap_fees(),
+    )
+}
+fn wire_recommended_fees_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "recommended_fees",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| recommended_fees(),
+    )
+}
+fn wire_execute_command_impl(port_: MessagePort, command: impl Wire2Api<String> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "execute_command",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_command = command.wire2api();
+            move |task_callback| execute_command(api_command)
+        },
     )
 }
 // Section: wrapper structs

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -86,15 +86,51 @@ uintptr_t new_dart_opaque(Dart_Handle handle);
 
 intptr_t init_frb_dart_api_dl(void *obj);
 
-void wire_initialized(int64_t port_);
-
 void wire_connect(int64_t port_, struct wire_Config *config, struct wire_uint_8_list *seed);
+
+void wire_is_initialized(int64_t port_);
+
+void wire_sync(int64_t port_);
+
+void wire_node_info(int64_t port_);
+
+void wire_disconnect(int64_t port_);
+
+void wire_mnemonic_to_seed(int64_t port_, struct wire_uint_8_list *phrase);
+
+void wire_default_config(int64_t port_,
+                         int32_t env_type,
+                         struct wire_uint_8_list *api_key,
+                         struct wire_NodeConfig *node_config);
 
 void wire_breez_events_stream(int64_t port_);
 
 void wire_breez_log_stream(int64_t port_);
 
-void wire_disconnect(int64_t port_);
+void wire_list_lsps(int64_t port_);
+
+void wire_connect_lsp(int64_t port_, struct wire_uint_8_list *lsp_id);
+
+void wire_lsp_id(int64_t port_);
+
+void wire_fetch_lsp_info(int64_t port_, struct wire_uint_8_list *id);
+
+void wire_close_lsp_channels(int64_t port_);
+
+void wire_backup(int64_t port_);
+
+void wire_backup_status(int64_t port_);
+
+void wire_parse_invoice(int64_t port_, struct wire_uint_8_list *invoice);
+
+void wire_parse_input(int64_t port_, struct wire_uint_8_list *input);
+
+void wire_list_payments(int64_t port_,
+                        int32_t filter,
+                        int64_t *from_timestamp,
+                        int64_t *to_timestamp);
+
+void wire_payment_by_hash(int64_t port_, struct wire_uint_8_list *hash);
 
 void wire_send_payment(int64_t port_, struct wire_uint_8_list *bolt11, uint64_t *amount_sats);
 
@@ -105,62 +141,6 @@ void wire_send_spontaneous_payment(int64_t port_,
 void wire_receive_payment(int64_t port_,
                           uint64_t amount_sats,
                           struct wire_uint_8_list *description);
-
-void wire_node_info(int64_t port_);
-
-void wire_list_payments(int64_t port_,
-                        int32_t filter,
-                        int64_t *from_timestamp,
-                        int64_t *to_timestamp);
-
-void wire_payment_by_hash(int64_t port_, struct wire_uint_8_list *hash);
-
-void wire_list_lsps(int64_t port_);
-
-void wire_connect_lsp(int64_t port_, struct wire_uint_8_list *lsp_id);
-
-void wire_fetch_lsp_info(int64_t port_, struct wire_uint_8_list *id);
-
-void wire_lsp_id(int64_t port_);
-
-void wire_fetch_fiat_rates(int64_t port_);
-
-void wire_list_fiat_currencies(int64_t port_);
-
-void wire_close_lsp_channels(int64_t port_);
-
-void wire_sweep(int64_t port_,
-                struct wire_uint_8_list *to_address,
-                uint64_t fee_rate_sats_per_vbyte);
-
-void wire_receive_onchain(int64_t port_);
-
-void wire_in_progress_swap(int64_t port_);
-
-void wire_list_refundables(int64_t port_);
-
-void wire_refund(int64_t port_,
-                 struct wire_uint_8_list *swap_address,
-                 struct wire_uint_8_list *to_address,
-                 uint32_t sat_per_vbyte);
-
-void wire_fetch_reverse_swap_fees(int64_t port_);
-
-void wire_in_progress_reverse_swaps(int64_t port_);
-
-void wire_send_onchain(int64_t port_,
-                       uint64_t amount_sat,
-                       struct wire_uint_8_list *onchain_recipient_address,
-                       struct wire_uint_8_list *pair_hash,
-                       uint64_t sat_per_vbyte);
-
-void wire_execute_command(int64_t port_, struct wire_uint_8_list *command);
-
-void wire_sync(int64_t port_);
-
-void wire_parse_invoice(int64_t port_, struct wire_uint_8_list *invoice);
-
-void wire_parse_input(int64_t port_, struct wire_uint_8_list *input);
 
 void wire_lnurl_pay(int64_t port_,
                     uint64_t user_amount_sat,
@@ -174,20 +154,40 @@ void wire_lnurl_withdraw(int64_t port_,
 
 void wire_lnurl_auth(int64_t port_, struct wire_LnUrlAuthRequestData *req_data);
 
-void wire_mnemonic_to_seed(int64_t port_, struct wire_uint_8_list *phrase);
+void wire_fetch_fiat_rates(int64_t port_);
 
-void wire_recommended_fees(int64_t port_);
+void wire_list_fiat_currencies(int64_t port_);
 
-void wire_default_config(int64_t port_,
-                         int32_t env_type,
-                         struct wire_uint_8_list *api_key,
-                         struct wire_NodeConfig *node_config);
+void wire_send_onchain(int64_t port_,
+                       uint64_t amount_sat,
+                       struct wire_uint_8_list *onchain_recipient_address,
+                       struct wire_uint_8_list *pair_hash,
+                       uint64_t sat_per_vbyte);
+
+void wire_receive_onchain(int64_t port_);
 
 void wire_buy_bitcoin(int64_t port_, int32_t provider);
 
-void wire_backup(int64_t port_);
+void wire_sweep(int64_t port_,
+                struct wire_uint_8_list *to_address,
+                uint64_t fee_rate_sats_per_vbyte);
 
-void wire_backup_status(int64_t port_);
+void wire_list_refundables(int64_t port_);
+
+void wire_refund(int64_t port_,
+                 struct wire_uint_8_list *swap_address,
+                 struct wire_uint_8_list *to_address,
+                 uint32_t sat_per_vbyte);
+
+void wire_in_progress_swap(int64_t port_);
+
+void wire_in_progress_reverse_swaps(int64_t port_);
+
+void wire_fetch_reverse_swap_fees(int64_t port_);
+
+void wire_recommended_fees(int64_t port_);
+
+void wire_execute_command(int64_t port_, struct wire_uint_8_list *command);
 
 struct wire_Config *new_box_autoadd_config_0(void);
 
@@ -215,45 +215,45 @@ void free_WireSyncReturn(WireSyncReturn ptr);
 
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
-    dummy_var ^= ((int64_t) (void*) wire_initialized);
     dummy_var ^= ((int64_t) (void*) wire_connect);
+    dummy_var ^= ((int64_t) (void*) wire_is_initialized);
+    dummy_var ^= ((int64_t) (void*) wire_sync);
+    dummy_var ^= ((int64_t) (void*) wire_node_info);
+    dummy_var ^= ((int64_t) (void*) wire_disconnect);
+    dummy_var ^= ((int64_t) (void*) wire_mnemonic_to_seed);
+    dummy_var ^= ((int64_t) (void*) wire_default_config);
     dummy_var ^= ((int64_t) (void*) wire_breez_events_stream);
     dummy_var ^= ((int64_t) (void*) wire_breez_log_stream);
-    dummy_var ^= ((int64_t) (void*) wire_disconnect);
+    dummy_var ^= ((int64_t) (void*) wire_list_lsps);
+    dummy_var ^= ((int64_t) (void*) wire_connect_lsp);
+    dummy_var ^= ((int64_t) (void*) wire_lsp_id);
+    dummy_var ^= ((int64_t) (void*) wire_fetch_lsp_info);
+    dummy_var ^= ((int64_t) (void*) wire_close_lsp_channels);
+    dummy_var ^= ((int64_t) (void*) wire_backup);
+    dummy_var ^= ((int64_t) (void*) wire_backup_status);
+    dummy_var ^= ((int64_t) (void*) wire_parse_invoice);
+    dummy_var ^= ((int64_t) (void*) wire_parse_input);
+    dummy_var ^= ((int64_t) (void*) wire_list_payments);
+    dummy_var ^= ((int64_t) (void*) wire_payment_by_hash);
     dummy_var ^= ((int64_t) (void*) wire_send_payment);
     dummy_var ^= ((int64_t) (void*) wire_send_spontaneous_payment);
     dummy_var ^= ((int64_t) (void*) wire_receive_payment);
-    dummy_var ^= ((int64_t) (void*) wire_node_info);
-    dummy_var ^= ((int64_t) (void*) wire_list_payments);
-    dummy_var ^= ((int64_t) (void*) wire_payment_by_hash);
-    dummy_var ^= ((int64_t) (void*) wire_list_lsps);
-    dummy_var ^= ((int64_t) (void*) wire_connect_lsp);
-    dummy_var ^= ((int64_t) (void*) wire_fetch_lsp_info);
-    dummy_var ^= ((int64_t) (void*) wire_lsp_id);
-    dummy_var ^= ((int64_t) (void*) wire_fetch_fiat_rates);
-    dummy_var ^= ((int64_t) (void*) wire_list_fiat_currencies);
-    dummy_var ^= ((int64_t) (void*) wire_close_lsp_channels);
-    dummy_var ^= ((int64_t) (void*) wire_sweep);
-    dummy_var ^= ((int64_t) (void*) wire_receive_onchain);
-    dummy_var ^= ((int64_t) (void*) wire_in_progress_swap);
-    dummy_var ^= ((int64_t) (void*) wire_list_refundables);
-    dummy_var ^= ((int64_t) (void*) wire_refund);
-    dummy_var ^= ((int64_t) (void*) wire_fetch_reverse_swap_fees);
-    dummy_var ^= ((int64_t) (void*) wire_in_progress_reverse_swaps);
-    dummy_var ^= ((int64_t) (void*) wire_send_onchain);
-    dummy_var ^= ((int64_t) (void*) wire_execute_command);
-    dummy_var ^= ((int64_t) (void*) wire_sync);
-    dummy_var ^= ((int64_t) (void*) wire_parse_invoice);
-    dummy_var ^= ((int64_t) (void*) wire_parse_input);
     dummy_var ^= ((int64_t) (void*) wire_lnurl_pay);
     dummy_var ^= ((int64_t) (void*) wire_lnurl_withdraw);
     dummy_var ^= ((int64_t) (void*) wire_lnurl_auth);
-    dummy_var ^= ((int64_t) (void*) wire_mnemonic_to_seed);
-    dummy_var ^= ((int64_t) (void*) wire_recommended_fees);
-    dummy_var ^= ((int64_t) (void*) wire_default_config);
+    dummy_var ^= ((int64_t) (void*) wire_fetch_fiat_rates);
+    dummy_var ^= ((int64_t) (void*) wire_list_fiat_currencies);
+    dummy_var ^= ((int64_t) (void*) wire_send_onchain);
+    dummy_var ^= ((int64_t) (void*) wire_receive_onchain);
     dummy_var ^= ((int64_t) (void*) wire_buy_bitcoin);
-    dummy_var ^= ((int64_t) (void*) wire_backup);
-    dummy_var ^= ((int64_t) (void*) wire_backup_status);
+    dummy_var ^= ((int64_t) (void*) wire_sweep);
+    dummy_var ^= ((int64_t) (void*) wire_list_refundables);
+    dummy_var ^= ((int64_t) (void*) wire_refund);
+    dummy_var ^= ((int64_t) (void*) wire_in_progress_swap);
+    dummy_var ^= ((int64_t) (void*) wire_in_progress_reverse_swaps);
+    dummy_var ^= ((int64_t) (void*) wire_fetch_reverse_swap_fees);
+    dummy_var ^= ((int64_t) (void*) wire_recommended_fees);
+    dummy_var ^= ((int64_t) (void*) wire_execute_command);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_config_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_credentials_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_node_config_0);

--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -6,23 +6,13 @@ import 'package:breez_sdk/native_toolkit.dart';
 import 'package:fimber/fimber.dart';
 import 'package:rxdart/rxdart.dart';
 
-class BreezBridge {
+class BreezSDK {
   final _lnToolkit = getNativeToolkit();
-  final _log = FimberLog("BreezBridge");
+  final _log = FimberLog("BreezSDK");
 
-  BreezBridge();
+  BreezSDK();
 
   /* Streams */
-  /// Listen to node state
-  final StreamController<NodeState?> nodeStateController = BehaviorSubject<NodeState?>();
-
-  Stream<NodeState?> get nodeStateStream => nodeStateController.stream;
-
-  /// Listen to payment list
-  final StreamController<List<Payment>> paymentsController = BehaviorSubject<List<Payment>>();
-
-  Stream<List<Payment>> get paymentsStream => paymentsController.stream;
-
   /// Listen to paid Invoice events
   final StreamController<InvoicePaidDetails> _invoicePaidStream = BehaviorSubject<InvoicePaidDetails>();
 
@@ -32,11 +22,6 @@ class BreezBridge {
   final StreamController<Payment> _paymentResultStream = BehaviorSubject<Payment>();
 
   Stream<Payment> get paymentResultStream => _paymentResultStream.stream;
-
-  // Listen to backup results
-  final StreamController<BreezEvent?> _backupStreamController = BehaviorSubject<BreezEvent?>();
-
-  Stream<BreezEvent?> get backupStream => _backupStreamController.stream;
 
   void initialize() {
     /// Listen to BreezEvent's(new block, invoice paid, synced)
@@ -70,8 +55,12 @@ class BreezBridge {
     _lnToolkit.breezLogStream().listen(_registerToolkitLog);
   }
 
-  /// Check whether node service is initialized or not
-  Future<bool> isInitialized() async => await _lnToolkit.initialized();
+  /* Breez Services API's & Streams*/
+
+  /// Listen to node state
+  final StreamController<NodeState?> nodeStateController = BehaviorSubject<NodeState?>();
+
+  Stream<NodeState?> get nodeStateStream => nodeStateController.stream;
 
   /// connect initializes the global NodeService, schedule the node to run in the cloud and
   /// run the signer. This must be called in order to start communicate with the node
@@ -91,8 +80,8 @@ class BreezBridge {
     await fetchNodeData();
   }
 
-  /// Cleanup node resources and stop the signer.
-  Future<void> disconnect() async => await _lnToolkit.disconnect();
+  /// Check whether node service is initialized or not
+  Future<bool> isInitialized() async => await _lnToolkit.isInitialized();
 
   /// This method sync the local state with the remote node state.
   /// The synced items are as follows:
@@ -100,6 +89,108 @@ class BreezBridge {
   /// * channels - The list of channels and their status
   /// * payments - The incoming/outgoing payments
   Future<void> sync() async => await _lnToolkit.sync();
+
+  /// get the node state from the persistent storage
+  Future<NodeState?> nodeInfo() async {
+    final nodeState = await _lnToolkit.nodeInfo();
+    nodeStateController.add(nodeState);
+    return nodeState;
+  }
+
+  /// Cleanup node resources and stop the signer.
+  Future<void> disconnect() async => await _lnToolkit.disconnect();
+
+  /* Breez Services Helper API's */
+
+  /// Attempts to convert the phrase to a mnemonic, then to a seed.
+  ///
+  /// If the phrase is not a valid mnemonic, an error is returned.
+  Future<Uint8List> mnemonicToSeed(String phrase) async => await _lnToolkit.mnemonicToSeed(phrase: phrase);
+
+  /// Get the full default config for a specific environment type
+  Future<Config> defaultConfig({
+    required EnvironmentType envType,
+    required String apiKey,
+    required NodeConfig nodeConfig,
+  }) {
+    return _lnToolkit.defaultConfig(
+      envType: envType,
+      apiKey: apiKey,
+      nodeConfig: nodeConfig,
+    );
+  }
+
+  /* LSP API's */
+
+  /// List available lsps that can be selected by the user
+  Future<List<LspInformation>> listLsps() async => await _lnToolkit.listLsps();
+
+  /// Select the lsp to be used and provide inbound liquidity
+  Future connectLSP(String lspId) async {
+    await _lnToolkit.connectLsp(lspId: lspId);
+  }
+
+  /// Get the current LSP's ID
+  Future<String?> lspId() async => await _lnToolkit.lspId();
+
+  /// Convenience method to look up LSP info
+  Future<LspInformation?> fetchLspInfo(String lspId) async => await _lnToolkit.fetchLspInfo(id: lspId);
+
+  /// close all channels with the current lsp
+  Future closeLspChannels() async => await _lnToolkit.closeLspChannels();
+
+  /* Backup API's & Streams*/
+
+  // Listen to backup results
+  final StreamController<BreezEvent?> _backupStreamController = BehaviorSubject<BreezEvent?>();
+
+  Stream<BreezEvent?> get backupStream => _backupStreamController.stream;
+
+  /// Start the backup process
+  Future<void> backup() => _lnToolkit.backup();
+
+  /// Returns the state of the backup process
+  Future<BackupStatus> backupStatus() => _lnToolkit.backupStatus();
+
+  /* Parse API's */
+
+  /// Parse a BOLT11 payment request and return a structure contains the parsed fields.
+  Future<LNInvoice> parseInvoice(String invoice) async => await _lnToolkit.parseInvoice(invoice: invoice);
+
+  /// Parses generic user input, typically pasted from clipboard or scanned from a QR.
+  Future<InputType> parseInput({required String input}) async => await _lnToolkit.parseInput(input: input);
+
+  /* Payment API's & Streams*/
+
+  /// Listen to payment list
+  final StreamController<List<Payment>> paymentsController = BehaviorSubject<List<Payment>>();
+
+  Stream<List<Payment>> get paymentsStream => paymentsController.stream;
+
+  /// list payments (incoming/outgoing payments) from the persistent storage
+  Future<List<Payment>> listPayments({
+    PaymentTypeFilter filter = PaymentTypeFilter.All,
+    int? fromTimestamp,
+    int? toTimestamp,
+  }) async {
+    var paymentsList = await _lnToolkit.listPayments(
+      filter: filter,
+      fromTimestamp: fromTimestamp,
+      toTimestamp: toTimestamp,
+    );
+    paymentsController.add(paymentsList);
+    return paymentsList;
+  }
+
+  /// Fetch a specific payment by its hash.
+  Future<Payment?> paymentByHash({
+    required String hash,
+  }) async =>
+      await _lnToolkit.paymentByHash(
+        hash: hash,
+      );
+
+  /* Lightning Payment API's */
 
   /// pay a bolt11 invoice
   ///
@@ -151,141 +242,7 @@ class BreezBridge {
         description: description,
       );
 
-  /// get the node state from the persistent storage
-  Future<NodeState?> nodeInfo() async {
-    final nodeState = await _lnToolkit.nodeInfo();
-    nodeStateController.add(nodeState);
-    return nodeState;
-  }
-
-  /// Get the full default config for a specific environment type
-  Future<Config> defaultConfig({
-    required EnvironmentType envType,
-    required String apiKey,
-    required NodeConfig nodeConfig,
-  }) {
-    return _lnToolkit.defaultConfig(
-      envType: envType,
-      apiKey: apiKey,
-      nodeConfig: nodeConfig,
-    );
-  }
-
-  /// list payments (incoming/outgoing payments) from the persistent storage
-  Future<List<Payment>> listPayments({
-    PaymentTypeFilter filter = PaymentTypeFilter.All,
-    int? fromTimestamp,
-    int? toTimestamp,
-  }) async {
-    var paymentsList = await _lnToolkit.listPayments(
-      filter: filter,
-      fromTimestamp: fromTimestamp,
-      toTimestamp: toTimestamp,
-    );
-    paymentsController.add(paymentsList);
-    return paymentsList;
-  }
-
-  /// Fetch a specific payment by its hash.
-  Future<Payment?> paymentByHash({
-    required String hash,
-  }) async =>
-      await _lnToolkit.paymentByHash(
-        hash: hash,
-      );
-
-  /// List available lsps that can be selected by the user
-  Future<List<LspInformation>> listLsps() async => await _lnToolkit.listLsps();
-
-  /// Select the lsp to be used and provide inbound liquidity
-  Future connectLSP(String lspId) async {
-    await _lnToolkit.connectLsp(lspId: lspId);
-  }
-
-  /// Convenience method to look up LSP info
-  Future<LspInformation?> fetchLspInfo(String lspId) async => await _lnToolkit.fetchLspInfo(id: lspId);
-
-  /// Get the current LSP's ID
-  Future<String?> getLspId() async => await _lnToolkit.lspId();
-
-  /// Fetch live rates of fiat currencies
-  Future<Map<String, Rate>> fetchFiatRates() async {
-    final List<Rate> rates = await _lnToolkit.fetchFiatRates();
-    return rates.fold<Map<String, Rate>>({}, (map, rate) {
-      map[rate.coin] = rate;
-      return map;
-    });
-  }
-
-  /// List all available fiat currencies
-  Future<List<FiatCurrency>> listFiatCurrencies() async => await _lnToolkit.listFiatCurrencies();
-
-  /// close all channels with the current lsp
-  Future closeLspChannels() async => await _lnToolkit.closeLspChannels();
-
-  /// Withdraw on-chain funds in the wallet to an external btc address
-  Future sweep({
-    required String toAddress,
-    required int feeRateSatsPerVbyte,
-  }) async {
-    await _lnToolkit.sweep(
-      toAddress: toAddress,
-      feeRateSatsPerVbyte: feeRateSatsPerVbyte,
-    );
-    await listPayments();
-  }
-
-  /// Onchain receive swap API
-  Future<SwapInfo> receiveOnchain() async => await _lnToolkit.receiveOnchain();
-
-  /// Returns the blocking [ReverseSwapInfo]s that are in progress
-  Future<SwapInfo?> inProgressSwap() async => await _lnToolkit.inProgressSwap();
-
-  /// list non-completed expired swaps that should be refunded by calling refund()
-  Future<List<SwapInfo>> listRefundables() async => await _lnToolkit.listRefundables();
-
-  /// Construct and broadcast a refund transaction for a failed/expired swap
-  Future<String> refund({
-    required String swapAddress,
-    required String toAddress,
-    required int satPerVbyte,
-  }) async =>
-      await _lnToolkit.refund(
-        swapAddress: swapAddress,
-        toAddress: toAddress,
-        satPerVbyte: satPerVbyte,
-      );
-
-  /// Lookup the most recent reverse swap pair info using the Boltz API
-  Future<ReverseSwapPairInfo> fetchReverseSwapFees() async => _lnToolkit.fetchReverseSwapFees();
-
-  /// Returns the blocking [ReverseSwapInfo]s that are in progress
-  Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async => _lnToolkit.inProgressReverseSwaps();
-
-  /// Creates a reverse swap and attempts to pay the HODL invoice
-  Future<ReverseSwapInfo> sendOnchain({
-    required int amountSat,
-    required String onchainRecipientAddress,
-    required String pairHash,
-    required int satPerVbyte,
-  }) async =>
-      _lnToolkit.sendOnchain(
-        amountSat: amountSat,
-        onchainRecipientAddress: onchainRecipientAddress,
-        pairHash: pairHash,
-        satPerVbyte: satPerVbyte,
-      );
-
-  /// Execute a command directly on the NodeAPI interface.
-  /// Mainly used to debugging.
-  Future<String> executeCommand({required String command}) async =>
-      _lnToolkit.executeCommand(command: command);
-
-  /// Parse a BOLT11 payment request and return a structure contains the parsed fields.
-  Future<LNInvoice> parseInvoice(String invoice) async => await _lnToolkit.parseInvoice(invoice: invoice);
-
-  /// Parses generic user input, typically pasted from clipboard or scanned from a QR.
-  Future<InputType> parseInput({required String input}) async => await _lnToolkit.parseInput(input: input);
+  /* LNURL API's */
 
   /// Second step of LNURL-pay. The first step is `parse()`, which also validates the LNURL destination
   /// and generates the `LnUrlPayRequestData` payload needed here.
@@ -332,21 +289,96 @@ class BreezBridge {
     );
   }
 
-  /// Attempts to convert the phrase to a mnemonic, then to a seed.
-  ///
-  /// If the phrase is not a valid mnemonic, an error is returned.
-  Future<Uint8List> mnemonicToSeed(String phrase) async => await _lnToolkit.mnemonicToSeed(phrase: phrase);
+  /* Fiat Currency API's */
+
+  /// Fetch live rates of fiat currencies
+  Future<Map<String, Rate>> fetchFiatRates() async {
+    final List<Rate> rates = await _lnToolkit.fetchFiatRates();
+    return rates.fold<Map<String, Rate>>({}, (map, rate) {
+      map[rate.coin] = rate;
+      return map;
+    });
+  }
+
+  /// List all available fiat currencies
+  Future<List<FiatCurrency>> listFiatCurrencies() async => await _lnToolkit.listFiatCurrencies();
+
+  /* On-Chain Swap API's */
+
+  /// Creates a reverse swap and attempts to pay the HODL invoice
+  Future<ReverseSwapInfo> sendOnchain({
+    required int amountSat,
+    required String onchainRecipientAddress,
+    required String pairHash,
+    required int satPerVbyte,
+  }) async =>
+      _lnToolkit.sendOnchain(
+        amountSat: amountSat,
+        onchainRecipientAddress: onchainRecipientAddress,
+        pairHash: pairHash,
+        satPerVbyte: satPerVbyte,
+      );
+
+  /// Onchain receive swap API
+  Future<SwapInfo> receiveOnchain() async => await _lnToolkit.receiveOnchain();
+
+  /// Generates an url that can be used by a third part provider to buy Bitcoin with fiat currency
+  Future<String> buyBitcoin(BuyBitcoinProvider provider) => _lnToolkit.buyBitcoin(provider: provider);
+
+  /// Withdraw on-chain funds in the wallet to an external btc address
+  Future sweep({
+    required String toAddress,
+    required int feeRateSatsPerVbyte,
+  }) async {
+    await _lnToolkit.sweep(
+      toAddress: toAddress,
+      feeRateSatsPerVbyte: feeRateSatsPerVbyte,
+    );
+    await listPayments();
+  }
+
+  /* Refundables API's */
+
+  /// list non-completed expired swaps that should be refunded by calling refund()
+  Future<List<SwapInfo>> listRefundables() async => await _lnToolkit.listRefundables();
+
+  /// Construct and broadcast a refund transaction for a failed/expired swap
+  Future<String> refund({
+    required String swapAddress,
+    required String toAddress,
+    required int satPerVbyte,
+  }) async =>
+      await _lnToolkit.refund(
+        swapAddress: swapAddress,
+        toAddress: toAddress,
+        satPerVbyte: satPerVbyte,
+      );
+
+  /* In Progress Swap API's */
+
+  /// Returns the blocking [ReverseSwapInfo]s that are in progress
+  Future<SwapInfo?> inProgressSwap() async => await _lnToolkit.inProgressSwap();
+
+  /// Returns the blocking [ReverseSwapInfo]s that are in progress
+  Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async => _lnToolkit.inProgressReverseSwaps();
+
+  /* Swap Fee API's */
+
+  /// Lookup the most recent reverse swap pair info using the Boltz API
+  Future<ReverseSwapPairInfo> fetchReverseSwapFees() async => _lnToolkit.fetchReverseSwapFees();
 
   /// Fetches the current recommended fees
   Future<RecommendedFees> recommendedFees() => _lnToolkit.recommendedFees();
 
-  /// Start the backup process
-  Future<void> backup() => _lnToolkit.backup();
+  /* CLI API's */
 
-  /// Returns the state of the backup process
-  Future<BackupStatus> backupStatus() => _lnToolkit.backupStatus();
+  /// Execute a command directly on the NodeAPI interface.
+  /// Mainly used to debugging.
+  Future<String> executeCommand({required String command}) async =>
+      _lnToolkit.executeCommand(command: command);
 
   /* Helper Methods */
+
   /// Validate if given address is a valid BTC address
   Future<bool> isValidBitcoinAddress(
     String address,
@@ -357,6 +389,12 @@ class BreezBridge {
     } catch (e) {
       return false;
     }
+  }
+
+  /// Fetch node state & payment list
+  Future fetchNodeData() async {
+    await nodeInfo();
+    await listPayments();
   }
 
   /// Log entries according to their severity
@@ -379,15 +417,6 @@ class BreezBridge {
         break;
     }
   }
-
-  /// Fetch node state & payment list
-  Future fetchNodeData() async {
-    await nodeInfo();
-    await listPayments();
-  }
-
-  /// Generates an url that can be used by a third part provider to buy Bitcoin with fiat currency
-  Future<String> buyBitcoin(BuyBitcoinProvider provider) => _lnToolkit.buyBitcoin(provider: provider);
 }
 
 extension SDKConfig on Config {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -14,22 +14,44 @@ import 'dart:ffi' as ffi;
 part 'bridge_generated.freezed.dart';
 
 abstract class BreezSdkCore {
-  /// Check whether node service is initialized or not
-  Future<bool> initialized({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kInitializedConstMeta;
-
-  /// connect initializes the global NodeService, schedule the node to run in the cloud and
-  /// run the signer. This must be called in order to start communicate with the node
-  ///
-  /// # Arguments
-  ///
-  /// * `config` - The sdk configuration
-  /// * `seed` - The node private key
-  ///
+  /// See [BreezServices::connect]
   Future<void> connect({required Config config, required Uint8List seed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kConnectConstMeta;
+
+  /// Check whether node service is initialized or not
+  Future<bool> isInitialized({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kIsInitializedConstMeta;
+
+  /// See [BreezServices::sync]
+  Future<void> sync({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kSyncConstMeta;
+
+  /// See [BreezServices::node_info]
+  Future<NodeState> nodeInfo({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kNodeInfoConstMeta;
+
+  /// Cleanup node resources and stop the signer.
+  Future<void> disconnect({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kDisconnectConstMeta;
+
+  /// See [breez_services::mnemonic_to_seed]
+  Future<Uint8List> mnemonicToSeed({required String phrase, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kMnemonicToSeedConstMeta;
+
+  /// See [BreezServices::default_config]
+  Future<Config> defaultConfig(
+      {required EnvironmentType envType,
+      required String apiKey,
+      required NodeConfig nodeConfig,
+      dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kDefaultConfigConstMeta;
 
   Stream<BreezEvent> breezEventsStream({dynamic hint});
 
@@ -39,10 +61,59 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kBreezLogStreamConstMeta;
 
-  /// Cleanup node resources and stop the signer.
-  Future<void> disconnect({dynamic hint});
+  /// See [BreezServices::list_lsps]
+  Future<List<LspInformation>> listLsps({dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kDisconnectConstMeta;
+  FlutterRustBridgeTaskConstMeta get kListLspsConstMeta;
+
+  /// See [BreezServices::connect_lsp]
+  Future<void> connectLsp({required String lspId, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kConnectLspConstMeta;
+
+  /// See [BreezServices::lsp_id]
+  Future<String?> lspId({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kLspIdConstMeta;
+
+  /// See [BreezServices::fetch_lsp_info]
+  Future<LspInformation?> fetchLspInfo({required String id, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kFetchLspInfoConstMeta;
+
+  /// See [BreezServices::close_lsp_channels]
+  Future<void> closeLspChannels({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kCloseLspChannelsConstMeta;
+
+  /// See [BreezServices::backup]
+  Future<void> backup({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kBackupConstMeta;
+
+  /// See [BreezServices::backup_status]
+  Future<BackupStatus> backupStatus({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kBackupStatusConstMeta;
+
+  Future<LNInvoice> parseInvoice({required String invoice, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kParseInvoiceConstMeta;
+
+  Future<InputType> parseInput({required String input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kParseInputConstMeta;
+
+  /// See [BreezServices::list_payments]
+  Future<List<Payment>> listPayments(
+      {required PaymentTypeFilter filter, int? fromTimestamp, int? toTimestamp, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kListPaymentsConstMeta;
+
+  /// See [BreezServices::list_payments]
+  Future<Payment?> paymentByHash({required String hash, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kPaymentByHashConstMeta;
 
   /// See [BreezServices::send_payment]
   Future<Payment> sendPayment({required String bolt11, int? amountSats, dynamic hint});
@@ -58,120 +129,6 @@ abstract class BreezSdkCore {
   Future<LNInvoice> receivePayment({required int amountSats, required String description, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kReceivePaymentConstMeta;
-
-  /// See [BreezServices::node_info]
-  Future<NodeState> nodeInfo({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kNodeInfoConstMeta;
-
-  /// See [BreezServices::list_payments]
-  Future<List<Payment>> listPayments(
-      {required PaymentTypeFilter filter, int? fromTimestamp, int? toTimestamp, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kListPaymentsConstMeta;
-
-  /// See [BreezServices::list_payments]
-  Future<Payment?> paymentByHash({required String hash, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kPaymentByHashConstMeta;
-
-  /// See [BreezServices::list_lsps]
-  Future<List<LspInformation>> listLsps({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kListLspsConstMeta;
-
-  /// See [BreezServices::connect_lsp]
-  Future<void> connectLsp({required String lspId, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kConnectLspConstMeta;
-
-  /// See [BreezServices::fetch_lsp_info]
-  Future<LspInformation?> fetchLspInfo({required String id, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kFetchLspInfoConstMeta;
-
-  /// See [BreezServices::lsp_id]
-  Future<String?> lspId({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kLspIdConstMeta;
-
-  /// See [BreezServices::fetch_fiat_rates]
-  Future<List<Rate>> fetchFiatRates({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kFetchFiatRatesConstMeta;
-
-  /// See [BreezServices::list_fiat_currencies]
-  Future<List<FiatCurrency>> listFiatCurrencies({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta;
-
-  /// See [BreezServices::close_lsp_channels]
-  Future<void> closeLspChannels({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kCloseLspChannelsConstMeta;
-
-  /// See [BreezServices::sweep]
-  Future<void> sweep({required String toAddress, required int feeRateSatsPerVbyte, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kSweepConstMeta;
-
-  /// See [BreezServices::receive_onchain]
-  Future<SwapInfo> receiveOnchain({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kReceiveOnchainConstMeta;
-
-  /// See [BreezServices::in_progress_swap]
-  Future<SwapInfo?> inProgressSwap({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kInProgressSwapConstMeta;
-
-  /// See [BreezServices::list_refundables]
-  Future<List<SwapInfo>> listRefundables({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kListRefundablesConstMeta;
-
-  /// See [BreezServices::refund]
-  Future<String> refund(
-      {required String swapAddress, required String toAddress, required int satPerVbyte, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kRefundConstMeta;
-
-  /// See [BreezServices::fetch_reverse_swap_fees]
-  Future<ReverseSwapPairInfo> fetchReverseSwapFees({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kFetchReverseSwapFeesConstMeta;
-
-  /// See [BreezServices::in_progress_reverse_swaps]
-  Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta;
-
-  /// See [BreezServices::send_onchain]
-  Future<ReverseSwapInfo> sendOnchain(
-      {required int amountSat,
-      required String onchainRecipientAddress,
-      required String pairHash,
-      required int satPerVbyte,
-      dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kSendOnchainConstMeta;
-
-  /// See [BreezServices::execute_dev_command]
-  Future<String> executeCommand({required String command, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kExecuteCommandConstMeta;
-
-  Future<void> sync({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kSyncConstMeta;
-
-  Future<LNInvoice> parseInvoice({required String invoice, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kParseInvoiceConstMeta;
-
-  Future<InputType> parseInput({required String input, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kParseInputConstMeta;
 
   /// See [BreezServices::lnurl_pay]
   Future<LnUrlPayResult> lnurlPay(
@@ -193,39 +150,76 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kLnurlAuthConstMeta;
 
-  /// See [breez_services::mnemonic_to_seed]
-  Future<Uint8List> mnemonicToSeed({required String phrase, dynamic hint});
+  /// See [BreezServices::fetch_fiat_rates]
+  Future<List<Rate>> fetchFiatRates({dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kMnemonicToSeedConstMeta;
+  FlutterRustBridgeTaskConstMeta get kFetchFiatRatesConstMeta;
 
-  /// See [BreezServices::recommended_fees]
-  Future<RecommendedFees> recommendedFees({dynamic hint});
+  /// See [BreezServices::list_fiat_currencies]
+  Future<List<FiatCurrency>> listFiatCurrencies({dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kRecommendedFeesConstMeta;
+  FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta;
 
-  /// See [BreezServices::default_config]
-  Future<Config> defaultConfig(
-      {required EnvironmentType envType,
-      required String apiKey,
-      required NodeConfig nodeConfig,
+  /// See [BreezServices::send_onchain]
+  Future<ReverseSwapInfo> sendOnchain(
+      {required int amountSat,
+      required String onchainRecipientAddress,
+      required String pairHash,
+      required int satPerVbyte,
       dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kDefaultConfigConstMeta;
+  FlutterRustBridgeTaskConstMeta get kSendOnchainConstMeta;
+
+  /// See [BreezServices::receive_onchain]
+  Future<SwapInfo> receiveOnchain({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kReceiveOnchainConstMeta;
 
   /// See [BreezServices::buy_bitcoin]
   Future<String> buyBitcoin({required BuyBitcoinProvider provider, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kBuyBitcoinConstMeta;
 
-  /// See [BreezServices::backup]
-  Future<void> backup({dynamic hint});
+  /// See [BreezServices::sweep]
+  Future<void> sweep({required String toAddress, required int feeRateSatsPerVbyte, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kBackupConstMeta;
+  FlutterRustBridgeTaskConstMeta get kSweepConstMeta;
 
-  /// See [BreezServices::backup_status]
-  Future<BackupStatus> backupStatus({dynamic hint});
+  /// See [BreezServices::list_refundables]
+  Future<List<SwapInfo>> listRefundables({dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kBackupStatusConstMeta;
+  FlutterRustBridgeTaskConstMeta get kListRefundablesConstMeta;
+
+  /// See [BreezServices::refund]
+  Future<String> refund(
+      {required String swapAddress, required String toAddress, required int satPerVbyte, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kRefundConstMeta;
+
+  /// See [BreezServices::in_progress_swap]
+  Future<SwapInfo?> inProgressSwap({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kInProgressSwapConstMeta;
+
+  /// See [BreezServices::in_progress_reverse_swaps]
+  Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta;
+
+  /// See [BreezServices::fetch_reverse_swap_fees]
+  Future<ReverseSwapPairInfo> fetchReverseSwapFees({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kFetchReverseSwapFeesConstMeta;
+
+  /// See [BreezServices::recommended_fees]
+  Future<RecommendedFees> recommendedFees({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kRecommendedFeesConstMeta;
+
+  /// See [BreezServices::execute_dev_command]
+  Future<String> executeCommand({required String command, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kExecuteCommandConstMeta;
 }
 
 /// Wrapper for the decrypted [AesSuccessActionData] payload
@@ -1140,21 +1134,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   /// Only valid on web/WASM platforms.
   factory BreezSdkCoreImpl.wasm(FutureOr<WasmModule> module) => BreezSdkCoreImpl(module as ExternalLibrary);
   BreezSdkCoreImpl.raw(this._platform);
-  Future<bool> initialized({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_initialized(port_),
-      parseSuccessData: _wire2api_bool,
-      constMeta: kInitializedConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kInitializedConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "initialized",
-        argNames: [],
-      );
-
   Future<void> connect({required Config config, required Uint8List seed, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_config(config);
     var arg1 = _platform.api2wire_uint_8_list(seed);
@@ -1170,6 +1149,104 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kConnectConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "connect",
         argNames: ["config", "seed"],
+      );
+
+  Future<bool> isInitialized({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_is_initialized(port_),
+      parseSuccessData: _wire2api_bool,
+      constMeta: kIsInitializedConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kIsInitializedConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "is_initialized",
+        argNames: [],
+      );
+
+  Future<void> sync({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_sync(port_),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kSyncConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kSyncConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "sync",
+        argNames: [],
+      );
+
+  Future<NodeState> nodeInfo({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_node_info(port_),
+      parseSuccessData: _wire2api_node_state,
+      constMeta: kNodeInfoConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kNodeInfoConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "node_info",
+        argNames: [],
+      );
+
+  Future<void> disconnect({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_disconnect(port_),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kDisconnectConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kDisconnectConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "disconnect",
+        argNames: [],
+      );
+
+  Future<Uint8List> mnemonicToSeed({required String phrase, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(phrase);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_mnemonic_to_seed(port_, arg0),
+      parseSuccessData: _wire2api_uint_8_list,
+      constMeta: kMnemonicToSeedConstMeta,
+      argValues: [phrase],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kMnemonicToSeedConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "mnemonic_to_seed",
+        argNames: ["phrase"],
+      );
+
+  Future<Config> defaultConfig(
+      {required EnvironmentType envType,
+      required String apiKey,
+      required NodeConfig nodeConfig,
+      dynamic hint}) {
+    var arg0 = api2wire_environment_type(envType);
+    var arg1 = _platform.api2wire_String(apiKey);
+    var arg2 = _platform.api2wire_box_autoadd_node_config(nodeConfig);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_default_config(port_, arg0, arg1, arg2),
+      parseSuccessData: _wire2api_config,
+      constMeta: kDefaultConfigConstMeta,
+      argValues: [envType, apiKey, nodeConfig],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kDefaultConfigConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "default_config",
+        argNames: ["envType", "apiKey", "nodeConfig"],
       );
 
   Stream<BreezEvent> breezEventsStream({dynamic hint}) {
@@ -1202,19 +1279,178 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
-  Future<void> disconnect({dynamic hint}) {
+  Future<List<LspInformation>> listLsps({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_disconnect(port_),
-      parseSuccessData: _wire2api_unit,
-      constMeta: kDisconnectConstMeta,
+      callFfi: (port_) => _platform.inner.wire_list_lsps(port_),
+      parseSuccessData: _wire2api_list_lsp_information,
+      constMeta: kListLspsConstMeta,
       argValues: [],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kDisconnectConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "disconnect",
+  FlutterRustBridgeTaskConstMeta get kListLspsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "list_lsps",
         argNames: [],
+      );
+
+  Future<void> connectLsp({required String lspId, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(lspId);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_connect_lsp(port_, arg0),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kConnectLspConstMeta,
+      argValues: [lspId],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kConnectLspConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "connect_lsp",
+        argNames: ["lspId"],
+      );
+
+  Future<String?> lspId({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_lsp_id(port_),
+      parseSuccessData: _wire2api_opt_String,
+      constMeta: kLspIdConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kLspIdConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "lsp_id",
+        argNames: [],
+      );
+
+  Future<LspInformation?> fetchLspInfo({required String id, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(id);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_fetch_lsp_info(port_, arg0),
+      parseSuccessData: _wire2api_opt_box_autoadd_lsp_information,
+      constMeta: kFetchLspInfoConstMeta,
+      argValues: [id],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kFetchLspInfoConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "fetch_lsp_info",
+        argNames: ["id"],
+      );
+
+  Future<void> closeLspChannels({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_close_lsp_channels(port_),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kCloseLspChannelsConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kCloseLspChannelsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "close_lsp_channels",
+        argNames: [],
+      );
+
+  Future<void> backup({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_backup(port_),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kBackupConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kBackupConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "backup",
+        argNames: [],
+      );
+
+  Future<BackupStatus> backupStatus({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_backup_status(port_),
+      parseSuccessData: _wire2api_backup_status,
+      constMeta: kBackupStatusConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kBackupStatusConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "backup_status",
+        argNames: [],
+      );
+
+  Future<LNInvoice> parseInvoice({required String invoice, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(invoice);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_parse_invoice(port_, arg0),
+      parseSuccessData: _wire2api_ln_invoice,
+      constMeta: kParseInvoiceConstMeta,
+      argValues: [invoice],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kParseInvoiceConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "parse_invoice",
+        argNames: ["invoice"],
+      );
+
+  Future<InputType> parseInput({required String input, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(input);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_parse_input(port_, arg0),
+      parseSuccessData: _wire2api_input_type,
+      constMeta: kParseInputConstMeta,
+      argValues: [input],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kParseInputConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "parse_input",
+        argNames: ["input"],
+      );
+
+  Future<List<Payment>> listPayments(
+      {required PaymentTypeFilter filter, int? fromTimestamp, int? toTimestamp, dynamic hint}) {
+    var arg0 = api2wire_payment_type_filter(filter);
+    var arg1 = _platform.api2wire_opt_box_autoadd_i64(fromTimestamp);
+    var arg2 = _platform.api2wire_opt_box_autoadd_i64(toTimestamp);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_list_payments(port_, arg0, arg1, arg2),
+      parseSuccessData: _wire2api_list_payment,
+      constMeta: kListPaymentsConstMeta,
+      argValues: [filter, fromTimestamp, toTimestamp],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kListPaymentsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "list_payments",
+        argNames: ["filter", "fromTimestamp", "toTimestamp"],
+      );
+
+  Future<Payment?> paymentByHash({required String hash, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(hash);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_payment_by_hash(port_, arg0),
+      parseSuccessData: _wire2api_opt_box_autoadd_payment,
+      constMeta: kPaymentByHashConstMeta,
+      argValues: [hash],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kPaymentByHashConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "payment_by_hash",
+        argNames: ["hash"],
       );
 
   Future<Payment> sendPayment({required String bolt11, int? amountSats, dynamic hint}) {
@@ -1266,361 +1502,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kReceivePaymentConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "receive_payment",
         argNames: ["amountSats", "description"],
-      );
-
-  Future<NodeState> nodeInfo({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_node_info(port_),
-      parseSuccessData: _wire2api_node_state,
-      constMeta: kNodeInfoConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kNodeInfoConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "node_info",
-        argNames: [],
-      );
-
-  Future<List<Payment>> listPayments(
-      {required PaymentTypeFilter filter, int? fromTimestamp, int? toTimestamp, dynamic hint}) {
-    var arg0 = api2wire_payment_type_filter(filter);
-    var arg1 = _platform.api2wire_opt_box_autoadd_i64(fromTimestamp);
-    var arg2 = _platform.api2wire_opt_box_autoadd_i64(toTimestamp);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_list_payments(port_, arg0, arg1, arg2),
-      parseSuccessData: _wire2api_list_payment,
-      constMeta: kListPaymentsConstMeta,
-      argValues: [filter, fromTimestamp, toTimestamp],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kListPaymentsConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "list_payments",
-        argNames: ["filter", "fromTimestamp", "toTimestamp"],
-      );
-
-  Future<Payment?> paymentByHash({required String hash, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(hash);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_payment_by_hash(port_, arg0),
-      parseSuccessData: _wire2api_opt_box_autoadd_payment,
-      constMeta: kPaymentByHashConstMeta,
-      argValues: [hash],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kPaymentByHashConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "payment_by_hash",
-        argNames: ["hash"],
-      );
-
-  Future<List<LspInformation>> listLsps({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_list_lsps(port_),
-      parseSuccessData: _wire2api_list_lsp_information,
-      constMeta: kListLspsConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kListLspsConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "list_lsps",
-        argNames: [],
-      );
-
-  Future<void> connectLsp({required String lspId, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(lspId);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_connect_lsp(port_, arg0),
-      parseSuccessData: _wire2api_unit,
-      constMeta: kConnectLspConstMeta,
-      argValues: [lspId],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kConnectLspConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "connect_lsp",
-        argNames: ["lspId"],
-      );
-
-  Future<LspInformation?> fetchLspInfo({required String id, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(id);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_fetch_lsp_info(port_, arg0),
-      parseSuccessData: _wire2api_opt_box_autoadd_lsp_information,
-      constMeta: kFetchLspInfoConstMeta,
-      argValues: [id],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kFetchLspInfoConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "fetch_lsp_info",
-        argNames: ["id"],
-      );
-
-  Future<String?> lspId({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_lsp_id(port_),
-      parseSuccessData: _wire2api_opt_String,
-      constMeta: kLspIdConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kLspIdConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "lsp_id",
-        argNames: [],
-      );
-
-  Future<List<Rate>> fetchFiatRates({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_fetch_fiat_rates(port_),
-      parseSuccessData: _wire2api_list_rate,
-      constMeta: kFetchFiatRatesConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kFetchFiatRatesConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "fetch_fiat_rates",
-        argNames: [],
-      );
-
-  Future<List<FiatCurrency>> listFiatCurrencies({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_list_fiat_currencies(port_),
-      parseSuccessData: _wire2api_list_fiat_currency,
-      constMeta: kListFiatCurrenciesConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "list_fiat_currencies",
-        argNames: [],
-      );
-
-  Future<void> closeLspChannels({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_close_lsp_channels(port_),
-      parseSuccessData: _wire2api_unit,
-      constMeta: kCloseLspChannelsConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kCloseLspChannelsConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "close_lsp_channels",
-        argNames: [],
-      );
-
-  Future<void> sweep({required String toAddress, required int feeRateSatsPerVbyte, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(toAddress);
-    var arg1 = _platform.api2wire_u64(feeRateSatsPerVbyte);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_sweep(port_, arg0, arg1),
-      parseSuccessData: _wire2api_unit,
-      constMeta: kSweepConstMeta,
-      argValues: [toAddress, feeRateSatsPerVbyte],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kSweepConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "sweep",
-        argNames: ["toAddress", "feeRateSatsPerVbyte"],
-      );
-
-  Future<SwapInfo> receiveOnchain({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_receive_onchain(port_),
-      parseSuccessData: _wire2api_swap_info,
-      constMeta: kReceiveOnchainConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kReceiveOnchainConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "receive_onchain",
-        argNames: [],
-      );
-
-  Future<SwapInfo?> inProgressSwap({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_in_progress_swap(port_),
-      parseSuccessData: _wire2api_opt_box_autoadd_swap_info,
-      constMeta: kInProgressSwapConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kInProgressSwapConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "in_progress_swap",
-        argNames: [],
-      );
-
-  Future<List<SwapInfo>> listRefundables({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_list_refundables(port_),
-      parseSuccessData: _wire2api_list_swap_info,
-      constMeta: kListRefundablesConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kListRefundablesConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "list_refundables",
-        argNames: [],
-      );
-
-  Future<String> refund(
-      {required String swapAddress, required String toAddress, required int satPerVbyte, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(swapAddress);
-    var arg1 = _platform.api2wire_String(toAddress);
-    var arg2 = api2wire_u32(satPerVbyte);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_refund(port_, arg0, arg1, arg2),
-      parseSuccessData: _wire2api_String,
-      constMeta: kRefundConstMeta,
-      argValues: [swapAddress, toAddress, satPerVbyte],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kRefundConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "refund",
-        argNames: ["swapAddress", "toAddress", "satPerVbyte"],
-      );
-
-  Future<ReverseSwapPairInfo> fetchReverseSwapFees({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_fetch_reverse_swap_fees(port_),
-      parseSuccessData: _wire2api_reverse_swap_pair_info,
-      constMeta: kFetchReverseSwapFeesConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kFetchReverseSwapFeesConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "fetch_reverse_swap_fees",
-        argNames: [],
-      );
-
-  Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_in_progress_reverse_swaps(port_),
-      parseSuccessData: _wire2api_list_reverse_swap_info,
-      constMeta: kInProgressReverseSwapsConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "in_progress_reverse_swaps",
-        argNames: [],
-      );
-
-  Future<ReverseSwapInfo> sendOnchain(
-      {required int amountSat,
-      required String onchainRecipientAddress,
-      required String pairHash,
-      required int satPerVbyte,
-      dynamic hint}) {
-    var arg0 = _platform.api2wire_u64(amountSat);
-    var arg1 = _platform.api2wire_String(onchainRecipientAddress);
-    var arg2 = _platform.api2wire_String(pairHash);
-    var arg3 = _platform.api2wire_u64(satPerVbyte);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_send_onchain(port_, arg0, arg1, arg2, arg3),
-      parseSuccessData: _wire2api_reverse_swap_info,
-      constMeta: kSendOnchainConstMeta,
-      argValues: [amountSat, onchainRecipientAddress, pairHash, satPerVbyte],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kSendOnchainConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "send_onchain",
-        argNames: ["amountSat", "onchainRecipientAddress", "pairHash", "satPerVbyte"],
-      );
-
-  Future<String> executeCommand({required String command, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(command);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_execute_command(port_, arg0),
-      parseSuccessData: _wire2api_String,
-      constMeta: kExecuteCommandConstMeta,
-      argValues: [command],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kExecuteCommandConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "execute_command",
-        argNames: ["command"],
-      );
-
-  Future<void> sync({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_sync(port_),
-      parseSuccessData: _wire2api_unit,
-      constMeta: kSyncConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kSyncConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "sync",
-        argNames: [],
-      );
-
-  Future<LNInvoice> parseInvoice({required String invoice, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(invoice);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_parse_invoice(port_, arg0),
-      parseSuccessData: _wire2api_ln_invoice,
-      constMeta: kParseInvoiceConstMeta,
-      argValues: [invoice],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kParseInvoiceConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "parse_invoice",
-        argNames: ["invoice"],
-      );
-
-  Future<InputType> parseInput({required String input, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(input);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_parse_input(port_, arg0),
-      parseSuccessData: _wire2api_input_type,
-      constMeta: kParseInputConstMeta,
-      argValues: [input],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kParseInputConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "parse_input",
-        argNames: ["input"],
       );
 
   Future<LnUrlPayResult> lnurlPay(
@@ -1680,57 +1561,73 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["reqData"],
       );
 
-  Future<Uint8List> mnemonicToSeed({required String phrase, dynamic hint}) {
-    var arg0 = _platform.api2wire_String(phrase);
+  Future<List<Rate>> fetchFiatRates({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_mnemonic_to_seed(port_, arg0),
-      parseSuccessData: _wire2api_uint_8_list,
-      constMeta: kMnemonicToSeedConstMeta,
-      argValues: [phrase],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kMnemonicToSeedConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "mnemonic_to_seed",
-        argNames: ["phrase"],
-      );
-
-  Future<RecommendedFees> recommendedFees({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_recommended_fees(port_),
-      parseSuccessData: _wire2api_recommended_fees,
-      constMeta: kRecommendedFeesConstMeta,
+      callFfi: (port_) => _platform.inner.wire_fetch_fiat_rates(port_),
+      parseSuccessData: _wire2api_list_rate,
+      constMeta: kFetchFiatRatesConstMeta,
       argValues: [],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kRecommendedFeesConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "recommended_fees",
+  FlutterRustBridgeTaskConstMeta get kFetchFiatRatesConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "fetch_fiat_rates",
         argNames: [],
       );
 
-  Future<Config> defaultConfig(
-      {required EnvironmentType envType,
-      required String apiKey,
-      required NodeConfig nodeConfig,
-      dynamic hint}) {
-    var arg0 = api2wire_environment_type(envType);
-    var arg1 = _platform.api2wire_String(apiKey);
-    var arg2 = _platform.api2wire_box_autoadd_node_config(nodeConfig);
+  Future<List<FiatCurrency>> listFiatCurrencies({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_default_config(port_, arg0, arg1, arg2),
-      parseSuccessData: _wire2api_config,
-      constMeta: kDefaultConfigConstMeta,
-      argValues: [envType, apiKey, nodeConfig],
+      callFfi: (port_) => _platform.inner.wire_list_fiat_currencies(port_),
+      parseSuccessData: _wire2api_list_fiat_currency,
+      constMeta: kListFiatCurrenciesConstMeta,
+      argValues: [],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kDefaultConfigConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "default_config",
-        argNames: ["envType", "apiKey", "nodeConfig"],
+  FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "list_fiat_currencies",
+        argNames: [],
+      );
+
+  Future<ReverseSwapInfo> sendOnchain(
+      {required int amountSat,
+      required String onchainRecipientAddress,
+      required String pairHash,
+      required int satPerVbyte,
+      dynamic hint}) {
+    var arg0 = _platform.api2wire_u64(amountSat);
+    var arg1 = _platform.api2wire_String(onchainRecipientAddress);
+    var arg2 = _platform.api2wire_String(pairHash);
+    var arg3 = _platform.api2wire_u64(satPerVbyte);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_send_onchain(port_, arg0, arg1, arg2, arg3),
+      parseSuccessData: _wire2api_reverse_swap_info,
+      constMeta: kSendOnchainConstMeta,
+      argValues: [amountSat, onchainRecipientAddress, pairHash, satPerVbyte],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kSendOnchainConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "send_onchain",
+        argNames: ["amountSat", "onchainRecipientAddress", "pairHash", "satPerVbyte"],
+      );
+
+  Future<SwapInfo> receiveOnchain({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_receive_onchain(port_),
+      parseSuccessData: _wire2api_swap_info,
+      constMeta: kReceiveOnchainConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kReceiveOnchainConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "receive_onchain",
+        argNames: [],
       );
 
   Future<String> buyBitcoin({required BuyBitcoinProvider provider, dynamic hint}) {
@@ -1749,34 +1646,131 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["provider"],
       );
 
-  Future<void> backup({dynamic hint}) {
+  Future<void> sweep({required String toAddress, required int feeRateSatsPerVbyte, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(toAddress);
+    var arg1 = _platform.api2wire_u64(feeRateSatsPerVbyte);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_backup(port_),
+      callFfi: (port_) => _platform.inner.wire_sweep(port_, arg0, arg1),
       parseSuccessData: _wire2api_unit,
-      constMeta: kBackupConstMeta,
+      constMeta: kSweepConstMeta,
+      argValues: [toAddress, feeRateSatsPerVbyte],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kSweepConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "sweep",
+        argNames: ["toAddress", "feeRateSatsPerVbyte"],
+      );
+
+  Future<List<SwapInfo>> listRefundables({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_list_refundables(port_),
+      parseSuccessData: _wire2api_list_swap_info,
+      constMeta: kListRefundablesConstMeta,
       argValues: [],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kBackupConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "backup",
+  FlutterRustBridgeTaskConstMeta get kListRefundablesConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "list_refundables",
         argNames: [],
       );
 
-  Future<BackupStatus> backupStatus({dynamic hint}) {
+  Future<String> refund(
+      {required String swapAddress, required String toAddress, required int satPerVbyte, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(swapAddress);
+    var arg1 = _platform.api2wire_String(toAddress);
+    var arg2 = api2wire_u32(satPerVbyte);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_backup_status(port_),
-      parseSuccessData: _wire2api_backup_status,
-      constMeta: kBackupStatusConstMeta,
+      callFfi: (port_) => _platform.inner.wire_refund(port_, arg0, arg1, arg2),
+      parseSuccessData: _wire2api_String,
+      constMeta: kRefundConstMeta,
+      argValues: [swapAddress, toAddress, satPerVbyte],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kRefundConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "refund",
+        argNames: ["swapAddress", "toAddress", "satPerVbyte"],
+      );
+
+  Future<SwapInfo?> inProgressSwap({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_in_progress_swap(port_),
+      parseSuccessData: _wire2api_opt_box_autoadd_swap_info,
+      constMeta: kInProgressSwapConstMeta,
       argValues: [],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kBackupStatusConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "backup_status",
+  FlutterRustBridgeTaskConstMeta get kInProgressSwapConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "in_progress_swap",
         argNames: [],
+      );
+
+  Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_in_progress_reverse_swaps(port_),
+      parseSuccessData: _wire2api_list_reverse_swap_info,
+      constMeta: kInProgressReverseSwapsConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "in_progress_reverse_swaps",
+        argNames: [],
+      );
+
+  Future<ReverseSwapPairInfo> fetchReverseSwapFees({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_fetch_reverse_swap_fees(port_),
+      parseSuccessData: _wire2api_reverse_swap_pair_info,
+      constMeta: kFetchReverseSwapFeesConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kFetchReverseSwapFeesConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "fetch_reverse_swap_fees",
+        argNames: [],
+      );
+
+  Future<RecommendedFees> recommendedFees({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_recommended_fees(port_),
+      parseSuccessData: _wire2api_recommended_fees,
+      constMeta: kRecommendedFeesConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kRecommendedFeesConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "recommended_fees",
+        argNames: [],
+      );
+
+  Future<String> executeCommand({required String command, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(command);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_execute_command(port_, arg0),
+      parseSuccessData: _wire2api_String,
+      constMeta: kExecuteCommandConstMeta,
+      argValues: [command],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kExecuteCommandConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "execute_command",
+        argNames: ["command"],
       );
 
   void dispose() {
@@ -2959,18 +2953,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _init_frb_dart_api_dl =
       _init_frb_dart_api_dlPtr.asFunction<int Function(ffi.Pointer<ffi.Void>)>();
 
-  void wire_initialized(
-    int port_,
-  ) {
-    return _wire_initialized(
-      port_,
-    );
-  }
-
-  late final _wire_initializedPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_initialized');
-  late final _wire_initialized = _wire_initializedPtr.asFunction<void Function(int)>();
-
   void wire_connect(
     int port_,
     ffi.Pointer<wire_Config> config,
@@ -2989,6 +2971,89 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
               ffi.Int64, ffi.Pointer<wire_Config>, ffi.Pointer<wire_uint_8_list>)>>('wire_connect');
   late final _wire_connect = _wire_connectPtr
       .asFunction<void Function(int, ffi.Pointer<wire_Config>, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_is_initialized(
+    int port_,
+  ) {
+    return _wire_is_initialized(
+      port_,
+    );
+  }
+
+  late final _wire_is_initializedPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_is_initialized');
+  late final _wire_is_initialized = _wire_is_initializedPtr.asFunction<void Function(int)>();
+
+  void wire_sync(
+    int port_,
+  ) {
+    return _wire_sync(
+      port_,
+    );
+  }
+
+  late final _wire_syncPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_sync');
+  late final _wire_sync = _wire_syncPtr.asFunction<void Function(int)>();
+
+  void wire_node_info(
+    int port_,
+  ) {
+    return _wire_node_info(
+      port_,
+    );
+  }
+
+  late final _wire_node_infoPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_node_info');
+  late final _wire_node_info = _wire_node_infoPtr.asFunction<void Function(int)>();
+
+  void wire_disconnect(
+    int port_,
+  ) {
+    return _wire_disconnect(
+      port_,
+    );
+  }
+
+  late final _wire_disconnectPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_disconnect');
+  late final _wire_disconnect = _wire_disconnectPtr.asFunction<void Function(int)>();
+
+  void wire_mnemonic_to_seed(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> phrase,
+  ) {
+    return _wire_mnemonic_to_seed(
+      port_,
+      phrase,
+    );
+  }
+
+  late final _wire_mnemonic_to_seedPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_mnemonic_to_seed');
+  late final _wire_mnemonic_to_seed =
+      _wire_mnemonic_to_seedPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_default_config(
+    int port_,
+    int env_type,
+    ffi.Pointer<wire_uint_8_list> api_key,
+    ffi.Pointer<wire_NodeConfig> node_config,
+  ) {
+    return _wire_default_config(
+      port_,
+      env_type,
+      api_key,
+      node_config,
+    );
+  }
+
+  late final _wire_default_configPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Pointer<wire_uint_8_list>,
+              ffi.Pointer<wire_NodeConfig>)>>('wire_default_config');
+  late final _wire_default_config = _wire_default_configPtr
+      .asFunction<void Function(int, int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_NodeConfig>)>();
 
   void wire_breez_events_stream(
     int port_,
@@ -3014,17 +3079,163 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_breez_log_stream');
   late final _wire_breez_log_stream = _wire_breez_log_streamPtr.asFunction<void Function(int)>();
 
-  void wire_disconnect(
+  void wire_list_lsps(
     int port_,
   ) {
-    return _wire_disconnect(
+    return _wire_list_lsps(
       port_,
     );
   }
 
-  late final _wire_disconnectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_disconnect');
-  late final _wire_disconnect = _wire_disconnectPtr.asFunction<void Function(int)>();
+  late final _wire_list_lspsPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_lsps');
+  late final _wire_list_lsps = _wire_list_lspsPtr.asFunction<void Function(int)>();
+
+  void wire_connect_lsp(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> lsp_id,
+  ) {
+    return _wire_connect_lsp(
+      port_,
+      lsp_id,
+    );
+  }
+
+  late final _wire_connect_lspPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_connect_lsp');
+  late final _wire_connect_lsp =
+      _wire_connect_lspPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_lsp_id(
+    int port_,
+  ) {
+    return _wire_lsp_id(
+      port_,
+    );
+  }
+
+  late final _wire_lsp_idPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_lsp_id');
+  late final _wire_lsp_id = _wire_lsp_idPtr.asFunction<void Function(int)>();
+
+  void wire_fetch_lsp_info(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> id,
+  ) {
+    return _wire_fetch_lsp_info(
+      port_,
+      id,
+    );
+  }
+
+  late final _wire_fetch_lsp_infoPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_fetch_lsp_info');
+  late final _wire_fetch_lsp_info =
+      _wire_fetch_lsp_infoPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_close_lsp_channels(
+    int port_,
+  ) {
+    return _wire_close_lsp_channels(
+      port_,
+    );
+  }
+
+  late final _wire_close_lsp_channelsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_close_lsp_channels');
+  late final _wire_close_lsp_channels = _wire_close_lsp_channelsPtr.asFunction<void Function(int)>();
+
+  void wire_backup(
+    int port_,
+  ) {
+    return _wire_backup(
+      port_,
+    );
+  }
+
+  late final _wire_backupPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_backup');
+  late final _wire_backup = _wire_backupPtr.asFunction<void Function(int)>();
+
+  void wire_backup_status(
+    int port_,
+  ) {
+    return _wire_backup_status(
+      port_,
+    );
+  }
+
+  late final _wire_backup_statusPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_backup_status');
+  late final _wire_backup_status = _wire_backup_statusPtr.asFunction<void Function(int)>();
+
+  void wire_parse_invoice(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> invoice,
+  ) {
+    return _wire_parse_invoice(
+      port_,
+      invoice,
+    );
+  }
+
+  late final _wire_parse_invoicePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_parse_invoice');
+  late final _wire_parse_invoice =
+      _wire_parse_invoicePtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_parse_input(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> input,
+  ) {
+    return _wire_parse_input(
+      port_,
+      input,
+    );
+  }
+
+  late final _wire_parse_inputPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_parse_input');
+  late final _wire_parse_input =
+      _wire_parse_inputPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_list_payments(
+    int port_,
+    int filter,
+    ffi.Pointer<ffi.Int64> from_timestamp,
+    ffi.Pointer<ffi.Int64> to_timestamp,
+  ) {
+    return _wire_list_payments(
+      port_,
+      filter,
+      from_timestamp,
+      to_timestamp,
+    );
+  }
+
+  late final _wire_list_paymentsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Int32, ffi.Pointer<ffi.Int64>, ffi.Pointer<ffi.Int64>)>>('wire_list_payments');
+  late final _wire_list_payments = _wire_list_paymentsPtr
+      .asFunction<void Function(int, int, ffi.Pointer<ffi.Int64>, ffi.Pointer<ffi.Int64>)>();
+
+  void wire_payment_by_hash(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> hash,
+  ) {
+    return _wire_payment_by_hash(
+      port_,
+      hash,
+    );
+  }
+
+  late final _wire_payment_by_hashPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_payment_by_hash');
+  late final _wire_payment_by_hash =
+      _wire_payment_by_hashPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_send_payment(
     int port_,
@@ -3080,327 +3291,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'wire_receive_payment');
   late final _wire_receive_payment =
       _wire_receive_paymentPtr.asFunction<void Function(int, int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_node_info(
-    int port_,
-  ) {
-    return _wire_node_info(
-      port_,
-    );
-  }
-
-  late final _wire_node_infoPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_node_info');
-  late final _wire_node_info = _wire_node_infoPtr.asFunction<void Function(int)>();
-
-  void wire_list_payments(
-    int port_,
-    int filter,
-    ffi.Pointer<ffi.Int64> from_timestamp,
-    ffi.Pointer<ffi.Int64> to_timestamp,
-  ) {
-    return _wire_list_payments(
-      port_,
-      filter,
-      from_timestamp,
-      to_timestamp,
-    );
-  }
-
-  late final _wire_list_paymentsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Int32, ffi.Pointer<ffi.Int64>, ffi.Pointer<ffi.Int64>)>>('wire_list_payments');
-  late final _wire_list_payments = _wire_list_paymentsPtr
-      .asFunction<void Function(int, int, ffi.Pointer<ffi.Int64>, ffi.Pointer<ffi.Int64>)>();
-
-  void wire_payment_by_hash(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> hash,
-  ) {
-    return _wire_payment_by_hash(
-      port_,
-      hash,
-    );
-  }
-
-  late final _wire_payment_by_hashPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_payment_by_hash');
-  late final _wire_payment_by_hash =
-      _wire_payment_by_hashPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_list_lsps(
-    int port_,
-  ) {
-    return _wire_list_lsps(
-      port_,
-    );
-  }
-
-  late final _wire_list_lspsPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_lsps');
-  late final _wire_list_lsps = _wire_list_lspsPtr.asFunction<void Function(int)>();
-
-  void wire_connect_lsp(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> lsp_id,
-  ) {
-    return _wire_connect_lsp(
-      port_,
-      lsp_id,
-    );
-  }
-
-  late final _wire_connect_lspPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_connect_lsp');
-  late final _wire_connect_lsp =
-      _wire_connect_lspPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_fetch_lsp_info(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> id,
-  ) {
-    return _wire_fetch_lsp_info(
-      port_,
-      id,
-    );
-  }
-
-  late final _wire_fetch_lsp_infoPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_fetch_lsp_info');
-  late final _wire_fetch_lsp_info =
-      _wire_fetch_lsp_infoPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_lsp_id(
-    int port_,
-  ) {
-    return _wire_lsp_id(
-      port_,
-    );
-  }
-
-  late final _wire_lsp_idPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_lsp_id');
-  late final _wire_lsp_id = _wire_lsp_idPtr.asFunction<void Function(int)>();
-
-  void wire_fetch_fiat_rates(
-    int port_,
-  ) {
-    return _wire_fetch_fiat_rates(
-      port_,
-    );
-  }
-
-  late final _wire_fetch_fiat_ratesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_fetch_fiat_rates');
-  late final _wire_fetch_fiat_rates = _wire_fetch_fiat_ratesPtr.asFunction<void Function(int)>();
-
-  void wire_list_fiat_currencies(
-    int port_,
-  ) {
-    return _wire_list_fiat_currencies(
-      port_,
-    );
-  }
-
-  late final _wire_list_fiat_currenciesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_fiat_currencies');
-  late final _wire_list_fiat_currencies = _wire_list_fiat_currenciesPtr.asFunction<void Function(int)>();
-
-  void wire_close_lsp_channels(
-    int port_,
-  ) {
-    return _wire_close_lsp_channels(
-      port_,
-    );
-  }
-
-  late final _wire_close_lsp_channelsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_close_lsp_channels');
-  late final _wire_close_lsp_channels = _wire_close_lsp_channelsPtr.asFunction<void Function(int)>();
-
-  void wire_sweep(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> to_address,
-    int fee_rate_sats_per_vbyte,
-  ) {
-    return _wire_sweep(
-      port_,
-      to_address,
-      fee_rate_sats_per_vbyte,
-    );
-  }
-
-  late final _wire_sweepPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Uint64)>>(
-          'wire_sweep');
-  late final _wire_sweep =
-      _wire_sweepPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
-
-  void wire_receive_onchain(
-    int port_,
-  ) {
-    return _wire_receive_onchain(
-      port_,
-    );
-  }
-
-  late final _wire_receive_onchainPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_receive_onchain');
-  late final _wire_receive_onchain = _wire_receive_onchainPtr.asFunction<void Function(int)>();
-
-  void wire_in_progress_swap(
-    int port_,
-  ) {
-    return _wire_in_progress_swap(
-      port_,
-    );
-  }
-
-  late final _wire_in_progress_swapPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_swap');
-  late final _wire_in_progress_swap = _wire_in_progress_swapPtr.asFunction<void Function(int)>();
-
-  void wire_list_refundables(
-    int port_,
-  ) {
-    return _wire_list_refundables(
-      port_,
-    );
-  }
-
-  late final _wire_list_refundablesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_refundables');
-  late final _wire_list_refundables = _wire_list_refundablesPtr.asFunction<void Function(int)>();
-
-  void wire_refund(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> swap_address,
-    ffi.Pointer<wire_uint_8_list> to_address,
-    int sat_per_vbyte,
-  ) {
-    return _wire_refund(
-      port_,
-      swap_address,
-      to_address,
-      sat_per_vbyte,
-    );
-  }
-
-  late final _wire_refundPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>,
-              ffi.Uint32)>>('wire_refund');
-  late final _wire_refund = _wire_refundPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>, int)>();
-
-  void wire_fetch_reverse_swap_fees(
-    int port_,
-  ) {
-    return _wire_fetch_reverse_swap_fees(
-      port_,
-    );
-  }
-
-  late final _wire_fetch_reverse_swap_feesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_fetch_reverse_swap_fees');
-  late final _wire_fetch_reverse_swap_fees =
-      _wire_fetch_reverse_swap_feesPtr.asFunction<void Function(int)>();
-
-  void wire_in_progress_reverse_swaps(
-    int port_,
-  ) {
-    return _wire_in_progress_reverse_swaps(
-      port_,
-    );
-  }
-
-  late final _wire_in_progress_reverse_swapsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_reverse_swaps');
-  late final _wire_in_progress_reverse_swaps =
-      _wire_in_progress_reverse_swapsPtr.asFunction<void Function(int)>();
-
-  void wire_send_onchain(
-    int port_,
-    int amount_sat,
-    ffi.Pointer<wire_uint_8_list> onchain_recipient_address,
-    ffi.Pointer<wire_uint_8_list> pair_hash,
-    int sat_per_vbyte,
-  ) {
-    return _wire_send_onchain(
-      port_,
-      amount_sat,
-      onchain_recipient_address,
-      pair_hash,
-      sat_per_vbyte,
-    );
-  }
-
-  late final _wire_send_onchainPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Uint64, ffi.Pointer<wire_uint_8_list>,
-              ffi.Pointer<wire_uint_8_list>, ffi.Uint64)>>('wire_send_onchain');
-  late final _wire_send_onchain = _wire_send_onchainPtr.asFunction<
-      void Function(int, int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>, int)>();
-
-  void wire_execute_command(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> command,
-  ) {
-    return _wire_execute_command(
-      port_,
-      command,
-    );
-  }
-
-  late final _wire_execute_commandPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_execute_command');
-  late final _wire_execute_command =
-      _wire_execute_commandPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_sync(
-    int port_,
-  ) {
-    return _wire_sync(
-      port_,
-    );
-  }
-
-  late final _wire_syncPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_sync');
-  late final _wire_sync = _wire_syncPtr.asFunction<void Function(int)>();
-
-  void wire_parse_invoice(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> invoice,
-  ) {
-    return _wire_parse_invoice(
-      port_,
-      invoice,
-    );
-  }
-
-  late final _wire_parse_invoicePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_parse_invoice');
-  late final _wire_parse_invoice =
-      _wire_parse_invoicePtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_parse_input(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> input,
-  ) {
-    return _wire_parse_input(
-      port_,
-      input,
-    );
-  }
-
-  late final _wire_parse_inputPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_parse_input');
-  late final _wire_parse_input =
-      _wire_parse_inputPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_lnurl_pay(
     int port_,
@@ -3460,54 +3350,64 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_lnurl_auth =
       _wire_lnurl_authPtr.asFunction<void Function(int, ffi.Pointer<wire_LnUrlAuthRequestData>)>();
 
-  void wire_mnemonic_to_seed(
-    int port_,
-    ffi.Pointer<wire_uint_8_list> phrase,
-  ) {
-    return _wire_mnemonic_to_seed(
-      port_,
-      phrase,
-    );
-  }
-
-  late final _wire_mnemonic_to_seedPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_mnemonic_to_seed');
-  late final _wire_mnemonic_to_seed =
-      _wire_mnemonic_to_seedPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_recommended_fees(
+  void wire_fetch_fiat_rates(
     int port_,
   ) {
-    return _wire_recommended_fees(
+    return _wire_fetch_fiat_rates(
       port_,
     );
   }
 
-  late final _wire_recommended_feesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_recommended_fees');
-  late final _wire_recommended_fees = _wire_recommended_feesPtr.asFunction<void Function(int)>();
+  late final _wire_fetch_fiat_ratesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_fetch_fiat_rates');
+  late final _wire_fetch_fiat_rates = _wire_fetch_fiat_ratesPtr.asFunction<void Function(int)>();
 
-  void wire_default_config(
+  void wire_list_fiat_currencies(
     int port_,
-    int env_type,
-    ffi.Pointer<wire_uint_8_list> api_key,
-    ffi.Pointer<wire_NodeConfig> node_config,
   ) {
-    return _wire_default_config(
+    return _wire_list_fiat_currencies(
       port_,
-      env_type,
-      api_key,
-      node_config,
     );
   }
 
-  late final _wire_default_configPtr = _lookup<
+  late final _wire_list_fiat_currenciesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_fiat_currencies');
+  late final _wire_list_fiat_currencies = _wire_list_fiat_currenciesPtr.asFunction<void Function(int)>();
+
+  void wire_send_onchain(
+    int port_,
+    int amount_sat,
+    ffi.Pointer<wire_uint_8_list> onchain_recipient_address,
+    ffi.Pointer<wire_uint_8_list> pair_hash,
+    int sat_per_vbyte,
+  ) {
+    return _wire_send_onchain(
+      port_,
+      amount_sat,
+      onchain_recipient_address,
+      pair_hash,
+      sat_per_vbyte,
+    );
+  }
+
+  late final _wire_send_onchainPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Pointer<wire_uint_8_list>,
-              ffi.Pointer<wire_NodeConfig>)>>('wire_default_config');
-  late final _wire_default_config = _wire_default_configPtr
-      .asFunction<void Function(int, int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_NodeConfig>)>();
+          ffi.Void Function(ffi.Int64, ffi.Uint64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Pointer<wire_uint_8_list>, ffi.Uint64)>>('wire_send_onchain');
+  late final _wire_send_onchain = _wire_send_onchainPtr.asFunction<
+      void Function(int, int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>, int)>();
+
+  void wire_receive_onchain(
+    int port_,
+  ) {
+    return _wire_receive_onchain(
+      port_,
+    );
+  }
+
+  late final _wire_receive_onchainPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_receive_onchain');
+  late final _wire_receive_onchain = _wire_receive_onchainPtr.asFunction<void Function(int)>();
 
   void wire_buy_bitcoin(
     int port_,
@@ -3523,28 +3423,122 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_buy_bitcoin');
   late final _wire_buy_bitcoin = _wire_buy_bitcoinPtr.asFunction<void Function(int, int)>();
 
-  void wire_backup(
+  void wire_sweep(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> to_address,
+    int fee_rate_sats_per_vbyte,
+  ) {
+    return _wire_sweep(
+      port_,
+      to_address,
+      fee_rate_sats_per_vbyte,
+    );
+  }
+
+  late final _wire_sweepPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Uint64)>>(
+          'wire_sweep');
+  late final _wire_sweep =
+      _wire_sweepPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
+
+  void wire_list_refundables(
     int port_,
   ) {
-    return _wire_backup(
+    return _wire_list_refundables(
       port_,
     );
   }
 
-  late final _wire_backupPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_backup');
-  late final _wire_backup = _wire_backupPtr.asFunction<void Function(int)>();
+  late final _wire_list_refundablesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_refundables');
+  late final _wire_list_refundables = _wire_list_refundablesPtr.asFunction<void Function(int)>();
 
-  void wire_backup_status(
+  void wire_refund(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> swap_address,
+    ffi.Pointer<wire_uint_8_list> to_address,
+    int sat_per_vbyte,
+  ) {
+    return _wire_refund(
+      port_,
+      swap_address,
+      to_address,
+      sat_per_vbyte,
+    );
+  }
+
+  late final _wire_refundPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>,
+              ffi.Uint32)>>('wire_refund');
+  late final _wire_refund = _wire_refundPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>, int)>();
+
+  void wire_in_progress_swap(
     int port_,
   ) {
-    return _wire_backup_status(
+    return _wire_in_progress_swap(
       port_,
     );
   }
 
-  late final _wire_backup_statusPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_backup_status');
-  late final _wire_backup_status = _wire_backup_statusPtr.asFunction<void Function(int)>();
+  late final _wire_in_progress_swapPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_swap');
+  late final _wire_in_progress_swap = _wire_in_progress_swapPtr.asFunction<void Function(int)>();
+
+  void wire_in_progress_reverse_swaps(
+    int port_,
+  ) {
+    return _wire_in_progress_reverse_swaps(
+      port_,
+    );
+  }
+
+  late final _wire_in_progress_reverse_swapsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_reverse_swaps');
+  late final _wire_in_progress_reverse_swaps =
+      _wire_in_progress_reverse_swapsPtr.asFunction<void Function(int)>();
+
+  void wire_fetch_reverse_swap_fees(
+    int port_,
+  ) {
+    return _wire_fetch_reverse_swap_fees(
+      port_,
+    );
+  }
+
+  late final _wire_fetch_reverse_swap_feesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_fetch_reverse_swap_fees');
+  late final _wire_fetch_reverse_swap_fees =
+      _wire_fetch_reverse_swap_feesPtr.asFunction<void Function(int)>();
+
+  void wire_recommended_fees(
+    int port_,
+  ) {
+    return _wire_recommended_fees(
+      port_,
+    );
+  }
+
+  late final _wire_recommended_feesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_recommended_fees');
+  late final _wire_recommended_fees = _wire_recommended_feesPtr.asFunction<void Function(int)>();
+
+  void wire_execute_command(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> command,
+  ) {
+    return _wire_execute_command(
+      port_,
+      command,
+    );
+  }
+
+  late final _wire_execute_commandPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_execute_command');
+  late final _wire_execute_command =
+      _wire_execute_commandPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   ffi.Pointer<wire_Config> new_box_autoadd_config_0() {
     return _new_box_autoadd_config_0();


### PR DESCRIPTION
This PR is a continuation of #342 and implements some of the suggested changes in #333 

- Grouped up Dart API's by concept
- Renamed initialized api to is_initialized
- Renamed BreezBridge to BreezSDK
  - getLspId to lspId