### PR TITLE
Update CLI readme and connect params

### DIFF
--- a/tools/sdk-cli/README.md
+++ b/tools/sdk-cli/README.md
@@ -14,13 +14,11 @@ or to specify a custom data directory:
 cargo run -- --data_dir <data directory>
 ```
 
-Once the CLI is started, the first thing we need to do is create a node and there are three ways (commands) to do it:
-* `register_node` - Registers a new node in the cloud. The node credentials and the BIP39 mnemonic seed are saved in the data directory (`creds` and `phrase` files). Use this as the first command if you have no seed and no wallet credentials.
-* `recover_node` - Recovers a node from BIP39 mnemonics. Use this if you already have a seed (`phrase` file) and you wish to start using the node associated with that seed.
-* `init` - Initializes an existing node from credentials. Use this if you already have the node credentials (`creds` file) and wish to start using the associated node.
+Once the CLI is started, the first thing we need to do is create a node and there are three ways to do it:
+* **With an invite code** - You can use a one-time invite code to register a new node. Use the command `connect -i <invite_code>` with your invite code.
+* **With a partner certificate** - You can use a Greenlight Partner Certificate to register a new node. Use the command `connect -c <partner_cert> -k <partner_key>` with your Greenlight Partner Certificate and Key. This Partner Cerificate can be reused to register multiple nodes.
+* **With a mnemonic phrase** - Create a `phrase` file in the data directory containing the BIP39 mnemonic phase of an existing node. Use the command `connect` to recover the node. 
 
-Once the node is created we can start to send commands to the node. Press `Enter` to see a list of available commands.
-
-Typically, on first run one would use `register_node` as the first command, and on subsequent runs one would start with `init`.
+The node credentials and the BIP39 mnemonic seed are saved in the data directory (`creds` and `phrase` files). Once the node is created we can start to send commands to the node. Press `Enter` to see a list of available commands. When restarting the CLI, use `connect` to reconnect to the node and start sending commands to it.
 
 Please note that the CLI is very simple and only intends to demonstrate the usage and investigate issues that are hard to debug on mobile platforms.

--- a/tools/sdk-cli/README.md
+++ b/tools/sdk-cli/README.md
@@ -16,7 +16,7 @@ cargo run -- --data_dir <data directory>
 
 Once the CLI is started, the first thing we need to do is create a node and there are three ways to do it:
 * **With an invite code** - You can use a one-time invite code to register a new node. Use the command `connect -i <invite_code>` with your invite code.
-* **With a partner certificate** - You can use a Greenlight Partner Certificate to register a new node. Use the command `connect -c <partner_cert> -k <partner_key>` with your Greenlight Partner Certificate and Key. This Partner Cerificate can be reused to register multiple nodes.
+* **With a partner certificate** - You can use a Greenlight Partner Certificate to register a new node. Use the command `connect -c <partner_cert> -k <partner_key>` with your Greenlight Partner Certificate and Key. This Partner Certificate can be reused to register multiple nodes.
 * **With a mnemonic phrase** - Create a `phrase` file in the data directory containing the BIP39 mnemonic phase of an existing node. Use the command `connect` to recover the node. 
 
 The node credentials and the BIP39 mnemonic seed are saved in the data directory (`creds` and `phrase` files). Once the node is created we can start to send commands to the node. Press `Enter` to see a list of available commands. When restarting the CLI, use `connect` to reconnect to the node and start sending commands to it.

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -65,17 +65,17 @@ pub(crate) async fn handle_command(
             Ok(format!("Environment was set to {:?}", env))
         }
         Commands::Connect {
-            device_cert,
-            device_key,
+            partner_cert,
+            partner_key,
             invite_code,
         } => {
             let mut config = persistence
                 .get_or_create_config()?
                 .to_sdk_config(&persistence.data_dir);
             let mut partner_credentials: Option<GreenlightCredentials> = None;
-            if device_cert.is_some() && device_key.is_some() {
-                let cert = fs::read(device_cert.unwrap())?;
-                let key = fs::read(device_key.unwrap())?;
+            if partner_cert.is_some() && partner_key.is_some() {
+                let cert = fs::read(partner_cert.unwrap())?;
+                let key = fs::read(partner_key.unwrap())?;
                 partner_credentials = Some(GreenlightCredentials {
                     device_cert: cert,
                     device_key: key,

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -23,13 +23,13 @@ pub(crate) enum Commands {
     },
     /// Connect to the sdk services, make it operational
     Connect {
-        /// The optional greenlight device certifiate
-        #[clap(name = "device_cert", short = 'c', long = "device_cert")]
-        device_cert: Option<std::path::PathBuf>,
+        /// The optional file location containing the greenlight partner certificate
+        #[clap(name = "partner_cert", short = 'c', long = "partner_cert")]
+        partner_cert: Option<std::path::PathBuf>,
 
-        /// The optional greenlight device key
-        #[clap(name = "device_key", short = 'k', long = "device_key")]
-        device_key: Option<std::path::PathBuf>,
+        /// The optional file location containing the greenlight partner key
+        #[clap(name = "partner_key", short = 'k', long = "partner_key")]
+        partner_key: Option<std::path::PathBuf>,
 
         /// The optional greenlight invite code
         #[clap(name = "invite_code", short = 'i', long = "invite_code")]


### PR DESCRIPTION
- CLI readme still contains a description of registering or recovering nodes. 
- Clarify the Greenlight Partner Certificate params and that they should be file references.