### PR TITLE
Add utils for reverse swap fees and amounts

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -288,6 +288,10 @@ dictionary OpeningFeeParams {
     string promise;
 };
 
+dictionary ReverseSwapFeesRequest {
+    u64? send_amount_sat;
+};
+
 dictionary ReceivePaymentRequest {
     u64 amount_sats;
     string description;
@@ -551,7 +555,7 @@ interface BlockingBreezServices {
    string refund(string swap_address, string to_address, u32 sat_per_vbyte);
 
    [Throws=SdkError]
-   ReverseSwapPairInfo fetch_reverse_swap_fees(u64? send_amount_sat);
+   ReverseSwapPairInfo fetch_reverse_swap_fees(ReverseSwapFeesRequest req);
 
    [Throws=SdkError]
    sequence<ReverseSwapInfo> in_progress_reverse_swaps();

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -379,6 +379,7 @@ dictionary ReverseSwapPairInfo {
     f64 fees_percentage;
     u64 fees_lockup;
     u64 fees_claim;
+    u64? fees_total_estimated;
 };
 
 dictionary ReverseSwapInfo {
@@ -550,7 +551,7 @@ interface BlockingBreezServices {
    string refund(string swap_address, string to_address, u32 sat_per_vbyte);
 
    [Throws=SdkError]
-   ReverseSwapPairInfo fetch_reverse_swap_fees();
+   ReverseSwapPairInfo fetch_reverse_swap_fees(u64? send_amount_sat);
 
    [Throws=SdkError]
    sequence<ReverseSwapInfo> in_progress_reverse_swaps();

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -383,7 +383,7 @@ dictionary ReverseSwapPairInfo {
     f64 fees_percentage;
     u64 fees_lockup;
     u64 fees_claim;
-    u64? fees_total_estimated;
+    u64? total_estimated_fees;
 };
 
 dictionary ReverseSwapInfo {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -277,8 +277,11 @@ impl BlockingBreezServices {
         .map_err(|e| e.into())
     }
 
-    pub fn fetch_reverse_swap_fees(&self) -> SdkResult<ReverseSwapPairInfo> {
-        rt().block_on(self.breez_services.fetch_reverse_swap_fees())
+    pub fn fetch_reverse_swap_fees(
+        &self,
+        send_amount_sat: Option<u64>,
+    ) -> SdkResult<ReverseSwapPairInfo> {
+        rt().block_on(self.breez_services.fetch_reverse_swap_fees(send_amount_sat))
             .map_err(|e| e.into())
     }
 

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -16,9 +16,9 @@ use breez_sdk_core::{
     LocalizedName, LogEntry, LogStream, LspInformation, MessageSuccessActionData, MetadataItem,
     Network, NodeConfig, NodeState, OpeningFeeParams, OpeningFeeParamsMenu, Payment,
     PaymentDetails, PaymentFailedData, PaymentType, PaymentTypeFilter, Rate, ReceiveOnchainRequest,
-    ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees, ReverseSwapInfo,
-    ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop, SignMessageRequest,
-    SignMessageResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
+    ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees, ReverseSwapFeesRequest,
+    ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
+    SignMessageRequest, SignMessageResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
     UnspentTransactionOutput, UrlSuccessActionData,
 };
 
@@ -279,9 +279,9 @@ impl BlockingBreezServices {
 
     pub fn fetch_reverse_swap_fees(
         &self,
-        send_amount_sat: Option<u64>,
+        req: ReverseSwapFeesRequest,
     ) -> SdkResult<ReverseSwapPairInfo> {
-        rt().block_on(self.breez_services.fetch_reverse_swap_fees(send_amount_sat))
+        rt().block_on(self.breez_services.fetch_reverse_swap_fees(req))
             .map_err(|e| e.into())
     }
 

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -33,8 +33,8 @@ use crate::models::{Config, LogEntry, NodeState, Payment, PaymentTypeFilter, Swa
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     EnvironmentType, LnUrlCallbackStatus, NodeConfig, ReceiveOnchainRequest, ReceivePaymentRequest,
-    ReceivePaymentResponse, ReverseSwapInfo, ReverseSwapPairInfo, SignMessageRequest,
-    SignMessageResponse,
+    ReceivePaymentResponse, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
+    SignMessageRequest, SignMessageResponse,
 };
 
 static BREEZ_SERVICES_INSTANCE: OnceCell<Arc<BreezServices>> = OnceCell::new();
@@ -363,12 +363,8 @@ pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
 /*  Swap Fee API's */
 
 /// See [BreezServices::fetch_reverse_swap_fees]
-pub fn fetch_reverse_swap_fees(send_amount_sat: Option<u64>) -> Result<ReverseSwapPairInfo> {
-    block_on(async {
-        get_breez_services()?
-            .fetch_reverse_swap_fees(send_amount_sat)
-            .await
-    })
+pub fn fetch_reverse_swap_fees(req: ReverseSwapFeesRequest) -> Result<ReverseSwapPairInfo> {
+    block_on(async { get_breez_services()?.fetch_reverse_swap_fees(req).await })
 }
 
 /// See [BreezServices::recommended_fees]

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -363,8 +363,12 @@ pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
 /*  Swap Fee API's */
 
 /// See [BreezServices::fetch_reverse_swap_fees]
-pub fn fetch_reverse_swap_fees() -> Result<ReverseSwapPairInfo> {
-    block_on(async { get_breez_services()?.fetch_reverse_swap_fees().await })
+pub fn fetch_reverse_swap_fees(send_amount_sat: Option<u64>) -> Result<ReverseSwapPairInfo> {
+    block_on(async {
+        get_breez_services()?
+            .fetch_reverse_swap_fees(send_amount_sat)
+            .await
+    })
 }
 
 /// See [BreezServices::recommended_fees]

--- a/libs/sdk-core/src/boltzswap.rs
+++ b/libs/sdk-core/src/boltzswap.rs
@@ -251,7 +251,7 @@ pub async fn reverse_swap_pair_info() -> Result<ReverseSwapPairInfo> {
                 fees_percentage: btc_pair.fees.percentage,
                 fees_lockup: btc_pair.fees.miner_fees.base_asset.reverse.lockup,
                 fees_claim: btc_pair.fees.miner_fees.base_asset.reverse.claim,
-                fees_total_estimated: None,
+                total_estimated_fees: None,
             })
         }
     }

--- a/libs/sdk-core/src/boltzswap.rs
+++ b/libs/sdk-core/src/boltzswap.rs
@@ -251,6 +251,7 @@ pub async fn reverse_swap_pair_info() -> Result<ReverseSwapPairInfo> {
                 fees_percentage: btc_pair.fees.percentage,
                 fees_lockup: btc_pair.fees.miner_fees.base_asset.reverse.lockup,
                 fees_claim: btc_pair.fees.miner_fees.base_asset.reverse.claim,
+                fees_total_estimated: None,
             })
         }
     }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -554,16 +554,16 @@ impl BreezServices {
     ///
     /// ### Errors
     ///
-    /// If a `send_amount_sat` is specified, but is outside the `min` and `max`, this will result in
-    /// an error. If you are not sure what are the `min` and `max`, please call this with `send_amount_sat`
-    /// as `None` first, then repeat the call with the desired amount.
+    /// If a `send_amount_sat` is specified in the request, but is outside the `min` and `max`,
+    /// this will result in an error. If you are not sure what are the `min` and `max`, please call
+    /// this with `send_amount_sat` as `None` first, then repeat the call with the desired amount.
     pub async fn fetch_reverse_swap_fees(
         &self,
-        send_amount_sat: Option<u64>,
+        req: ReverseSwapFeesRequest,
     ) -> Result<ReverseSwapPairInfo> {
         let mut res = self.btc_send_swapper.fetch_reverse_swap_fees().await?;
 
-        if let Some(send_amount_sat) = send_amount_sat {
+        if let Some(send_amount_sat) = req.send_amount_sat {
             ensure!(send_amount_sat <= res.max, "Send amount is too high");
             ensure!(send_amount_sat >= res.min, "Send amount is too low");
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 use bip39::*;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::{sha256, Hash};
@@ -546,9 +546,32 @@ impl BreezServices {
         Ok(None)
     }
 
-    /// See [ReverseSwapperAPI::fetch_reverse_swap_fees]
-    pub async fn fetch_reverse_swap_fees(&self) -> Result<ReverseSwapPairInfo> {
-        self.btc_send_swapper.fetch_reverse_swap_fees().await
+    /// Lookup the reverse swap fees (see [ReverseSwapperAPI::fetch_reverse_swap_fees]).
+    ///
+    /// To get the total estimated fees for a specific amount, specify the amount to be sent in
+    /// `send_amount_sat`. The result will then contain the total estimated fees in
+    /// [`ReverseSwapPairInfo::fees_total_estimated`].
+    ///
+    /// ### Errors
+    ///
+    /// If a `send_amount_sat` is specified, but is outside the `min` and `max`, this will result in
+    /// an error. If you are not sure what are the `min` and `max`, please call this with `send_amount_sat`
+    /// as `None` first, then repeat the call with the desired amount.
+    pub async fn fetch_reverse_swap_fees(
+        &self,
+        send_amount_sat: Option<u64>,
+    ) -> Result<ReverseSwapPairInfo> {
+        let mut res = self.btc_send_swapper.fetch_reverse_swap_fees().await?;
+
+        if let Some(send_amount_sat) = send_amount_sat {
+            ensure!(send_amount_sat <= res.max, "Send amount is too high");
+            ensure!(send_amount_sat >= res.min, "Send amount is too low");
+
+            let service_fee_sat = ((send_amount_sat as f64) * res.fees_percentage / 100.0) as u64;
+            res.fees_total_estimated = Some(service_fee_sat + res.fees_lockup + res.fees_claim);
+        }
+
+        Ok(res)
     }
 
     /// Creates a reverse swap and attempts to pay the HODL invoice

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -550,7 +550,7 @@ impl BreezServices {
     ///
     /// To get the total estimated fees for a specific amount, specify the amount to be sent in
     /// `send_amount_sat`. The result will then contain the total estimated fees in
-    /// [`ReverseSwapPairInfo::fees_total_estimated`].
+    /// [`ReverseSwapPairInfo::total_estimated_fees`].
     ///
     /// ### Errors
     ///
@@ -568,7 +568,7 @@ impl BreezServices {
             ensure!(send_amount_sat >= res.min, "Send amount is too low");
 
             let service_fee_sat = ((send_amount_sat as f64) * res.fees_percentage / 100.0) as u64;
-            res.fees_total_estimated = Some(service_fee_sat + res.fees_lockup + res.fees_claim);
+            res.total_estimated_fees = Some(service_fee_sat + res.fees_lockup + res.fees_claim);
         }
 
         Ok(res)

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -246,8 +246,8 @@ pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_fetch_reverse_swap_fees(port_: i64) {
-    wire_fetch_reverse_swap_fees_impl(port_)
+pub extern "C" fn wire_fetch_reverse_swap_fees(port_: i64, send_amount_sat: *mut u64) {
+    wire_fetch_reverse_swap_fees_impl(port_, send_amount_sat)
 }
 
 #[no_mangle]

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -246,8 +246,8 @@ pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_fetch_reverse_swap_fees(port_: i64, send_amount_sat: *mut u64) {
-    wire_fetch_reverse_swap_fees_impl(port_, send_amount_sat)
+pub extern "C" fn wire_fetch_reverse_swap_fees(port_: i64, req: *mut wire_ReverseSwapFeesRequest) {
+    wire_fetch_reverse_swap_fees_impl(port_, req)
 }
 
 #[no_mangle]
@@ -326,6 +326,12 @@ pub extern "C" fn new_box_autoadd_receive_onchain_request_0() -> *mut wire_Recei
 #[no_mangle]
 pub extern "C" fn new_box_autoadd_receive_payment_request_0() -> *mut wire_ReceivePaymentRequest {
     support::new_leak_box_ptr(wire_ReceivePaymentRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn new_box_autoadd_reverse_swap_fees_request_0() -> *mut wire_ReverseSwapFeesRequest
+{
+    support::new_leak_box_ptr(wire_ReverseSwapFeesRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -432,6 +438,12 @@ impl Wire2Api<ReceivePaymentRequest> for *mut wire_ReceivePaymentRequest {
     fn wire2api(self) -> ReceivePaymentRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<ReceivePaymentRequest>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<ReverseSwapFeesRequest> for *mut wire_ReverseSwapFeesRequest {
+    fn wire2api(self) -> ReverseSwapFeesRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<ReverseSwapFeesRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<SignMessageRequest> for *mut wire_SignMessageRequest {
@@ -575,6 +587,13 @@ impl Wire2Api<ReceivePaymentRequest> for wire_ReceivePaymentRequest {
         }
     }
 }
+impl Wire2Api<ReverseSwapFeesRequest> for wire_ReverseSwapFeesRequest {
+    fn wire2api(self) -> ReverseSwapFeesRequest {
+        ReverseSwapFeesRequest {
+            send_amount_sat: self.send_amount_sat.wire2api(),
+        }
+    }
+}
 impl Wire2Api<SignMessageRequest> for wire_SignMessageRequest {
     fn wire2api(self) -> SignMessageRequest {
         SignMessageRequest {
@@ -691,6 +710,12 @@ pub struct wire_ReceivePaymentRequest {
     description: *mut wire_uint_8_list,
     preimage: *mut wire_uint_8_list,
     opening_fee_params: *mut wire_OpeningFeeParams,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_ReverseSwapFeesRequest {
+    send_amount_sat: *mut u64,
 }
 
 #[repr(C)]
@@ -943,6 +968,20 @@ impl NewWithNullPtr for wire_ReceivePaymentRequest {
 }
 
 impl Default for wire_ReceivePaymentRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_ReverseSwapFeesRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            send_amount_sat: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_ReverseSwapFeesRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -628,14 +628,20 @@ fn wire_in_progress_reverse_swaps_impl(port_: MessagePort) {
         move || move |task_callback| in_progress_reverse_swaps(),
     )
 }
-fn wire_fetch_reverse_swap_fees_impl(port_: MessagePort) {
+fn wire_fetch_reverse_swap_fees_impl(
+    port_: MessagePort,
+    send_amount_sat: impl Wire2Api<Option<u64>> + UnwindSafe,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "fetch_reverse_swap_fees",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| fetch_reverse_swap_fees(),
+        move || {
+            let api_send_amount_sat = send_amount_sat.wire2api();
+            move |task_callback| fetch_reverse_swap_fees(api_send_amount_sat)
+        },
     )
 }
 fn wire_recommended_fees_impl(port_: MessagePort) {
@@ -1270,6 +1276,7 @@ impl support::IntoDart for ReverseSwapPairInfo {
             self.fees_percentage.into_dart(),
             self.fees_lockup.into_dart(),
             self.fees_claim.into_dart(),
+            self.fees_total_estimated.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -74,6 +74,7 @@ use crate::models::PaymentTypeFilter;
 use crate::models::ReceiveOnchainRequest;
 use crate::models::ReceivePaymentRequest;
 use crate::models::ReceivePaymentResponse;
+use crate::models::ReverseSwapFeesRequest;
 use crate::models::ReverseSwapInfo;
 use crate::models::ReverseSwapPairInfo;
 use crate::models::ReverseSwapStatus;
@@ -630,7 +631,7 @@ fn wire_in_progress_reverse_swaps_impl(port_: MessagePort) {
 }
 fn wire_fetch_reverse_swap_fees_impl(
     port_: MessagePort,
-    send_amount_sat: impl Wire2Api<Option<u64>> + UnwindSafe,
+    req: impl Wire2Api<ReverseSwapFeesRequest> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -639,8 +640,8 @@ fn wire_fetch_reverse_swap_fees_impl(
             mode: FfiCallMode::Normal,
         },
         move || {
-            let api_send_amount_sat = send_amount_sat.wire2api();
-            move |task_callback| fetch_reverse_swap_fees(api_send_amount_sat)
+            let api_req = req.wire2api();
+            move |task_callback| fetch_reverse_swap_fees(api_req)
         },
     )
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1277,7 +1277,7 @@ impl support::IntoDart for ReverseSwapPairInfo {
             self.fees_percentage.into_dart(),
             self.fees_lockup.into_dart(),
             self.fees_claim.into_dart(),
-            self.fees_total_estimated.into_dart(),
+            self.total_estimated_fees.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -105,6 +105,8 @@
 //! ### D. Sending to an on-chain address (swap-out)
 //!
 //! * [BreezServices::fetch_reverse_swap_fees] to get the current swap-out fees
+//!   * Based on the amount to send, [ReverseSwapPairInfo::estimate_amount_sat_received] can estimate the net amount received
+//!   * Based on the amount to receive, [ReverseSwapPairInfo::estimate_amount_sat_to_send] can estimate what amount to send
 //! * [BreezServices::send_onchain] to start the swap-out
 //! * [BreezServices::in_progress_reverse_swaps] to see any in-progress swaps
 //!
@@ -192,3 +194,4 @@ pub use invoice::{parse_invoice, LNInvoice, RouteHint, RouteHintHop};
 pub use lnurl::pay::model::*;
 pub use lsp::LspInformation;
 pub use models::*;
+pub use reverseswap::{ESTIMATED_CLAIM_TX_VSIZE, ESTIMATED_LOCKUP_TX_VSIZE};

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -105,8 +105,6 @@
 //! ### D. Sending to an on-chain address (swap-out)
 //!
 //! * [BreezServices::fetch_reverse_swap_fees] to get the current swap-out fees
-//!   * Based on the amount to send, [ReverseSwapPairInfo::estimate_amount_sat_received] can estimate the net amount received
-//!   * Based on the amount to receive, [ReverseSwapPairInfo::estimate_amount_sat_to_send] can estimate what amount to send
 //! * [BreezServices::send_onchain] to start the swap-out
 //! * [BreezServices::in_progress_reverse_swaps] to see any in-progress swaps
 //!

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -655,6 +655,11 @@ pub struct ClosedChannelPaymentDetails {
     pub funding_txid: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReverseSwapFeesRequest {
+    pub send_amount_sat: Option<u64>,
+}
+
 /// Represents a receive payment request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceivePaymentRequest {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -149,7 +149,7 @@ pub struct ReverseSwapPairInfo {
     /// [`crate::ESTIMATED_CLAIM_TX_VSIZE`] vbytes
     pub fees_claim: u64,
     /// Estimated total fees in sats, based on the given send amount. Only set when the send amount is known.
-    pub fees_total_estimated: Option<u64>,
+    pub total_estimated_fees: Option<u64>,
 }
 
 /// Details of past or ongoing reverse swaps, as stored in the Breez local DB

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -28,7 +28,7 @@ use crate::grpc::{self, PaymentInformation, RegisterPaymentReply};
 use crate::lnurl::pay::model::SuccessActionProcessed;
 use crate::lsp::LspInformation;
 use crate::models::Network::*;
-use crate::{LNInvoice, LnUrlErrorData};
+use crate::{LNInvoice, LnUrlErrorData, ESTIMATED_CLAIM_TX_VSIZE};
 
 use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
@@ -142,10 +142,36 @@ pub struct ReverseSwapPairInfo {
     pub fees_hash: String,
     /// Percentage fee for the reverse swap service
     pub fees_percentage: f64,
-    /// Estimated miner fees in sats for locking up funds
+    /// Estimated miner fees in sats for locking up funds, assuming a transaction virtual size of
+    /// [`crate::ESTIMATED_LOCKUP_TX_VSIZE`] vbytes and [ReverseSwapPairInfo::feerate]
     pub fees_lockup: u64,
-    /// Estimated miner fees in sats for claiming funds
+    /// Estimated miner fees in sats for claiming funds, assuming a transaction virtual size of
+    /// [`crate::ESTIMATED_CLAIM_TX_VSIZE`] vbytes and [ReverseSwapPairInfo::feerate]
     pub fees_claim: u64,
+}
+
+impl ReverseSwapPairInfo {
+    /// Estimates the net amount received at the destination onchain address, for these fees and a given
+    /// `send_amount_sat`
+    pub fn estimate_amount_sat_received(&self, send_amount_sat: u64) -> Result<u64> {
+        ensure!(send_amount_sat <= self.max, "Send amount is too high");
+        ensure!(send_amount_sat >= self.min, "Send amount is too low");
+
+        let service_fee_sat = ((send_amount_sat as f64) * self.fees_percentage / 100.0) as u64;
+        Ok(send_amount_sat - service_fee_sat - self.fees_lockup - self.fees_claim)
+    }
+
+    /// Given a desired amount to receive (`recv_amount_sat`) and these fees, it estimates the
+    /// amount in sat that has to be sent
+    pub fn estimate_amount_sat_to_send(&self, recv_amount_sat: u64) -> u64 {
+        let estimate_amount_sat_send = recv_amount_sat + self.fees_lockup + self.fees_claim;
+        (estimate_amount_sat_send as f64 * 100.0 / (100.0 - self.fees_percentage)) as u64
+    }
+
+    /// Get the onchain feerate used for the [self::fees_lockup] and [self::fees_claim] estimations
+    pub fn feerate(&self) -> f64 {
+        (self.fees_claim / ESTIMATED_CLAIM_TX_VSIZE) as f64
+    }
 }
 
 /// Details of past or ongoing reverse swaps, as stored in the Breez local DB

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -21,6 +21,10 @@ use bitcoin::{
 use serde::{Deserialize, Serialize};
 use tokio::time::{sleep, Duration};
 
+// Estimates based on https://github.com/BoltzExchange/boltz-backend/blob/master/lib/rates/FeeProvider.ts#L31-L42
+pub const ESTIMATED_CLAIM_TX_VSIZE: u64 = 138;
+pub const ESTIMATED_LOCKUP_TX_VSIZE: u64 = 153;
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateReverseSwapResponse {

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -226,7 +226,7 @@ void wire_in_progress_swap(int64_t port_);
 
 void wire_in_progress_reverse_swaps(int64_t port_);
 
-void wire_fetch_reverse_swap_fees(int64_t port_);
+void wire_fetch_reverse_swap_fees(int64_t port_, uint64_t *send_amount_sat);
 
 void wire_recommended_fees(int64_t port_);
 

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -113,6 +113,10 @@ typedef struct wire_BuyBitcoinRequest {
   struct wire_OpeningFeeParams *opening_fee_params;
 } wire_BuyBitcoinRequest;
 
+typedef struct wire_ReverseSwapFeesRequest {
+  uint64_t *send_amount_sat;
+} wire_ReverseSwapFeesRequest;
+
 typedef struct DartCObject *WireSyncReturn;
 
 void store_dart_post_cobject(DartPostCObjectFnType ptr);
@@ -226,7 +230,7 @@ void wire_in_progress_swap(int64_t port_);
 
 void wire_in_progress_reverse_swaps(int64_t port_);
 
-void wire_fetch_reverse_swap_fees(int64_t port_, uint64_t *send_amount_sat);
+void wire_fetch_reverse_swap_fees(int64_t port_, struct wire_ReverseSwapFeesRequest *req);
 
 void wire_recommended_fees(int64_t port_);
 
@@ -257,6 +261,8 @@ struct wire_OpeningFeeParams *new_box_autoadd_opening_fee_params_0(void);
 struct wire_ReceiveOnchainRequest *new_box_autoadd_receive_onchain_request_0(void);
 
 struct wire_ReceivePaymentRequest *new_box_autoadd_receive_payment_request_0(void);
+
+struct wire_ReverseSwapFeesRequest *new_box_autoadd_reverse_swap_fees_request_0(void);
 
 struct wire_SignMessageRequest *new_box_autoadd_sign_message_request_0(void);
 
@@ -325,6 +331,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_opening_fee_params_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_receive_onchain_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_receive_payment_request_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_reverse_swap_fees_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_sign_message_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_u64_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -3,6 +3,10 @@
 #include <stdlib.h>
 typedef struct _Dart_Handle* Dart_Handle;
 
+#define ESTIMATED_CLAIM_TX_VSIZE 138
+
+#define ESTIMATED_LOCKUP_TX_VSIZE 153
+
 typedef struct DartCObject DartCObject;
 
 typedef int64_t DartPort;

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1064,7 +1064,7 @@ class ReverseSwapPairInfo {
   final int feesClaim;
 
   /// Estimated total fees in sats, based on the given send amount. Only set when the send amount is known.
-  final int? feesTotalEstimated;
+  final int? totalEstimatedFees;
 
   const ReverseSwapPairInfo({
     required this.min,
@@ -1073,7 +1073,7 @@ class ReverseSwapPairInfo {
     required this.feesPercentage,
     required this.feesLockup,
     required this.feesClaim,
-    this.feesTotalEstimated,
+    this.totalEstimatedFees,
   });
 }
 
@@ -2738,7 +2738,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       feesPercentage: _wire2api_f64(arr[3]),
       feesLockup: _wire2api_u64(arr[4]),
       feesClaim: _wire2api_u64(arr[5]),
-      feesTotalEstimated: _wire2api_opt_box_autoadd_u64(arr[6]),
+      totalEstimatedFees: _wire2api_opt_box_autoadd_u64(arr[6]),
     );
   }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -14,7 +14,7 @@ import 'dart:ffi' as ffi;
 part 'bridge_generated.freezed.dart';
 
 abstract class BreezSdkCore {
-  /// See [BreezServices::connect]
+  /// Wrapper around [BreezServices::connect] which also initializes SDK logging
   Future<void> connect({required Config config, required Uint8List seed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kConnectConstMeta;
@@ -1047,10 +1047,12 @@ class ReverseSwapPairInfo {
   /// Percentage fee for the reverse swap service
   final double feesPercentage;
 
-  /// Estimated miner fees in sats for locking up funds
+  /// Estimated miner fees in sats for locking up funds, assuming a transaction virtual size of
+  /// [`crate::ESTIMATED_LOCKUP_TX_VSIZE`] vbytes and [ReverseSwapPairInfo::feerate]
   final int feesLockup;
 
-  /// Estimated miner fees in sats for claiming funds
+  /// Estimated miner fees in sats for claiming funds, assuming a transaction virtual size of
+  /// [`crate::ESTIMATED_CLAIM_TX_VSIZE`] vbytes and [ReverseSwapPairInfo::feerate]
   final int feesClaim;
 
   const ReverseSwapPairInfo({
@@ -4325,3 +4327,7 @@ class wire_BuyBitcoinRequest extends ffi.Struct {
 typedef DartPostCObjectFnType
     = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message)>>;
 typedef DartPort = ffi.Int64;
+
+const int ESTIMATED_CLAIM_TX_VSIZE = 138;
+
+const int ESTIMATED_LOCKUP_TX_VSIZE = 153;

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -224,7 +224,7 @@ abstract class BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta;
 
   /// See [BreezServices::fetch_reverse_swap_fees]
-  Future<ReverseSwapPairInfo> fetchReverseSwapFees({int? sendAmountSat, dynamic hint});
+  Future<ReverseSwapPairInfo> fetchReverseSwapFees({required ReverseSwapFeesRequest req, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kFetchReverseSwapFeesConstMeta;
 
@@ -1013,6 +1013,14 @@ class RecommendedFees {
     required this.hourFee,
     required this.economyFee,
     required this.minimumFee,
+  });
+}
+
+class ReverseSwapFeesRequest {
+  final int? sendAmountSat;
+
+  const ReverseSwapFeesRequest({
+    this.sendAmountSat,
   });
 }
 
@@ -1931,20 +1939,20 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
-  Future<ReverseSwapPairInfo> fetchReverseSwapFees({int? sendAmountSat, dynamic hint}) {
-    var arg0 = _platform.api2wire_opt_box_autoadd_u64(sendAmountSat);
+  Future<ReverseSwapPairInfo> fetchReverseSwapFees({required ReverseSwapFeesRequest req, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_reverse_swap_fees_request(req);
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_fetch_reverse_swap_fees(port_, arg0),
       parseSuccessData: _wire2api_reverse_swap_pair_info,
       constMeta: kFetchReverseSwapFeesConstMeta,
-      argValues: [sendAmountSat],
+      argValues: [req],
       hint: hint,
     ));
   }
 
   FlutterRustBridgeTaskConstMeta get kFetchReverseSwapFeesConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "fetch_reverse_swap_fees",
-        argNames: ["sendAmountSat"],
+        argNames: ["req"],
       );
 
   Future<RecommendedFees> recommendedFees({dynamic hint}) {
@@ -3033,6 +3041,14 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_ReverseSwapFeesRequest> api2wire_box_autoadd_reverse_swap_fees_request(
+      ReverseSwapFeesRequest raw) {
+    final ptr = inner.new_box_autoadd_reverse_swap_fees_request_0();
+    _api_fill_to_wire_reverse_swap_fees_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_SignMessageRequest> api2wire_box_autoadd_sign_message_request(SignMessageRequest raw) {
     final ptr = inner.new_box_autoadd_sign_message_request_0();
     _api_fill_to_wire_sign_message_request(raw, ptr.ref);
@@ -3153,6 +3169,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_receive_payment_request(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_reverse_swap_fees_request(
+      ReverseSwapFeesRequest apiObj, ffi.Pointer<wire_ReverseSwapFeesRequest> wireObj) {
+    _api_fill_to_wire_reverse_swap_fees_request(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_sign_message_request(
       SignMessageRequest apiObj, ffi.Pointer<wire_SignMessageRequest> wireObj) {
     _api_fill_to_wire_sign_message_request(apiObj, wireObj.ref);
@@ -3261,6 +3282,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.description = api2wire_String(apiObj.description);
     wireObj.preimage = api2wire_opt_uint_8_list(apiObj.preimage);
     wireObj.opening_fee_params = api2wire_opt_box_autoadd_opening_fee_params(apiObj.openingFeeParams);
+  }
+
+  void _api_fill_to_wire_reverse_swap_fees_request(
+      ReverseSwapFeesRequest apiObj, wire_ReverseSwapFeesRequest wireObj) {
+    wireObj.send_amount_sat = api2wire_opt_box_autoadd_u64(apiObj.sendAmountSat);
   }
 
   void _api_fill_to_wire_sign_message_request(SignMessageRequest apiObj, wire_SignMessageRequest wireObj) {
@@ -3947,19 +3973,19 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
 
   void wire_fetch_reverse_swap_fees(
     int port_,
-    ffi.Pointer<ffi.Uint64> send_amount_sat,
+    ffi.Pointer<wire_ReverseSwapFeesRequest> req,
   ) {
     return _wire_fetch_reverse_swap_fees(
       port_,
-      send_amount_sat,
+      req,
     );
   }
 
   late final _wire_fetch_reverse_swap_feesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Uint64>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ReverseSwapFeesRequest>)>>(
           'wire_fetch_reverse_swap_fees');
-  late final _wire_fetch_reverse_swap_fees =
-      _wire_fetch_reverse_swap_feesPtr.asFunction<void Function(int, ffi.Pointer<ffi.Uint64>)>();
+  late final _wire_fetch_reverse_swap_fees = _wire_fetch_reverse_swap_feesPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_ReverseSwapFeesRequest>)>();
 
   void wire_recommended_fees(
     int port_,
@@ -4120,6 +4146,16 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'new_box_autoadd_receive_payment_request_0');
   late final _new_box_autoadd_receive_payment_request_0 = _new_box_autoadd_receive_payment_request_0Ptr
       .asFunction<ffi.Pointer<wire_ReceivePaymentRequest> Function()>();
+
+  ffi.Pointer<wire_ReverseSwapFeesRequest> new_box_autoadd_reverse_swap_fees_request_0() {
+    return _new_box_autoadd_reverse_swap_fees_request_0();
+  }
+
+  late final _new_box_autoadd_reverse_swap_fees_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ReverseSwapFeesRequest> Function()>>(
+          'new_box_autoadd_reverse_swap_fees_request_0');
+  late final _new_box_autoadd_reverse_swap_fees_request_0 = _new_box_autoadd_reverse_swap_fees_request_0Ptr
+      .asFunction<ffi.Pointer<wire_ReverseSwapFeesRequest> Function()>();
 
   ffi.Pointer<wire_SignMessageRequest> new_box_autoadd_sign_message_request_0() {
     return _new_box_autoadd_sign_message_request_0();
@@ -4331,6 +4367,10 @@ class wire_BuyBitcoinRequest extends ffi.Struct {
   external int provider;
 
   external ffi.Pointer<wire_OpeningFeeParams> opening_fee_params;
+}
+
+class wire_ReverseSwapFeesRequest extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint64> send_amount_sat;
 }
 
 typedef DartPostCObjectFnType

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -690,7 +690,7 @@ fun readableMapOf(reverseSwapPairInfo: ReverseSwapPairInfo): ReadableMap {
             "feesPercentage" to reverseSwapPairInfo.feesPercentage,
             "feesLockup" to reverseSwapPairInfo.feesLockup,
             "feesClaim" to reverseSwapPairInfo.feesClaim,
-            "feesTotalEstimated" to reverseSwapPairInfo.feesTotalEstimated
+            "totalEstimatedFees" to reverseSwapPairInfo.totalEstimatedFees
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -94,8 +94,8 @@ fun asCheckMessageRequest(reqData: ReadableMap): CheckMessageRequest? {
     return null
 }
 
-fun asReverseSwapFeesRequest(reqData: ReadableMap): ReverseSwapFeesRequest? {
-    val sendAmountSats = reqData.getDouble("sendAmountSats")
+fun asReverseSwapFeesRequest(reqData: ReadableMap): ReverseSwapFeesRequest {
+    val sendAmountSats = if (hasNonNullKey(reqData, "sendAmountSats")) reqData.getDouble("sendAmountSats") else null
     return ReverseSwapFeesRequest(sendAmountSats)
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -94,6 +94,11 @@ fun asCheckMessageRequest(reqData: ReadableMap): CheckMessageRequest? {
     return null
 }
 
+fun asReverseSwapFeesRequest(reqData: ReadableMap): ReverseSwapFeesRequest? {
+    val sendAmountSats = reqData.getDouble("sendAmountSats")
+    return ReverseSwapFeesRequest(sendAmountSats)
+}
+
 fun asReceivePaymentRequest(reqData: ReadableMap): ReceivePaymentRequest? {
     val amountSats = reqData.getDouble("amountSats")
     val description = reqData.getString("description")

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -95,8 +95,12 @@ fun asCheckMessageRequest(reqData: ReadableMap): CheckMessageRequest? {
 }
 
 fun asReverseSwapFeesRequest(reqData: ReadableMap): ReverseSwapFeesRequest {
-    val sendAmountSats = if (hasNonNullKey(reqData, "sendAmountSats")) reqData.getDouble("sendAmountSats") else null
-    return ReverseSwapFeesRequest(sendAmountSats)
+    if (hasNonNullKey(reqData, "sendAmountSats")) {
+        val sendAmountSats = reqData.getDouble("sendAmountSats")
+        return ReverseSwapFeesRequest(sendAmountSats.toULong())
+    }
+
+    return ReverseSwapFeesRequest(null)
 }
 
 fun asReceivePaymentRequest(reqData: ReadableMap): ReceivePaymentRequest? {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -680,7 +680,8 @@ fun readableMapOf(reverseSwapPairInfo: ReverseSwapPairInfo): ReadableMap {
             "feesHash" to reverseSwapPairInfo.feesHash,
             "feesPercentage" to reverseSwapPairInfo.feesPercentage,
             "feesLockup" to reverseSwapPairInfo.feesLockup,
-            "feesClaim" to reverseSwapPairInfo.feesClaim
+            "feesClaim" to reverseSwapPairInfo.feesClaim,
+            "feesTotalEstimated" to reverseSwapPairInfo.feesTotalEstimated
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -548,16 +548,12 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         executor.execute {
             val reverseSwapFeesRequest = asReverseSwapFeesRequest(reqData)
 
-            if (reverseSwapFeesRequest == null) {
-                promise.reject(GENERIC_CODE, "Invalid reqData")
-            } else {
-                try {
-                    val reverseSwapFees = getBreezServices().fetchReverseSwapFees(reverseSwapFeesRequest)
-                    promise.resolve(readableMapOf(reverseSwapFees))
-                } catch (e: SdkException) {
-                    e.printStackTrace()
-                    promise.reject(e.javaClass.simpleName, e.message, e)
-                }
+            try {
+                val reverseSwapFees = getBreezServices().fetchReverseSwapFees(reverseSwapFeesRequest)
+                promise.resolve(readableMapOf(reverseSwapFees))
+            } catch (e: SdkException) {
+                e.printStackTrace()
+                promise.reject(e.javaClass.simpleName, e.message, e)
             }
         }
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -544,10 +544,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun fetchReverseSwapFees(promise: Promise) {
+    fun fetchReverseSwapFees(sendAmountSat: Double, promise: Promise) {
         executor.execute {
             try {
-                val reverseSwapFees = getBreezServices().fetchReverseSwapFees()
+                val reverseSwapFees = getBreezServices().fetchReverseSwapFees(sendAmountSat)
                 promise.resolve(readableMapOf(reverseSwapFees))
             } catch (e: SdkException) {
                 e.printStackTrace()

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -544,14 +544,20 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun fetchReverseSwapFees(sendAmountSat: Double, promise: Promise) {
+    fun fetchReverseSwapFees(reqData: ReadableMap, promise: Promise) {
         executor.execute {
-            try {
-                val reverseSwapFees = getBreezServices().fetchReverseSwapFees(sendAmountSat)
-                promise.resolve(readableMapOf(reverseSwapFees))
-            } catch (e: SdkException) {
-                e.printStackTrace()
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            val reverseSwapFeesRequest = asReverseSwapFeesRequest(reqData)
+
+            if (reverseSwapFeesRequest == null) {
+                promise.reject(GENERIC_CODE, "Invalid reqData")
+            } else {
+                try {
+                    val reverseSwapFees = getBreezServices().fetchReverseSwapFees(reverseSwapFeesRequest)
+                    promise.resolve(readableMapOf(reverseSwapFees))
+                } catch (e: SdkException) {
+                    e.printStackTrace()
+                    promise.reject(e.javaClass.simpleName, e.message, e)
+                }
             }
         }
     }

--- a/libs/sdk-react-native/example/App.js
+++ b/libs/sdk-react-native/example/App.js
@@ -102,7 +102,7 @@ const App = () => {
                 const fiatRates = await fetchFiatRates()
                 addLine("fetchFiatRates", JSON.stringify(fiatRates))
 
-                const revSwapFees = await fetchReverseSwapFees()
+                const revSwapFees = await fetchReverseSwapFees(null)
                 addLine("revSwapFees", JSON.stringify(revSwapFees))
 
                 const inProgressRevSwaps = await inProgressReverseSwaps()

--- a/libs/sdk-react-native/example/App.js
+++ b/libs/sdk-react-native/example/App.js
@@ -102,7 +102,7 @@ const App = () => {
                 const fiatRates = await fetchFiatRates()
                 addLine("fetchFiatRates", JSON.stringify(fiatRates))
 
-                const revSwapFees = await fetchReverseSwapFees(null)
+                const revSwapFees = await fetchReverseSwapFees( { sendAmountSat: null } )
                 addLine("revSwapFees", JSON.stringify(revSwapFees))
 
                 const inProgressRevSwaps = await inProgressReverseSwaps()

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -211,6 +211,15 @@ class BreezSDKMapper {
         
         return nil
     }
+
+    static func asReverseSwapFeesRequest(reqData: [String: Any?]) -> ReverseSwapFeesRequest? {
+        if let sendAmountSat = reqData["sendAmountSat"] as? UInt64
+        {
+            return ReverseSwapFeesRequest(sendAmountSat: sendAmountSat)
+        }
+
+        return nil
+    }
     
     static func asReceivePaymentRequest(reqData: [String: Any?]) -> ReceivePaymentRequest? {
         if let amountSats = reqData["amountSats"] as? UInt64,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -212,13 +212,9 @@ class BreezSDKMapper {
         return nil
     }
 
-    static func asReverseSwapFeesRequest(reqData: [String: Any?]) -> ReverseSwapFeesRequest? {
-        if let sendAmountSat = reqData["sendAmountSat"] as? UInt64
-        {
-            return ReverseSwapFeesRequest(sendAmountSat: sendAmountSat)
-        }
-
-        return nil
+    static func asReverseSwapFeesRequest(reqData: [String: Any?]) -> ReverseSwapFeesRequest {
+        let sendAmountSat = reqData["sendAmountSat"] as? UInt64
+        return ReverseSwapFeesRequest(sendAmountSat: sendAmountSat)
     }
     
     static func asReceivePaymentRequest(reqData: [String: Any?]) -> ReceivePaymentRequest? {

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -687,7 +687,7 @@ class BreezSDKMapper {
             "feesPercentage": reverseSwapPairInfo.feesPercentage,
             "feesLockup": reverseSwapPairInfo.feesLockup,
             "feesClaim": reverseSwapPairInfo.feesClaim,
-            "feesTotalEstimated": reverseSwapPairInfo.feesTotalEstimated
+            "totalEstimatedFees": reverseSwapPairInfo.totalEstimatedFees
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -681,7 +681,8 @@ class BreezSDKMapper {
             "feesHash": reverseSwapPairInfo.feesHash,
             "feesPercentage": reverseSwapPairInfo.feesPercentage,
             "feesLockup": reverseSwapPairInfo.feesLockup,
-            "feesClaim": reverseSwapPairInfo.feesClaim
+            "feesClaim": reverseSwapPairInfo.feesClaim,
+            "feesTotalEstimated": reverseSwapPairInfo.feesTotalEstimated
         ]
     }
 

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -186,7 +186,8 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    fetchReverseSwapFees: (RCTPromiseResolveBlock)resolve
+    fetchReverseSwapFees: (NSUInteger*)sendAmountSat
+    resolver: (RCTPromiseResolveBlock)resolve
     rejecter: (RCTPromiseRejectBlock)reject
 )
 

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -186,7 +186,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    fetchReverseSwapFees: (NSUInteger*)sendAmountSat
+    fetchReverseSwapFees: (NSDictionary*)reqData
     resolver: (RCTPromiseResolveBlock)resolve
     rejecter: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -419,7 +419,7 @@ class RNBreezSDK: RCTEventEmitter {
         do {
             let reverseSwapFeesRequest = BreezSDKMapper.asReverseSwapFeesRequest(reqData: req)
             let fees = try getBreezServices().fetchReverseSwapFees(req: reverseSwapFeesRequest)
-            resolve(fees)
+            resolve(BreezSDKMapper.dictionaryOf(reverseSwapPairInfo: fees))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -415,9 +415,9 @@ class RNBreezSDK: RCTEventEmitter {
     }
 
     @objc(fetchReverseSwapFees:rejecter:)
-    func fetchReverseSwapFees(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+    func fetchReverseSwapFees(_ sendAmountSats:UInt64, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            let fees = try getBreezServices().fetchReverseSwapFees()
+            let fees = try getBreezServices().fetchReverseSwapFees(sendAmountSats: sendAmountSats)
             resolve(fees)        
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -415,10 +415,10 @@ class RNBreezSDK: RCTEventEmitter {
     }
 
     @objc(fetchReverseSwapFees:resolver:rejecter:)
-    func fetchReverseSwapFees(_ reqData:[String: Any], resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+    func fetchReverseSwapFees(_ req:[String: Any], resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            let reverseSwapFeesRequest = BreezSDKMapper.asReverseSwapFeesRequest(reqData: reqData)
-            let fees = try getBreezServices().fetchReverseSwapFees(reqData: reverseSwapFeesRequest)
+            let reverseSwapFeesRequest = BreezSDKMapper.asReverseSwapFeesRequest(reqData: req)
+            let fees = try getBreezServices().fetchReverseSwapFees(req: reverseSwapFeesRequest)
             resolve(fees)
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -416,15 +416,12 @@ class RNBreezSDK: RCTEventEmitter {
 
     @objc(fetchReverseSwapFees:resolver:rejecter:)
     func fetchReverseSwapFees(_ reqData:[String: Any], resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        if let reverseSwapFeesRequest = BreezSDKMapper.asReverseSwapFeesRequest(reqData: reqData) {
-            do {
-                let fees = try getBreezServices().fetchReverseSwapFees(reqData: reverseSwapFeesRequest)
-                resolve(fees)
-            } catch let err {
-                rejectErr(err: err, reject: reject)
-            }
-        } else {
-            rejectErr(err: SdkError.Generic(message:"Invalid reqData"), reject: reject)
+        do {
+            let reverseSwapFeesRequest = BreezSDKMapper.asReverseSwapFeesRequest(reqData: reqData)
+            let fees = try getBreezServices().fetchReverseSwapFees(reqData: reverseSwapFeesRequest)
+            resolve(fees)
+        } catch let err {
+            rejectErr(err: err, reject: reject)
         }
     }
 

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -414,13 +414,17 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
-    @objc(fetchReverseSwapFees:rejecter:)
-    func fetchReverseSwapFees(_ sendAmountSats:UInt64, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-        do {
-            let fees = try getBreezServices().fetchReverseSwapFees(sendAmountSats: sendAmountSats)
-            resolve(fees)        
-        } catch let err {
-            rejectErr(err: err, reject: reject)
+    @objc(fetchReverseSwapFees:resolver:rejecter:)
+    func fetchReverseSwapFees(_ reqData:[String: Any], resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        if let reverseSwapFeesRequest = BreezSDKMapper.asReverseSwapFeesRequest(reqData: reqData) {
+            do {
+                let fees = try getBreezServices().fetchReverseSwapFees(reqData: reverseSwapFeesRequest)
+                resolve(fees)
+            } catch let err {
+                rejectErr(err: err, reject: reject)
+            }
+        } else {
+            rejectErr(err: SdkError.Generic(message:"Invalid reqData"), reject: reject)
         }
     }
 

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -416,6 +416,7 @@ export type ReverseSwapPairInfo = {
     feesPercentage: number
     feesLockup: number
     feesClaim: number
+    feesTotalEstimated?: number
 }
 
 export type ReverseSwapInfo = {
@@ -700,8 +701,8 @@ export const refund = async (swapAddress: string, toAddress: string, satPerVbyte
     return response
 }
 
-export const fetchReverseSwapFees = async (): Promise<ReverseSwapPairInfo> => {
-    const response = await BreezSDK.fetchReverseSwapFees()
+export const fetchReverseSwapFees = async (feesTotalEstimated?: number): Promise<ReverseSwapPairInfo> => {
+    const response = await BreezSDK.fetchReverseSwapFees(feesTotalEstimated)
     return response as ReverseSwapPairInfo
 }
 

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -103,6 +103,10 @@ export type OpeningFeeParamsMenu = {
     values: OpeningFeeParams[]
 }
 
+export type ReverseSwapFeesRequest = {
+    sendAmountSat?: number
+}
+
 export type ReceivePaymentRequest = {
     amountSats: number
     description: string
@@ -701,8 +705,8 @@ export const refund = async (swapAddress: string, toAddress: string, satPerVbyte
     return response
 }
 
-export const fetchReverseSwapFees = async (feesTotalEstimated?: number): Promise<ReverseSwapPairInfo> => {
-    const response = await BreezSDK.fetchReverseSwapFees(feesTotalEstimated)
+export const fetchReverseSwapFees = async (req: ReverseSwapFeesRequest): Promise<ReverseSwapPairInfo> => {
+    const response = await BreezSDK.fetchReverseSwapFees(req)
     return response as ReverseSwapPairInfo
 }
 

--- a/libs/sdk-react-native/src/index.tsx
+++ b/libs/sdk-react-native/src/index.tsx
@@ -420,7 +420,7 @@ export type ReverseSwapPairInfo = {
     feesPercentage: number
     feesLockup: number
     feesClaim: number
-    feesTotalEstimated?: number
+    totalEstimatedFees?: number
 }
 
 export type ReverseSwapInfo = {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -123,7 +123,7 @@ pub(crate) async fn handle_command(
             sat_per_byte,
         } => {
             let pair_info = sdk()?
-                .fetch_reverse_swap_fees()
+                .fetch_reverse_swap_fees(None)
                 .await
                 .map_err(|e| anyhow!("Failed to fetch reverse swap fee infos: {e}"))?;
             let rev_swap_res = sdk()?
@@ -136,9 +136,9 @@ pub(crate) async fn handle_command(
                 .await?;
             serde_json::to_string_pretty(&rev_swap_res).map_err(|e| e.into())
         }
-        Commands::FetchOnchainFees {} => {
+        Commands::FetchOnchainFees { send_amount_sat } => {
             let pair_info = sdk()?
-                .fetch_reverse_swap_fees()
+                .fetch_reverse_swap_fees(send_amount_sat)
                 .await
                 .map_err(|e| anyhow!("Failed to fetch reverse swap fee infos: {e}"))?;
             serde_json::to_string_pretty(&pair_info).map_err(|e| e.into())

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -6,7 +6,7 @@ use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
     parse, BreezEvent, BreezServices, BuyBitcoinRequest, CheckMessageRequest, EventListener,
     GreenlightCredentials, PaymentTypeFilter, ReceiveOnchainRequest, ReceivePaymentRequest,
-    SignMessageRequest,
+    ReverseSwapFeesRequest, SignMessageRequest,
 };
 use breez_sdk_core::{Config, GreenlightNodeConfig, NodeConfig};
 use once_cell::sync::OnceCell;
@@ -123,7 +123,9 @@ pub(crate) async fn handle_command(
             sat_per_byte,
         } => {
             let pair_info = sdk()?
-                .fetch_reverse_swap_fees(None)
+                .fetch_reverse_swap_fees(ReverseSwapFeesRequest {
+                    send_amount_sat: None,
+                })
                 .await
                 .map_err(|e| anyhow!("Failed to fetch reverse swap fee infos: {e}"))?;
             let rev_swap_res = sdk()?
@@ -138,7 +140,7 @@ pub(crate) async fn handle_command(
         }
         Commands::FetchOnchainFees { send_amount_sat } => {
             let pair_info = sdk()?
-                .fetch_reverse_swap_fees(send_amount_sat)
+                .fetch_reverse_swap_fees(ReverseSwapFeesRequest { send_amount_sat })
                 .await
                 .map_err(|e| anyhow!("Failed to fetch reverse swap fee infos: {e}"))?;
             serde_json::to_string_pretty(&pair_info).map_err(|e| e.into())

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -69,7 +69,10 @@ pub(crate) enum Commands {
     },
 
     /// Get the current fees for a potential new reverse swap
-    FetchOnchainFees {},
+    FetchOnchainFees {
+        #[clap(name = "amount", short = 'a', long = "amt")]
+        send_amount_sat: Option<u64>,
+    },
 
     /// Get the current blocking in-progress reverse swaps, if any exist
     InProgressReverseSwaps {},


### PR DESCRIPTION
Add utilities around the `send_onchain` feerates:
* `ReverseSwapPairInfo::estimate_amount_sat_received` lets callers estimate how many sats will arrive, based on the sent amount and current fees
* `ReverseSwapPairInfo::estimate_amount_sat_to_send` lets callers estimate how much to send in order to receive a target amount
* `ReverseSwapPairInfo::feerate` estimates which feerate was used in this `ReverseSwapPairInfo`, to give the caller a reference point for the claim tx feerate argument of `send_onchain` (if the fees and estimated amounts are ok, keep the feerate, else increase or decrease)

These are all methods on the `ReverseSwapPairInfo` struct, so no binding or service method was needed.