### PR TITLE
ci: add kotlin mpp to all platforms

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -71,3 +71,34 @@ jobs:
       with:
         name: sdk-bindings-${{ matrix.target }}
         path: dist/*
+  
+  jnilibs:
+    needs: build
+    runs-on: ubuntu-latest
+    name: build jniLibs
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-aarch64-linux-android
+          path: arm64-v8a
+      
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-armv7-linux-androideabi
+          path: armeabi-v7a
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-i686-linux-android
+          path: x86
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-x86_64-linux-android
+          path: x86_64
+      
+      - name: Archive jniLibs
+        uses: actions/upload-artifact@v3
+        with:
+          name: android-jniLibs
+          path: ./*

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,62 @@
+name: Build iOS
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    name: build ${{ matrix.target }}
+    strategy:
+      matrix:
+        target: [
+          aarch64-apple-ios,
+          x86_64-apple-ios,
+          aarch64-apple-ios-sim,
+        ]
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+      with: 
+        ref: ${{ inputs.ref }}
+
+    - name: Install rust toolchain
+      run: |
+        rustup set auto-self-update disable
+        rustup toolchain install stable --profile minimal
+        rustup target add ${{ matrix.target }}
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v2
+      with:
+        version: "23.4"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: libs
+
+    - name: Install xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Build Breez
+      working-directory: libs/sdk-bindings
+      run: cargo build --release --target ${{ matrix.target }}
+    
+    - name: Archive release
+      uses: actions/upload-artifact@v3
+      with:
+        name: sdk-bindings-${{ matrix.target }}
+        path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a

--- a/.github/workflows/build-kotlin-binding.yml
+++ b/.github/workflows/build-kotlin-binding.yml
@@ -43,3 +43,9 @@ jobs:
         with:
           name: breez_sdk.kt
           path: libs/sdk-bindings/ffi/kotlin/breez_sdk/breez_sdk.kt
+
+      - name: Archive KMM bindings
+        uses: actions/upload-artifact@v3
+        with:
+          name: kmm
+          path: libs/sdk-bindings/ffi/kmm/*

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -22,6 +22,10 @@ on:
         description: 'version for the android package (MAJOR.MINOR.BUILD)'
         required: false
         type: string
+      kotlin-mpp-package-version:
+        description: 'version for the kotlin multiplatform package (MAJOR.MINOR.BUILD)'
+        required: false
+        type: string
 
 jobs:
   build-windows:
@@ -38,6 +42,10 @@ jobs:
       ref: ${{ inputs.ref || github.sha }}
   build-android:
     uses: ./.github/workflows/build-android.yml
+    with:
+      ref: ${{ inputs.ref || github.sha }}
+  build-ios:
+    uses: ./.github/workflows/build-ios.yml
     with:
       ref: ${{ inputs.ref || github.sha }}
   build-kotlin-binding:
@@ -75,11 +83,25 @@ jobs:
     needs: 
       - build-android
       - build-kotlin-binding
-    # if: ${{ inputs.maven-package-version }}
+    if: ${{ inputs.maven-package-version }}
     uses: ./.github/workflows/publish-android.yml
     with:
       ref: ${{ inputs.ref || github.sha }}
       package-version: ${{ inputs.maven-package-version || '0.0.2' }}
+    secrets:
+      BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}
+      BREEZ_MVN_PASSWORD: ${{ secrets.BREEZ_MVN_PASSWORD }}
+  
+  publish-kotlin-mpp:
+    needs: 
+      - build-android
+      - build-ios
+      - build-kotlin-binding
+    if: ${{ inputs.kotlin-mpp-package-version }}
+    uses: ./.github/workflows/publish-kotlin-mpp.yml
+    with:
+      ref: ${{ inputs.ref || github.sha }}
+      package-version: ${{ inputs.kotlin-mpp-package-version || '0.0.2' }}
     secrets:
       BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}
       BREEZ_MVN_PASSWORD: ${{ secrets.BREEZ_MVN_PASSWORD }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,15 +1,5 @@
 name: Publish Android Bindings
 on:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'commit/tag/branch reference'
-        required: true
-        type: string
-      package-version:
-        description: 'version for the gradle library (MAJOR.MINOR.BUILD)'
-        required: true
-        type: string
   workflow_call:
     inputs:
       ref:
@@ -39,23 +29,8 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: sdk-bindings-aarch64-linux-android
-          path: libs/sdk-bindings/bindings-android/lib/src/main/arm64-v8a
-      
-      - uses: actions/download-artifact@v3
-        with:
-          name: sdk-bindings-armv7-linux-androideabi
-          path: libs/sdk-bindings/bindings-android/lib/src/main/armeabi-v7a
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: sdk-bindings-i686-linux-android
-          path: libs/sdk-bindings/bindings-android/lib/src/main/x86
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: sdk-bindings-x86_64-linux-android
-          path: libs/sdk-bindings/bindings-android/lib/src/main/x86_64
+          name: android-jniLibs
+          path: libs/sdk-bindings/bindings-android/lib/src/main
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-kotlin-mpp.yml
+++ b/.github/workflows/publish-kotlin-mpp.yml
@@ -1,47 +1,85 @@
-name: Publish Android Bindings
+name: Publish Kotlin multiplatform Bindings
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      version:
-        description: 'breez-sdk repo release (MAJOR.MINOR.PATCH)'
+      ref:
+        description: 'commit/tag/branch reference'
         required: true
         type: string
+      package-version:
+        description: 'version for the gradle library (MAJOR.MINOR.BUILD)'
+        required: true
+        type: string
+    secrets:
+      BREEZ_MVN_USERNAME:
+        description: 'username for gradlew publish'
+        required: true
+      BREEZ_MVN_PASSWORD:
+        description: 'password for gradlew publish'
+        required: true
 
 jobs:
-  publish-android:
+  build-package:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y protobuf-compiler
-          cargo install --version 0.22.0 uniffi_bindgen
-      - name: Checkout repository
+      - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.version }}
-      - name: Setup SSH key
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          ref: ${{ inputs.ref || github.sha }}
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: android-jniLibs
+          path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/jniLibs
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: kmm
+          path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src
+
+      - name: Copy jvmMain
+        working-directory: libs/sdk-bindings
         run: |
-          mkdir -p /home/runner/.ssh
-          echo "${{ secrets.REPO_SSH_KEY }}" > /home/runner/.ssh/github_actions
-          chmod 600 /home/runner/.ssh/github_actions
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add /home/runner/.ssh/github_actions
-      - name: Build Android project
+          cp -r bindings-kotlin-multiplatform/breez-sdk-kmp/src/jvmMain/kotlin bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-aarch64-apple-ios
+          path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/libs/ios-arm64
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-aarch64-apple-ios-sim
+          path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/libs/ios-simulator-arm64
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-x86_64-apple-ios
+          path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/libs/ios-simulator-x64
+
+      - name: Build Kotlin Multiplatform project
+        working-directory: libs/sdk-bindings/bindings-kotlin-multiplatform
         env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          ORG_GRADLE_PROJECT_libraryVersion: ${{ inputs.version }}
-        run: |
-          cd libs/sdk-bindings
-          make init
-          make bindings-kotlin-multiplatform
+          ORG_GRADLE_PROJECT_libraryVersion: ${{ inputs.package-version || '0.0.1' }}
+        run: ./gradlew :breez-sdk-kmp:assemble
+
+      - name: Archive aar
+        uses: actions/upload-artifact@v3
+        with:
+          name: kotlin-multiplatform-release.aar
+          path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/build/outputs/aar/breez-sdk-kmp-release.aar
+        
       - name: Publish artifacts
+        if: ${{ inputs.package-version }}
+        working-directory: libs/sdk-bindings/bindings-kotlin-multiplatform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}
+          BREEZ_MVN_PASSWORD: ${{ secrets.BREEZ_MVN_PASSWORD }}
         run: |
-          cd libs/sdk-bindings/bindings-kotlin-multiplatform
-          ./gradlew publish -PlibraryVersion=${{ inputs.version }} -PbreezReposiliteUsername=${{ secrets.BREEZ_MVN_USERNAME }} -PbreezReposilitePassword=${{ secrets.BREEZ_MVN_PASSWORD }}
+          ./gradlew publish -PlibraryVersion=${{ inputs.package-version }} -PbreezReposiliteUsername="$BREEZ_MVN_USERNAME" -PbreezReposilitePassword="$BREEZ_MVN_PASSWORD"


### PR DESCRIPTION
Same procedure as the golang/C#/android publishes, the kotlin-mpp gets the same structure for publish.