### PR TITLE
Add correct routing hint in reverse swaps invoice

### DIFF
--- a/libs/sdk-core/src/boltzswap.rs
+++ b/libs/sdk-core/src/boltzswap.rs
@@ -13,7 +13,7 @@ use reqwest::{Body, Client};
 
 use crate::models::ReverseSwapPairInfo;
 use crate::reverseswap::CreateReverseSwapResponse;
-use crate::ReverseSwapperAPI;
+use crate::ReverseSwapServiceAPI;
 
 const BOLTZ_API_URL: &str = "https://boltz.exchange/api/";
 const GET_PAIRS_ENDPOINT: &str = concatcp!(BOLTZ_API_URL, "getpairs");
@@ -160,7 +160,7 @@ pub enum BoltzApiReverseSwapStatus {
 pub struct BoltzApi {}
 
 #[tonic::async_trait]
-impl ReverseSwapperAPI for BoltzApi {
+impl ReverseSwapServiceAPI for BoltzApi {
     async fn fetch_reverse_swap_fees(&self) -> Result<ReverseSwapPairInfo> {
         reverse_swap_pair_info().await
     }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1068,15 +1068,15 @@ impl BreezServices {
             .parse_filters(
                 r#"
                 info,
-                gl_client=info,
+                gl_client=warn,
                 h2=warn,
                 hyper=warn,
                 breez_sdk_core::reverseswap=info,
-                lightning_signer=info,
+                lightning_signer=warn,
                 reqwest=warn,
                 rustls=warn,
                 rustyline=warn,
-                vls_protocol_signer=info
+                vls_protocol_signer=warn
             "#,
             )
             .format(|buf, record| {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -584,19 +584,15 @@ impl BreezServices {
         sat_per_vbyte: u64,
     ) -> Result<ReverseSwapInfo> {
         match self.in_progress_reverse_swaps().await?.is_empty() {
-            true => {
-                let reverse_routing_node = self.btc_send_swapper.reverse_swapper_api.fetch_reverse_routing_node().await?;
-                self.btc_send_swapper
-                    .create_reverse_swap(
-                        amount_sat,
-                        onchain_recipient_address,
-                        pair_hash,
-                        hex::encode(reverse_routing_node),
-                        sat_per_vbyte,
-                    )
-                    .await
-                    .map(Into::into)
-            }
+            true => self.btc_send_swapper
+                .create_reverse_swap(
+                    amount_sat,
+                    onchain_recipient_address,
+                    pair_hash,
+                    sat_per_vbyte,
+                )
+                .await
+                .map(Into::into),
             false => Err(anyhow!(
                 "There already is at least one Reverse Swap in progress. You can only start a new one after after the ongoing ones finish. \
                 Use the in_progress_reverse_swaps method to get an overview of currently ongoing reverse swaps."
@@ -1072,14 +1068,15 @@ impl BreezServices {
             .parse_filters(
                 r#"
                 info,
-                gl_client=warn,
+                gl_client=info,
                 h2=warn,
                 hyper=warn,
-                lightning_signer=warn,
+                breez_sdk_core::reverseswap=info,
+                lightning_signer=info,
                 reqwest=warn,
                 rustls=warn,
                 rustyline=warn,
-                vls_protocol_signer=warn
+                vls_protocol_signer=info
             "#,
             )
             .format(|buf, record| {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1165,7 +1165,7 @@ struct BreezServicesBuilder {
     persister: Option<Arc<SqliteStorage>>,
     swapper_api: Option<Arc<dyn SwapperAPI>>,
     /// Reverse swap functionality on the Breez Server
-    reverse_swapper_api: Option<Arc<dyn ReverseSwapperAPI>>,
+    reverse_swapper_api: Option<Arc<dyn ReverseSwapperRoutingAPI>>,
     /// Reverse swap functionality on the 3rd party reverse swap service
     reverse_swap_service_api: Option<Arc<dyn ReverseSwapServiceAPI>>,
     moonpay_api: Option<Arc<dyn MoonPayApi>>,
@@ -1221,7 +1221,7 @@ impl BreezServicesBuilder {
 
     pub fn reverse_swapper_api(
         &mut self,
-        reverse_swapper_api: Arc<dyn ReverseSwapperAPI>,
+        reverse_swapper_api: Arc<dyn ReverseSwapperRoutingAPI>,
     ) -> &mut Self {
         self.reverse_swapper_api = Some(reverse_swapper_api.clone());
         self

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -390,12 +390,12 @@ impl TryFrom<i32> for ReverseSwapStatus {
 
 /// Trait covering Breez Server reverse swap functionality
 #[tonic::async_trait]
-pub(crate) trait ReverseSwapperAPI: Send + Sync {
+pub(crate) trait ReverseSwapperRoutingAPI: Send + Sync {
     async fn fetch_reverse_routing_node(&self) -> Result<Vec<u8>>;
 }
 
 #[tonic::async_trait]
-impl ReverseSwapperAPI for BreezServer {
+impl ReverseSwapperRoutingAPI for BreezServer {
     async fn fetch_reverse_routing_node(&self) -> Result<Vec<u8>> {
         self.get_swapper_client()
             .await?

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -97,17 +97,20 @@ impl BTCSendSwap {
         amount_sat: u64,
         claim_pubkey: String,
         pair_hash: String,
-        routing_node: String,
         sat_per_vbyte: u64,
     ) -> Result<FullReverseSwapInfo> {
         Self::validate_rev_swap_args(&claim_pubkey)?;
 
+        let reverse_routing_node = self
+            .reverse_swapper_api
+            .fetch_reverse_routing_node()
+            .await?;
         let created_rsi = self
             .create_and_validate_rev_swap_on_remote(
                 amount_sat,
                 claim_pubkey,
                 pair_hash,
-                routing_node,
+                hex::encode(reverse_routing_node),
                 sat_per_vbyte,
             )
             .await?;

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus::*};
 use crate::chain::{get_utxos, ChainService, MempoolSpace};
-use crate::models::{ReverseSwapServiceAPI, ReverseSwapperAPI};
+use crate::models::{ReverseSwapServiceAPI, ReverseSwapperRoutingAPI};
 use crate::ReverseSwapStatus::*;
 use crate::{
     BreezEvent, Config, FullReverseSwapInfo, NodeAPI, ReverseSwapInfoCached, ReverseSwapPairInfo,
@@ -57,7 +57,7 @@ enum TxStatus {
 /// It uses internally an implementation of [ReverseSwapServiceAPI] that represents Boltz reverse swapper service.
 pub(crate) struct BTCSendSwap {
     config: Config,
-    pub(crate) reverse_swapper_api: Arc<dyn ReverseSwapperAPI>,
+    pub(crate) reverse_swapper_api: Arc<dyn ReverseSwapperRoutingAPI>,
     pub(crate) reverse_swap_service_api: Arc<dyn ReverseSwapServiceAPI>,
     persister: Arc<crate::persist::db::SqliteStorage>,
     chain_service: Arc<dyn ChainService>,
@@ -67,7 +67,7 @@ pub(crate) struct BTCSendSwap {
 impl BTCSendSwap {
     pub(crate) fn new(
         config: Config,
-        reverse_swapper_api: Arc<dyn ReverseSwapperAPI>,
+        reverse_swapper_api: Arc<dyn ReverseSwapperRoutingAPI>,
         reverse_swap_service_api: Arc<dyn ReverseSwapServiceAPI>,
         persister: Arc<crate::persist::db::SqliteStorage>,
         chain_service: Arc<MempoolSpace>,

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus::*};
 use crate::chain::{get_utxos, ChainService, MempoolSpace};
-use crate::models::ReverseSwapperAPI;
+use crate::models::{ReverseSwapServiceAPI, ReverseSwapperAPI};
 use crate::ReverseSwapStatus::*;
 use crate::{
     BreezEvent, Config, FullReverseSwapInfo, NodeAPI, ReverseSwapInfoCached, ReverseSwapPairInfo,
@@ -54,10 +54,11 @@ enum TxStatus {
 }
 
 /// This struct is responsible for sending to an onchain address using lightning payments.
-/// It uses internally an implementation of [ReverseSwapperAPI] that represents Boltz reverse swapper service.
+/// It uses internally an implementation of [ReverseSwapServiceAPI] that represents Boltz reverse swapper service.
 pub(crate) struct BTCSendSwap {
     config: Config,
     pub(crate) reverse_swapper_api: Arc<dyn ReverseSwapperAPI>,
+    pub(crate) reverse_swap_service_api: Arc<dyn ReverseSwapServiceAPI>,
     persister: Arc<crate::persist::db::SqliteStorage>,
     chain_service: Arc<dyn ChainService>,
     node_api: Arc<dyn NodeAPI>,
@@ -67,6 +68,7 @@ impl BTCSendSwap {
     pub(crate) fn new(
         config: Config,
         reverse_swapper_api: Arc<dyn ReverseSwapperAPI>,
+        reverse_swap_service_api: Arc<dyn ReverseSwapServiceAPI>,
         persister: Arc<crate::persist::db::SqliteStorage>,
         chain_service: Arc<MempoolSpace>,
         node_api: Arc<dyn NodeAPI>,
@@ -74,6 +76,7 @@ impl BTCSendSwap {
         Self {
             config,
             reverse_swapper_api,
+            reverse_swap_service_api,
             persister,
             chain_service,
             node_api,
@@ -153,8 +156,10 @@ impl BTCSendSwap {
             sleep(Duration::from_secs(5)).await;
 
             info!("Checking reverse swap status, attempt {i}");
-            let reverse_swap_boltz_status =
-                self.reverse_swapper_api.get_boltz_status(id.into()).await?;
+            let reverse_swap_boltz_status = self
+                .reverse_swap_service_api
+                .get_boltz_status(id.into())
+                .await?;
             if let LockTxMempool { transaction: _ } = reverse_swap_boltz_status {
                 return Ok(());
             }
@@ -175,7 +180,7 @@ impl BTCSendSwap {
         let reverse_swap_keys = crate::swap::create_swap_keys()?;
 
         let boltz_response = self
-            .reverse_swapper_api
+            .reverse_swap_service_api
             .create_reverse_swap_on_remote(
                 amount_sat,
                 reverse_swap_keys.preimage_hash_bytes().to_hex(),
@@ -403,7 +408,7 @@ impl BTCSendSwap {
             {
                 Some(_) => Some(InProgress),
                 None => match self
-                    .reverse_swapper_api
+                    .reverse_swap_service_api
                     .get_boltz_status(rsi.id.clone())
                     .await?
                 {
@@ -470,8 +475,10 @@ impl BTCSendSwap {
         Ok(matching_reverse_swaps)
     }
 
-    /// See [ReverseSwapperAPI::fetch_reverse_swap_fees]
+    /// See [ReverseSwapServiceAPI::fetch_reverse_swap_fees]
     pub(crate) async fn fetch_reverse_swap_fees(&self) -> Result<ReverseSwapPairInfo> {
-        self.reverse_swapper_api.fetch_reverse_swap_fees().await
+        self.reverse_swap_service_api
+            .fetch_reverse_swap_fees()
+            .await
     }
 }

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -120,7 +120,7 @@ pub(crate) async fn handle_command(
         Commands::SendOnchain {
             amount_sat,
             onchain_recipient_address,
-            sat_per_byte,
+            sat_per_vbyte: sat_per_byte,
         } => {
             let pair_info = sdk()?
                 .fetch_reverse_swap_fees(ReverseSwapFeesRequest {
@@ -175,7 +175,7 @@ pub(crate) async fn handle_command(
         }
         Commands::Sweep {
             to_address,
-            sat_per_byte,
+            sat_per_vbyte: sat_per_byte,
         } => {
             sdk()?.sweep(to_address, sat_per_byte).await?;
             Ok("Onchain funds were swept succesfully".to_string())

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -65,7 +65,7 @@ pub(crate) enum Commands {
         amount_sat: u64,
         onchain_recipient_address: String,
         /// The fee rate for the claim transaction
-        sat_per_byte: u64,
+        sat_per_vbyte: u64,
     },
 
     /// Get the current fees for a potential new reverse swap
@@ -110,7 +110,7 @@ pub(crate) enum Commands {
         to_address: String,
 
         /// The fee rate for the sweep transaction
-        sat_per_byte: u64,
+        sat_per_vbyte: u64,
     },
 
     /// List available LSPs


### PR DESCRIPTION
This PR changes the routing hint used when creating a new reverse swap. Before it was the LSP node ID, now it is the reverse routing node ID.

Changes include:
* renamed existing `ReverseSwapperAPI` to `ReverseSwapServiceAPI` for consistency. In the case of normal swaps, the `SwapperAPI` is used for `BreezServer` API calls. Therefore, for consistency reasons, it makes sense to reserve the `ReverseSwapperAPI` name for `BreezServer` calls as well.
* introduced `ReverseSwapperAPI` which exposes a simple call to the `BreezServer` API, a [getter for the reverse routing node](https://github.com/breez/breez/blob/7c8560ca2dc18c65e3ccc2b0cd470328ba1d044c/breez/breez.proto#L58)