### PR TITLE
Use the channel close tx blocktime as fallback close ts

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -730,16 +730,18 @@ impl BreezServices {
         }
 
         //fetch closed_channel and convert them to Payment items.
-        let closed_channel_payments_res: Result<Vec<Payment>> = self
-            .persister
-            .list_channels()?
-            .into_iter()
-            .filter(|c| c.state == ChannelState::Closed || c.state == ChannelState::PendingClose)
-            .map(closed_channel_to_transaction)
-            .collect();
+        let mut closed_channel_payments: Vec<Payment> = vec![];
+        for closed_channel in
+            self.persister.list_channels()?.into_iter().filter(|c| {
+                c.state == ChannelState::Closed || c.state == ChannelState::PendingClose
+            })
+        {
+            let closed_channel_tx = self.closed_channel_to_transaction(closed_channel).await?;
+            closed_channel_payments.push(closed_channel_tx);
+        }
 
         // update both closed channels and lightning transaction payments
-        let mut payments = closed_channel_payments_res?;
+        let mut payments = closed_channel_payments;
         payments.extend(new_data.payments.clone());
         self.persister.insert_or_update_payments(&payments)?;
 
@@ -1193,6 +1195,57 @@ impl BreezServices {
 
         Ok(())
     }
+
+    async fn closed_channel_to_transaction(
+        &self,
+        channel: crate::models::Channel,
+    ) -> Result<Payment> {
+        let now_epoch_sec = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+        // If closed_at is missing (older DB where field was not yet part of the schema),
+        // we get it from the channel closing tx
+        let channel_closed_at = channel.closed_at.unwrap_or(
+            {
+                // Lookup tx based on channel funding tx ID
+                let outspends = self
+                    .chain_service
+                    .transaction_outspends(channel.funding_txid.clone())
+                    .await?;
+
+                // If outputs are spent, take the block time as the channel closing timestamp
+                match outspends.iter().find(|&out| out.spent) {
+                    None => {
+                        warn!("No confirmed outputs of funding tx for closed channel, defaulting closed_at to epoch time");
+                        now_epoch_sec
+                    }
+                    Some(out) => match out.status.block_time {
+                        None => {
+                            warn!("No blocktime found for confirmed tx output {out:#?}, defaulting closed_at to epoch time");
+                            now_epoch_sec
+                        },
+                        Some(block_time) => block_time
+                    }
+                }
+            }
+        ) as i64;
+
+        Ok(Payment {
+            id: channel.funding_txid.clone(),
+            payment_type: PaymentType::ClosedChannel,
+            payment_time: channel_closed_at,
+            amount_msat: channel.spendable_msat,
+            fee_msat: 0,
+            pending: channel.state == ChannelState::PendingClose,
+            description: Some("Closed Channel".to_string()),
+            details: PaymentDetails::ClosedChannel {
+                data: ClosedChannelPaymentDetails {
+                    short_channel_id: channel.short_channel_id,
+                    state: channel.state,
+                    funding_txid: channel.funding_txid,
+                },
+            },
+        })
+    }
 }
 
 struct GlobalSdkLogger {
@@ -1219,28 +1272,6 @@ impl log::Log for GlobalSdkLogger {
     }
 
     fn flush(&self) {}
-}
-
-fn closed_channel_to_transaction(channel: crate::models::Channel) -> Result<Payment> {
-    let now = SystemTime::now();
-    Ok(Payment {
-        id: channel.funding_txid.clone(),
-        payment_type: PaymentType::ClosedChannel,
-        payment_time: channel
-            .closed_at
-            .unwrap_or(now.duration_since(UNIX_EPOCH)?.as_secs()) as i64,
-        amount_msat: channel.spendable_msat,
-        fee_msat: 0,
-        pending: channel.state == ChannelState::PendingClose,
-        description: Some("Closed Channel".to_string()),
-        details: PaymentDetails::ClosedChannel {
-            data: ClosedChannelPaymentDetails {
-                short_channel_id: channel.short_channel_id,
-                state: channel.state,
-                funding_txid: channel.funding_txid,
-            },
-        },
-    })
 }
 
 /// A helper struct to configure and build BreezServices

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -11,6 +11,10 @@ pub trait ChainService: Send + Sync {
     /// See <https://mempool.space/docs/api/rest#get-address-transactions>
     async fn address_transactions(&self, address: String) -> Result<Vec<OnchainTx>>;
     async fn current_tip(&self) -> Result<u32>;
+    /// Gets a transaction.
+    ///
+    /// See <https://mempool.space/docs/api/rest#get-transaction>
+    async fn transaction(&self, txid: String) -> Result<OnchainTx>;
     /// Gets the spending status of all tx outputs for this tx.
     ///
     /// See <https://mempool.space/docs/api/rest#get-transaction-outspends>
@@ -237,6 +241,13 @@ impl ChainService for MempoolSpace {
                 .await?
                 .parse()?,
         )
+    }
+
+    async fn transaction(&self, txid: String) -> Result<OnchainTx> {
+        Ok(reqwest::get(format!("{}/api/tx/{txid}", self.base_url))
+            .await?
+            .json()
+            .await?)
     }
 
     async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>> {

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -11,6 +11,11 @@ pub trait ChainService: Send + Sync {
     /// See <https://mempool.space/docs/api/rest#get-address-transactions>
     async fn address_transactions(&self, address: String) -> Result<Vec<OnchainTx>>;
     async fn current_tip(&self) -> Result<u32>;
+    /// Gets the spending status of all tx outputs for this tx.
+    ///
+    /// See <https://mempool.space/docs/api/rest#get-transaction-outspends>
+    async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>>;
+    /// If successful, it returns the transaction ID. Otherwise returns an `Err` describing the error.
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String>;
 }
 
@@ -181,6 +186,15 @@ pub struct Vin {
     pub sequence: u32,
 }
 
+/// Spending status of a transaction output
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Outspend {
+    pub spent: bool,
+    pub txid: Option<String>,
+    pub vin: u32,
+    pub status: TxStatus,
+}
+
 impl Default for MempoolSpace {
     fn default() -> Self {
         MempoolSpace {
@@ -225,7 +239,15 @@ impl ChainService for MempoolSpace {
         )
     }
 
-    /// If successful, it returns the transaction ID. Otherwise returns an `Err` describing the error.
+    async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>> {
+        Ok(
+            reqwest::get(format!("{}/api/tx/{txid}/outspends", self.base_url))
+                .await?
+                .json()
+                .await?,
+        )
+    }
+
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String> {
         let client = reqwest::Client::new();
         let txid_or_error = client

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -11,10 +11,6 @@ pub trait ChainService: Send + Sync {
     /// See <https://mempool.space/docs/api/rest#get-address-transactions>
     async fn address_transactions(&self, address: String) -> Result<Vec<OnchainTx>>;
     async fn current_tip(&self) -> Result<u32>;
-    /// Gets a transaction.
-    ///
-    /// See <https://mempool.space/docs/api/rest#get-transaction>
-    async fn transaction(&self, txid: String) -> Result<OnchainTx>;
     /// Gets the spending status of all tx outputs for this tx.
     ///
     /// See <https://mempool.space/docs/api/rest#get-transaction-outspends>
@@ -241,13 +237,6 @@ impl ChainService for MempoolSpace {
                 .await?
                 .parse()?,
         )
-    }
-
-    async fn transaction(&self, txid: String) -> Result<OnchainTx> {
-        Ok(reqwest::get(format!("{}/api/tx/{txid}", self.base_url))
-            .await?
-            .json()
-            .await?)
     }
 
     async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>> {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1042,6 +1042,7 @@ impl From<cln::ListpeersPeersChannels> for Channel {
             spendable_msat: c.spendable_msat.unwrap_or_default().msat,
             receivable_msat: c.receivable_msat.unwrap_or_default().msat,
             closed_at: None,
+            funding_outnum: c.funding_outnum,
         }
     }
 }
@@ -1050,19 +1051,19 @@ impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
     type Error = anyhow::Error;
 
     fn try_from(c: ListclosedchannelsClosedchannels) -> std::result::Result<Self, Self::Error> {
-        let to_us = c
-            .final_to_us_msat
-            .ok_or(anyhow!("final_to_us_msat is missing"))?
-            .msat;
         Ok(Channel {
             short_channel_id: c
                 .short_channel_id
                 .ok_or(anyhow!("short_channel_id is missing"))?,
             state: ChannelState::Closed,
             funding_txid: hex::encode(c.funding_txid),
-            spendable_msat: to_us,
+            spendable_msat: c
+                .final_to_us_msat
+                .ok_or(anyhow!("final_to_us_msat is missing"))?
+                .msat,
             receivable_msat: 0,
-            closed_at: None,
+            closed_at: None, // Don't fill at his time, because it involves a chain_service lookup
+            funding_outnum: Some(c.funding_outnum),
         })
     }
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -947,6 +947,8 @@ pub struct Channel {
     pub spendable_msat: u64,
     pub receivable_msat: u64,
     pub closed_at: Option<u64>,
+    /// The output number of the funding tx which opened the channel
+    pub funding_outnum: Option<u32>,
 }
 
 /// State of a Lightning channel

--- a/libs/sdk-core/src/persist/channels.rs
+++ b/libs/sdk-core/src/persist/channels.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use crate::models::*;
 
 use super::db::SqliteStorage;
@@ -105,7 +103,7 @@ impl SqliteStorage {
                 c.receivable_msat,
                 match c.state {
                     ChannelState::Opened | ChannelState::PendingOpen => None,
-                    _ => Some(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs()),
+                    _ => c.closed_at,
                 },
             ),
         )?;

--- a/libs/sdk-core/src/persist/channels.rs
+++ b/libs/sdk-core/src/persist/channels.rs
@@ -174,7 +174,7 @@ fn test_sync_closed_channels() {
             state: ChannelState::Closed,
             spendable_msat: 200,
             receivable_msat: 2000,
-            closed_at: None,
+            closed_at: Some(1),
             funding_outnum: None,
         },
     ];

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -431,7 +431,10 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
         channel_opening_fees TEXT NOT NULL
        ) STRICT;
-       ",    
+       ",
+       "
+       ALTER TABLE channels ADD COLUMN funding_outnum INTEGER;
+       "
     ]
 }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -184,6 +184,24 @@ impl ChainService for MockChainService {
     async fn current_tip(&self) -> Result<u32> {
         Ok(self.tip)
     }
+    async fn transaction(&self, txid: String) -> Result<OnchainTx> {
+        Ok(OnchainTx {
+            txid,
+            version: 0,
+            locktime: 123,
+            vin: vec![],
+            vout: vec![],
+            size: 234,
+            weight: 345,
+            fee: 0,
+            status: TxStatus {
+                confirmed: false,
+                block_height: None,
+                block_hash: None,
+                block_time: None,
+            },
+        })
+    }
 
     async fn transaction_outspends(&self, _txid: String) -> Result<Vec<Outspend>> {
         Ok(vec![Outspend {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -23,7 +23,7 @@ use tonic::Streaming;
 
 use crate::backup::{BackupState, BackupTransport};
 use crate::breez_services::Receiver;
-use crate::chain::{ChainService, OnchainTx, RecommendedFees};
+use crate::chain::{ChainService, OnchainTx, Outspend, RecommendedFees, TxStatus};
 use crate::error::SdkResult;
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentReply};
@@ -184,6 +184,23 @@ impl ChainService for MockChainService {
     async fn current_tip(&self) -> Result<u32> {
         Ok(self.tip)
     }
+
+    async fn transaction_outspends(&self, _txid: String) -> Result<Vec<Outspend>> {
+        Ok(vec![
+            Outspend {
+                spent: true,
+                txid: Some("test-tx-id".into()),
+                vin: 0,
+                status: TxStatus {
+                    confirmed: true,
+                    block_height: Some(123),
+                    block_hash: Some("test-hash".into()),
+                    block_time: Some(123),
+                },
+            }
+        ])
+    }
+
     async fn broadcast_transaction(&self, _tx: Vec<u8>) -> Result<String> {
         let mut array = [0; 32];
         rand::thread_rng().fill(&mut array);

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -184,24 +184,6 @@ impl ChainService for MockChainService {
     async fn current_tip(&self) -> Result<u32> {
         Ok(self.tip)
     }
-    async fn transaction(&self, txid: String) -> Result<OnchainTx> {
-        Ok(OnchainTx {
-            txid,
-            version: 0,
-            locktime: 123,
-            vin: vec![],
-            vout: vec![],
-            size: 234,
-            weight: 345,
-            fee: 0,
-            status: TxStatus {
-                confirmed: false,
-                block_height: None,
-                block_hash: None,
-                block_time: None,
-            },
-        })
-    }
 
     async fn transaction_outspends(&self, _txid: String) -> Result<Vec<Outspend>> {
         Ok(vec![Outspend {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -186,19 +186,17 @@ impl ChainService for MockChainService {
     }
 
     async fn transaction_outspends(&self, _txid: String) -> Result<Vec<Outspend>> {
-        Ok(vec![
-            Outspend {
-                spent: true,
-                txid: Some("test-tx-id".into()),
-                vin: 0,
-                status: TxStatus {
-                    confirmed: true,
-                    block_height: Some(123),
-                    block_hash: Some("test-hash".into()),
-                    block_time: Some(123),
-                },
-            }
-        ])
+        Ok(vec![Outspend {
+            spent: true,
+            txid: Some("test-tx-id".into()),
+            vin: 0,
+            status: TxStatus {
+                confirmed: true,
+                block_height: Some(123),
+                block_hash: Some("test-hash".into()),
+                block_time: Some(123),
+            },
+        }])
     }
 
     async fn broadcast_transaction(&self, _tx: Vec<u8>) -> Result<String> {


### PR DESCRIPTION
For older DBs, where the channel `closed_at` was not part of the schema, we were defaulting to the epoch time.

This PR changes that, such that now the channel close time is taken from the closing tx block time.

Tested with a pre-December-2022 wallet.