### PR TITLE
Open channel fee simplification

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -346,7 +346,7 @@ dictionary LspInformation {
 
 dictionary OpenChannelFeeRequest {
     u64 amount_msat;
-    u64? expiry;
+    u32? expiry;
 };
 
 dictionary OpenChannelFeeResponse {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -12,10 +12,12 @@ dictionary RouteHintHop {
 enum SdkError {
     "Generic",
     "InitFailed",
+    "NotReady",
     "LspConnectFailed",
     "LspOpenChannelNotSupported",
     "PersistenceFailure",
     "ReceivePaymentFailed",
+    "CalculateOpenChannelFeesFailed",
 };
 
 enum EnvironmentType {
@@ -342,6 +344,16 @@ dictionary LspInformation {
     OpeningFeeParamsMenu opening_fee_params_list;
 };
 
+dictionary OpenChannelFeeRequest {
+    u64 amount_msat;
+    u64? expiry;
+};
+
+dictionary OpenChannelFeeResponse {
+    u64 fee_msat;
+    OpeningFeeParams used_fee_params;
+};
+
 enum SwapStatus {
     "Initial",
     "Expired",
@@ -535,6 +547,9 @@ interface BlockingBreezServices {
 
    [Throws=SdkError]
    LspInformation? fetch_lsp_info(string lsp_id);
+
+   [Throws=SdkError]
+   OpenChannelFeeResponse open_channel_fee(OpenChannelFeeRequest req);
 
    [Throws=SdkError]
    string? lsp_id();

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -311,12 +311,12 @@ dictionary ReceivePaymentResponse {
 };
 
 dictionary ReceiveOnchainRequest {
-    OpeningFeeParams? opening_fee_params;
+    OpeningFeeParams? opening_fee_params=null;
 };
 
 dictionary BuyBitcoinRequest {
     BuyBitcoinProvider provider;
-    OpeningFeeParams? opening_fee_params;
+    OpeningFeeParams? opening_fee_params=null;
 };
 
 dictionary BuyBitcoinResponse {
@@ -351,7 +351,7 @@ dictionary OpenChannelFeeRequest {
 
 dictionary OpenChannelFeeResponse {
     u64 fee_msat;
-    OpeningFeeParams used_fee_params;
+    OpeningFeeParams? used_fee_params;
 };
 
 enum SwapStatus {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -346,7 +346,7 @@ dictionary LspInformation {
 
 dictionary OpenChannelFeeRequest {
     u64 amount_msat;
-    u32? expiry;
+    u32? expiry = null;
 };
 
 dictionary OpenChannelFeeResponse {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -300,7 +300,7 @@ dictionary ReceivePaymentRequest {
     sequence<u8>? preimage = null;
     OpeningFeeParams? opening_fee_params = null;
     boolean? use_description_hash = null;
-    u64? expiry = null;
+    u32? expiry = null;
     u32? cltv = null;
 };
 

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -291,7 +291,7 @@ dictionary OpeningFeeParams {
 };
 
 dictionary ReverseSwapFeesRequest {
-    u64? send_amount_sat;
+    u64? send_amount_sat = null;
 };
 
 dictionary ReceivePaymentRequest {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -14,11 +14,12 @@ use breez_sdk_core::{
     InvoicePaidDetails, LNInvoice, LnPaymentDetails, LnUrlAuthRequestData, LnUrlCallbackStatus,
     LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult, LnUrlWithdrawRequestData, LocaleOverrides,
     LocalizedName, LogEntry, LogStream, LspInformation, MessageSuccessActionData, MetadataItem,
-    Network, NodeConfig, NodeState, OpeningFeeParams, OpeningFeeParamsMenu, Payment,
-    PaymentDetails, PaymentFailedData, PaymentType, PaymentTypeFilter, Rate, ReceiveOnchainRequest,
-    ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees, ReverseSwapFeesRequest,
-    ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
-    SignMessageRequest, SignMessageResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
+    Network, NodeConfig, NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse,
+    OpeningFeeParams, OpeningFeeParamsMenu, Payment, PaymentDetails, PaymentFailedData,
+    PaymentType, PaymentTypeFilter, Rate, ReceiveOnchainRequest, ReceivePaymentRequest,
+    ReceivePaymentResponse, RecommendedFees, ReverseSwapFeesRequest, ReverseSwapInfo,
+    ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop, SignMessageRequest,
+    SignMessageResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol,
     UnspentTransactionOutput, UrlSuccessActionData,
 };
 
@@ -235,6 +236,13 @@ impl BlockingBreezServices {
     pub fn lsp_info(&self) -> SdkResult<LspInformation> {
         rt().block_on(self.breez_services.lsp_info())
             .map_err(|e: anyhow::Error| e.into())
+    }
+
+    pub fn open_channel_fee(
+        &self,
+        req: OpenChannelFeeRequest,
+    ) -> SdkResult<OpenChannelFeeResponse> {
+        rt().block_on(self.breez_services.open_channel_fee(req))
     }
 
     pub fn close_lsp_channels(&self) -> SdkResult<()> {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -500,6 +500,10 @@ impl BreezServices {
         get_lsp_by_id(self.persister.clone(), self.lsp_api.clone(), id.as_str()).await
     }
 
+    /// Gets the fees required to open a channel for a given amount.
+    /// If there is no channel needed, returns 0.
+    /// If there is a channel needed, returns the required open channel fees, with a fee params object
+    /// to pass to methods that require a channel open, like receive_payment, or receive_onchain.
     pub async fn open_channel_fee(
         &self,
         req: OpenChannelFeeRequest,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -54,6 +54,9 @@ use crate::swap::BTCReceiveSwap;
 use crate::BuyBitcoinProvider::Moonpay;
 use crate::*;
 
+const SWAP_PAYMENT_FEE_EXPIRY: u64 = 60 * 60 * 24 * 7; // 1 week
+const INVOICE_PAYMENT_FEE_EXPIRY: u64 = 60 * 60; // 1 hours
+
 /// Trait that can be used to react to various [BreezEvent]s emitted by the SDK.
 pub trait EventListener: Send + Sync {
     fn on_event(&self, e: BreezEvent);
@@ -499,6 +502,35 @@ impl BreezServices {
         get_lsp_by_id(self.persister.clone(), self.lsp_api.clone(), id.as_str()).await
     }
 
+    pub async fn open_channel_fee(
+        &self,
+        req: OpenChannelFeeRequest,
+    ) -> SdkResult<OpenChannelFeeResponse> {
+        let lsp_info = self.lsp_info().await?;
+        let used_fee_params =
+            lsp_info.cheapest_open_channel_fee(req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY))?;
+
+        // get the node state to fetch the current inbound liquidity.
+        let node_state = self.persister.get_node_state()?.ok_or(SdkError::NotReady {
+            err: "Failed to read node state".to_string(),
+        })?;
+
+        // In case we have enough inbound liquidity we return zero fee.
+        if node_state.inbound_liquidity_msats >= req.amount_msat {
+            return Ok(OpenChannelFeeResponse {
+                fee_msat: 0,
+                used_fee_params: used_fee_params.clone(),
+            });
+        }
+
+        let fee_msat = used_fee_params.get_channel_fees_msat_for(req.amount_msat);
+
+        Ok(OpenChannelFeeResponse {
+            fee_msat,
+            used_fee_params: used_fee_params.clone(),
+        })
+    }
+
     /// Close all channels with the current LSP.
     ///
     /// Should be called  when the user wants to close all the channels.
@@ -528,10 +560,15 @@ impl BreezServices {
                   in_progress.bitcoin_address
               )));
         }
-        let channel_opening_fees = self
-            .lsp_info()
-            .await?
-            .choose_channel_opening_fees(req.opening_fee_params, DynamicFeeType::Longest)?;
+        let channel_opening_fees = match req.opening_fee_params {
+            Some(fee_params) => fee_params,
+            None => self
+                .lsp_info()
+                .await?
+                .cheapest_open_channel_fee(SWAP_PAYMENT_FEE_EXPIRY)?
+                .clone(),
+        };
+
         let swap_info = self
             .btc_receive_swapper
             .create_swap_address(channel_opening_fees)
@@ -1507,6 +1544,7 @@ impl Receiver for PaymentReceiver {
             .get_node_state()?
             .ok_or("Failed to retrieve node state")
             .map_err(|err| anyhow!(err))?;
+        let expiry = req_data.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY);
 
         let amount_sats = req_data.amount_sats;
         let amount_msats = amount_sats * 1000;
@@ -1523,10 +1561,11 @@ impl Receiver for PaymentReceiver {
             info!("We need to open a channel");
 
             // we need to open channel so we are calculating the fees for the LSP (coming either from the user, or from the LSP)
-            let ofp = lsp_info.choose_channel_opening_fees(
-                req_data.opening_fee_params,
-                DynamicFeeType::Cheapest,
-            )?;
+            let ofp = match req_data.opening_fee_params {
+                Some(fee_params) => fee_params,
+                None => lsp_info.cheapest_open_channel_fee(expiry)?.clone(),
+            };
+
             channel_opening_fee_params = Some(ofp.clone());
             channel_fees_msat = Some(ofp.get_channel_fees_msat_for(amount_msats));
             if let Some(channel_fees_msat) = channel_fees_msat {
@@ -1575,7 +1614,7 @@ impl Receiver for PaymentReceiver {
                 req_data.description,
                 req_data.preimage,
                 req_data.use_description_hash,
-                req_data.expiry,
+                Some(expiry),
                 req_data.cltv,
             )
             .await?;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -46,6 +46,7 @@ use crate::models::{
     parse_short_channel_id, ChannelState, ClosedChannelPaymentDetails, Config, EnvironmentType,
     FiatAPI, LnUrlCallbackStatus, LspAPI, NodeAPI, NodeState, Payment, PaymentDetails, PaymentType,
     PaymentTypeFilter, ReverseSwapPairInfo, ReverseSwapServiceAPI, SwapInfo, SwapperAPI,
+    INVOICE_PAYMENT_FEE_EXPIRY,
 };
 use crate::moonpay::MoonPayApi;
 use crate::persist::db::SqliteStorage;
@@ -53,9 +54,6 @@ use crate::reverseswap::BTCSendSwap;
 use crate::swap::BTCReceiveSwap;
 use crate::BuyBitcoinProvider::Moonpay;
 use crate::*;
-
-const SWAP_PAYMENT_FEE_EXPIRY: u64 = 60 * 60 * 24 * 7; // 1 week
-const INVOICE_PAYMENT_FEE_EXPIRY: u64 = 60 * 60; // 1 hours
 
 /// Trait that can be used to react to various [BreezEvent]s emitted by the SDK.
 pub trait EventListener: Send + Sync {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1578,7 +1578,7 @@ impl Receiver for PaymentReceiver {
                     });
                 }
                 // remove the fees from the amount to get the small amount on the current node invoice.
-                destination_invoice_amount_sats = amount_sats - channel_fees_msat / 1000;
+                destination_invoice_amount_sats = (amount_msats - channel_fees_msat) / 1000;
             }
         } else {
             // not opening a channel so we need to get the real channel id into the routing hints

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1,6 +1,5 @@
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::ops::Add;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -10,7 +9,7 @@ use bip39::*;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::util::bip32::ChildNumber;
-use chrono::{Local, Utc};
+use chrono::Local;
 use log::{LevelFilter, Metadata, Record};
 use serde_json::json;
 use tokio::sync::{mpsc, watch, Mutex};
@@ -1546,20 +1545,6 @@ impl Receiver for PaymentReceiver {
         let expiry = req_data
             .expiry
             .unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS);
-
-        // Validate opening_fee_params in case were given as input
-        if let Some(fee_params) = req_data.opening_fee_params.clone() {
-            let invoice_expiration = Utc::now().add(chrono::Duration::seconds(expiry as i64));
-            if !fee_params.valid_for(expiry)? {
-                return Err(SdkError::ReceivePaymentFailed {
-                    err: format!(
-                        "The given open channel fee expires at ({}) which is before invoice expiry: {}",
-                        fee_params.valid_until_date()?,
-                        invoice_expiration.to_rfc3339(),
-                    ),
-                });
-            }
-        }
 
         let amount_sats = req_data.amount_sats;
         let amount_msats = amount_sats * 1000;

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -735,7 +735,7 @@ pub struct wire_ReceivePaymentRequest {
     preimage: *mut wire_uint_8_list,
     opening_fee_params: *mut wire_OpeningFeeParams,
     use_description_hash: *mut bool,
-    expiry: *mut u64,
+    expiry: *mut u32,
     cltv: *mut u32,
 }
 

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -12,11 +12,17 @@ pub enum SdkError {
     #[error("Failed to initialize the SDK: {err}")]
     InitFailed { err: String },
 
+    #[error("SDK is not ready: {err}")]
+    NotReady { err: String },
+
     #[error("Failed to communicate with the LSP API: {err}")]
     LspConnectFailed { err: String },
 
     #[error("LSP doesn't support opening a new channel: {err}")]
     LspOpenChannelNotSupported { err: String },
+
+    #[error("Failed to calculate channel opening fee: {err}")]
+    CalculateOpenChannelFeesFailed { err: String },
 
     #[error("Failed to use the local DB for persistence: {err}")]
     PersistenceFailure { err: String },

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -292,7 +292,7 @@ impl NodeAPI for Greenlight {
         description: String,
         preimage: Option<Vec<u8>>,
         use_description_hash: Option<bool>,
-        expiry: Option<u64>,
+        expiry: Option<u32>,
         cltv: Option<u32>,
     ) -> Result<String> {
         let mut client = self.get_node_client().await?;
@@ -311,7 +311,7 @@ impl NodeAPI for Greenlight {
             description,
             preimage,
             deschashonly: use_description_hash,
-            expiry,
+            expiry: expiry.map(|e| e as u64),
             fallbacks: vec![],
             cltv,
         };

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -188,7 +188,7 @@ mod tests {
 
         // Test that the fee is returned even after the expiry
         let fee = lsp_info.cheapest_open_channel_fee(4 * 3600 - 1000).unwrap();
-        assert_eq!(fee.min_msat, 2 as u64);
+        assert_eq!(fee.min_msat, 2);
 
         // Test the correct error when there are no fees in the menu
         lsp_info.opening_fee_params_list = OpeningFeeParamsMenu { values: vec![] };

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -1,5 +1,3 @@
-use std::ops::Add;
-
 use crate::breez_services::BreezServer;
 use crate::crypt::encrypt;
 use crate::error::{SdkError, SdkResult};
@@ -8,7 +6,6 @@ use crate::grpc::{
 };
 use crate::models::{LspAPI, OpeningFeeParams, OpeningFeeParamsMenu};
 use anyhow::Result;
-use chrono::{Duration, Utc};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use tonic::Request;
@@ -86,9 +83,9 @@ impl LspInformation {
             });
         }
         for fee in &self.opening_fee_params_list.values {
-            match fee.valid_until_date() {
-                Ok(valid_until) => {
-                    if valid_until > Utc::now().add(Duration::seconds(expiry as i64)) {
+            match fee.valid_for(expiry) {
+                Ok(valid) => {
+                    if valid {
                         return Ok(fee);
                     }
                 }
@@ -156,7 +153,7 @@ mod tests {
     #[test]
     fn test_cheapest_open_channel_fee() -> Result<()> {
         let mut tested_fees: Vec<OpeningFeeParams> = vec![];
-        for i in 0..3 {
+        for i in 1..3 {
             tested_fees.push(OpeningFeeParams {
                 min_msat: i,
                 proportional: i as u32,

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -77,11 +77,6 @@ impl LspInformation {
     /// If the LSP fees are needed, the LSP is expected to have at least one dynamic fee entry in its menu,
     /// otherwise this will result in an error.
     pub(crate) fn cheapest_open_channel_fee(&self, expiry: u32) -> SdkResult<&OpeningFeeParams> {
-        if self.opening_fee_params_list.values.is_empty() {
-            return Err(SdkError::LspOpenChannelNotSupported {
-                err: "Dynamic fees menu contains no values".to_string(),
-            });
-        }
         for fee in &self.opening_fee_params_list.values {
             match fee.valid_for(expiry) {
                 Ok(valid) => {
@@ -94,9 +89,10 @@ impl LspInformation {
                 }
             }
         }
-
-        Err(SdkError::CalculateOpenChannelFeesFailed {
-            err: format!("There is no fee option that is valid for {expiry} seconds"),
+        self.opening_fee_params_list.values.last().ok_or_else(|| {
+            SdkError::LspOpenChannelNotSupported {
+                err: "Dynamic fees menu contains no values".to_string(),
+            }
         })
     }
 }
@@ -190,17 +186,9 @@ mod tests {
             assert_eq!(fee.min_msat, expiry as u64);
         }
 
-        // Test that the fee is not valid after the expiry
-        if let SdkError::CalculateOpenChannelFeesFailed { err } =
-            lsp_info.cheapest_open_channel_fee(4 * 3600).err().unwrap()
-        {
-            assert_eq!(
-                err,
-                "There is no fee option that is valid for 14400 seconds"
-            );
-        } else {
-            panic!("Expected CalculateOpenChannelFeesFailed error");
-        }
+        // Test that the fee is returned even after the expiry
+        let fee = lsp_info.cheapest_open_channel_fee(4 * 3600 - 1000).unwrap();
+        assert_eq!(fee.min_msat, 2 as u64);
 
         // Test the correct error when there are no fees in the menu
         lsp_info.opening_fee_params_list = OpeningFeeParamsMenu { values: vec![] };

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -79,7 +79,7 @@ impl LspInformation {
     ///
     /// If the LSP fees are needed, the LSP is expected to have at least one dynamic fee entry in its menu,
     /// otherwise this will result in an error.
-    pub(crate) fn cheapest_open_channel_fee(&self, expiry: u64) -> SdkResult<&OpeningFeeParams> {
+    pub(crate) fn cheapest_open_channel_fee(&self, expiry: u32) -> SdkResult<&OpeningFeeParams> {
         for fee in &self.opening_fee_params_list.values {
             match fee.valid_until_date() {
                 Ok(valid_until) => {

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -92,9 +92,12 @@ impl LspInformation {
                 }
             }
         }
-        Err(SdkError::CalculateOpenChannelFeesFailed {
-            err: "No matching opening channel fee found".to_string(),
-        })
+        self.opening_fee_params_list
+            .values
+            .last()
+            .ok_or(SdkError::CalculateOpenChannelFeesFailed {
+                err: "No matching opening channel fee found".to_string(),
+            })
     }
 }
 

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -95,9 +95,11 @@ impl LspInformation {
         self.opening_fee_params_list
             .values
             .last()
-            .ok_or(SdkError::CalculateOpenChannelFeesFailed {
-                err: "No matching opening channel fee found".to_string(),
-            })
+            .ok_or(SdkError::LspOpenChannelNotSupported {
+            err:
+                "The LSP doesn't support opening new channels: Dynamic fees menu contains no values"
+                    .to_string(),
+        })
     }
 }
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1194,6 +1194,6 @@ mod tests {
     fn test_dynamic_fee_valid_until_format() -> Result<()> {
         let mut ofp: OpeningFeeParams = get_test_ofp(1, 1, true).into();
         ofp.valid_until = "2023-08-03T00:30:35.117Z".to_string();
-        ofp.validate()
+        ofp.valid_until_date().map(|_| ())
     }
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -727,7 +727,7 @@ pub struct OpenChannelFeeRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenChannelFeeResponse {
     pub fee_msat: u64,
-    pub used_fee_params: OpeningFeeParams,
+    pub used_fee_params: Option<OpeningFeeParams>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -34,8 +34,8 @@ use crate::breez_services::BreezServer;
 use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
 
-pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 7; // 1 week
-pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 1 hours
+pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
+pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 1 hour
 
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -34,6 +34,9 @@ use crate::breez_services::BreezServer;
 use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
 
+pub const SWAP_PAYMENT_FEE_EXPIRY: u64 = 60 * 60 * 24 * 7; // 1 week
+pub const INVOICE_PAYMENT_FEE_EXPIRY: u64 = 60 * 60; // 1 hours
+
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]
 pub enum PaymentType {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1,3 +1,4 @@
+use std::ops::Add;
 use std::str::FromStr;
 
 use anyhow::{anyhow, ensure, Result};
@@ -8,7 +9,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
 use bitcoin::{Address, Script};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use gl_client::pb::WithdrawResponse;
 use lightning_invoice::RawInvoice;
 use ripemd::Digest;
@@ -769,6 +770,10 @@ impl OpeningFeeParams {
         DateTime::parse_from_rfc3339(&self.valid_until)
             .map_err(|e| anyhow!(e))
             .map(|d| d.with_timezone(&Utc))
+    }
+
+    pub(crate) fn valid_for(&self, expiry: u32) -> Result<bool> {
+        Ok(self.valid_until_date()? > Utc::now().add(Duration::seconds(expiry as i64)))
     }
 
     pub(crate) fn get_channel_fees_msat_for(&self, amount_msats: u64) -> u64 {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -36,7 +36,7 @@ use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
 
 pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
-pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 30; // 30 minutes
+pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 36; // 60 minutes
 
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -36,7 +36,7 @@ use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
 
 pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
-pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 1 hour
+pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 30; // 30 minutes
 
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -34,8 +34,8 @@ use crate::breez_services::BreezServer;
 use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
 
-pub const SWAP_PAYMENT_FEE_EXPIRY: u64 = 60 * 60 * 24 * 7; // 1 week
-pub const INVOICE_PAYMENT_FEE_EXPIRY: u64 = 60 * 60; // 1 hours
+pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u64 = 60 * 60 * 24 * 7; // 1 week
+pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u64 = 60 * 60; // 1 hours
 
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -715,6 +715,17 @@ pub struct ReceivePaymentResponse {
     pub opening_fee_msat: Option<u64>,
 }
 
+pub struct OpenChannelFeeRequest {
+    pub amount_msat: u64,
+    pub expiry: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OpenChannelFeeResponse {
+    pub fee_msat: u64,
+    pub used_fee_params: OpeningFeeParams,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceiveOnchainRequest {
     pub opening_fee_params: Option<OpeningFeeParams>,
@@ -751,11 +762,6 @@ pub struct OpeningFeeParams {
 }
 
 impl OpeningFeeParams {
-    /// Simple validation: checks if `valid_until` is a valid date
-    pub(crate) fn validate(&self) -> Result<()> {
-        self.valid_until_date().map(|_| ())
-    }
-
     pub(crate) fn valid_until_date(&self) -> Result<DateTime<Utc>> {
         DateTime::parse_from_rfc3339(&self.valid_until)
             .map_err(|e| anyhow!(e))

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -36,7 +36,7 @@ use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
 
 pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
-pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 36; // 60 minutes
+pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 60 minutes
 
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -34,8 +34,8 @@ use crate::breez_services::BreezServer;
 use crate::error::{SdkError, SdkResult};
 use strum_macros::{Display, EnumString};
 
-pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u64 = 60 * 60 * 24 * 7; // 1 week
-pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u64 = 60 * 60; // 1 hours
+pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 7; // 1 week
+pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 1 hours
 
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]
@@ -54,7 +54,7 @@ pub trait NodeAPI: Send + Sync {
         description: String,
         preimage: Option<Vec<u8>>,
         use_description_hash: Option<bool>,
-        expiry: Option<u64>,
+        expiry: Option<u32>,
         cltv: Option<u32>,
     ) -> Result<String>;
     async fn pull_changed(
@@ -705,7 +705,7 @@ pub struct ReceivePaymentRequest {
     /// If set to true, then the bolt11 invoice returned includes the description hash.
     pub use_description_hash: Option<bool>,
     /// if specified, set the time the invoice is valid for, in seconds.
-    pub expiry: Option<u64>,
+    pub expiry: Option<u32>,
     /// if specified, sets the min_final_cltv_expiry for the invoice
     pub cltv: Option<u32>,
 }
@@ -720,7 +720,7 @@ pub struct ReceivePaymentResponse {
 
 pub struct OpenChannelFeeRequest {
     pub amount_msat: u64,
-    pub expiry: Option<u64>,
+    pub expiry: Option<u32>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::binding::parse_invoice;
 use crate::chain::{get_utxos, AddressUtxos, ChainService, MempoolSpace, OnchainTx};
 use crate::grpc::{AddFundInitRequest, GetSwapPaymentRequest};
-use crate::{OpeningFeeParams, ReceivePaymentRequest};
+use crate::{OpeningFeeParams, ReceivePaymentRequest, SWAP_PAYMENT_FEE_EXPIRY};
 use anyhow::{anyhow, Result};
 use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
 use bitcoin::blockdata::opcodes;
@@ -400,9 +400,9 @@ impl BTCReceiveSwap {
                     amount_sats: swap_info.confirmed_sats,
                     description: String::from("Bitcoin Transfer"),
                     preimage: Some(swap_info.preimage),
-                    opening_fee_params: None,
+                    opening_fee_params: swap_info.channel_opening_fees,
                     use_description_hash: Some(false),
-                    expiry: None,
+                    expiry: Some(SWAP_PAYMENT_FEE_EXPIRY),
                     cltv: None,
                 })
                 .await?

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::binding::parse_invoice;
 use crate::chain::{get_utxos, AddressUtxos, ChainService, MempoolSpace, OnchainTx};
 use crate::grpc::{AddFundInitRequest, GetSwapPaymentRequest};
-use crate::{OpeningFeeParams, ReceivePaymentRequest, SWAP_PAYMENT_FEE_EXPIRY};
+use crate::{OpeningFeeParams, ReceivePaymentRequest, SWAP_PAYMENT_FEE_EXPIRY_SECONDS};
 use anyhow::{anyhow, Result};
 use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
 use bitcoin::blockdata::opcodes;
@@ -402,7 +402,7 @@ impl BTCReceiveSwap {
                     preimage: Some(swap_info.preimage),
                     opening_fee_params: swap_info.channel_opening_fees,
                     use_description_hash: Some(false),
-                    expiry: Some(SWAP_PAYMENT_FEE_EXPIRY),
+                    expiry: Some(SWAP_PAYMENT_FEE_EXPIRY_SECONDS),
                     cltv: None,
                 })
                 .await?

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -647,7 +647,7 @@ fn sign_invoice(invoice: RawInvoice) -> String {
 
 /// [OpeningFeeParams] that are valid for more than 48h
 pub(crate) fn get_test_ofp_48h(min_msat: u64, proportional: u32) -> crate::grpc::OpeningFeeParams {
-    get_test_ofp_generic(min_msat, proportional, true, chrono::Duration::days(3))
+    get_test_ofp_generic(min_msat, proportional, true, chrono::Duration::days(10))
 }
 
 /// [OpeningFeeParams] with 1 minute in the future or the past

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -255,7 +255,7 @@ impl NodeAPI for MockNodeAPI {
         description: String,
         preimage: Option<Vec<u8>>,
         _use_description_hash: Option<bool>,
-        _expiry: Option<u64>,
+        _expiry: Option<u32>,
         _cltv: Option<u32>,
     ) -> Result<String> {
         let invoice = create_invoice(description, amount_sats * 1000, vec![], preimage);

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -3,6 +3,10 @@
 #include <stdlib.h>
 typedef struct _Dart_Handle* Dart_Handle;
 
+#define SWAP_PAYMENT_FEE_EXPIRY_SECONDS (((60 * 60) * 24) * 7)
+
+#define INVOICE_PAYMENT_FEE_EXPIRY_SECONDS (60 * 60)
+
 #define ESTIMATED_CLAIM_TX_VSIZE 138
 
 #define ESTIMATED_LOCKUP_TX_VSIZE 153
@@ -78,7 +82,7 @@ typedef struct wire_ReceivePaymentRequest {
   struct wire_uint_8_list *preimage;
   struct wire_OpeningFeeParams *opening_fee_params;
   bool *use_description_hash;
-  uint64_t *expiry;
+  uint32_t *expiry;
   uint32_t *cltv;
 } wire_ReceivePaymentRequest;
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -3362,7 +3362,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.preimage = api2wire_opt_uint_8_list(apiObj.preimage);
     wireObj.opening_fee_params = api2wire_opt_box_autoadd_opening_fee_params(apiObj.openingFeeParams);
     wireObj.use_description_hash = api2wire_opt_box_autoadd_bool(apiObj.useDescriptionHash);
-    wireObj.expiry = api2wire_opt_box_autoadd_u64(apiObj.expiry);
+    wireObj.expiry = api2wire_opt_box_autoadd_u32(apiObj.expiry);
     wireObj.cltv = api2wire_opt_box_autoadd_u32(apiObj.cltv);
   }
 
@@ -4424,7 +4424,7 @@ class wire_ReceivePaymentRequest extends ffi.Struct {
 
   external ffi.Pointer<ffi.Bool> use_description_hash;
 
-  external ffi.Pointer<ffi.Uint64> expiry;
+  external ffi.Pointer<ffi.Uint32> expiry;
 
   external ffi.Pointer<ffi.Uint32> cltv;
 }
@@ -4490,6 +4490,10 @@ class wire_ReverseSwapFeesRequest extends ffi.Struct {
 typedef DartPostCObjectFnType
     = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message)>>;
 typedef DartPort = ffi.Int64;
+
+const int SWAP_PAYMENT_FEE_EXPIRY_SECONDS = 604800;
+
+const int INVOICE_PAYMENT_FEE_EXPIRY_SECONDS = 3600;
 
 const int ESTIMATED_CLAIM_TX_VSIZE = 138;
 

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -194,6 +194,18 @@ pub(crate) async fn handle_command(
             sdk()?.connect_lsp(lsp_id).await?;
             Ok("LSP connected succesfully".to_string())
         }
+        Commands::OpenChannelFee {
+            amount_msat,
+            expiry,
+        } => {
+            let res = sdk()?
+                .open_channel_fee(breez_sdk_core::OpenChannelFeeRequest {
+                    amount_msat,
+                    expiry,
+                })
+                .await?;
+            serde_json::to_string_pretty(&res).map_err(|e| e.into())
+        }
         Commands::NodeInfo {} => {
             serde_json::to_string_pretty(&sdk()?.node_info()?).map_err(|e| e.into())
         }

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -131,6 +131,14 @@ pub(crate) enum Commands {
         lsp_id: String,
     },
 
+    OpenChannelFee {
+        /// The received amount
+        amount_msat: u64,
+
+        /// The expiration of the fee returned
+        expiry: Option<u64>,
+    },
+
     /// The up to date node information
     NodeInfo {},
 

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -55,7 +55,7 @@ pub(crate) enum Commands {
         #[clap(name = "use_description_hash", short = 's', long = "desc_hash")]
         use_description_hash: Option<bool>,
         #[clap(name = "expiry", short = 'e', long = "expiry")]
-        expiry: Option<u64>,
+        expiry: Option<u32>,
         #[clap(name = "cltv", short = 'c', long = "cltv")]
         cltv: Option<u32>,
     },
@@ -136,7 +136,7 @@ pub(crate) enum Commands {
         amount_msat: u64,
 
         /// The expiration of the fee returned
-        expiry: Option<u64>,
+        expiry: Option<u32>,
     },
 
     /// The up to date node information


### PR DESCRIPTION
This PR simplifies the user experience when dealing with open channel fees.
We expose a new method:
pseudo: `open_channel_fee(amount, expiry)` which returns the absolute amount and the fee params used for the calculation. The rational is that the fee params can be used on the next step to create the invoice so the user fee that were promised holds.
It simplify because the users don't need anymore to calculate the amount themselves (which we saw can be tricky) and don't need to implement the select logic for the lsp fees.