### PR TITLE
Fix rev swap issues causing reverse swaps to not complete

### DIFF
--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -10,10 +10,6 @@ pub trait ChainService: Send + Sync {
     ///
     /// See <https://mempool.space/docs/api/rest#get-address-transactions>
     async fn address_transactions(&self, address: String) -> Result<Vec<OnchainTx>>;
-    /// Gets up to 25 onchain transactions associated with this address.
-    ///
-    /// See <https://mempool.space/docs/api/rest#get-address-transactions-chain>
-    async fn address_transactions_chain(&self, address: String) -> Result<Vec<OnchainTx>>;
     async fn current_tip(&self) -> Result<u32>;
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String>;
 }
@@ -217,16 +213,6 @@ impl ChainService for MempoolSpace {
                 .json()
                 .await?,
         )
-    }
-
-    async fn address_transactions_chain(&self, address: String) -> Result<Vec<OnchainTx>> {
-        Ok(reqwest::get(format!(
-            "{}/api/address/{}/txs/chain",
-            self.base_url, address
-        ))
-        .await?
-        .json()
-        .await?)
     }
 
     async fn current_tip(&self) -> Result<u32> {

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -14,10 +14,6 @@ pub trait ChainService: Send + Sync {
     ///
     /// See <https://mempool.space/docs/api/rest#get-address-transactions-chain>
     async fn address_transactions_chain(&self, address: String) -> Result<Vec<OnchainTx>>;
-    /// Gets up to 50 mempool transactions associated with this address.
-    ///
-    /// See <https://mempool.space/docs/api/rest#get-address-transactions-mempool>
-    async fn address_transactions_mempool(&self, address: String) -> Result<Vec<OnchainTx>>;
     async fn current_tip(&self) -> Result<u32>;
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String>;
 }
@@ -226,16 +222,6 @@ impl ChainService for MempoolSpace {
     async fn address_transactions_chain(&self, address: String) -> Result<Vec<OnchainTx>> {
         Ok(reqwest::get(format!(
             "{}/api/address/{}/txs/chain",
-            self.base_url, address
-        ))
-        .await?
-        .json()
-        .await?)
-    }
-
-    async fn address_transactions_mempool(&self, address: String) -> Result<Vec<OnchainTx>> {
-        Ok(reqwest::get(format!(
-            "{}/api/address/{}/txs/mempool",
             self.base_url, address
         ))
         .await?

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -13,6 +13,7 @@ use anyhow::{anyhow, ensure, Result};
 use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
 use bitcoin::consensus::serialize;
 use bitcoin::hashes::hex::{FromHex, ToHex};
+use bitcoin::psbt::serialize::Serialize as PsbtSerialize;
 use bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
 use bitcoin::util::sighash::SighashCache;
 use bitcoin::{
@@ -47,6 +48,7 @@ pub struct CreateReverseSwapResponse {
     lockup_address: String,
 }
 
+#[derive(Debug)]
 enum TxStatus {
     Unknown,
     Mempool,
@@ -144,26 +146,43 @@ impl BTCSendSwap {
             }
         };
 
-        if res.is_err() {
-            // Failed payment results in a cancelled state
-            self.persister
-                .update_reverse_swap_status(&created_rsi.id, &Cancelled)?;
+        // The result of the creation call can succeed or fail
+        // We update the rev swap status accordingly, which would otherwise have needed a fully fledged sync() call
+        match res {
+            Ok(_) => self
+                .persister
+                .update_reverse_swap_status(&created_rsi.id, &InProgress)?,
+            Err(_) => self
+                .persister
+                .update_reverse_swap_status(&created_rsi.id, &Cancelled)?,
         }
 
         res
     }
 
+    /// Endless loop that periodically polls whether the reverse swap transitioned away from the
+    /// initial status.
+    ///
+    /// The loop returns as soon as the lock tx is seen by Boltz. In other words, it returns as soon as
+    /// the reverse swap status, as reported by Boltz, is [BoltzApiReverseSwapStatus::LockTxMempool]
+    /// or [BoltzApiReverseSwapStatus::LockTxConfirmed]
     async fn poll_initial_boltz_status_transition(&self, id: &str) -> Result<()> {
         let mut i = 0;
         loop {
             sleep(Duration::from_secs(5)).await;
 
-            info!("Checking reverse swap status, attempt {i}");
+            info!("Checking Boltz status for reverse swap {id}, attempt {i}");
             let reverse_swap_boltz_status = self
                 .reverse_swap_service_api
                 .get_boltz_status(id.into())
                 .await?;
-            if let LockTxMempool { transaction: _ } = reverse_swap_boltz_status {
+            info!("Got Boltz status {reverse_swap_boltz_status:?}");
+
+            // Return when lock tx is seen in the mempool or onchain
+            // Typically we first detect when the lock tx is in the mempool
+            // However, if the tx is broadcast and the block is mined between the iterations of this loop,
+            // we might not see the LockTxMempool state and instead directly get the LockTxConfirmed
+            if let LockTxMempool { .. } | LockTxConfirmed { .. } = reverse_swap_boltz_status {
                 return Ok(());
             }
             i += 1;
@@ -239,10 +258,23 @@ impl BTCSendSwap {
 
         match lockup_addr.address_type() {
             Some(AddressType::P2wsh) => {
+                // We explicitly only get the confirmed onchain transactions
+                //
+                // Otherwise, if we had gotten all txs, we risk a race condition when we try
+                // to re-broadcast the claim tx. On re-broadcast, the claim tx is already in the
+                // mempool, so it would be returned in the list below. This however would mark
+                // the utxos as spent, so this address would have a confirmed amount of 0. When
+                // building the claim tx below and trying to subtract fees from the confirmed amount,
+                // this would lead to creating a tx with a negative amount. This doesn't happen
+                // if we restrict this to confirmed txs, because then the mempool claim tx is not returned.
+                //
+                // If the claim tx is confirmed, we would not try to re-broadcast it, so the race
+                // condition only exists when a re-broadcast is tried and the claim tx is unconfirmed.
                 let txs = self
                     .chain_service
-                    .address_transactions(lockup_addr.to_string())
+                    .address_transactions_chain(lockup_addr.to_string())
                     .await?;
+                debug!("Found confirmed txs for lockup address {lockup_addr}: {txs:?}");
                 let utxos = get_utxos(lockup_addr.to_string(), txs)?;
 
                 let confirmed_amount: u64 = utxos
@@ -274,13 +306,15 @@ impl BTCSendSwap {
                     output: tx_out,
                 };
 
-                let claim_script_bytes = serialize(&redeem_script);
+                let claim_script_bytes = PsbtSerialize::serialize(&redeem_script);
 
                 // Based on https://github.com/breez/boltz/blob/master/boltz.go#L31
                 let claim_witness_input_size: u32 = 1 + 1 + 8 + 73 + 1 + 32 + 1 + 100;
                 let tx_weight = tx.strippedsize() as u32 * WITNESS_SCALE_FACTOR as u32
                     + claim_witness_input_size * txins.len() as u32;
                 let fees: u64 = tx_weight as u64 * rs.sat_per_vbyte / WITNESS_SCALE_FACTOR as u64;
+                debug!("Locked confirmed amount: {confirmed_amount}");
+                debug!("Claim tx fees: {fees}");
                 tx.output[0].value = confirmed_amount - fees;
 
                 let scpt = Secp256k1::signing_only();
@@ -338,7 +372,10 @@ impl BTCSendSwap {
                     .chain_service
                     .broadcast_transaction(serialize(&claim_tx))
                     .await;
-                info!("Broadcast claim tx result: {claim_tx_broadcast_res:?}");
+                match claim_tx_broadcast_res {
+                    Ok(txid) => info!("Claim tx was broadcast with txid {txid}"),
+                    Err(e) => error!("Claim tx failed to broadcast: {e}"),
+                }
             }
         }
 
@@ -368,7 +405,6 @@ impl BTCSendSwap {
         }
     }
 
-    /// The lockup tx is seen when it has an incoming tx of the expected amount
     async fn get_lockup_tx_status(&self, rsi: &FullReverseSwapInfo) -> Result<TxStatus> {
         let lockup_addr = rsi.get_lockup_address(self.config.network)?;
         let maybe_lockup_tx = self
@@ -377,18 +413,22 @@ impl BTCSendSwap {
             .await?
             .into_iter()
             .find(|tx| {
-                tx.vin
+                // Lockup tx is identified by having a vout matching the expected rev swap amount
+                trace!("Evaluating tx {tx:#?}");
+                tx.vout
                     .iter()
-                    .any(|vin| vin.prevout.value == rsi.onchain_amount_sat)
+                    .any(|vout| vout.value == rsi.onchain_amount_sat)
             });
 
-        match maybe_lockup_tx {
-            None => Ok(TxStatus::Unknown),
+        let tx_status = match maybe_lockup_tx {
+            None => TxStatus::Unknown,
             Some(tx) => match tx.status.block_height {
-                Some(_) => Ok(TxStatus::Confirmed),
-                None => Ok(TxStatus::Mempool),
+                Some(_) => TxStatus::Confirmed,
+                None => TxStatus::Mempool,
             },
-        }
+        };
+        debug!("Lockup tx status is {tx_status:?} for lockup address {lockup_addr}");
+        Ok(tx_status)
     }
 
     /// Determine the new active status of a monitored reverse swap.

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -270,12 +270,15 @@ impl BTCSendSwap {
                 //
                 // If the claim tx is confirmed, we would not try to re-broadcast it, so the race
                 // condition only exists when a re-broadcast is tried and the claim tx is unconfirmed.
-                let txs = self
+                let confirmed_txs = self
                     .chain_service
-                    .address_transactions_chain(lockup_addr.to_string())
-                    .await?;
-                debug!("Found confirmed txs for lockup address {lockup_addr}: {txs:?}");
-                let utxos = get_utxos(lockup_addr.to_string(), txs)?;
+                    .address_transactions(lockup_addr.to_string())
+                    .await?
+                    .into_iter()
+                    .filter(|tx| tx.status.confirmed)
+                    .collect();
+                debug!("Found confirmed txs for lockup address {lockup_addr}: {confirmed_txs:?}");
+                let utxos = get_utxos(lockup_addr.to_string(), confirmed_txs)?;
 
                 let confirmed_amount: u64 = utxos
                     .confirmed

--- a/libs/sdk-core/src/reverseswap.rs
+++ b/libs/sdk-core/src/reverseswap.rs
@@ -414,10 +414,12 @@ impl BTCSendSwap {
             .into_iter()
             .find(|tx| {
                 // Lockup tx is identified by having a vout matching the expected rev swap amount
-                trace!("Evaluating tx {tx:#?}");
-                tx.vout
-                    .iter()
-                    .any(|vout| vout.value == rsi.onchain_amount_sat)
+                // going to the lockup address (P2WSH)
+                trace!("Checking potential lock tx {tx:#?}");
+                tx.vout.iter().any(|vout| {
+                    vout.value == rsi.onchain_amount_sat
+                        && vout.scriptpubkey_address == lockup_addr.to_string()
+                })
             });
 
         let tx_status = match maybe_lockup_tx {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -181,10 +181,6 @@ impl ChainService for MockChainService {
             .clone())
     }
 
-    async fn address_transactions_chain(&self, _address: String) -> Result<Vec<OnchainTx>> {
-        Ok(vec![])
-    }
-
     async fn current_tip(&self) -> Result<u32> {
         Ok(self.tip)
     }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -185,10 +185,6 @@ impl ChainService for MockChainService {
         Ok(vec![])
     }
 
-    async fn address_transactions_mempool(&self, _address: String) -> Result<Vec<OnchainTx>> {
-        Ok(vec![])
-    }
-
     async fn current_tip(&self) -> Result<u32> {
         Ok(self.tip)
     }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -181,6 +181,14 @@ impl ChainService for MockChainService {
             .clone())
     }
 
+    async fn address_transactions_chain(&self, _address: String) -> Result<Vec<OnchainTx>> {
+        Ok(vec![])
+    }
+
+    async fn address_transactions_mempool(&self, _address: String) -> Result<Vec<OnchainTx>> {
+        Ok(vec![])
+    }
+
     async fn current_tip(&self) -> Result<u32> {
         Ok(self.tip)
     }


### PR DESCRIPTION
This PR brings three fixes to the reverse swap workflow

* Use a more robust way to detect if the lock tx is confirmed: The previous logic caused the lock tx to sometimes not be detected, which caused the workflow to not broadcast the claim tx.
* Switch from `bitcoin::consensus::serialize` to `bitcoin::psbt::serialize` when building the claim tx script: The PSBT version preserves the order of elements that need to be signed, whereas the previous method sometimes did not, leading to occasional `Witness program hash mismatch` errors when broadcasting the claim tx.
* Handle possible race condition when re-broadcasting claim tx: In the situation when the claim tx was broadcast but not confirmed yet (e.g. in the mempool), and a new `Synched` event was triggered, the handling of ongoing reverse swaps would try to re-broadcast the claim tx, but due to a faulty tx lookup logic, it would end up with the claim utxo cancelling out the lock utxo, thus appearing as if there were 0 sats locked. The tx lookup logic was refined to fix this.

and two improvements

* Persist reverse swap state on successful creation: Before, a successful reverse swap creation, a lookup would show it in the state `Initial`. However that's incorrect, as it means the HODL invoice payment is still being attempted. The new state is now persisted, and a lookup after successful creation will show the `InProgress` state.
* Handle edge-case whereby we might not advance the reverse swap in the case of fast mined block: If Boltz broadcasts the lock tx and it gets mined within less than 5 seconds, the previous logic would not have advanced the reverse swap from `Initial` to `InProgress`. Reason is, we were looking for the lock tx in the mempool only. The logic is now expanded to also check onchain.