### PR TITLE
Revisit sign_message from #319

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,11 @@
-libs/sdk-bindings/storage.sql
+libs/sdk-bindings/*.sql
 .DS_Store
 .idea/
-
 tools/sdk-cli/config.json
 libs/sdk-react-native/ios/breez_sdk.swift
 libs/sdk-react-native/ios/bindings-swift/**
-
-# Visual Studio Code
 .vscode/*
 !.vscode/settings.json
 !.vscode/extensions.json
+.envrc
+*.jar

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "zbase32",
 ]
 
 [[package]]
@@ -3736,6 +3737,12 @@ checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time 0.3.22",
 ]
+
+[[package]]
+name = "zbase32"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9079049688da5871a7558ddacb7f04958862c703e68258594cb7a862b5e33f"
 
 [[package]]
 name = "zeroize"

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -96,6 +96,24 @@ dictionary NodeState {
     u64 inbound_liquidity_msats;    
 };
 
+dictionary SignMessageRequest {
+    string message;
+};
+
+dictionary SignMessageResponse {
+    string signed_message;
+};
+
+dictionary CheckMessageRequest {
+    string message;
+    string pubkey;
+    string signature;
+};
+
+dictionary CheckMessageResponse {
+    boolean is_valid;
+};
+
 enum PaymentTypeFilter {
     "Sent",
     "Received",
@@ -433,6 +451,12 @@ interface BlockingBreezServices {
 
    [Throws=SdkError]
    NodeState node_info();
+
+   [Throws=SdkError]
+   SignMessageResponse sign_message(SignMessageRequest request);
+
+   [Throws=SdkError]
+   CheckMessageResponse check_message(CheckMessageRequest request);
 
    [Throws=SdkError]
    BackupStatus backup_status();

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -8,15 +8,16 @@ use breez_sdk_core::{
     error::*, mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
     parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BackupFailedData,
     BackupStatus, BitcoinAddressData, BreezEvent, BreezServices, BuyBitcoinProvider, ChannelState,
-    ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType, EventListener,
-    FeeratePreset, FiatCurrency, GreenlightCredentials, GreenlightNodeConfig, InputType,
-    InvoicePaidDetails, LNInvoice, LnPaymentDetails, LnUrlAuthRequestData, LnUrlCallbackStatus,
-    LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult, LnUrlWithdrawRequestData, LocaleOverrides,
-    LocalizedName, LogEntry, LspInformation, MessageSuccessActionData, MetadataItem, Network,
-    NodeConfig, NodeState, Payment, PaymentDetails, PaymentFailedData, PaymentType,
-    PaymentTypeFilter, Rate, RecommendedFees, ReverseSwapInfo, ReverseSwapPairInfo,
-    ReverseSwapStatus, RouteHint, RouteHintHop, SuccessActionProcessed, SwapInfo, SwapStatus,
-    Symbol, UnspentTransactionOutput, UrlSuccessActionData,
+    CheckMessageRequest, CheckMessageResponse, ClosedChannelPaymentDetails, Config, CurrencyInfo,
+    EnvironmentType, EventListener, FeeratePreset, FiatCurrency, GreenlightCredentials,
+    GreenlightNodeConfig, InputType, InvoicePaidDetails, LNInvoice, LnPaymentDetails,
+    LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult,
+    LnUrlWithdrawRequestData, LocaleOverrides, LocalizedName, LogEntry, LspInformation,
+    MessageSuccessActionData, MetadataItem, Network, NodeConfig, NodeState, Payment,
+    PaymentDetails, PaymentFailedData, PaymentType, PaymentTypeFilter, Rate, RecommendedFees,
+    ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
+    SignMessageRequest, SignMessageResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
+    UnspentTransactionOutput, UrlSuccessActionData,
 };
 
 static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| tokio::runtime::Runtime::new().unwrap());
@@ -123,6 +124,16 @@ impl BlockingBreezServices {
 
     pub fn node_info(&self) -> SdkResult<NodeState> {
         self.breez_services.node_info()
+    }
+
+    pub fn sign_message(&self, request: SignMessageRequest) -> SdkResult<SignMessageResponse> {
+        rt().block_on(self.breez_services.sign_message(request))
+            .map_err(|e| e.into())
+    }
+
+    pub fn check_message(&self, request: CheckMessageRequest) -> SdkResult<CheckMessageResponse> {
+        rt().block_on(self.breez_services.check_message(request))
+            .map_err(|e| e.into())
     }
 
     pub fn backup_status(&self) -> SdkResult<BackupStatus> {

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -58,6 +58,7 @@ tempfile = "3"
 thiserror = "*"
 const_format = "*"
 miniz_oxide = "0.7.1"
+zbase32 = "0.1.2"
 
 [dev-dependencies]
 futures = "0.3.28"

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -96,6 +96,34 @@ pub struct InvoicePaidDetails {
     pub bolt11: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct SignMessageRequest {
+    /// The message to be signed
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SignMessageResponse {
+    /// The signed message
+    pub signed_message: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CheckMessageRequest {
+    /// The message to be checked
+    pub message: String,
+    /// The public key
+    pub pubkey: String,
+    /// The signature
+    pub signature: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CheckMessageResponse {
+    /// Boolean value indicating if the message is valid or not
+    pub is_valid: bool,
+}
+
 /// BreezServices is a facade and the single entry point for the SDK.
 pub struct BreezServices {
     started: Mutex<bool>,
@@ -334,6 +362,24 @@ impl BreezServices {
             .ok_or(SdkError::PersistenceFailure {
                 err: "No node info found".into(),
             })
+    }
+
+    /// Sign given message with privkey
+    pub async fn sign_message(&self, request: SignMessageRequest) -> Result<SignMessageResponse> {
+        let signed_message = self.node_api.sign_message(&request.message).await?;
+        Ok(SignMessageResponse { signed_message })
+    }
+
+    /// Check given message for pubkey with signature (zbase)
+    pub async fn check_message(
+        &self,
+        request: CheckMessageRequest,
+    ) -> Result<CheckMessageResponse> {
+        let is_valid = self
+            .node_api
+            .check_message(&request.message, &request.pubkey, &request.signature)
+            .await?;
+        Ok(CheckMessageResponse { is_valid })
     }
 
     /// Retrieve the node up to date BackupStatus

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -172,8 +172,9 @@ mod swap;
 mod test_utils;
 
 pub use breez_services::{
-    mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, EventListener,
-    InvoicePaidDetails, PaymentFailedData,
+    mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, CheckMessageRequest,
+    CheckMessageResponse, EventListener, InvoicePaidDetails, PaymentFailedData, SignMessageRequest,
+    SignMessageResponse,
 };
 pub use chain::RecommendedFees;
 pub use fiat::{CurrencyInfo, FiatCurrency, LocaleOverrides, LocalizedName, Rate, Symbol};

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -67,6 +67,8 @@ pub trait NodeAPI: Send + Sync {
     async fn stream_incoming_payments(&self) -> Result<Streaming<gl_client::pb::IncomingPayment>>;
     async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>>;
     async fn execute_command(&self, command: String) -> Result<String>;
+    async fn sign_message(&self, message: &str) -> Result<String>;
+    async fn check_message(&self, message: &str, pubkey: &str, signature: &str) -> Result<bool>;
 
     /// Gets the private key at the path specified
     fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> Result<ExtendedPrivKey>;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -326,6 +326,14 @@ impl NodeAPI for MockNodeAPI {
         Ok(())
     }
 
+    async fn sign_message(&self, _message: &str) -> Result<String> {
+        Ok("".to_string())
+    }
+
+    async fn check_message(&self, _message: &str, _pubkey: &str, _signature: &str) -> Result<bool> {
+        Ok(true)
+    }
+
     fn sign_invoice(&self, invoice: RawInvoice) -> Result<String> {
         Ok(sign_invoice(invoice))
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -82,6 +82,30 @@ fun asLnUrlWithdrawRequestData(reqData: ReadableMap): LnUrlWithdrawRequestData? 
     return null
 }
 
+fun asCheckMessageRequest(reqData: ReadableMap): CheckMessageRequest? {
+    val callback = reqData.getString("callback")
+    val message = reqData.getString("message")
+    val signature = reqData.getString("signature")
+    val pubkey = reqData.getString("pubkey")
+
+    if (callback != null && message != null && signature != null && pubkey != null) {
+        return CheckMessageRequest(message, signature, pubkey)
+    }
+
+    return null
+}
+
+fun asSignMessageRequest(reqData: ReadableMap): SignMessageRequest? {
+    val callback = reqData.getString("callback")
+    val message = reqData.getString("message")
+
+    if (callback != null && message != null) {
+        return SignMessageRequest(message)
+    }
+
+    return null
+}
+
 fun asPaymentTypeFilter(filter: String): PaymentTypeFilter {
     return PaymentTypeFilter.valueOf(filter.uppercase())
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -13,6 +13,24 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 
+data class SignMessageRequest(
+    val message: String
+)
+
+data class SignMessageResponse(
+    val signed_message: String
+)
+
+data class CheckMessageRequest(
+    val message: String,
+    val pubkey: String,
+    val signature: String
+)
+
+data class CheckMessageResponse(
+    val is_valid: Boolean
+)
+
 class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
     private lateinit var executor: ExecutorService
     private var breezServices: BlockingBreezServices? = null
@@ -145,6 +163,46 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             }
         }
     }
+
+    @ReactMethod
+    fun signMessage(reqData: ReadableMap, message: String, promise: Promise) {
+        executor.execute {
+            val signMessageRequest = asSignMessageRequest(reqData)
+            if signMessageRequest == null {
+                 promise.reject(TAG, "Invalid reqData")
+            } else {
+                try {
+                    val response = getBreezServices().sign_message(signMessageRequest)
+                    val signedMessage = response.signed_message
+                    promise.resolve(signedMessage)
+                } catch (e: SdkException) {
+                    e.printStackTrace()
+                    promise.reject(TAG, e.message ?: "Error calling signMessage", e)
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun checkMessage(reqData: ReadableMap, message: String, signature: String, pubkey: String, promise: Promise) {
+        executor.execute {
+            val checkMessageRequest = asCheckMessageRequest(reqData)
+            if checkMessageRequest == null {
+                 promise.reject(TAG, "Invalid reqData")
+            } else {
+                try {
+                    val response = getBreezServices().check_message(checkMessageRequest)
+                    val signedMessage = response.signed_message
+                    promise.resolve(signedMessage)
+                } catch (e: SdkException) {
+                    e.printStackTrace()
+                    promise.reject(TAG, e.message ?: "Error calling signMessage", e)
+                }
+            }
+        }
+    }
+
+
 
     @ReactMethod
     fun sync(promise: Promise) {

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -1,6 +1,24 @@
 import Foundation
 import BreezSDK
 
+struct SignMessageRequest {
+    var message: String
+}
+
+struct SignMessageResponse {
+    var signedMessage: String
+}
+
+struct CheckMessageRequest {
+    var message: String
+    var pubkey: String
+    var signature: String
+}
+
+struct CheckMessageResponse {
+    var isValid: Bool
+}
+
 @objc(RNBreezSDK)
 class RNBreezSDK: RCTEventEmitter {
     static let TAG: String = "BreezSDK"
@@ -109,6 +127,26 @@ class RNBreezSDK: RCTEventEmitter {
             }
         } else {
             reject(RNBreezSDK.TAG, "Invalid config", nil)
+        }
+    }
+
+    @objc(signMessage:resolver:rejecter:)
+    func signMessage(_ request: SignMessageRequest, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> SignMessageResponse {
+        do {
+            let response = try BreezSDK.sign_message(message)
+            resolve(response)
+        } catch let error {
+            reject(RNBreezSDK.TAG, "Error calling signMessage", error)
+        }
+    }
+
+    @objc(checkMessage:pubkey:signature:resolver:rejecter:)
+    func checkMessage(_ request: CheckMessageRequest, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> CheckMessageResponse {
+        do {
+            let response = try BreezSDK.check_message(request)
+            resolve(response)
+        } catch let error {
+            reject(RNBreezSDK.TAG, "Error calling checkMessage", error)
         }
     }
     

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -415,6 +415,25 @@ export type BackupStatus = {
     lastBackupTime?: number
 }
 
+export type SignMessageRequest = {
+    message: string;
+}
+
+export type SignMessageResponse = {
+    signedMessage: string;
+}
+
+export type CheckMessageRequest = {
+    message: string;
+    pubkey: string;
+    signature: string;
+}
+
+export type CheckMessageResponse = {
+    isValid: boolean;
+}
+
+
 const processEvent = (eventFn: EventFn) => {
     return (event: any) => {
         switch (event.type) {
@@ -513,6 +532,14 @@ export const defaultConfig = async (envType: EnvironmentType, apiKey: string, no
 export const connect = async (config: Config, seed: Uint8Array): Promise<void> => {
     config.nodeConfig = prepareNodeConfig(config.nodeConfig)
     await BreezSDK.connect(config, seed)
+}
+
+export const signMessage = async (request: SignMessageRequest): Promise<SignMessageResponse> => {
+    return await BreezSDK.sign_message(request);
+}
+
+export const checkMessage = async (request: CheckMessageRequest): Promise<CheckMessageResponse> => {
+    return await BreezSDK.check_message(request);
 }
 
 export const sync = async (): Promise<void> => {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use anyhow::{anyhow, Error, Result};
 use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
-    parse, BreezEvent, BreezServices, EventListener, GreenlightCredentials, PaymentTypeFilter,
+    parse, BreezEvent, BreezServices, CheckMessageRequest, EventListener, GreenlightCredentials,
+    PaymentTypeFilter, SignMessageRequest,
 };
 use breez_sdk_core::{Config, GreenlightNodeConfig, NodeConfig};
 use once_cell::sync::OnceCell;
@@ -216,6 +217,24 @@ pub(crate) async fn handle_command(
                 .refund(swap_address, to_address, sat_per_vbyte)
                 .await?;
             Ok(format!("Refund tx: {}", res))
+        }
+        Commands::SignMessage { message } => {
+            let req = SignMessageRequest { message };
+            let res = sdk()?.sign_message(req).await?;
+            Ok(format!("Message signature: {}", res.signed_message))
+        }
+        Commands::CheckMessage {
+            message,
+            pubkey,
+            signature,
+        } => {
+            let req = CheckMessageRequest {
+                message,
+                pubkey,
+                signature,
+            };
+            let res = sdk()?.check_message(req).await?;
+            Ok(format!("Message was signed by node: {}", res.is_valid))
         }
         Commands::LnurlPay { lnurl } => match parse(&lnurl).await? {
             LnUrlPay { data: pd } => {

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -49,16 +49,25 @@ pub(crate) enum Commands {
     },
 
     /// Generate a bolt11 invoice
-    ReceivePayment { amount: u64, description: String },
+    ReceivePayment {
+        amount: u64,
+        description: String,
+    },
 
     /// Pay using lnurl pay
-    LnurlPay { lnurl: String },
+    LnurlPay {
+        lnurl: String,
+    },
 
     /// Withdraw using lnurl withdraw
-    LnurlWithdraw { lnurl: String },
+    LnurlWithdraw {
+        lnurl: String,
+    },
 
     /// Authenticate using lnurl auth
-    LnurlAuth { lnurl: String },
+    LnurlAuth {
+        lnurl: String,
+    },
 
     /// Send on-chain using a reverse swap
     SendOnchain {
@@ -83,13 +92,28 @@ pub(crate) enum Commands {
     },
 
     /// Send a spontaneous (keysend) payment
-    SendSpontaneousPayment { node_id: String, amount: u64 },
+    SendSpontaneousPayment {
+        node_id: String,
+        amount: u64,
+    },
+
+    SignMessage {
+        message: String,
+    },
+
+    CheckMessage {
+        message: String,
+        pubkey: String,
+        signature: String,
+    },
 
     /// List all payments
     ListPayments {},
 
     /// Retrieve a payment by its hash
-    PaymentByHash { hash: String },
+    PaymentByHash {
+        hash: String,
+    },
 
     /// Send on-chain funds to an external address
     Sweep {
@@ -144,8 +168,12 @@ pub(crate) enum Commands {
     },
 
     /// Execute a low level node command (used for debugging)
-    ExecuteDevCommand { command: String },
+    ExecuteDevCommand {
+        command: String,
+    },
 
     /// Generates an URL to buy bitcoin from a 3rd party provider
-    BuyBitcoin { provider: BuyBitcoinProvider },
+    BuyBitcoin {
+        provider: BuyBitcoinProvider,
+    },
 }


### PR DESCRIPTION
This PR is the squashed version of https://github.com/breez/breez-sdk/pull/319
The only difference is that `sign_message` now uses the `sign_message` function from Greenlight, as proposed in this PR: https://github.com/Blockstream/greenlight/pull/222

TODO: update Greenlight dependency to contain the exposed `sign_message` function.
