### PR TITLE
Decouple log settings from connect

### DIFF
--- a/libs/sdk-bindings/bindings-csharp/test/Program.cs
+++ b/libs/sdk-bindings/bindings-csharp/test/Program.cs
@@ -3,30 +3,30 @@ using Breez.Sdk;
 
 try
 {
- var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
- BreezSdkMethods.SetLogStream(new LogStreamListener());
- var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
- BlockingBreezServices sdkServices = BreezSdkMethods.Connect(config, seed, new SDKListener());
- NodeState? nodeInfo = sdkServices.NodeInfo();
- Console.WriteLine(nodeInfo!.id);
+    var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
+    BreezSdkMethods.SetLogListener(new LogStreamListener());
+    var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
+    BlockingBreezServices sdkServices = BreezSdkMethods.Connect(config, seed, new SDKListener());
+    NodeState? nodeInfo = sdkServices.NodeInfo();
+    Console.WriteLine(nodeInfo!.id);
 }
 catch (Exception e)
 {
- Console.WriteLine(e.Message);
+    Console.WriteLine(e.Message);
 }
 
 class SDKListener : EventListener
 {
- public void OnEvent(BreezEvent e)
- {
-  Console.WriteLine("received event " + e);
- }
+    public void OnEvent(BreezEvent e)
+    {
+        Console.WriteLine("received event " + e);
+    }
 }
 
 class LogStreamListener : LogStream
 {
- public void Log(LogEntry l)
- {
-  Console.WriteLine(l.line);
- }
+    public void Log(LogEntry l)
+    {
+        Console.WriteLine(l.line);
+    }
 }

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -600,7 +600,10 @@ namespace breez_sdk {
  BlockingBreezServices connect(Config config, sequence<u8> seed, EventListener listener);
 
  [Throws=SdkError]
- void set_log_stream(LogStream log_stream);
+ void set_log_listener(LogStream log_stream);
+
+ [Throws=SdkError]
+ void set_log_directory(string log_directory);
 
  [Throws=SdkError]
  LNInvoice parse_invoice(string invoice);

--- a/libs/sdk-bindings/tests/bindings/csharp/Program.cs
+++ b/libs/sdk-bindings/tests/bindings/csharp/Program.cs
@@ -3,30 +3,30 @@ using Breez.Sdk;
 
 try
 {
- var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
- BreezSdkMethods.SetLogStream(new LogStreamListener());
- var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
- BlockingBreezServices sdkServices = BreezSdkMethods.Connect(config, seed, new SDKListener());
- NodeState? nodeInfo = sdkServices.NodeInfo();
- Console.WriteLine(nodeInfo!.id);
+    var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
+    BreezSdkMethods.SetLogListener(new LogStreamListener());
+    var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
+    BlockingBreezServices sdkServices = BreezSdkMethods.Connect(config, seed, new SDKListener());
+    NodeState? nodeInfo = sdkServices.NodeInfo();
+    Console.WriteLine(nodeInfo!.id);
 }
 catch (Exception e)
 {
- Console.WriteLine(e.Message);
+    Console.WriteLine(e.Message);
 }
 
 class SDKListener : EventListener
 {
- public void OnEvent(BreezEvent e)
- {
-  Console.WriteLine("received event " + e);
- }
+    public void OnEvent(BreezEvent e)
+    {
+        Console.WriteLine("received event " + e);
+    }
 }
 
 class LogStreamListener : LogStream
 {
- public void Log(LogEntry l)
- {
-  Console.WriteLine(l.line);
- }
+    public void Log(LogEntry l)
+    {
+        Console.WriteLine(l.line);
+    }
 }

--- a/libs/sdk-bindings/tests/bindings/golang/test_breez_sdk.go
+++ b/libs/sdk-bindings/tests/bindings/golang/test_breez_sdk.go
@@ -22,7 +22,7 @@ func (BreezListener) OnEvent(e breez_sdk.BreezEvent) {
 func main() {
 	breezListener := BreezListener{}
 
-	breez_sdk.SetLogStream(breezListener)
+	breez_sdk.SetLogListener(breezListener)
 
 	seed, err := breez_sdk.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff")
 

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.cs
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.cs
@@ -3,32 +3,33 @@ using breez.breez_sdk;
 
 try
 {
- var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
- BreezSdkMethods.SetLogStream(new LogStreamListener());
- var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
- BlockingBreezServices sdkServices = BreezSdkMethods.Connect(config, seed, new SDKListener());
- NodeState? nodeInfo = sdkServices.NodeInfo();
- Console.WriteLine(nodeInfo!.id);
+    var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
+    BreezSdkMethods.SetLogListener(new LogStreamListener());
+    var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
+    BlockingBreezServices sdkServices = BreezSdkMethods.Connect(config, seed, new SDKListener());
+    NodeState? nodeInfo = sdkServices.NodeInfo();
+    Console.WriteLine(nodeInfo!.id);
 }
 catch (Exception e)
 {
- Console.WriteLine(e.Message);
+    Console.WriteLine(e.Message);
 }
 
 class SDKListener : EventListener
 {
- public void OnEvent(BreezEvent e)
- {
-  Console.WriteLine("received event " + e);
- }
+    public void OnEvent(BreezEvent e)
+    {
+        Console.WriteLine("received event " + e);
+    }
 }
 
 class LogStreamListener : LogStream
 {
- public void Log(LogEntry l)
- {
-  if (l.level != "TRACE") {
-   Console.WriteLine(l.line);
-  }
- }
+    public void Log(LogEntry l)
+    {
+        if (l.level != "TRACE")
+        {
+            Console.WriteLine(l.line);
+        }
+    }
 }

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.kts
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.kts
@@ -16,7 +16,7 @@ class LogStreamListener: breez_sdk.LogStream {
 }
 
 try {
-    breez_sdk.setLogStream(LogStreamListener());
+    breez_sdk.setLogListener(LogStreamListener());
     var seed = breez_sdk.mnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
     var config = breez_sdk.defaultConfig(breez_sdk.EnvironmentType.STAGING, "code", breez_sdk.NodeConfig.Greenlight(breez_sdk.GreenlightNodeConfig(null, "")))
     var sdkServices = breez_sdk.connect(config, seed, SDKListener());    

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.swift
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.swift
@@ -16,7 +16,7 @@ class LogStreamListener: LogStream {
 }
 
 do {
-    try setLogStream(logStream: LogStreamListener());
+    try setLogListener(logStream: LogStreamListener());
     let seed = try mnemonicToSeed(phrase: "cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
     let config = breez_sdk.defaultConfig(envType: EnvironmentType.staging, apiKey: "", nodeConfig: NodeConfig.greenlight(config: GreenlightNodeConfig(partnerCredentials: nil,inviteCode:  "code")));
     let sdkServices = try connect(config: config, seed: seed, listener: SDKListener());    

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -131,7 +131,7 @@ pub fn set_log_directory(log_dir: String) -> Result<()> {
 }
 
 /// If used, this must be called before `connect`. It can only be called once.
-pub fn breez_log_stream(sink: StreamSink<LogEntry>) -> Result<()> {
+pub fn set_log_listener(sink: StreamSink<LogEntry>) -> Result<()> {
     BreezServices::set_log_listener(Box::new(StreamSinkWrapper { sink }))?;
     Ok(())
 }

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -116,18 +116,16 @@ pub fn default_config(
     BreezServices::default_config(env_type, api_key, node_config)
 }
 
-/*  Stream API's */
+pub fn set_log_directory(log_dir: String) -> Result<()> {
+    BreezServices::set_log_directory(log_dir).map_err(anyhow::Error::new)
+}
 
-/// If used, this must be called before `connect`. It can only be called once.
+/*  Stream API's */
 pub fn breez_events_stream(s: StreamSink<BreezEvent>) -> Result<()> {
     NOTIFICATION_STREAM
         .set(s)
         .map_err(|_| anyhow!("events stream already created"))?;
     Ok(())
-}
-
-pub fn set_log_directory(log_dir: String) -> Result<()> {
-    BreezServices::set_log_directory(log_dir).map_err(anyhow::Error::new)
 }
 
 /// If used, this must be called before `connect`. It can only be called once.

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -43,7 +43,7 @@ static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| tokio::runtime::Runtime:
 
 /*  Breez Services API's */
 
-/// Wrapper around [BreezServices::connect] which also initializes SDK logging
+/// Wrapper around [BreezServices::connect]
 pub fn connect(config: Config, seed: Vec<u8>) -> Result<()> {
     block_on(async move {
         let breez_services =

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1073,15 +1073,35 @@ impl BreezServices {
         });
     }
 
+    /// Configures a log listener that will receive all SDK log output.
+    /// It allows applications redirect logs to the app log file.
+    ///    
+    /// ### Arguments    
+    ///
+    /// - `log_listener`: Log listener that receives log records.
+    ///    
+    /// ### Errors        
+    ///
+    /// An error is thrown if the there was a failure in initializing the underline logger.
     pub fn set_log_listener(log_listener: Box<dyn LogStream>) -> SdkResult<()> {
         let mut sdk_logger = SDK_LOGGER.get_or_try_init(init_logger)?.write().unwrap();
         sdk_logger.log_listener = Some(log_listener);
         Ok(())
     }
 
-    pub fn set_log_directory(log_dir: String) -> SdkResult<()> {
+    /// Configures a global SDK logger that will log to file.
+    ///
+    /// ### Arguments
+    ///
+    /// - `log_directory`: Location where the the SDK log file will be created. The directory must already exist.       
+    ///
+    /// ### Errors
+    ///
+    /// An error is thrown if the log file cannot be created in the working directory.
+    ///    
+    pub fn set_log_directory(log_directory: String) -> SdkResult<()> {
         let mut sdk_logger = SDK_LOGGER.get_or_try_init(init_logger)?.write().unwrap();
-        let file_logger = build_env_logger(log_dir.as_str())?;
+        let file_logger = build_env_logger(log_directory.as_str())?;
         sdk_logger.file_logger = Some(file_logger);
         Ok(())
     }

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -57,8 +57,13 @@ pub extern "C" fn wire_breez_events_stream(port_: i64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_breez_log_stream(port_: i64) {
-    wire_breez_log_stream_impl(port_)
+pub extern "C" fn wire_set_log_directory(port_: i64, log_dir: *mut wire_uint_8_list) {
+    wire_set_log_directory_impl(port_, log_dir)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_set_log_listener(port_: i64) {
+    wire_set_log_listener_impl(port_)
 }
 
 #[no_mangle]

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -52,13 +52,13 @@ pub extern "C" fn wire_default_config(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_breez_events_stream(port_: i64) {
-    wire_breez_events_stream_impl(port_)
+pub extern "C" fn wire_set_log_directory(port_: i64, log_dir: *mut wire_uint_8_list) {
+    wire_set_log_directory_impl(port_, log_dir)
 }
 
 #[no_mangle]
-pub extern "C" fn wire_set_log_directory(port_: i64, log_dir: *mut wire_uint_8_list) {
-    wire_set_log_directory_impl(port_, log_dir)
+pub extern "C" fn wire_breez_events_stream(port_: i64) {
+    wire_breez_events_stream_impl(port_)
 }
 
 #[no_mangle]

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -207,16 +207,6 @@ fn wire_default_config_impl(
         },
     )
 }
-fn wire_breez_events_stream_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "breez_events_stream",
-            port: Some(port_),
-            mode: FfiCallMode::Stream,
-        },
-        move || move |task_callback| breez_events_stream(task_callback.stream_sink()),
-    )
-}
 fn wire_set_log_directory_impl(port_: MessagePort, log_dir: impl Wire2Api<String> + UnwindSafe) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -228,6 +218,16 @@ fn wire_set_log_directory_impl(port_: MessagePort, log_dir: impl Wire2Api<String
             let api_log_dir = log_dir.wire2api();
             move |task_callback| set_log_directory(api_log_dir)
         },
+    )
+}
+fn wire_breez_events_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "breez_events_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || move |task_callback| breez_events_stream(task_callback.stream_sink()),
     )
 }
 fn wire_set_log_listener_impl(port_: MessagePort) {

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -217,14 +217,27 @@ fn wire_breez_events_stream_impl(port_: MessagePort) {
         move || move |task_callback| breez_events_stream(task_callback.stream_sink()),
     )
 }
-fn wire_breez_log_stream_impl(port_: MessagePort) {
+fn wire_set_log_directory_impl(port_: MessagePort, log_dir: impl Wire2Api<String> + UnwindSafe) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "breez_log_stream",
+            debug_name: "set_log_directory",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_log_dir = log_dir.wire2api();
+            move |task_callback| set_log_directory(api_log_dir)
+        },
+    )
+}
+fn wire_set_log_listener_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "set_log_listener",
             port: Some(port_),
             mode: FfiCallMode::Stream,
         },
-        move || move |task_callback| breez_log_stream(task_callback.stream_sink()),
+        move || move |task_callback| set_log_listener(task_callback.stream_sink()),
     )
 }
 fn wire_list_lsps_impl(port_: MessagePort) {

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -175,6 +175,7 @@ mod grpc;
 pub mod input_parser;
 mod invoice;
 mod lnurl;
+mod logging;
 mod lsp;
 mod models;
 mod moonpay;
@@ -186,8 +187,8 @@ mod test_utils;
 
 pub use breez_services::{
     mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, CheckMessageRequest,
-    CheckMessageResponse, EventListener, InvoicePaidDetails, LogStream, PaymentFailedData,
-    SignMessageRequest, SignMessageResponse,
+    CheckMessageResponse, EventListener, InvoicePaidDetails, PaymentFailedData, SignMessageRequest,
+    SignMessageResponse,
 };
 pub use chain::RecommendedFees;
 pub use fiat::{CurrencyInfo, FiatCurrency, LocaleOverrides, LocalizedName, Rate, Symbol};

--- a/libs/sdk-core/src/logging.rs
+++ b/libs/sdk-core/src/logging.rs
@@ -69,29 +69,6 @@ pub(crate) fn init_logger() -> Result<RwLock<GlobalSdkLogger>> {
     Ok(RwLock::new(logger))
 }
 
-/// Configures a global SDK logger that will log to file and will forward log events to
-/// an optional application-specific logger.
-///
-/// If called, it should be called before any SDK methods (for example, before `connect`).
-///
-/// It must be called only once in the application lifecycle. Alternatively, If the application
-/// already uses a globally-registered logger, this method shouldn't be called at all.
-///
-/// ### Arguments
-///
-/// - `log_dir`: Location where the the SDK log file will be created. The directory must already exist.
-///
-/// - `app_logger`: Optional application logger.
-///
-/// If the application is to use it's own logger, but would also like the SDK to log SDK-specific
-/// log output to a file in the configured `log_dir`, then do not register the
-/// app-specific logger as a global logger and instead call this method with the app logger as an arg.
-///
-/// ### Errors
-///
-/// An error is thrown if the log file cannot be created in the working directory.
-///
-/// An error is thrown if a global logger is already configured.
 pub(crate) fn build_env_logger(log_dir: &str) -> SdkResult<Logger> {
     let target_log_file = Box::new(
         OpenOptions::new()

--- a/libs/sdk-core/src/logging.rs
+++ b/libs/sdk-core/src/logging.rs
@@ -1,0 +1,135 @@
+use crate::{
+    error::{SdkError, SdkResult},
+    LogEntry, LogStream,
+};
+use anyhow::Result;
+use chrono::Local;
+use env_logger::Logger;
+use log::{Metadata, Record};
+use once_cell::sync::OnceCell;
+use std::io::Write;
+use std::{fs::OpenOptions, sync::RwLock};
+
+pub(crate) static SDK_LOGGER: OnceCell<RwLock<GlobalSdkLogger>> = OnceCell::new();
+
+struct RustLogger {}
+
+impl log::Log for RustLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::Level::Debug
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            if let Some(l) = SDK_LOGGER.get() {
+                l.read().unwrap().log(record);
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub(crate) struct GlobalSdkLogger {
+    /// SDK internal logger, which logs to file
+    pub(crate) file_logger: Option<Logger>,
+    /// Optional external logger, that can receive a stream of log statements
+    pub(crate) log_listener: Option<Box<dyn LogStream>>,
+}
+
+impl log::Log for GlobalSdkLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::Level::Debug
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            if let Some(logger) = &self.log_listener {
+                logger.log(LogEntry {
+                    line: record.args().to_string(),
+                    level: record.level().as_str().to_string(),
+                });
+            }
+            if let Some(logger) = &self.file_logger {
+                logger.log(record);
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub(crate) fn init_logger() -> Result<RwLock<GlobalSdkLogger>> {
+    let logger = GlobalSdkLogger {
+        file_logger: None,
+        log_listener: None,
+    };
+    log::set_boxed_logger(Box::new(RustLogger {}))?;
+    log::set_max_level(log::LevelFilter::Debug);
+    Ok(RwLock::new(logger))
+}
+
+/// Configures a global SDK logger that will log to file and will forward log events to
+/// an optional application-specific logger.
+///
+/// If called, it should be called before any SDK methods (for example, before `connect`).
+///
+/// It must be called only once in the application lifecycle. Alternatively, If the application
+/// already uses a globally-registered logger, this method shouldn't be called at all.
+///
+/// ### Arguments
+///
+/// - `log_dir`: Location where the the SDK log file will be created. The directory must already exist.
+///
+/// - `app_logger`: Optional application logger.
+///
+/// If the application is to use it's own logger, but would also like the SDK to log SDK-specific
+/// log output to a file in the configured `log_dir`, then do not register the
+/// app-specific logger as a global logger and instead call this method with the app logger as an arg.
+///
+/// ### Errors
+///
+/// An error is thrown if the log file cannot be created in the working directory.
+///
+/// An error is thrown if a global logger is already configured.
+pub(crate) fn build_env_logger(log_dir: &str) -> SdkResult<Logger> {
+    let target_log_file = Box::new(
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(format!("{log_dir}/sdk.log"))
+            .map_err(|_| SdkError::InitFailed {
+                err: "Can't create log file".into(),
+            })?,
+    );
+    let logger = env_logger::Builder::new()
+        .target(env_logger::Target::Pipe(target_log_file))
+        .parse_filters(
+            r#"
+                info,
+                gl_client=warn,
+                h2=warn,
+                hyper=warn,
+                breez_sdk_core::reverseswap=info,
+                lightning_signer=warn,
+                reqwest=warn,
+                rustls=warn,
+                rustyline=warn,
+                vls_protocol_signer=warn
+            "#,
+        )
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "[{} {} {}:{}] {}",
+                Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+                record.level(),
+                record.module_path().unwrap_or("unknown"),
+                record.line().unwrap_or(0),
+                record.args()
+            )
+        })
+        .build();
+
+    Ok(logger)
+}

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -37,6 +37,9 @@ use strum_macros::{Display, EnumString};
 
 pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
 pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 60 minutes
+pub trait LogStream: Send + Sync {
+    fn log(&self, l: LogEntry);
+}
 
 /// Different types of supported payments
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 typedef struct _Dart_Handle* Dart_Handle;
 
-#define SWAP_PAYMENT_FEE_EXPIRY_SECONDS (((60 * 60) * 24) * 7)
+#define SWAP_PAYMENT_FEE_EXPIRY_SECONDS (((60 * 60) * 24) * 2)
 
 #define INVOICE_PAYMENT_FEE_EXPIRY_SECONDS (60 * 60)
 
@@ -157,9 +157,9 @@ void wire_default_config(int64_t port_,
                          struct wire_uint_8_list *api_key,
                          struct wire_NodeConfig *node_config);
 
-void wire_breez_events_stream(int64_t port_);
-
 void wire_set_log_directory(int64_t port_, struct wire_uint_8_list *log_dir);
+
+void wire_breez_events_stream(int64_t port_);
 
 void wire_set_log_listener(int64_t port_);
 
@@ -298,8 +298,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_check_message);
     dummy_var ^= ((int64_t) (void*) wire_mnemonic_to_seed);
     dummy_var ^= ((int64_t) (void*) wire_default_config);
-    dummy_var ^= ((int64_t) (void*) wire_breez_events_stream);
     dummy_var ^= ((int64_t) (void*) wire_set_log_directory);
+    dummy_var ^= ((int64_t) (void*) wire_breez_events_stream);
     dummy_var ^= ((int64_t) (void*) wire_set_log_listener);
     dummy_var ^= ((int64_t) (void*) wire_list_lsps);
     dummy_var ^= ((int64_t) (void*) wire_connect_lsp);

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -159,7 +159,9 @@ void wire_default_config(int64_t port_,
 
 void wire_breez_events_stream(int64_t port_);
 
-void wire_breez_log_stream(int64_t port_);
+void wire_set_log_directory(int64_t port_, struct wire_uint_8_list *log_dir);
+
+void wire_set_log_listener(int64_t port_);
 
 void wire_list_lsps(int64_t port_);
 
@@ -297,7 +299,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_mnemonic_to_seed);
     dummy_var ^= ((int64_t) (void*) wire_default_config);
     dummy_var ^= ((int64_t) (void*) wire_breez_events_stream);
-    dummy_var ^= ((int64_t) (void*) wire_breez_log_stream);
+    dummy_var ^= ((int64_t) (void*) wire_set_log_directory);
+    dummy_var ^= ((int64_t) (void*) wire_set_log_listener);
     dummy_var ^= ((int64_t) (void*) wire_list_lsps);
     dummy_var ^= ((int64_t) (void*) wire_connect_lsp);
     dummy_var ^= ((int64_t) (void*) wire_lsp_id);

--- a/libs/sdk-flutter/lib/breez_bridge.dart
+++ b/libs/sdk-flutter/lib/breez_bridge.dart
@@ -52,7 +52,7 @@ class BreezSDK {
     });
 
     /// Listen to SDK logs and log them accordingly to their severity
-    _lnToolkit.breezLogStream().listen(_registerToolkitLog);
+    _lnToolkit.setLogListener().listen(_registerToolkitLog);
   }
 
   /* Breez Services API's & Streams*/

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -63,14 +63,13 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kDefaultConfigConstMeta;
 
-  /// If used, this must be called before `connect`. It can only be called once.
-  Stream<BreezEvent> breezEventsStream({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kBreezEventsStreamConstMeta;
-
   Future<void> setLogDirectory({required String logDir, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kSetLogDirectoryConstMeta;
+
+  Stream<BreezEvent> breezEventsStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kBreezEventsStreamConstMeta;
 
   /// If used, this must be called before `connect`. It can only be called once.
   Stream<LogEntry> setLogListener({dynamic hint});
@@ -1504,21 +1503,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["envType", "apiKey", "nodeConfig"],
       );
 
-  Stream<BreezEvent> breezEventsStream({dynamic hint}) {
-    return _platform.executeStream(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_breez_events_stream(port_),
-      parseSuccessData: _wire2api_breez_event,
-      constMeta: kBreezEventsStreamConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kBreezEventsStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "breez_events_stream",
-        argNames: [],
-      );
-
   Future<void> setLogDirectory({required String logDir, dynamic hint}) {
     var arg0 = _platform.api2wire_String(logDir);
     return _platform.executeNormal(FlutterRustBridgeTask(
@@ -1533,6 +1517,21 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kSetLogDirectoryConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "set_log_directory",
         argNames: ["logDir"],
+      );
+
+  Stream<BreezEvent> breezEventsStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_breez_events_stream(port_),
+      parseSuccessData: _wire2api_breez_event,
+      constMeta: kBreezEventsStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kBreezEventsStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "breez_events_stream",
+        argNames: [],
       );
 
   Stream<LogEntry> setLogListener({dynamic hint}) {
@@ -3614,18 +3613,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_default_config = _wire_default_configPtr
       .asFunction<void Function(int, int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_NodeConfig>)>();
 
-  void wire_breez_events_stream(
-    int port_,
-  ) {
-    return _wire_breez_events_stream(
-      port_,
-    );
-  }
-
-  late final _wire_breez_events_streamPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_breez_events_stream');
-  late final _wire_breez_events_stream = _wire_breez_events_streamPtr.asFunction<void Function(int)>();
-
   void wire_set_log_directory(
     int port_,
     ffi.Pointer<wire_uint_8_list> log_dir,
@@ -3641,6 +3628,18 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'wire_set_log_directory');
   late final _wire_set_log_directory =
       _wire_set_log_directoryPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_breez_events_stream(
+    int port_,
+  ) {
+    return _wire_breez_events_stream(
+      port_,
+    );
+  }
+
+  late final _wire_breez_events_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_breez_events_stream');
+  late final _wire_breez_events_stream = _wire_breez_events_streamPtr.asFunction<void Function(int)>();
 
   void wire_set_log_listener(
     int port_,
@@ -4527,7 +4526,7 @@ typedef DartPostCObjectFnType
     = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message)>>;
 typedef DartPort = ffi.Int64;
 
-const int SWAP_PAYMENT_FEE_EXPIRY_SECONDS = 604800;
+const int SWAP_PAYMENT_FEE_EXPIRY_SECONDS = 172800;
 
 const int INVOICE_PAYMENT_FEE_EXPIRY_SECONDS = 3600;
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -68,10 +68,14 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kBreezEventsStreamConstMeta;
 
-  /// If used, this must be called before `connect`. It can only be called once.
-  Stream<LogEntry> breezLogStream({dynamic hint});
+  Future<void> setLogDirectory({required String logDir, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kBreezLogStreamConstMeta;
+  FlutterRustBridgeTaskConstMeta get kSetLogDirectoryConstMeta;
+
+  /// If used, this must be called before `connect`. It can only be called once.
+  Stream<LogEntry> setLogListener({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kSetLogListenerConstMeta;
 
   /// See [BreezServices::list_lsps]
   Future<List<LspInformation>> listLsps({dynamic hint});
@@ -1515,18 +1519,34 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
-  Stream<LogEntry> breezLogStream({dynamic hint}) {
+  Future<void> setLogDirectory({required String logDir, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(logDir);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_set_log_directory(port_, arg0),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kSetLogDirectoryConstMeta,
+      argValues: [logDir],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kSetLogDirectoryConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "set_log_directory",
+        argNames: ["logDir"],
+      );
+
+  Stream<LogEntry> setLogListener({dynamic hint}) {
     return _platform.executeStream(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_breez_log_stream(port_),
+      callFfi: (port_) => _platform.inner.wire_set_log_listener(port_),
       parseSuccessData: _wire2api_log_entry,
-      constMeta: kBreezLogStreamConstMeta,
+      constMeta: kSetLogListenerConstMeta,
       argValues: [],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kBreezLogStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "breez_log_stream",
+  FlutterRustBridgeTaskConstMeta get kSetLogListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "set_log_listener",
         argNames: [],
       );
 
@@ -3606,17 +3626,33 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_breez_events_stream');
   late final _wire_breez_events_stream = _wire_breez_events_streamPtr.asFunction<void Function(int)>();
 
-  void wire_breez_log_stream(
+  void wire_set_log_directory(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> log_dir,
+  ) {
+    return _wire_set_log_directory(
+      port_,
+      log_dir,
+    );
+  }
+
+  late final _wire_set_log_directoryPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_set_log_directory');
+  late final _wire_set_log_directory =
+      _wire_set_log_directoryPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_set_log_listener(
     int port_,
   ) {
-    return _wire_breez_log_stream(
+    return _wire_set_log_listener(
       port_,
     );
   }
 
-  late final _wire_breez_log_streamPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_breez_log_stream');
-  late final _wire_breez_log_stream = _wire_breez_log_streamPtr.asFunction<void Function(int)>();
+  late final _wire_set_log_listenerPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_set_log_listener');
+  late final _wire_set_log_listener = _wire_set_log_listenerPtr.asFunction<void Function(int)>();
 
   void wire_list_lsps(
     int port_,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -14,7 +14,7 @@ import 'dart:ffi' as ffi;
 part 'bridge_generated.freezed.dart';
 
 abstract class BreezSdkCore {
-  /// Wrapper around [BreezServices::connect] which also initializes SDK logging
+  /// Wrapper around [BreezServices::connect]
   Future<void> connect({required Config config, required Uint8List seed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kConnectConstMeta;

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -42,7 +42,6 @@ async fn connect(config: Config, seed: &[u8]) -> Result<()> {
     BREEZ_SERVICES
         .set(service)
         .map_err(|_| anyhow!("Failed to set Breez Service"))?;
-
     Ok(())
 }
 

--- a/tools/sdk-cli/src/main.rs
+++ b/tools/sdk-cli/src/main.rs
@@ -25,8 +25,7 @@ async fn main() {
         return;
     }
 
-    BreezServices::set_log_directory("/Users/roeierez/test/sdk-logs".to_string())
-        .expect("Failed to init logging");
+    BreezServices::set_log_directory(data_dir.clone()).expect("Failed to init logging");
 
     let persistence = CliPersistence { data_dir };
     let history_file = &persistence.history_file();

--- a/tools/sdk-cli/src/main.rs
+++ b/tools/sdk-cli/src/main.rs
@@ -25,7 +25,8 @@ async fn main() {
         return;
     }
 
-    BreezServices::init_logging(&data_dir, None).expect("Failed to init logging");
+    BreezServices::set_log_directory("/Users/roeierez/test/sdk-logs".to_string())
+        .expect("Failed to init logging");
 
     let persistence = CliPersistence { data_dir };
     let history_file = &persistence.history_file();


### PR DESCRIPTION
The first goal of this PR is to decouple the global file system logger and log listener from the connect method which is per instance.
Two methods were introduced:

`set_log_listener`
`set_log_directory`

Both of these methods can be called multiple times now.
The next step IMO is to add logger per node instance allowing to isolate the log records between different nodes and better understand the context in multi-instance mode.