### PR TITLE
Add CI for publishing React Native plugin

### DIFF
--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -65,7 +65,7 @@ jobs:
       golang-package-version: ${{ inputs.golang-package-version || '0.0.2' }}
       maven-package-version: ${{ inputs.maven-package-version || '0.0.2' }}
       kotlin-mpp-package-version: ${{ inputs.kotlin-mpp-package-version || '0.0.2' }}
-      react-native-package-version: ${{ inputs.react-native-package-version }}
+      react-native-package-version: ${{ inputs.react-native-package-version || '0.0.2' }}
       publish: ${{ inputs.publish }}
     steps:
       - run: echo "set output variables"

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -175,11 +175,11 @@ jobs:
       BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}
       BREEZ_MVN_PASSWORD: ${{ secrets.BREEZ_MVN_PASSWORD }}
 
+  # react native version x.y.z will at runtime require
+  # ios and android packages x.y.z being published already.
   publish-react-native:
     needs:
       - setup
-      - publish-maven
-      # todo: - publish-cocoapods
     if: ${{ needs.setup.outputs.react-native == 'true' }}
     uses: ./.github/workflows/publish-react-native.yml
     with:

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -26,6 +26,10 @@ on:
         description: 'version for the kotlin multiplatform package (MAJOR.MINOR.BUILD)'
         required: false
         type: string
+      react-native-package-version:
+        description: 'version for the react native package (MAJOR.MINOR.BUILD)'
+        required: false
+        type: string
       publish:
         description: 'boolean indicating whether packages should be published. true to publish. false to build only. Default = false.'
         required: false
@@ -54,12 +58,14 @@ jobs:
       golang: ${{ !!inputs.golang-package-version }}
       maven: ${{ !!inputs.maven-package-version }}
       kotlin-mpp: ${{ !!inputs.kotlin-mpp-package-version }}
+      react-native: ${{ !!inputs.react-native-package-version }}
       ref: ${{ inputs.ref || github.sha }}
       csharp-package-version: ${{ inputs.csharp-package-version || '0.0.2' }}
       csharp-ref: ${{ inputs.csharp-ref || inputs.ref || github.sha }}
       golang-package-version: ${{ inputs.golang-package-version || '0.0.2' }}
       maven-package-version: ${{ inputs.maven-package-version || '0.0.2' }}
       kotlin-mpp-package-version: ${{ inputs.kotlin-mpp-package-version || '0.0.2' }}
+      react-native-package-version: ${{ inputs.react-native-package-version }}
       publish: ${{ inputs.publish }}
     steps:
       - run: echo "set output variables"
@@ -168,3 +174,17 @@ jobs:
     secrets:
       BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}
       BREEZ_MVN_PASSWORD: ${{ secrets.BREEZ_MVN_PASSWORD }}
+
+  publish-react-native:
+    needs:
+      - setup
+      - publish-maven
+      # todo: - publish-cocoapods
+    if: ${{ needs.setup.outputs.react-native == 'true' }}
+    uses: ./.github/workflows/publish-react-native.yml
+    with:
+      ref: ${{ needs.setup.outputs.ref }}
+      package-version: ${{ needs.setup.outputs.react-native-package-version }}
+      publish: ${{ needs.setup.outputs.publish == 'true' }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -63,3 +63,16 @@ jobs:
           BREEZ_MVN_PASSWORD: ${{ secrets.BREEZ_MVN_PASSWORD }}
         run: |
           ./gradlew publish -PlibraryVersion=${{ inputs.package-version }} -PbreezReposiliteUsername="$BREEZ_MVN_USERNAME" -PbreezReposilitePassword="$BREEZ_MVN_PASSWORD"
+
+      - name: Trigger Jitpack build
+        if: ${{ inputs.publish }}
+        shell: bash
+        run: |
+          # Jitpack only makes artifacts avaiable when someone requests them.
+          # Here we trick Jitpack into thinking we're already requesting the newly built package
+          # to make sure it is available right away for anyone that needs it later.
+          # We're sleeping for 30s before triggering the Jitpack build to give our Maven repo
+          # some time to process the just uploaded files (the Jitpack build is dependent upon them being available).
+          # If anything fails here, we'll still finish sucessfully as this is an optional optimization.
+          sleep 30s
+          curl -s -m 30 https://jitpack.io/api/builds/com.github.breez/breez-sdk/${{ inputs.package-version }} || true

--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -1,0 +1,52 @@
+name: Publish React Native Plugin
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+      package-version:
+        description: 'version for the npm package (MAJOR.MINOR.BUILD)'
+        required: true
+        type: string
+      publish:
+        description: 'value indicating whether to publish to npm.'
+        required: true
+        type: boolean
+        default: false
+    secrets:
+      NPM_TOKEN:
+        description: 'access token for npm publish'
+        required: true
+
+jobs:
+  build-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout breez-sdk repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@breeztech'
+
+      - name: Make sure we publish the version as specified
+        working-directory: libs/sdk-react-native
+        run: npm --no-git-tag-version --allow-same-version version ${{ inputs.package-version }}
+
+      - name: Install dependencies
+        working-directory: libs/sdk-react-native
+        run: yarn
+
+      - name: Publish package to npm
+        if: ${{ inputs.publish }}
+        working-directory: libs/sdk-react-native
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn publish

--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Make sure we publish the version as specified
         working-directory: libs/sdk-react-native
-        run: npm --no-git-tag-version --allow-same-version version ${{ inputs.package-version }}
+        run: npm --no-git-tag-version --allow-same-version version ${{ inputs.package-version || '0.0.2' }}
 
       - name: Install dependencies
         working-directory: libs/sdk-react-native

--- a/libs/sdk-react-native/android/build.gradle
+++ b/libs/sdk-react-native/android/build.gradle
@@ -1,3 +1,12 @@
+import groovy.json.JsonSlurper
+
+def getVersionFromNpmPackage() {
+    def inputFile = new File("$rootDir/../node_modules/@breeztech/react-native-breez-sdk/package.json")
+    def packageJson = new JsonSlurper().parseText(inputFile.text)
+
+    return packageJson["version"]
+}
+
 buildscript {
     repositories {
         google()
@@ -68,6 +77,6 @@ dependencies {
     // the Android platform versions of JNA (specifically libjnadispatch.so) are missing when downloading the Breez SDK from Jitpack.
     // Thereforew we ignore the version of JNA that comes with the Breez SDK from Jitpack
     // and manually add one that does include the necessary Android platoform binaries.
-    implementation("com.github.breez:breez-sdk:0.1.4") { exclude group:"net.java.dev.jna" } // remove for using locally built bindings during development
+    implementation("com.github.breez:breez-sdk:${getVersionFromNpmPackage()}") { exclude group:"net.java.dev.jna" } // remove for using locally built bindings during development
     implementation("net.java.dev.jna:jna:5.8.0@aar")
 }


### PR DESCRIPTION
Adds CI for uploading the RN plugin to NPM and integrates that into the main "publish all packages" workflow.

⚠️ Note that the [iOS publishing CI is still external](https://github.com/breez/breez-sdk-swift/blob/main/.github/workflows/publish-swift-package.yaml) and that the RN plugin also requires publishing the respective Cocoapod. That means that while we can publish the RN plugin to NPM independently from the iOS workflow being run or not, for the plugin to actually function one also needs to run the iOS publishing workflow. 
👉  We could (and probably should) of course also bring the iOS CI into the main repo to automate all of this this.

This PR also fixes an issue where the Android package dependency was hardcoded in the RN plugin. Now it is dynamically loaded from the RN plugin's `package.json`. This is [also what we do](https://github.com/breez/breez-sdk/blob/main/libs/sdk-react-native/breez_sdk.podspec#L20) for the Cocoapod dependency.