### PR TITLE
Fix Cocoapod integration in RN plugin

### DIFF
--- a/libs/sdk-react-native/breez_sdk.podspec
+++ b/libs/sdk-react-native/breez_sdk.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/breez-sdk/breez-sdk.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.exclude_files = "ios/bindings-swift/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
   s.dependency "BreezSDK", package["version"]

--- a/libs/sdk-react-native/breez_sdk.podspec
+++ b/libs/sdk-react-native/breez_sdk.podspec
@@ -13,6 +13,8 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "11.0" }
   s.source       = { :git => "https://github.com/breez-sdk/breez-sdk.git", :tag => "#{s.version}" }
 
+  s.source_files = "ios/**/*.{h,m,mm,swift}"
+
   s.dependency "React-Core"
   s.dependency "BreezSDK", package["version"]
 end

--- a/libs/sdk-react-native/example/package.json
+++ b/libs/sdk-react-native/example/package.json
@@ -9,7 +9,7 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint .",
-    "pods": "cd ios && pod install",
+    "pods": "cd ios && pod install --repo-update",
     "rebuild": "rm -rf node_modules && yarn && yarn pods"
   },
   "dependencies": {


### PR DESCRIPTION
It seems that this is all that was missing in the RN plugin to make pulling in the bindings from Cocoapods work. We've had that line in before but I must've accidentally deleted it when setting up the second podfile (the one to use the locally built bindings during development) in [this commit](https://github.com/breez/breez-sdk/pull/263/commits/bb5775ff54cabf4ba101211bbffc27ac60dbf24c).

Anyway, what I did to test was to checkout the 0.1.4 tag to make sure the RN plugin and the bindings line up. Then I applied this PR's diff and:

- ✅ Ran the example app as is without the locally built bindings present (pulling in BreezSDK from Cocoapods).
- ✅ Ran the example app using the plugin's second dev podspec which makes use of the locally built bindings for development.
- ❌ Removed the line added in this PR and reproduced the exact same error we observed before ("react-native-breez-sdk doesn't seem to be linked)

@dangeross Would be much appreciated if you could double check my testing just to rule out any weirdness with my machine (which we've seen before when it came to Cocoapods). 🙏 

Let me know what you think!

After this we should be ready to publish to npm without having to include full copies of the Android/iOS bindings in the package. I'll take care of updating the CI then.