### PR TITLE
ci: remove rust cache for platform builds

### DIFF
--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -44,10 +44,6 @@ jobs:
         version: "23.4"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: libs
-
     - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
       run: |

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -42,10 +42,6 @@ jobs:
         version: "23.4"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: libs
-
     - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
       run: cargo lipo --release --targets ${{ matrix.target }}

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -42,10 +42,6 @@ jobs:
         version: "23.4"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: libs
-
     - name: Install xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -53,10 +53,6 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu 
 
-    - uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: libs
-
     - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
       env:

--- a/.github/workflows/build-bindings-windows.yml
+++ b/.github/workflows/build-bindings-windows.yml
@@ -41,10 +41,6 @@ jobs:
         version: "23.4"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: libs
-
     - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
       run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/build-core-android.yml
+++ b/.github/workflows/build-core-android.yml
@@ -44,10 +44,6 @@ jobs:
         version: "23.4"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: libs
-
     - name: Build sdk-core
       working-directory: libs/sdk-core
       run: |


### PR DESCRIPTION
When compiling for specific targets, the rust cache is almost always a miss.
This causes the rust cache to only cost more time for a release, because it takes quite a long time to upload the cache.
Plus, these caches take space, which is stolen from the main CI caches.

So remove the rust caches for platform-specific builds.