### PR TITLE
Fix clippy warning regarding workspace versions

### DIFF
--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "sdk-core",
   "sdk-bindings",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.4"


### PR DESCRIPTION
Before this, `clippy` would show the warning

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

The v2 resolver is the default when setting `edition = 2021` in the `Cargo.toml`, but workspaces still used v1 for backward compatibility for a while. Now we had two conflicting versions (v1 for the workspace, v2 for the individual modules each with their own `Cargo.toml`). Setting it to v2 in the workspace gets rid of this version conflict.