### PR TITLE
Add `SdkError::LspOpenChannelNotSupported`

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -13,6 +13,7 @@ enum SdkError {
     "Generic",
     "InitFailed",
     "LspConnectFailed",
+    "LspOpenChannelNotSupported",
     "PersistenceFailure",
     "ReceivePaymentFailed",
 };

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -15,6 +15,9 @@ pub enum SdkError {
     #[error("Failed to communicate with the LSP API: {err}")]
     LspConnectFailed { err: String },
 
+    #[error("LSP doesn't support opening a new channel: {err}")]
+    LspOpenChannelNotSupported { err: String },
+
     #[error("Failed to use the local DB for persistence: {err}")]
     PersistenceFailure { err: String },
 

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -1,5 +1,6 @@
 use crate::breez_services::BreezServer;
 use crate::crypt::encrypt;
+use crate::error::SdkResult;
 use crate::grpc::{
     self, LspListRequest, PaymentInformation, RegisterPaymentReply, RegisterPaymentRequest,
 };
@@ -60,7 +61,7 @@ impl LspInformation {
         &self,
         maybe_user_supplied_fee_params: Option<OpeningFeeParams>,
         fee_type: DynamicFeeType,
-    ) -> Result<OpeningFeeParams> {
+    ) -> SdkResult<OpeningFeeParams> {
         match maybe_user_supplied_fee_params {
             // Validate given opening_fee_params and use it if possible
             Some(user_supplied_fees) => {


### PR DESCRIPTION
Add a new error type to allow callers to more reliably identify this specific LSP scenario, like https://github.com/breez/c-breez/issues/618.