### PR TITLE
Fix flutter release

### DIFF
--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -1,0 +1,104 @@
+name: Build sdk-bindings for Android
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: build ${{ matrix.target }}
+    strategy:
+      matrix:
+        target: [
+          aarch64-linux-android,
+          armv7-linux-androideabi,
+          i686-linux-android,
+          x86_64-linux-android,
+        ]
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+      with: 
+        ref: ${{ inputs.ref }}
+
+    - name: Install rust toolchain
+      run: |
+        rustup set auto-self-update disable
+        rustup toolchain install stable --profile minimal
+        rustup target add ${{ matrix.target }}
+        cargo install cargo-ndk
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v2
+      with:
+        version: "23.4"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: libs
+
+    - name: Build sdk-bindings
+      working-directory: libs/sdk-bindings
+      run: |
+        cargo ndk -t ${{ matrix.target }} build --release
+
+    - name: Copy build output
+      run: |
+        mkdir -p dist
+        cp libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.so dist
+
+    - name: Copy libc++_shared
+      if: ${{ matrix.target == 'armv7-linux-androideabi'}}
+      run: cp $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc++_shared.so dist
+
+    - name: Copy libc++_shared
+      if: ${{ matrix.target != 'armv7-linux-androideabi'}}
+      run: cp $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${{ matrix.target }}/libc++_shared.so dist
+
+    - name: Archive release
+      uses: actions/upload-artifact@v3
+      with:
+        name: sdk-bindings-${{ matrix.target }}
+        path: dist/*
+  
+  jnilibs:
+    needs: build
+    runs-on: ubuntu-latest
+    name: build jniLibs
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-aarch64-linux-android
+          path: arm64-v8a
+      
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-armv7-linux-androideabi
+          path: armeabi-v7a
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-i686-linux-android
+          path: x86
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-x86_64-linux-android
+          path: x86_64
+      
+      - name: Archive jniLibs
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdk-bindings-android-jniLibs
+          path: ./*

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -1,4 +1,4 @@
-name: Build Darwin
+name: Build sdk-bindings for Darwin
 on:
   workflow_dispatch:
     inputs:
@@ -46,7 +46,7 @@ jobs:
       with:
         workspaces: libs
 
-    - name: Build Breez 
+    - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
       run: cargo lipo --release --targets ${{ matrix.target }}
     

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -1,4 +1,4 @@
-name: Build Linux
+name: Build sdk-bindings for iOS
 on:
   workflow_dispatch:
     inputs:
@@ -15,13 +15,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: macOS-latest
     name: build ${{ matrix.target }}
     strategy:
       matrix:
         target: [
-          aarch64-unknown-linux-gnu,
-          x86_64-unknown-linux-gnu,
+          aarch64-apple-ios,
+          x86_64-apple-ios,
+          aarch64-apple-ios-sim,
         ]
     steps:
     - name: checkout
@@ -41,31 +42,21 @@ jobs:
         version: "23.4"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install gcc-aarch64-linux-gnu
-      if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu 
-
-    - name: Install gcc-x86-64-linux-gnu
-      if: matrix.target == 'x86_64-unknown-linux-gnu'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu 
-
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: libs
 
-    - name: Build Breez
+    - name: Install xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
-      env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/x86_64-linux-gnu-gcc
       run: cargo build --release --target ${{ matrix.target }}
     
     - name: Archive release
       uses: actions/upload-artifact@v3
       with:
         name: sdk-bindings-${{ matrix.target }}
-        path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.so
+        path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a

--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -1,4 +1,4 @@
-name: Build Windows
+name: Build sdk-bindings for Linux
 on:
   workflow_dispatch:
     inputs:
@@ -15,13 +15,13 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     name: build ${{ matrix.target }}
     strategy:
       matrix:
         target: [
-          x86_64-pc-windows-msvc,
-          i686-pc-windows-msvc,
+          aarch64-unknown-linux-gnu,
+          x86_64-unknown-linux-gnu,
         ]
     steps:
     - name: checkout
@@ -41,16 +41,31 @@ jobs:
         version: "23.4"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Install gcc-aarch64-linux-gnu
+      if: matrix.target == 'aarch64-unknown-linux-gnu'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu 
+
+    - name: Install gcc-x86-64-linux-gnu
+      if: matrix.target == 'x86_64-unknown-linux-gnu'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu 
+
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: libs
 
-    - name: Build Breez
+    - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
+      env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/x86_64-linux-gnu-gcc
       run: cargo build --release --target ${{ matrix.target }}
     
     - name: Archive release
       uses: actions/upload-artifact@v3
       with:
         name: sdk-bindings-${{ matrix.target }}
-        path: libs/target/${{ matrix.target }}/release/breez_sdk_bindings.dll
+        path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.so

--- a/.github/workflows/build-bindings-windows.yml
+++ b/.github/workflows/build-bindings-windows.yml
@@ -1,4 +1,4 @@
-name: Build iOS
+name: Build sdk-bindings for Windows
 on:
   workflow_dispatch:
     inputs:
@@ -15,14 +15,13 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: windows-latest
     name: build ${{ matrix.target }}
     strategy:
       matrix:
         target: [
-          aarch64-apple-ios,
-          x86_64-apple-ios,
-          aarch64-apple-ios-sim,
+          x86_64-pc-windows-msvc,
+          i686-pc-windows-msvc,
         ]
     steps:
     - name: checkout
@@ -46,12 +45,7 @@ jobs:
       with:
         workspaces: libs
 
-    - name: Install xcode
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-
-    - name: Build Breez
+    - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
       run: cargo build --release --target ${{ matrix.target }}
     
@@ -59,4 +53,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: sdk-bindings-${{ matrix.target }}
-        path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a
+        path: libs/target/${{ matrix.target }}/release/breez_sdk_bindings.dll

--- a/.github/workflows/build-core-android.yml
+++ b/.github/workflows/build-core-android.yml
@@ -1,4 +1,4 @@
-name: Build Android
+name: Build sdk-core for Android
 on:
   workflow_dispatch:
     inputs:
@@ -48,15 +48,15 @@ jobs:
       with:
         workspaces: libs
 
-    - name: Build Breez
-      working-directory: libs/sdk-bindings
+    - name: Build sdk-core
+      working-directory: libs/sdk-core
       run: |
         cargo ndk -t ${{ matrix.target }} build --release
 
     - name: Copy build output
       run: |
         mkdir -p dist
-        cp libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.so dist
+        cp libs/target/${{ matrix.target }}/release/libbreez_sdk_core.so dist
 
     - name: Copy libc++_shared
       if: ${{ matrix.target == 'armv7-linux-androideabi'}}
@@ -69,7 +69,7 @@ jobs:
     - name: Archive release
       uses: actions/upload-artifact@v3
       with:
-        name: sdk-bindings-${{ matrix.target }}
+        name: sdk-core-${{ matrix.target }}
         path: dist/*
   
   jnilibs:
@@ -79,26 +79,26 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: sdk-bindings-aarch64-linux-android
+          name: sdk-core-aarch64-linux-android
           path: arm64-v8a
       
       - uses: actions/download-artifact@v3
         with:
-          name: sdk-bindings-armv7-linux-androideabi
+          name: sdk-core-armv7-linux-androideabi
           path: armeabi-v7a
 
       - uses: actions/download-artifact@v3
         with:
-          name: sdk-bindings-i686-linux-android
+          name: sdk-core-i686-linux-android
           path: x86
 
       - uses: actions/download-artifact@v3
         with:
-          name: sdk-bindings-x86_64-linux-android
+          name: sdk-core-x86_64-linux-android
           path: x86_64
       
       - name: Archive jniLibs
         uses: actions/upload-artifact@v3
         with:
-          name: android-jniLibs
+          name: sdk-core-android-jniLibs
           path: ./*

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -48,13 +48,14 @@ jobs:
       # Careful, a boolean input is not a boolean output. A boolean input is
       # actually a boolean, but these outputs are strings. All the boolean
       # checks in this file have the format `boolean == 'true'`. So feel free
-      # to set these variables here to `true` or `false` (e.g. windows: true)
-      # if you want to test something.
-      windows: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
-      darwin: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
-      linux: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
-      android: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version || !!inputs.flutter-package-version || !!inputs.golang-package-version }}
-      ios: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version }}
+      # to set these variables here to `true` or `false` 
+      # (e.g. bindings-windows: true) if you want to test something.
+      bindings-windows: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
+      bindings-darwin: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
+      bindings-linux: ${{ !!inputs.csharp-package-version || !!inputs.golang-package-version }}
+      bindings-android: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version || !!inputs.golang-package-version }}
+      bindings-ios: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version }}
+      core-android: ${{ !!inputs.flutter-package-version }}
       kotlin: ${{ !!inputs.kotlin-mpp-package-version || !!inputs.maven-package-version }}
       swift: false
       python: false
@@ -76,34 +77,40 @@ jobs:
     steps:
       - run: echo "set output variables"
 
-  build-windows:
+  build-bindings-windows:
     needs: setup
-    if: ${{ needs.setup.outputs.windows == 'true' }}
-    uses: ./.github/workflows/build-windows.yml
+    if: ${{ needs.setup.outputs.bindings-windows == 'true' }}
+    uses: ./.github/workflows/build-bindings-windows.yml
     with:
       ref: ${{ needs.setup.outputs.ref }}
-  build-darwin:
+  build-bindings-darwin:
     needs: setup
-    if: ${{ needs.setup.outputs.darwin == 'true' }}
-    uses: ./.github/workflows/build-darwin.yml
+    if: ${{ needs.setup.outputs.bindings-darwin == 'true' }}
+    uses: ./.github/workflows/build-bindings-darwin.yml
     with:
       ref: ${{ needs.setup.outputs.ref }}
-  build-linux:
+  build-bindings-linux:
     needs: setup
-    if: ${{ needs.setup.outputs.linux == 'true' }}
-    uses: ./.github/workflows/build-linux.yml
+    if: ${{ needs.setup.outputs.bindings-linux == 'true' }}
+    uses: ./.github/workflows/build-bindings-linux.yml
     with:
       ref: ${{ needs.setup.outputs.ref }}
-  build-android:
+  build-bindings-android:
     needs: setup
-    if: ${{ needs.setup.outputs.android == 'true' }}
-    uses: ./.github/workflows/build-android.yml
+    if: ${{ needs.setup.outputs.bindings-android == 'true' }}
+    uses: ./.github/workflows/build-bindings-android.yml
     with:
       ref: ${{ needs.setup.outputs.ref }}
-  build-ios:
+  build-bindings-ios:
     needs: setup
-    if: ${{ needs.setup.outputs.ios == 'true' }}
-    uses: ./.github/workflows/build-ios.yml
+    if: ${{ needs.setup.outputs.bindings-ios == 'true' }}
+    uses: ./.github/workflows/build-bindings-ios.yml
+    with:
+      ref: ${{ needs.setup.outputs.ref }}
+  build-core-android:
+    needs: setup
+    if: ${{ needs.setup.outputs.core-android == 'true' }}
+    uses: ./.github/workflows/build-core-android.yml
     with:
       ref: ${{ needs.setup.outputs.ref }}
 
@@ -121,9 +128,9 @@ jobs:
   publish-csharp:
     needs: 
       - setup
-      - build-windows
-      - build-darwin
-      - build-linux
+      - build-bindings-windows
+      - build-bindings-darwin
+      - build-bindings-linux
       - build-language-bindings
     if: ${{ needs.setup.outputs.csharp == 'true' }}
     uses: ./.github/workflows/publish-csharp.yml
@@ -137,10 +144,10 @@ jobs:
   publish-golang:
     needs: 
       - setup
-      - build-android
-      - build-windows
-      - build-darwin
-      - build-linux
+      - build-bindings-android
+      - build-bindings-windows
+      - build-bindings-darwin
+      - build-bindings-linux
       - build-language-bindings
     if: ${{ needs.setup.outputs.golang == 'true' }}
     uses: ./.github/workflows/publish-golang.yml
@@ -154,7 +161,7 @@ jobs:
   publish-maven:
     needs: 
       - setup
-      - build-android
+      - build-bindings-android
       - build-language-bindings
     if: ${{ needs.setup.outputs.maven == 'true' }}
     uses: ./.github/workflows/publish-android.yml
@@ -169,8 +176,8 @@ jobs:
   publish-kotlin-mpp:
     needs: 
       - setup
-      - build-android
-      - build-ios
+      - build-bindings-android
+      - build-bindings-ios
       - build-language-bindings
     if: ${{ needs.setup.outputs.kotlin-mpp == 'true' }}
     uses: ./.github/workflows/publish-kotlin-mpp.yml
@@ -185,7 +192,7 @@ jobs:
   publish-flutter:
     needs: 
       - setup
-      - build-android      
+      - build-core-android      
     if: ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: android-jniLibs
+          name: sdk-bindings-android-jniLibs
           path: libs/sdk-bindings/bindings-android/lib/src/main/jniLibs
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -58,15 +58,25 @@ jobs:
           cp -r ../breez-sdk/libs/sdk-flutter/lib .
           cp ../breez-sdk/libs/sdk-flutter/pubspec.yaml .
           cp ../breez-sdk/libs/sdk-flutter/pubspec.lock .          
-           
+      
+      - name: Set package version
+        working-directory: flutter
+        run: |
+          flutter pub global activate pubspec_version
+          pubver set ${{ inputs.package-version }}
+
+      - name: Archive flutter release
+        uses: actions/upload-artifact@v3
+        with:
+          name: breez-sdk-flutter-${{ inputs.package-version || github.sha }}
+          path: flutter/*
+
       - name: Tag the Flutter package        
         working-directory: flutter
         if: ${{ inputs.publish }}
         run: |
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
-          flutter pub global activate pubspec_version     
-          pubver set ${{ inputs.package-version }}    
           git add .          
           git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
           git push

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: android-jniLibs
+          name: sdk-core-android-jniLibs
           path: flutter/android/src/main/jniLibs
 
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/publish-kotlin-mpp.yml
+++ b/.github/workflows/publish-kotlin-mpp.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: android-jniLibs
+          name: sdk-bindings-android-jniLibs
           path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/jniLibs
 
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This PR builds sdk-core jniLibs for the flutter release instead of the sdk-bindings jniLibs in CI.
Also, it now archives the package. I tested the archived package and it works on an Android emulator.