### PR TITLE
fix sync db swap migration

### DIFF
--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -423,15 +423,15 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
          data BLOB NOT NULL,
          created_at TEXT DEFAULT CURRENT_TIMESTAMP
         ) STRICT;
-       ",
-        // Swaps synchronization: Add sync table that stores the fees used in swaps
-        "
-        CREATE TABLE IF NOT EXISTS sync.swaps_fees (
-         bitcoin_address TEXT PRIMARY KEY NOT NULL,
-         created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
-         channel_opening_fees TEXT NOT NULL
-        ) STRICT;
-        ",
+       ",       
+       // Swaps synchronization: Add sync table that stores the fees used in swaps
+       "
+       CREATE TABLE IF NOT EXISTS sync.swaps_fees (
+        bitcoin_address TEXT PRIMARY KEY NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        channel_opening_fees TEXT NOT NULL
+       ) STRICT;
+       ",    
     ]
 }
 
@@ -443,6 +443,14 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
          payer_amount_msat INTEGER NOT NULL
         ) STRICT;
 
+       ",
+        // Swaps synchronization: Add sync table that stores the fees used in swaps
+        "
+       CREATE TABLE IF NOT EXISTS swaps_fees (
+        bitcoin_address TEXT PRIMARY KEY NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        channel_opening_fees TEXT NOT NULL
+       ) STRICT;
        ",
     ]
 }


### PR DESCRIPTION
The migration for the sync database should go to the sync migration rather than the main db migration so the remote backups can be migrated as well.
I believe this was the issue with the error "table swap_fees not found" that we saw on some devices.
I left the previous migration in the main db so already migrated databases won't fail.