### PR TITLE
Poll for balance changes where hinted.

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -347,7 +347,7 @@ impl NodeAPI for Greenlight {
         };
 
         // calculate the node new balance and in case the caller signals balance has changed
-        // keep pooling until the balance is updated
+        // keep poling until the balance is updated
         let (mut all_channels, mut opened_channels, mut connected_peers, mut channels_balance) =
             self.fetch_channels_and_balance().await?;
         if balance_changed {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -157,7 +157,7 @@ impl Greenlight {
             tls_config,
             gl_client: Mutex::new(None),
             node_client: Mutex::new(None),
-            persister: persister.clone(),
+            persister,
         })
     }
 
@@ -252,13 +252,12 @@ impl Greenlight {
         // filter only connected peers
         let connected_peers: Vec<String> = peers
             .peers
-            .clone()
             .iter()
             .filter(|p| p.connected)
             .map(|p| hex::encode(p.id.clone()))
             .collect();
         let mut all_channels: Vec<pb::Channel> = vec![];
-        peers.peers.clone().iter().for_each(|p| {
+        peers.peers.iter().for_each(|p| {
             let peer_channels = &mut p.channels.clone();
             all_channels.append(peer_channels);
         });
@@ -272,7 +271,6 @@ impl Greenlight {
 
         // calculate channels balance only from opened channels
         let channels_balance = opened_channels
-            .clone()
             .iter()
             .map(|c: &pb::Channel| {
                 amount_to_msat(&parse_amount(c.spendable.clone()).unwrap_or_default())

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -354,7 +354,8 @@ impl NodeAPI for Greenlight {
             if let Some(state) = node_state {
                 let mut retry_count = 0;
                 while state.channels_balance_msat == channels_balance && retry_count < 3 {
-                    warn!("balance update was required but was not updated, retrying...");
+                    warn!("balance update was required but was not updated, retrying in 100ms...");
+                    sleep(Duration::from_millis(100)).await;
                     (
                         all_channels,
                         opened_channels,
@@ -362,7 +363,6 @@ impl NodeAPI for Greenlight {
                         channels_balance,
                     ) = self.fetch_channels_and_balance().await?;
                     retry_count += 1;
-                    sleep(Duration::from_millis(100)).await;
                 }
             }
         }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -51,7 +51,11 @@ pub trait NodeAPI: Send + Sync {
         description: String,
         preimage: Option<Vec<u8>>,
     ) -> Result<Invoice>;
-    async fn pull_changed(&self, since_timestamp: i64) -> Result<SyncResponse>;
+    async fn pull_changed(
+        &self,
+        since_timestamp: i64,
+        balance_changed: bool,
+    ) -> Result<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_sats` is only needed when the invoice doesn't specify an amount
     async fn send_payment(
         &self,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -272,7 +272,11 @@ impl NodeAPI for MockNodeAPI {
         })
     }
 
-    async fn pull_changed(&self, _since_timestamp: i64) -> Result<SyncResponse> {
+    async fn pull_changed(
+        &self,
+        _since_timestamp: i64,
+        _balance_changed: bool,
+    ) -> Result<SyncResponse> {
         Ok(SyncResponse {
             node_state: self.node_state.clone(),
             payments: self

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -588,7 +588,7 @@ pub fn rand_vec_u8(len: usize) -> Vec<u8> {
 
 pub fn create_test_config() -> crate::models::Config {
     let mut conf = Config {
-        ..Config::staging(
+        ..Config::production(
             "".into(),
             crate::NodeConfig::Greenlight {
                 config: crate::GreenlightNodeConfig {


### PR DESCRIPTION
When a payment succeeds (either incoming or outgoing) there is some race in greenlight which results in the list_peers response is not up to date with the new balance.
In order to overcome this we poll in these cases (3 retries seems to be more than enough) until we detect a change in the balance before returning the list of changes.
In addition to minimize the cases where the race even needs a retry, I moved the call to list_peers as the final call in the sync.
We also have experienced in outgoing payments that the `get_completed_payment_by_hash` returned error which is probably a different variant of the same issue where the payment is still pending. The code was changed to use `get_payment_by_hash` which includes pending payments.