### PR TITLE
ci: Add android bindings to publish-golang

### DIFF
--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -45,7 +45,7 @@ jobs:
       windows: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
       darwin: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
       linux: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
-      android: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version }}
+      android: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version || !!inputs.golang-package-version }}
       ios: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version }}
       kotlin: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version }}
       swift: false

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -125,6 +125,7 @@ jobs:
   publish-golang:
     needs: 
       - setup
+      - build-android
       - build-windows
       - build-darwin
       - build-linux

--- a/.github/workflows/publish-golang.yml
+++ b/.github/workflows/publish-golang.yml
@@ -38,6 +38,26 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
+          name: sdk-bindings-i686-linux-android
+          path: breez_sdk/lib/android-386
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-armv7-linux-androideabi
+          path: breez_sdk/lib/android-aarch
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-aarch64-linux-android
+          path: breez_sdk/lib/android-aarch64
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-x86_64-linux-android
+          path: breez_sdk/lib/android-amd64
+
+      - uses: actions/download-artifact@v3
+        with:
           name: sdk-bindings-aarch64-apple-darwin
           path: breez_sdk/lib/darwin-aarch64
 
@@ -67,6 +87,10 @@ jobs:
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
           git add breez_sdk/breez_sdk.go
+          git add breez_sdk/lib/android-386/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/android-aarch/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/android-aarch64/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/android-amd64/libbreez_sdk_bindings.so
           git add breez_sdk/lib/darwin-aarch64/libbreez_sdk_bindings.dylib
           git add breez_sdk/lib/darwin-amd64/libbreez_sdk_bindings.dylib
           git add breez_sdk/lib/linux-aarch64/libbreez_sdk_bindings.so

--- a/.github/workflows/publish-golang.yml
+++ b/.github/workflows/publish-golang.yml
@@ -88,9 +88,13 @@ jobs:
           git config --global user.name github-actions
           git add breez_sdk/breez_sdk.go
           git add breez_sdk/lib/android-386/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/android-386/libc++_shared.so
           git add breez_sdk/lib/android-aarch/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/android-aarch/libc++_shared.so
           git add breez_sdk/lib/android-aarch64/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/android-aarch64/libc++_shared.so
           git add breez_sdk/lib/android-amd64/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/android-amd64/libc++_shared.so
           git add breez_sdk/lib/darwin-aarch64/libbreez_sdk_bindings.dylib
           git add breez_sdk/lib/darwin-amd64/libbreez_sdk_bindings.dylib
           git add breez_sdk/lib/linux-aarch64/libbreez_sdk_bindings.so


### PR DESCRIPTION
This PR updates the publish-golang CI to depend on the build-android job and download the android binding artifacts into the breez-sdk-go repository.

See PR breez/breez-sdk-go#11 which adds the android lib structure to breez-sdk-go.
