### PR TITLE
Persist failed payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ libs/sdk-bindings/*.sql
 .DS_Store
 .idea/
 
-tools/sdk-cli/config.json
 libs/sdk-react-native/ios/breez_sdk.swift
 libs/sdk-react-native/ios/bindings-swift/**
 

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -145,8 +145,8 @@ dictionary Payment {
     u64 fee_msat;
     PaymentStatus status;
     string? description;
-    string? last_error;
     PaymentDetails details;
+    string? last_error;
 };
 
 [Enum]

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -125,6 +125,12 @@ enum PaymentTypeFilter {
     "All",
 };
 
+enum PaymentStatus {
+    "Pending",
+    "Complete",
+    "Failed",
+};
+
 enum PaymentType {
     "Sent",
     "Received",
@@ -137,8 +143,9 @@ dictionary Payment {
     i64 payment_time;    
     u64 amount_msat;
     u64 fee_msat;
-    boolean pending;
+    PaymentStatus status;
     string? description;
+    string? last_error;
     PaymentDetails details;
 };
 

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -149,6 +149,13 @@ dictionary Payment {
     string? last_error;
 };
 
+dictionary ListPaymentsRequest {
+    PaymentTypeFilter filter;
+    i64? from_timestamp = null;
+    i64? to_timestamp = null;
+    boolean? include_failures = null;
+};
+
 [Enum]
 interface PaymentDetails {
     Ln(LnPaymentDetails data);
@@ -545,7 +552,7 @@ interface BlockingBreezServices {
    Payment? payment_by_hash(string hash);
 
    [Throws=SdkError]
-   sequence<Payment> list_payments(PaymentTypeFilter filter, i64? from_timestamp, i64? to_timestamp);
+   sequence<Payment> list_payments(ListPaymentsRequest request);
 
    [Throws=SdkError]
    void sweep(string to_address, u64 fee_rate_sats_per_vbyte);

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -146,7 +146,6 @@ dictionary Payment {
     PaymentStatus status;
     string? description;
     PaymentDetails details;
-    string? last_error;
 };
 
 dictionary ListPaymentsRequest {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -16,11 +16,12 @@ use breez_sdk_core::{
     LocalizedName, LogEntry, LogStream, LspInformation, MessageSuccessActionData, MetadataItem,
     Network, NodeConfig, NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse,
     OpeningFeeParams, OpeningFeeParamsMenu, Payment, PaymentDetails, PaymentFailedData,
-    PaymentType, PaymentTypeFilter, Rate, ReceiveOnchainRequest, ReceivePaymentRequest,
-    ReceivePaymentResponse, RecommendedFees, ReverseSwapFeesRequest, ReverseSwapInfo,
-    ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop, SignMessageRequest,
-    SignMessageResponse, StaticBackupRequest, StaticBackupResponse, SuccessActionProcessed,
-    SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput, UrlSuccessActionData,
+    PaymentStatus, PaymentType, PaymentTypeFilter, Rate, ReceiveOnchainRequest,
+    ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees, ReverseSwapFeesRequest,
+    ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
+    SignMessageRequest, SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
+    SuccessActionProcessed, SwapInfo, SwapStatus, Symbol, UnspentTransactionOutput,
+    UrlSuccessActionData,
 };
 
 static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| tokio::runtime::Runtime::new().unwrap());

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -11,12 +11,12 @@ use breez_sdk_core::{
     BuyBitcoinRequest, BuyBitcoinResponse, ChannelState, CheckMessageRequest, CheckMessageResponse,
     ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType, EventListener,
     FeeratePreset, FiatCurrency, GreenlightCredentials, GreenlightNodeConfig, InputType,
-    InvoicePaidDetails, LNInvoice, LnPaymentDetails, LnUrlAuthRequestData, LnUrlCallbackStatus,
-    LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult, LnUrlWithdrawRequestData, LocaleOverrides,
-    LocalizedName, LogEntry, LogStream, LspInformation, MessageSuccessActionData, MetadataItem,
-    Network, NodeConfig, NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse,
-    OpeningFeeParams, OpeningFeeParamsMenu, Payment, PaymentDetails, PaymentFailedData,
-    PaymentStatus, PaymentType, PaymentTypeFilter, Rate, ReceiveOnchainRequest,
+    InvoicePaidDetails, LNInvoice, ListPaymentsRequest, LnPaymentDetails, LnUrlAuthRequestData,
+    LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult,
+    LnUrlWithdrawRequestData, LocaleOverrides, LocalizedName, LogEntry, LogStream, LspInformation,
+    MessageSuccessActionData, MetadataItem, Network, NodeConfig, NodeState, OpenChannelFeeRequest,
+    OpenChannelFeeResponse, OpeningFeeParams, OpeningFeeParamsMenu, Payment, PaymentDetails,
+    PaymentFailedData, PaymentStatus, PaymentType, PaymentTypeFilter, Rate, ReceiveOnchainRequest,
     ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees, ReverseSwapFeesRequest,
     ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
     SignMessageRequest, SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
@@ -157,16 +157,8 @@ impl BlockingBreezServices {
             .map_err(|e| e.into())
     }
 
-    pub fn list_payments(
-        &self,
-        filter: PaymentTypeFilter,
-        from_timestamp: Option<i64>,
-        to_timestamp: Option<i64>,
-    ) -> SdkResult<Vec<Payment>> {
-        rt().block_on(
-            self.breez_services
-                .list_payments(filter, from_timestamp, to_timestamp),
-        )
+    pub fn list_payments(&self, request: ListPaymentsRequest) -> SdkResult<Vec<Payment>> {
+        rt().block_on(self.breez_services.list_payments(request))
     }
 
     pub fn payment_by_hash(&self, hash: String) -> SdkResult<Option<Payment>> {

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -29,12 +29,13 @@ use crate::input_parser::{
 use crate::invoice::{self, LNInvoice};
 use crate::lnurl::pay::model::LnUrlPayResult;
 use crate::lsp::LspInformation;
-use crate::models::{Config, LogEntry, NodeState, Payment, PaymentTypeFilter, SwapInfo};
+use crate::models::{Config, LogEntry, NodeState, Payment, SwapInfo};
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
-    EnvironmentType, LnUrlCallbackStatus, NodeConfig, ReceiveOnchainRequest, ReceivePaymentRequest,
-    ReceivePaymentResponse, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
-    SignMessageRequest, SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
+    EnvironmentType, ListPaymentsRequest, LnUrlCallbackStatus, NodeConfig, ReceiveOnchainRequest,
+    ReceivePaymentRequest, ReceivePaymentResponse, ReverseSwapFeesRequest, ReverseSwapInfo,
+    ReverseSwapPairInfo, SignMessageRequest, SignMessageResponse, StaticBackupRequest,
+    StaticBackupResponse,
 };
 
 static BREEZ_SERVICES_INSTANCE: OnceCell<Arc<BreezServices>> = OnceCell::new();
@@ -203,17 +204,9 @@ pub fn parse_input(input: String) -> Result<InputType> {
 /*  Payment API's */
 
 /// See [BreezServices::list_payments]
-pub fn list_payments(
-    filter: PaymentTypeFilter,
-    from_timestamp: Option<i64>,
-    to_timestamp: Option<i64>,
-) -> Result<Vec<Payment>> {
-    block_on(async {
-        get_breez_services()?
-            .list_payments(filter, from_timestamp, to_timestamp)
-            .await
-    })
-    .map_err(anyhow::Error::new)
+pub fn list_payments(request: ListPaymentsRequest) -> Result<Vec<Payment>> {
+    block_on(async { get_breez_services()?.list_payments(request).await })
+        .map_err(anyhow::Error::new)
 }
 
 /// See [BreezServices::list_payments]

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1835,7 +1835,7 @@ pub(crate) mod tests {
     use crate::models::{LnPaymentDetails, NodeState, Payment, PaymentDetails, PaymentTypeFilter};
     use crate::{
         input_parser, parse_short_channel_id, test_utils::*, BuyBitcoinProvider, BuyBitcoinRequest,
-        InputType, ReceivePaymentRequest, PaymentStatus,
+        InputType, PaymentStatus, ReceivePaymentRequest,
     };
     use crate::{NodeAPI, PaymentType};
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1835,7 +1835,7 @@ pub(crate) mod tests {
     use crate::models::{LnPaymentDetails, NodeState, Payment, PaymentDetails, PaymentTypeFilter};
     use crate::{
         input_parser, parse_short_channel_id, test_utils::*, BuyBitcoinProvider, BuyBitcoinRequest,
-        InputType, ReceivePaymentRequest,
+        InputType, ReceivePaymentRequest, PaymentStatus,
     };
     use crate::{NodeAPI, PaymentType};
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -795,7 +795,6 @@ impl BreezServices {
                 if let Some(inv) = invoice.clone() {
                     let mut payment = Payment::try_from(inv)?;
                     payment.status = PaymentStatus::Failed;
-                    payment.last_error = Some(e.to_string());
                     self.persister.insert_or_update_payments(&vec![payment])?;
                 }
 
@@ -1266,7 +1265,6 @@ impl BreezServices {
                     funding_txid: channel.funding_txid,
                 },
             },
-            last_error: None,
         })
     }
 }
@@ -1921,7 +1919,6 @@ pub(crate) mod tests {
                         ln_address: None,
                     },
                 },
-                last_error: None,
             },
             Payment {
                 id: payment_hash_with_lnurl_success_action.to_string(),
@@ -1944,7 +1941,6 @@ pub(crate) mod tests {
                         ln_address: Some(test_ln_address.to_string()),
                     },
                 },
-                last_error: None,
             },
         ];
         let node_api = Arc::new(MockNodeAPI::new(dummy_node_state.clone()));

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -117,13 +117,8 @@ pub extern "C" fn wire_parse_input(port_: i64, input: *mut wire_uint_8_list) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_list_payments(
-    port_: i64,
-    filter: i32,
-    from_timestamp: *mut i64,
-    to_timestamp: *mut i64,
-) {
-    wire_list_payments_impl(port_, filter, from_timestamp, to_timestamp)
+pub extern "C" fn wire_list_payments(port_: i64, request: *mut wire_ListPaymentsRequest) {
+    wire_list_payments_impl(port_, request)
 }
 
 #[no_mangle]
@@ -303,6 +298,11 @@ pub extern "C" fn new_box_autoadd_i64_0(value: i64) -> *mut i64 {
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_list_payments_request_0() -> *mut wire_ListPaymentsRequest {
+    support::new_leak_box_ptr(wire_ListPaymentsRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_ln_url_auth_request_data_0() -> *mut wire_LnUrlAuthRequestData {
     support::new_leak_box_ptr(wire_LnUrlAuthRequestData::new_with_null_ptr())
 }
@@ -422,6 +422,12 @@ impl Wire2Api<GreenlightNodeConfig> for *mut wire_GreenlightNodeConfig {
 impl Wire2Api<i64> for *mut i64 {
     fn wire2api(self) -> i64 {
         unsafe { *support::box_from_leak_ptr(self) }
+    }
+}
+impl Wire2Api<ListPaymentsRequest> for *mut wire_ListPaymentsRequest {
+    fn wire2api(self) -> ListPaymentsRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<ListPaymentsRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<LnUrlAuthRequestData> for *mut wire_LnUrlAuthRequestData {
@@ -546,6 +552,16 @@ impl Wire2Api<GreenlightNodeConfig> for wire_GreenlightNodeConfig {
     }
 }
 
+impl Wire2Api<ListPaymentsRequest> for wire_ListPaymentsRequest {
+    fn wire2api(self) -> ListPaymentsRequest {
+        ListPaymentsRequest {
+            filter: self.filter.wire2api(),
+            from_timestamp: self.from_timestamp.wire2api(),
+            to_timestamp: self.to_timestamp.wire2api(),
+            include_failures: self.include_failures.wire2api(),
+        }
+    }
+}
 impl Wire2Api<LnUrlAuthRequestData> for wire_LnUrlAuthRequestData {
     fn wire2api(self) -> LnUrlAuthRequestData {
         LnUrlAuthRequestData {
@@ -702,6 +718,15 @@ pub struct wire_GreenlightCredentials {
 pub struct wire_GreenlightNodeConfig {
     partner_credentials: *mut wire_GreenlightCredentials,
     invite_code: *mut wire_uint_8_list,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_ListPaymentsRequest {
+    filter: i32,
+    from_timestamp: *mut i64,
+    to_timestamp: *mut i64,
+    include_failures: *mut bool,
 }
 
 #[repr(C)]
@@ -898,6 +923,23 @@ impl NewWithNullPtr for wire_GreenlightNodeConfig {
 }
 
 impl Default for wire_GreenlightNodeConfig {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_ListPaymentsRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            filter: Default::default(),
+            from_timestamp: core::ptr::null_mut(),
+            to_timestamp: core::ptr::null_mut(),
+            include_failures: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_ListPaymentsRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1208,8 +1208,8 @@ impl support::IntoDart for Payment {
             self.fee_msat.into_dart(),
             self.status.into_dart(),
             self.description.into_dart(),
-            self.last_error.into_dart(),
             self.details.into_dart(),
+            self.last_error.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -59,6 +59,7 @@ use crate::models::Config;
 use crate::models::EnvironmentType;
 use crate::models::GreenlightCredentials;
 use crate::models::GreenlightNodeConfig;
+use crate::models::ListPaymentsRequest;
 use crate::models::LnPaymentDetails;
 use crate::models::LnUrlCallbackStatus;
 use crate::models::LogEntry;
@@ -360,9 +361,7 @@ fn wire_parse_input_impl(port_: MessagePort, input: impl Wire2Api<String> + Unwi
 }
 fn wire_list_payments_impl(
     port_: MessagePort,
-    filter: impl Wire2Api<PaymentTypeFilter> + UnwindSafe,
-    from_timestamp: impl Wire2Api<Option<i64>> + UnwindSafe,
-    to_timestamp: impl Wire2Api<Option<i64>> + UnwindSafe,
+    request: impl Wire2Api<ListPaymentsRequest> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -371,10 +370,8 @@ fn wire_list_payments_impl(
             mode: FfiCallMode::Normal,
         },
         move || {
-            let api_filter = filter.wire2api();
-            let api_from_timestamp = from_timestamp.wire2api();
-            let api_to_timestamp = to_timestamp.wire2api();
-            move |task_callback| list_payments(api_filter, api_from_timestamp, api_to_timestamp)
+            let api_request = request.wire2api();
+            move |task_callback| list_payments(api_request)
         },
     )
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -69,6 +69,7 @@ use crate::models::OpeningFeeParams;
 use crate::models::OpeningFeeParamsMenu;
 use crate::models::Payment;
 use crate::models::PaymentDetails;
+use crate::models::PaymentStatus;
 use crate::models::PaymentType;
 use crate::models::PaymentTypeFilter;
 use crate::models::ReceiveOnchainRequest;
@@ -1205,8 +1206,9 @@ impl support::IntoDart for Payment {
             self.payment_time.into_dart(),
             self.amount_msat.into_dart(),
             self.fee_msat.into_dart(),
-            self.pending.into_dart(),
+            self.status.into_dart(),
             self.description.into_dart(),
+            self.last_error.into_dart(),
             self.details.into_dart(),
         ]
         .into_dart()
@@ -1236,6 +1238,17 @@ impl support::IntoDart for PaymentFailedData {
 }
 impl support::IntoDartExceptPrimitive for PaymentFailedData {}
 
+impl support::IntoDart for PaymentStatus {
+    fn into_dart(self) -> support::DartAbi {
+        match self {
+            Self::Pending => 0,
+            Self::Complete => 1,
+            Self::Failed => 2,
+        }
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for PaymentStatus {}
 impl support::IntoDart for PaymentType {
     fn into_dart(self) -> support::DartAbi {
         match self {

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1206,7 +1206,6 @@ impl support::IntoDart for Payment {
             self.status.into_dart(),
             self.description.into_dart(),
             self.details.into_dart(),
-            self.last_error.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -12,12 +12,14 @@ use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
 use ecies::utils::{aes_decrypt, aes_encrypt};
 use gl_client::node::ClnClient;
 use gl_client::pb::amount::Unit;
+use gl_client::pb::cln::listinvoices_invoices::ListinvoicesInvoicesStatus;
+use gl_client::pb::cln::listpays_pays::ListpaysPaysStatus;
 use gl_client::pb::cln::{
     self, CloseRequest, ListclosedchannelsClosedchannels, ListclosedchannelsRequest,
-    ListpeerchannelsRequest, StaticbackupRequest,
+    ListinvoicesInvoices, ListpaysPays, ListpeerchannelsRequest, StaticbackupRequest,
 };
 use gl_client::pb::cln::{AmountOrAny, InvoiceRequest};
-use gl_client::pb::{Amount, InvoiceStatus, OffChainPayment, PayStatus, Peer, WithdrawResponse};
+use gl_client::pb::{Amount, OffChainPayment, PayStatus, Peer, WithdrawResponse};
 
 use gl_client::pb::cln::listpeers_peers_channels::ListpeersPeersChannelsState::*;
 use gl_client::scheduler::Scheduler;
@@ -352,7 +354,7 @@ impl NodeAPI for Greenlight {
     // implemenet pull changes from greenlight
     async fn pull_changed(
         &self,
-        since_timestamp: i64,
+        since_timestamp: u64,
         balance_changed: bool,
     ) -> Result<SyncResponse> {
         info!("pull changed since {}", since_timestamp);
@@ -492,7 +494,7 @@ impl NodeAPI for Greenlight {
 
         Ok(SyncResponse {
             node_state,
-            payments: pull_transactions(since_timestamp, client.clone()).await?,
+            payments: pull_transactions(since_timestamp, node_client.clone()).await?,
             channels: all_channel_models,
         })
     }
@@ -833,12 +835,12 @@ enum NodeCommand {
 
 // pulls transactions from greenlight based on last sync timestamp.
 // greenlight gives us the payments via API and for received payments we are looking for settled invoices.
-async fn pull_transactions(since_timestamp: i64, client: node::Client) -> Result<Vec<Payment>> {
+async fn pull_transactions(since_timestamp: u64, client: node::ClnClient) -> Result<Vec<Payment>> {
     let mut c = client.clone();
 
     // list invoices
     let invoices = c
-        .list_invoices(pb::ListInvoicesRequest::default())
+        .list_invoices(pb::cln::ListinvoicesRequest::default())
         .await?
         .into_inner();
 
@@ -847,27 +849,23 @@ async fn pull_transactions(since_timestamp: i64, client: node::Client) -> Result
         .invoices
         .into_iter()
         .filter(|i| {
-            i.payment_time > 0
-                && i.status() == InvoiceStatus::Paid
-                && i.payment_time as i64 > since_timestamp
+            i.paid_at.unwrap_or_default() > since_timestamp
+                && i.status() == ListinvoicesInvoicesStatus::Paid
         })
         .map(TryInto::try_into)
         .collect();
 
     // fetch payments from greenlight
     let payments = c
-        .list_payments(pb::ListPaymentsRequest::default())
+        .list_pays(pb::cln::ListpaysRequest::default())
         .await?
         .into_inner();
     debug!("list payments: {:?}", payments);
     // construct the payment transactions (pending and complete)
     let outbound_transactions: Result<Vec<Payment>> = payments
-        .payments
+        .pays
         .into_iter()
-        .filter(|p| {
-            p.created_at as i64 > since_timestamp
-                && (p.status() == PayStatus::Pending || p.status() == PayStatus::Complete)
-        })
+        .filter(|p| p.created_at > since_timestamp)
         .map(TryInto::try_into)
         .collect();
 
@@ -945,6 +943,17 @@ impl TryFrom<pb::Invoice> for Payment {
     }
 }
 
+impl From<PayStatus> for PaymentStatus {
+    fn from(value: PayStatus) -> Self {
+        match value {
+            PayStatus::Pending => PaymentStatus::Pending,
+            PayStatus::Complete => PaymentStatus::Complete,
+            PayStatus::Failed => PaymentStatus::Failed,
+        }
+    }
+}
+
+/// Construct a lightning transaction from an invoice
 impl TryFrom<pb::Payment> for Payment {
     type Error = anyhow::Error;
 
@@ -954,9 +963,9 @@ impl TryFrom<pb::Payment> for Payment {
             description = parse_invoice(&payment.bolt11)?.description;
         }
 
-        let payment_amount = amount_to_msat(&payment.amount.unwrap_or_default());
-        let payment_amount_sent = amount_to_msat(&payment.amount_sent.unwrap_or_default());
-        let status = payment.status.try_into()?;
+        let payment_amount = amount_to_msat(&payment.amount.clone().unwrap_or_default());
+        let payment_amount_sent = amount_to_msat(&payment.amount_sent.clone().unwrap_or_default());
+        let status = payment.status().into();
 
         Ok(Payment {
             id: hex::encode(payment.payment_hash.clone()),
@@ -980,6 +989,102 @@ impl TryFrom<pb::Payment> for Payment {
                 },
             },
             last_error: None,
+        })
+    }
+}
+
+/// Construct a lightning transaction from an invoice
+impl TryFrom<ListinvoicesInvoices> for Payment {
+    type Error = anyhow::Error;
+
+    fn try_from(invoice: ListinvoicesInvoices) -> std::result::Result<Self, Self::Error> {
+        let ln_invoice = invoice
+            .bolt11
+            .as_ref()
+            .ok_or(anyhow!("No bolt11 invoice"))
+            .and_then(|b| parse_invoice(b))?;
+        Ok(Payment {
+            id: hex::encode(invoice.payment_hash.clone()),
+            payment_type: PaymentType::Received,
+            payment_time: invoice.paid_at.map(|i| i as i64).unwrap_or_default(),
+            amount_msat: invoice.amount_msat.map(|a| a.msat).unwrap_or_default(),
+            fee_msat: 0,
+            status: PaymentStatus::Complete,
+            description: ln_invoice.description,
+            details: PaymentDetails::Ln {
+                data: LnPaymentDetails {
+                    payment_hash: hex::encode(invoice.payment_hash),
+                    label: invoice.label,
+                    destination_pubkey: ln_invoice.payee_pubkey,
+                    payment_preimage: invoice
+                        .payment_preimage
+                        .map(hex::encode)
+                        .unwrap_or_default(),
+                    keysend: false,
+                    bolt11: invoice.bolt11.unwrap_or_default(),
+                    lnurl_success_action: None, // For received payments, this is None
+                    lnurl_metadata: None,       // For received payments, this is None
+                    ln_address: None,
+                },
+            },
+            last_error: None,
+        })
+    }
+}
+
+impl From<ListpaysPaysStatus> for PaymentStatus {
+    fn from(value: ListpaysPaysStatus) -> Self {
+        match value {
+            ListpaysPaysStatus::Pending => PaymentStatus::Pending,
+            ListpaysPaysStatus::Complete => PaymentStatus::Complete,
+            ListpaysPaysStatus::Failed => PaymentStatus::Failed,
+        }
+    }
+}
+
+impl TryFrom<ListpaysPays> for Payment {
+    type Error = anyhow::Error;
+
+    fn try_from(payment: ListpaysPays) -> std::result::Result<Self, Self::Error> {
+        let ln_invoice = payment
+            .bolt11
+            .as_ref()
+            .ok_or(anyhow!("No bolt11 invoice"))
+            .and_then(|b| parse_invoice(b));
+        let payment_amount = payment
+            .amount_msat
+            .clone()
+            .map(|a| a.msat)
+            .unwrap_or_default();
+        let payment_amount_sent = payment
+            .amount_sent_msat
+            .clone()
+            .map(|a| a.msat)
+            .unwrap_or_default();
+        let status = payment.status().into();
+
+        Ok(Payment {
+            id: hex::encode(payment.payment_hash.clone()),
+            payment_type: PaymentType::Sent,
+            payment_time: payment.created_at as i64,
+            amount_msat: payment_amount,
+            fee_msat: payment_amount_sent - payment_amount,
+            status,
+            description: ln_invoice.map(|i| i.description).unwrap_or_default(),
+            details: PaymentDetails::Ln {
+                data: LnPaymentDetails {
+                    payment_hash: hex::encode(payment.payment_hash),
+                    label: "".to_string(),
+                    destination_pubkey: payment.destination.map(hex::encode).unwrap_or_default(),
+                    payment_preimage: payment.preimage.map(hex::encode).unwrap_or_default(),
+                    keysend: payment.bolt11.is_none(),
+                    bolt11: payment.bolt11.unwrap_or_default(),
+                    lnurl_success_action: None,
+                    lnurl_metadata: None,
+                    ln_address: None,
+                },
+            },
+            last_error: payment.erroronion.map(hex::encode),
         })
     }
 }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -890,7 +890,6 @@ impl TryFrom<OffChainPayment> for Payment {
             fee_msat: 0,
             status: PaymentStatus::Complete,
             description: ln_invoice.description,
-            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: hex::encode(p.payment_hash),
@@ -938,7 +937,6 @@ impl TryFrom<pb::Invoice> for Payment {
                     ln_address: None,
                 },
             },
-            last_error: None,
         })
     }
 }
@@ -988,7 +986,6 @@ impl TryFrom<pb::Payment> for Payment {
                     ln_address: None,
                 },
             },
-            last_error: None,
         })
     }
 }
@@ -1027,7 +1024,6 @@ impl TryFrom<ListinvoicesInvoices> for Payment {
                     ln_address: None,
                 },
             },
-            last_error: None,
         })
     }
 }
@@ -1084,7 +1080,6 @@ impl TryFrom<ListpaysPays> for Payment {
                     ln_address: None,
                 },
             },
-            last_error: payment.erroronion.map(hex::encode),
         })
     }
 }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -927,7 +927,6 @@ impl TryFrom<pb::Invoice> for Payment {
             fee_msat: 0,
             status: PaymentStatus::Complete,
             description: ln_invoice.description,
-            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: hex::encode(invoice.payment_hash),
@@ -941,6 +940,7 @@ impl TryFrom<pb::Invoice> for Payment {
                     ln_address: None,
                 },
             },
+            last_error: None,
         })
     }
 }
@@ -966,7 +966,6 @@ impl TryFrom<pb::Payment> for Payment {
             fee_msat: payment_amount_sent - payment_amount,
             status,
             description,
-            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: hex::encode(payment.payment_hash),
@@ -980,6 +979,7 @@ impl TryFrom<pb::Payment> for Payment {
                     ln_address: None,
                 },
             },
+            last_error: None,
         })
     }
 }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1063,7 +1063,12 @@ impl TryFrom<ListpaysPays> for Payment {
             id: hex::encode(payment.payment_hash.clone()),
             payment_type: PaymentType::Sent,
             payment_time: payment.created_at as i64,
-            amount_msat: payment_amount,
+            amount_msat: match status {
+                PaymentStatus::Failed => ln_invoice
+                    .as_ref()
+                    .map_or(0, |i| i.amount_msat.unwrap_or_default()),
+                _ => payment_amount,
+            },
             fee_msat: payment_amount_sent - payment_amount,
             status,
             description: ln_invoice.map(|i| i.description).unwrap_or_default(),

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -645,7 +645,6 @@ pub struct Payment {
     pub status: PaymentStatus,
     pub description: Option<String>,
     pub details: PaymentDetails,
-    pub last_error: Option<String>,
 }
 
 impl TryFrom<LNInvoice> for Payment {
@@ -673,7 +672,6 @@ impl TryFrom<LNInvoice> for Payment {
                     ln_address: None,
                 },
             },
-            last_error: None,
         })
     }
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -690,6 +690,14 @@ impl TryFrom<LNInvoice> for Payment {
     }
 }
 
+/// Represents a list payments request.
+pub struct ListPaymentsRequest {
+    pub filter: PaymentTypeFilter,
+    pub from_timestamp: Option<i64>,
+    pub to_timestamp: Option<i64>,
+    pub include_failures: Option<bool>,
+}
+
 /// Represents a payment response.
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentResponse {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -656,8 +656,8 @@ pub struct Payment {
     pub fee_msat: u64,
     pub status: PaymentStatus,
     pub description: Option<String>,
-    pub last_error: Option<String>,
     pub details: PaymentDetails,
+    pub last_error: Option<String>,
 }
 
 impl TryFrom<LNInvoice> for Payment {
@@ -672,7 +672,6 @@ impl TryFrom<LNInvoice> for Payment {
             fee_msat: 0,
             status: PaymentStatus::Pending,
             description: inv.description,
-            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: inv.payment_hash.clone(),
@@ -686,6 +685,7 @@ impl TryFrom<LNInvoice> for Payment {
                     ln_address: None,
                 },
             },
+            last_error: None,
         })
     }
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -647,35 +647,6 @@ pub struct Payment {
     pub details: PaymentDetails,
 }
 
-impl TryFrom<LNInvoice> for Payment {
-    type Error = anyhow::Error;
-
-    fn try_from(inv: LNInvoice) -> std::result::Result<Self, Self::Error> {
-        Ok(Payment {
-            id: inv.payment_hash.clone(),
-            payment_type: PaymentType::Sent,
-            payment_time: inv.timestamp as i64,
-            amount_msat: inv.amount_msat.unwrap_or(0),
-            fee_msat: 0,
-            status: PaymentStatus::Pending,
-            description: inv.description,
-            details: PaymentDetails::Ln {
-                data: LnPaymentDetails {
-                    payment_hash: inv.payment_hash.clone(),
-                    label: "".to_string(),
-                    destination_pubkey: inv.payee_pubkey,
-                    payment_preimage: "".to_string(),
-                    keysend: false,
-                    bolt11: inv.bolt11,
-                    lnurl_success_action: None,
-                    lnurl_metadata: None,
-                    ln_address: None,
-                },
-            },
-        })
-    }
-}
-
 /// Represents a list payments request.
 pub struct ListPaymentsRequest {
     pub filter: PaymentTypeFilter,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -60,7 +60,7 @@ pub trait NodeAPI: Send + Sync {
     ) -> Result<String>;
     async fn pull_changed(
         &self,
-        since_timestamp: i64,
+        since_timestamp: u64,
         balance_changed: bool,
     ) -> Result<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_sats` is only needed when the invoice doesn't specify an amount
@@ -632,18 +632,6 @@ pub enum PaymentStatus {
     Pending = 0,
     Complete = 1,
     Failed = 2,
-}
-
-impl TryFrom<i32> for PaymentStatus {
-    type Error = anyhow::Error;
-    fn try_from(value: i32) -> std::result::Result<Self, Self::Error> {
-        match value {
-            0 => Ok(PaymentStatus::Pending),
-            1 => Ok(PaymentStatus::Complete),
-            2 => Ok(PaymentStatus::Failed),
-            _ => Err(anyhow!("illegal value")),
-        }
-    }
 }
 
 /// Represents a payment, including its [PaymentType] and [PaymentDetails].

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -437,7 +437,6 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ",
        "
        ALTER TABLE payments RENAME COLUMN pending TO status;
-       ALTER TABLE payments ADD COLUMN last_error TEXT;
        UPDATE payments SET status = CASE WHEN status = 1 THEN 0 ELSE 1 END;
        ",
     ]

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -431,7 +431,12 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
         channel_opening_fees TEXT NOT NULL
        ) STRICT;
-       ",    
+       ",
+       "
+       ALTER TABLE payments RENAME COLUMN pending TO status;
+       ALTER TABLE payments ADD COLUMN last_error TEXT;
+       UPDATE payments SET status = CASE WHEN status = 1 THEN 0 ELSE 1 END;
+       ",
     ]
 }
 

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -116,11 +116,9 @@ impl SqliteStorage {
 
     pub fn last_payment_timestamp(&self) -> Result<u64> {
         self.get_connection()?
-            .query_row(
-                "SELECT max(payment_time) FROM payments WHERE status != ?1",
-                [PaymentStatus::Failed],
-                |row| row.get(0),
-            )
+            .query_row("SELECT max(payment_time) FROM payments", [], |row| {
+                row.get(0)
+            })
             .map_err(anyhow::Error::msg)
     }
 
@@ -459,7 +457,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(retrieve_txs[0], txs[1]);
 
     let max_ts = storage.last_payment_timestamp()?;
-    assert_eq!(max_ts, 1001);
+    assert_eq!(max_ts, 2000);
 
     storage.insert_or_update_payments(&txs)?;
     let retrieve_txs = storage.list_payments(PaymentTypeFilter::All, None, None, None)?;

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -116,7 +116,7 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub fn last_payment_timestamp(&self) -> Result<i64> {
+    pub fn last_payment_timestamp(&self) -> Result<u64> {
         self.get_connection()?
             .query_row(
                 "SELECT max(payment_time) FROM payments WHERE status != ?1",

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -31,10 +31,9 @@ impl SqliteStorage {
            fee_msat,                 
            status,
            description,
-           details,
-           last_error
+           details
         )
-         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8)
         ",
         )?;
 
@@ -48,7 +47,6 @@ impl SqliteStorage {
                 &ln_tx.status,
                 &ln_tx.description,
                 &ln_tx.details,
-                &ln_tx.last_error,
             ))?;
         }
         Ok(())
@@ -152,7 +150,6 @@ impl SqliteStorage {
              p.status,
              p.description,
              p.details,
-             p.last_error,
              e.lnurl_success_action,
              e.lnurl_metadata,
              e.ln_address,
@@ -196,7 +193,6 @@ impl SqliteStorage {
                  p.status,
                  p.description,
                  p.details,
-                 p.last_error,
                  e.lnurl_success_action,
                  e.lnurl_metadata,
                  e.ln_address,
@@ -239,17 +235,16 @@ impl SqliteStorage {
             status: row.get(5)?,
             description: row.get(6)?,
             details: row.get(7)?,
-            last_error: row.get(8)?,
         };
 
         if let PaymentDetails::Ln { ref mut data } = payment.details {
-            data.lnurl_success_action = row.get(9)?;
-            data.lnurl_metadata = row.get(10)?;
-            data.ln_address = row.get(11)?;
+            data.lnurl_success_action = row.get(8)?;
+            data.lnurl_metadata = row.get(9)?;
+            data.ln_address = row.get(10)?;
         }
 
         // In case we have a record of the open channel fee, let's use it.
-        let payer_amount_msat: Option<u64> = row.get(12)?;
+        let payer_amount_msat: Option<u64> = row.get(11)?;
         if let Some(payer_amount) = payer_amount_msat {
             payment.fee_msat = payer_amount - amount_msat;
         }
@@ -385,7 +380,6 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
                     ln_address: Some(test_ln_address.to_string()),
                 },
             },
-            last_error: None,
         },
         Payment {
             id: "124".to_string(),
@@ -408,7 +402,6 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
                     ln_address: None,
                 },
             },
-            last_error: None,
         },
     ];
     let failed_txs = [Payment {
@@ -432,7 +425,6 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
                 ln_address: None,
             },
         },
-        last_error: None,
     }];
     let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
     storage.init()?;

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -31,9 +31,9 @@ impl SqliteStorage {
            fee_msat,                 
            status,
            description,
-           last_error,
-           details
-         )
+           details,
+           last_error
+        )
          VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
         ",
         )?;
@@ -47,8 +47,8 @@ impl SqliteStorage {
                 &ln_tx.fee_msat,
                 &ln_tx.status,
                 &ln_tx.description,
-                &ln_tx.last_error,
                 &ln_tx.details,
+                &ln_tx.last_error,
             ))?;
         }
         Ok(())
@@ -147,8 +147,8 @@ impl SqliteStorage {
              p.fee_msat,
              p.status,
              p.description,
-             p.last_error,
              p.details,
+             p.last_error,
              e.lnurl_success_action,
              e.lnurl_metadata,
              e.ln_address,
@@ -191,8 +191,8 @@ impl SqliteStorage {
                  p.fee_msat,
                  p.status,
                  p.description,
-                 p.last_error,
                  p.details,
+                 p.last_error,
                  e.lnurl_success_action,
                  e.lnurl_metadata,
                  e.ln_address,
@@ -234,8 +234,8 @@ impl SqliteStorage {
             fee_msat: row.get(4)?,
             status: row.get(5)?,
             description: row.get(6)?,
-            last_error: row.get(7)?,
-            details: row.get(8)?,
+            details: row.get(7)?,
+            last_error: row.get(8)?,
         };
 
         if let PaymentDetails::Ln { ref mut data } = payment.details {
@@ -363,7 +363,6 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
             fee_msat: 20,
             status: PaymentStatus::Complete,
             description: None,
-            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: payment_hash_with_lnurl_success_action.to_string(),
@@ -377,6 +376,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
                     ln_address: Some(test_ln_address.to_string()),
                 },
             },
+            last_error: None,
         },
         Payment {
             id: "124".to_string(),
@@ -386,7 +386,6 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
             fee_msat: 20,
             status: PaymentStatus::Complete,
             description: Some("desc".to_string()),
-            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: "124".to_string(),
@@ -400,6 +399,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
                     ln_address: None,
                 },
             },
+            last_error: None,
         },
     ];
     let storage = SqliteStorage::new(test_utils::create_test_sql_dir());

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -817,7 +817,6 @@ mod tests {
             fee_msat: 0,
             status: PaymentStatus::Complete,
             description: Some("desc".to_string()),
-            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: hex::encode(swap_info.payment_hash.clone()),
@@ -831,6 +830,7 @@ mod tests {
                     ln_address: None,
                 },
             },
+            last_error: None,
         };
         persister.insert_or_update_payments(&vec![payment.clone()])?;
 

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -815,8 +815,9 @@ mod tests {
             payment_time: 0,
             amount_msat: 5000,
             fee_msat: 0,
-            pending: false,
+            status: PaymentStatus::Complete,
             description: Some("desc".to_string()),
+            last_error: None,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: hex::encode(swap_info.payment_hash.clone()),

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -830,7 +830,6 @@ mod tests {
                     ln_address: None,
                 },
             },
-            last_error: None,
         };
         persister.insert_or_update_payments(&vec![payment.clone()])?;
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -264,7 +264,7 @@ impl NodeAPI for MockNodeAPI {
 
     async fn pull_changed(
         &self,
-        _since_timestamp: i64,
+        _since_timestamp: u64,
         _balance_changed: bool,
     ) -> Result<SyncResponse> {
         Ok(SyncResponse {

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -72,6 +72,13 @@ typedef struct wire_StaticBackupRequest {
   struct wire_uint_8_list *working_dir;
 } wire_StaticBackupRequest;
 
+typedef struct wire_ListPaymentsRequest {
+  int32_t filter;
+  int64_t *from_timestamp;
+  int64_t *to_timestamp;
+  bool *include_failures;
+} wire_ListPaymentsRequest;
+
 typedef struct wire_OpeningFeeParams {
   uint64_t min_msat;
   uint32_t proportional;
@@ -188,10 +195,7 @@ void wire_parse_invoice(int64_t port_, struct wire_uint_8_list *invoice);
 
 void wire_parse_input(int64_t port_, struct wire_uint_8_list *input);
 
-void wire_list_payments(int64_t port_,
-                        int32_t filter,
-                        int64_t *from_timestamp,
-                        int64_t *to_timestamp);
+void wire_list_payments(int64_t port_, struct wire_ListPaymentsRequest *request);
 
 void wire_payment_by_hash(int64_t port_, struct wire_uint_8_list *hash);
 
@@ -263,6 +267,8 @@ struct wire_GreenlightCredentials *new_box_autoadd_greenlight_credentials_0(void
 struct wire_GreenlightNodeConfig *new_box_autoadd_greenlight_node_config_0(void);
 
 int64_t *new_box_autoadd_i64_0(int64_t value);
+
+struct wire_ListPaymentsRequest *new_box_autoadd_list_payments_request_0(void);
 
 struct wire_LnUrlAuthRequestData *new_box_autoadd_ln_url_auth_request_data_0(void);
 
@@ -346,6 +352,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_credentials_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_node_config_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_i64_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_list_payments_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_auth_request_data_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_pay_request_data_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_withdraw_request_data_0);

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -942,8 +942,9 @@ class Payment {
   final int paymentTime;
   final int amountMsat;
   final int feeMsat;
-  final bool pending;
+  final PaymentStatus status;
   final String? description;
+  final String? lastError;
   final PaymentDetails details;
 
   const Payment({
@@ -952,8 +953,9 @@ class Payment {
     required this.paymentTime,
     required this.amountMsat,
     required this.feeMsat,
-    required this.pending,
+    required this.status,
     this.description,
+    this.lastError,
     required this.details,
   });
 }
@@ -978,6 +980,13 @@ class PaymentFailedData {
     required this.nodeId,
     this.invoice,
   });
+}
+
+/// The status of a payment
+enum PaymentStatus {
+  Pending,
+  Complete,
+  Failed,
 }
 
 /// Different types of supported payments
@@ -2746,16 +2755,17 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   Payment _wire2api_payment(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    if (arr.length != 9) throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return Payment(
       id: _wire2api_String(arr[0]),
       paymentType: _wire2api_payment_type(arr[1]),
       paymentTime: _wire2api_i64(arr[2]),
       amountMsat: _wire2api_u64(arr[3]),
       feeMsat: _wire2api_u64(arr[4]),
-      pending: _wire2api_bool(arr[5]),
+      status: _wire2api_payment_status(arr[5]),
       description: _wire2api_opt_String(arr[6]),
-      details: _wire2api_payment_details(arr[7]),
+      lastError: _wire2api_opt_String(arr[7]),
+      details: _wire2api_payment_details(arr[8]),
     );
   }
 
@@ -2782,6 +2792,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       nodeId: _wire2api_String(arr[1]),
       invoice: _wire2api_opt_box_autoadd_ln_invoice(arr[2]),
     );
+  }
+
+  PaymentStatus _wire2api_payment_status(dynamic raw) {
+    return PaymentStatus.values[raw as int];
   }
 
   PaymentType _wire2api_payment_type(dynamic raw) {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -959,7 +959,6 @@ class Payment {
   final PaymentStatus status;
   final String? description;
   final PaymentDetails details;
-  final String? lastError;
 
   const Payment({
     required this.id,
@@ -970,7 +969,6 @@ class Payment {
     required this.status,
     this.description,
     required this.details,
-    this.lastError,
   });
 }
 
@@ -2766,7 +2764,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   Payment _wire2api_payment(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 9) throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return Payment(
       id: _wire2api_String(arr[0]),
       paymentType: _wire2api_payment_type(arr[1]),
@@ -2776,7 +2774,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       status: _wire2api_payment_status(arr[5]),
       description: _wire2api_opt_String(arr[6]),
       details: _wire2api_payment_details(arr[7]),
-      lastError: _wire2api_opt_String(arr[8]),
     );
   }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -944,8 +944,8 @@ class Payment {
   final int feeMsat;
   final PaymentStatus status;
   final String? description;
-  final String? lastError;
   final PaymentDetails details;
+  final String? lastError;
 
   const Payment({
     required this.id,
@@ -955,8 +955,8 @@ class Payment {
     required this.feeMsat,
     required this.status,
     this.description,
-    this.lastError,
     required this.details,
+    this.lastError,
   });
 }
 
@@ -2764,8 +2764,8 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       feeMsat: _wire2api_u64(arr[4]),
       status: _wire2api_payment_status(arr[5]),
       description: _wire2api_opt_String(arr[6]),
-      lastError: _wire2api_opt_String(arr[7]),
-      details: _wire2api_payment_details(arr[8]),
+      details: _wire2api_payment_details(arr[7]),
+      lastError: _wire2api_opt_String(arr[8]),
     );
   }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -127,8 +127,7 @@ abstract class BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kParseInputConstMeta;
 
   /// See [BreezServices::list_payments]
-  Future<List<Payment>> listPayments(
-      {required PaymentTypeFilter filter, int? fromTimestamp, int? toTimestamp, dynamic hint});
+  Future<List<Payment>> listPayments({required ListPaymentsRequest request, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kListPaymentsConstMeta;
 
@@ -568,6 +567,21 @@ class InvoicePaidDetails {
   const InvoicePaidDetails({
     required this.paymentHash,
     required this.bolt11,
+  });
+}
+
+/// Represents a list payments request.
+class ListPaymentsRequest {
+  final PaymentTypeFilter filter;
+  final int? fromTimestamp;
+  final int? toTimestamp;
+  final bool? includeFailures;
+
+  const ListPaymentsRequest({
+    required this.filter,
+    this.fromTimestamp,
+    this.toTimestamp,
+    this.includeFailures,
   });
 }
 
@@ -1736,23 +1750,20 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["input"],
       );
 
-  Future<List<Payment>> listPayments(
-      {required PaymentTypeFilter filter, int? fromTimestamp, int? toTimestamp, dynamic hint}) {
-    var arg0 = api2wire_payment_type_filter(filter);
-    var arg1 = _platform.api2wire_opt_box_autoadd_i64(fromTimestamp);
-    var arg2 = _platform.api2wire_opt_box_autoadd_i64(toTimestamp);
+  Future<List<Payment>> listPayments({required ListPaymentsRequest request, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_list_payments_request(request);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_list_payments(port_, arg0, arg1, arg2),
+      callFfi: (port_) => _platform.inner.wire_list_payments(port_, arg0),
       parseSuccessData: _wire2api_list_payment,
       constMeta: kListPaymentsConstMeta,
-      argValues: [filter, fromTimestamp, toTimestamp],
+      argValues: [request],
       hint: hint,
     ));
   }
 
   FlutterRustBridgeTaskConstMeta get kListPaymentsConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "list_payments",
-        argNames: ["filter", "fromTimestamp", "toTimestamp"],
+        argNames: ["request"],
       );
 
   Future<Payment?> paymentByHash({required String hash, dynamic hint}) {
@@ -3121,6 +3132,13 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_ListPaymentsRequest> api2wire_box_autoadd_list_payments_request(ListPaymentsRequest raw) {
+    final ptr = inner.new_box_autoadd_list_payments_request_0();
+    _api_fill_to_wire_list_payments_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_LnUrlAuthRequestData> api2wire_box_autoadd_ln_url_auth_request_data(
       LnUrlAuthRequestData raw) {
     final ptr = inner.new_box_autoadd_ln_url_auth_request_data_0();
@@ -3291,6 +3309,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_greenlight_node_config(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_list_payments_request(
+      ListPaymentsRequest apiObj, ffi.Pointer<wire_ListPaymentsRequest> wireObj) {
+    _api_fill_to_wire_list_payments_request(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_ln_url_auth_request_data(
       LnUrlAuthRequestData apiObj, ffi.Pointer<wire_LnUrlAuthRequestData> wireObj) {
     _api_fill_to_wire_ln_url_auth_request_data(apiObj, wireObj.ref);
@@ -3374,6 +3397,13 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
       GreenlightNodeConfig apiObj, wire_GreenlightNodeConfig wireObj) {
     wireObj.partner_credentials = api2wire_opt_box_autoadd_greenlight_credentials(apiObj.partnerCredentials);
     wireObj.invite_code = api2wire_opt_String(apiObj.inviteCode);
+  }
+
+  void _api_fill_to_wire_list_payments_request(ListPaymentsRequest apiObj, wire_ListPaymentsRequest wireObj) {
+    wireObj.filter = api2wire_payment_type_filter(apiObj.filter);
+    wireObj.from_timestamp = api2wire_opt_box_autoadd_i64(apiObj.fromTimestamp);
+    wireObj.to_timestamp = api2wire_opt_box_autoadd_i64(apiObj.toTimestamp);
+    wireObj.include_failures = api2wire_opt_box_autoadd_bool(apiObj.includeFailures);
   }
 
   void _api_fill_to_wire_ln_url_auth_request_data(
@@ -3855,24 +3885,19 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
 
   void wire_list_payments(
     int port_,
-    int filter,
-    ffi.Pointer<ffi.Int64> from_timestamp,
-    ffi.Pointer<ffi.Int64> to_timestamp,
+    ffi.Pointer<wire_ListPaymentsRequest> request,
   ) {
     return _wire_list_payments(
       port_,
-      filter,
-      from_timestamp,
-      to_timestamp,
+      request,
     );
   }
 
-  late final _wire_list_paymentsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Int32, ffi.Pointer<ffi.Int64>, ffi.Pointer<ffi.Int64>)>>('wire_list_payments');
-  late final _wire_list_payments = _wire_list_paymentsPtr
-      .asFunction<void Function(int, int, ffi.Pointer<ffi.Int64>, ffi.Pointer<ffi.Int64>)>();
+  late final _wire_list_paymentsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ListPaymentsRequest>)>>(
+          'wire_list_payments');
+  late final _wire_list_payments =
+      _wire_list_paymentsPtr.asFunction<void Function(int, ffi.Pointer<wire_ListPaymentsRequest>)>();
 
   void wire_payment_by_hash(
     int port_,
@@ -4275,6 +4300,16 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_i64_0 =
       _new_box_autoadd_i64_0Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
+  ffi.Pointer<wire_ListPaymentsRequest> new_box_autoadd_list_payments_request_0() {
+    return _new_box_autoadd_list_payments_request_0();
+  }
+
+  late final _new_box_autoadd_list_payments_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ListPaymentsRequest> Function()>>(
+          'new_box_autoadd_list_payments_request_0');
+  late final _new_box_autoadd_list_payments_request_0 = _new_box_autoadd_list_payments_request_0Ptr
+      .asFunction<ffi.Pointer<wire_ListPaymentsRequest> Function()>();
+
   ffi.Pointer<wire_LnUrlAuthRequestData> new_box_autoadd_ln_url_auth_request_data_0() {
     return _new_box_autoadd_ln_url_auth_request_data_0();
   }
@@ -4512,6 +4547,17 @@ class wire_CheckMessageRequest extends ffi.Struct {
 
 class wire_StaticBackupRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> working_dir;
+}
+
+class wire_ListPaymentsRequest extends ffi.Struct {
+  @ffi.Int32()
+  external int filter;
+
+  external ffi.Pointer<ffi.Int64> from_timestamp;
+
+  external ffi.Pointer<ffi.Int64> to_timestamp;
+
+  external ffi.Pointer<ffi.Bool> include_failures;
 }
 
 class wire_OpeningFeeParams extends ffi.Struct {

--- a/libs/sdk-flutter/pubspec.lock
+++ b/libs/sdk-flutter/pubspec.lock
@@ -21,26 +21,26 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      sha256: e0902a06f0e00414e4e3438a084580161279f137aeb862274710f29ec10cf01e
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.7"
+    version: "3.3.9"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      sha256: d912852cce27c9e80a93603db721c267716894462e7033165178b91138587972
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   build_runner:
     dependency: "direct dev"
     description:
@@ -117,18 +117,18 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "7dd62d9faf105c434f3d829bbe9c4be02ec67f5ed94832222116122df67c5452"
+      sha256: ff627b645b28fb8bdb69e645f910c2458fd6b65f6585c3a53e0626024897dedf
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.0"
+    version: "8.6.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -157,18 +157,18 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "4ad01d6e56db961d29661561effde45e519939fdaeb46c351275b182eac70189"
+      sha256: "315a598c7fbe77f22de1c9da7cfd6fd21816312f16ffa124453b4fc679e540f1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.6.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   colorize:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
+      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   fake_async:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   ffigen:
     dependency: "direct dev"
     description:
@@ -258,10 +258,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   flutter_rust_bridge:
     dependency: "direct main"
     description:
@@ -279,18 +279,18 @@ packages:
     dependency: "direct main"
     description:
       name: freezed
-      sha256: a9520490532087cf38bf3f7de478ab6ebeb5f68bb1eb2641546d92719b224445
+      sha256: "2df89855fe181baae3b6d714dc3c4317acf4fccd495a6f36e5e00f24144c6c3b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.4.1"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -351,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -367,10 +367,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   logging:
     dependency: transitive
     description:
@@ -383,26 +383,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -423,18 +423,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.4.0"
   pointycastle:
     dependency: transitive
     description:
@@ -524,18 +524,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "373f96cf5a8744bc9816c1ff41cf5391bbdbe3d7a96fe98c622b6738a8a7bd33"
+      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -580,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.0"
   timing:
     dependency: transitive
     description:
@@ -596,10 +596,10 @@ packages:
     dependency: transitive
     description:
       name: tuple
-      sha256: "0ea99cd2f9352b2586583ab2ce6489d1f95a5f6de6fb9492faaf97ae2060f0aa"
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -628,10 +628,18 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -657,5 +665,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.19.6 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.12"

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1399,8 +1399,8 @@ fun asPayment(data: ReadableMap): Payment? {
     val feeMsat = data.getDouble("feeMsat").toULong()
     val status = data.getString("status")?.let { asPaymentStatus(it) }!!
     val description = if (hasNonNullKey(data, "description")) data.getString("description") else null
-    val lastError = if (hasNonNullKey(data, "lastError")) data.getString("lastError") else null
     val details = data.getMap("details")?.let { asPaymentDetails(it) }!!
+    val lastError = if (hasNonNullKey(data, "lastError")) data.getString("lastError") else null
     return Payment(
         id,
         paymentType,
@@ -1409,8 +1409,8 @@ fun asPayment(data: ReadableMap): Payment? {
         feeMsat,
         status,
         description,
-        lastError,
         details,
+        lastError,
     )
 }
 
@@ -1423,8 +1423,8 @@ fun readableMapOf(payment: Payment): ReadableMap {
         "feeMsat" to payment.feeMsat,
         "status" to payment.status.name.lowercase(),
         "description" to payment.description,
-        "lastError" to payment.lastError,
         "details" to readableMapOf(payment.details),
+        "lastError" to payment.lastError,
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1513,7 +1513,6 @@ fun asPayment(data: ReadableMap): Payment? {
     val status = data.getString("status")?.let { asPaymentStatus(it) }!!
     val description = if (hasNonNullKey(data, "description")) data.getString("description") else null
     val details = data.getMap("details")?.let { asPaymentDetails(it) }!!
-    val lastError = if (hasNonNullKey(data, "lastError")) data.getString("lastError") else null
     return Payment(
         id,
         paymentType,
@@ -1523,7 +1522,6 @@ fun asPayment(data: ReadableMap): Payment? {
         status,
         description,
         details,
-        lastError,
     )
 }
 
@@ -1537,7 +1535,6 @@ fun readableMapOf(payment: Payment): ReadableMap {
         "status" to payment.status.name.lowercase(),
         "description" to payment.description,
         "details" to readableMapOf(payment.details),
-        "lastError" to payment.lastError,
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1385,7 +1385,7 @@ fun asPayment(data: ReadableMap): Payment? {
                 "paymentTime",
                 "amountMsat",
                 "feeMsat",
-                "pending",
+                "status",
                 "details",
             ),
         )
@@ -1397,8 +1397,9 @@ fun asPayment(data: ReadableMap): Payment? {
     val paymentTime = data.getDouble("paymentTime").toLong()
     val amountMsat = data.getDouble("amountMsat").toULong()
     val feeMsat = data.getDouble("feeMsat").toULong()
-    val pending = data.getBoolean("pending")
+    val status = data.getString("status")?.let { asPaymentStatus(it) }!!
     val description = if (hasNonNullKey(data, "description")) data.getString("description") else null
+    val lastError = if (hasNonNullKey(data, "lastError")) data.getString("lastError") else null
     val details = data.getMap("details")?.let { asPaymentDetails(it) }!!
     return Payment(
         id,
@@ -1406,8 +1407,9 @@ fun asPayment(data: ReadableMap): Payment? {
         paymentTime,
         amountMsat,
         feeMsat,
-        pending,
+        status,
         description,
+        lastError,
         details,
     )
 }
@@ -1419,8 +1421,9 @@ fun readableMapOf(payment: Payment): ReadableMap {
         "paymentTime" to payment.paymentTime,
         "amountMsat" to payment.amountMsat,
         "feeMsat" to payment.feeMsat,
-        "pending" to payment.pending,
+        "status" to payment.status.name.lowercase(),
         "description" to payment.description,
+        "lastError" to payment.lastError,
         "details" to readableMapOf(payment.details),
     )
 }
@@ -2494,6 +2497,10 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
     return map
 }
 
+fun asPaymentStatus(type: String): PaymentStatus {
+    return PaymentStatus.valueOf(type.uppercase())
+}
+
 fun asPaymentType(type: String): PaymentType {
     return PaymentType.valueOf(type.uppercase())
 }
@@ -2542,7 +2549,8 @@ fun readableMapOf(successActionProcessed: SuccessActionProcessed): ReadableMap? 
 
 fun asSwapStatus(type: String): SwapStatus {
     return SwapStatus.valueOf(type.uppercase())
-} fun readableMapOf(vararg values: Pair<String, *>): ReadableMap {
+}
+    fun readableMapOf(vararg values: Pair<String, *>): ReadableMap {
     val map = Arguments.createMap()
     for ((key, value) in values) {
         pushToMap(map, key, value)

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -39,6 +39,7 @@ fun asAesSuccessActionDataDecryptedList(arr: ReadableArray): List<AesSuccessActi
     }
     return list
 }
+
 fun asBackupFailedData(data: ReadableMap): BackupFailedData? {
     if (!validateMandatoryFields(
             data,
@@ -71,6 +72,7 @@ fun asBackupFailedDataList(arr: ReadableArray): List<BackupFailedData> {
     }
     return list
 }
+
 fun asBackupStatus(data: ReadableMap): BackupStatus? {
     if (!validateMandatoryFields(
             data,
@@ -106,6 +108,7 @@ fun asBackupStatusList(arr: ReadableArray): List<BackupStatus> {
     }
     return list
 }
+
 fun asBitcoinAddressData(data: ReadableMap): BitcoinAddressData? {
     if (!validateMandatoryFields(
             data,
@@ -151,6 +154,7 @@ fun asBitcoinAddressDataList(arr: ReadableArray): List<BitcoinAddressData> {
     }
     return list
 }
+
 fun asBuyBitcoinRequest(data: ReadableMap): BuyBitcoinRequest? {
     if (!validateMandatoryFields(
             data,
@@ -162,7 +166,14 @@ fun asBuyBitcoinRequest(data: ReadableMap): BuyBitcoinRequest? {
         return null
     }
     val provider = data.getString("provider")?.let { asBuyBitcoinProvider(it) }!!
-    val openingFeeParams = if (hasNonNullKey(data, "openingFeeParams")) data.getMap("openingFeeParams")?.let { asOpeningFeeParams(it) } else null
+    val openingFeeParams =
+        if (hasNonNullKey(data, "openingFeeParams")) {
+            data.getMap("openingFeeParams")?.let {
+                asOpeningFeeParams(it)
+            }
+        } else {
+            null
+        }
     return BuyBitcoinRequest(
         provider,
         openingFeeParams,
@@ -186,6 +197,7 @@ fun asBuyBitcoinRequestList(arr: ReadableArray): List<BuyBitcoinRequest> {
     }
     return list
 }
+
 fun asBuyBitcoinResponse(data: ReadableMap): BuyBitcoinResponse? {
     if (!validateMandatoryFields(
             data,
@@ -197,7 +209,14 @@ fun asBuyBitcoinResponse(data: ReadableMap): BuyBitcoinResponse? {
         return null
     }
     val url = data.getString("url")!!
-    val openingFeeParams = if (hasNonNullKey(data, "openingFeeParams")) data.getMap("openingFeeParams")?.let { asOpeningFeeParams(it) } else null
+    val openingFeeParams =
+        if (hasNonNullKey(data, "openingFeeParams")) {
+            data.getMap("openingFeeParams")?.let {
+                asOpeningFeeParams(it)
+            }
+        } else {
+            null
+        }
     return BuyBitcoinResponse(
         url,
         openingFeeParams,
@@ -221,6 +240,7 @@ fun asBuyBitcoinResponseList(arr: ReadableArray): List<BuyBitcoinResponse> {
     }
     return list
 }
+
 fun asCheckMessageRequest(data: ReadableMap): CheckMessageRequest? {
     if (!validateMandatoryFields(
             data,
@@ -261,6 +281,7 @@ fun asCheckMessageRequestList(arr: ReadableArray): List<CheckMessageRequest> {
     }
     return list
 }
+
 fun asCheckMessageResponse(data: ReadableMap): CheckMessageResponse? {
     if (!validateMandatoryFields(
             data,
@@ -293,6 +314,7 @@ fun asCheckMessageResponseList(arr: ReadableArray): List<CheckMessageResponse> {
     }
     return list
 }
+
 fun asClosedChannelPaymentDetails(data: ReadableMap): ClosedChannelPaymentDetails? {
     if (!validateMandatoryFields(
             data,
@@ -333,6 +355,7 @@ fun asClosedChannelPaymentDetailsList(arr: ReadableArray): List<ClosedChannelPay
     }
     return list
 }
+
 fun asConfig(data: ReadableMap): Config? {
     if (!validateMandatoryFields(
             data,
@@ -399,6 +422,7 @@ fun asConfigList(arr: ReadableArray): List<Config> {
     }
     return list
 }
+
 fun asCurrencyInfo(data: ReadableMap): CurrencyInfo? {
     if (!validateMandatoryFields(
             data,
@@ -416,7 +440,14 @@ fun asCurrencyInfo(data: ReadableMap): CurrencyInfo? {
     val symbol = if (hasNonNullKey(data, "symbol")) data.getMap("symbol")?.let { asSymbol(it) } else null
     val uniqSymbol = if (hasNonNullKey(data, "uniqSymbol")) data.getMap("uniqSymbol")?.let { asSymbol(it) } else null
     val localizedName = if (hasNonNullKey(data, "localizedName")) data.getArray("localizedName")?.let { asLocalizedNameList(it) } else null
-    val localeOverrides = if (hasNonNullKey(data, "localeOverrides")) data.getArray("localeOverrides")?.let { asLocaleOverridesList(it) } else null
+    val localeOverrides =
+        if (hasNonNullKey(data, "localeOverrides")) {
+            data.getArray("localeOverrides")?.let {
+                asLocaleOverridesList(it)
+            }
+        } else {
+            null
+        }
     return CurrencyInfo(
         name,
         fractionSize,
@@ -450,6 +481,7 @@ fun asCurrencyInfoList(arr: ReadableArray): List<CurrencyInfo> {
     }
     return list
 }
+
 fun asFiatCurrency(data: ReadableMap): FiatCurrency? {
     if (!validateMandatoryFields(
             data,
@@ -486,6 +518,7 @@ fun asFiatCurrencyList(arr: ReadableArray): List<FiatCurrency> {
     }
     return list
 }
+
 fun asGreenlightCredentials(data: ReadableMap): GreenlightCredentials? {
     if (!validateMandatoryFields(
             data,
@@ -522,11 +555,23 @@ fun asGreenlightCredentialsList(arr: ReadableArray): List<GreenlightCredentials>
     }
     return list
 }
+
 fun asGreenlightNodeConfig(data: ReadableMap): GreenlightNodeConfig? {
-    if (!validateMandatoryFields(data, arrayOf())) {
+    if (!validateMandatoryFields(
+            data,
+            arrayOf(),
+        )
+    ) {
         return null
     }
-    val partnerCredentials = if (hasNonNullKey(data, "partnerCredentials")) data.getMap("partnerCredentials")?.let { asGreenlightCredentials(it) } else null
+    val partnerCredentials =
+        if (hasNonNullKey(data, "partnerCredentials")) {
+            data.getMap("partnerCredentials")?.let {
+                asGreenlightCredentials(it)
+            }
+        } else {
+            null
+        }
     val inviteCode = if (hasNonNullKey(data, "inviteCode")) data.getString("inviteCode") else null
     return GreenlightNodeConfig(
         partnerCredentials,
@@ -551,6 +596,7 @@ fun asGreenlightNodeConfigList(arr: ReadableArray): List<GreenlightNodeConfig> {
     }
     return list
 }
+
 fun asInvoicePaidDetails(data: ReadableMap): InvoicePaidDetails? {
     if (!validateMandatoryFields(
             data,
@@ -587,6 +633,7 @@ fun asInvoicePaidDetailsList(arr: ReadableArray): List<InvoicePaidDetails> {
     }
     return list
 }
+
 fun asLnInvoice(data: ReadableMap): LnInvoice? {
     if (!validateMandatoryFields(
             data,
@@ -652,6 +699,49 @@ fun asLnInvoiceList(arr: ReadableArray): List<LnInvoice> {
     }
     return list
 }
+
+fun asListPaymentsRequest(data: ReadableMap): ListPaymentsRequest? {
+    if (!validateMandatoryFields(
+            data,
+            arrayOf(
+                "filter",
+            ),
+        )
+    ) {
+        return null
+    }
+    val filter = data.getString("filter")?.let { asPaymentTypeFilter(it) }!!
+    val fromTimestamp = if (hasNonNullKey(data, "fromTimestamp")) data.getDouble("fromTimestamp").toLong() else null
+    val toTimestamp = if (hasNonNullKey(data, "toTimestamp")) data.getDouble("toTimestamp").toLong() else null
+    val includeFailures = if (hasNonNullKey(data, "includeFailures")) data.getBoolean("includeFailures") else null
+    return ListPaymentsRequest(
+        filter,
+        fromTimestamp,
+        toTimestamp,
+        includeFailures,
+    )
+}
+
+fun readableMapOf(listPaymentsRequest: ListPaymentsRequest): ReadableMap {
+    return readableMapOf(
+        "filter" to listPaymentsRequest.filter.name.lowercase(),
+        "fromTimestamp" to listPaymentsRequest.fromTimestamp,
+        "toTimestamp" to listPaymentsRequest.toTimestamp,
+        "includeFailures" to listPaymentsRequest.includeFailures,
+    )
+}
+
+fun asListPaymentsRequestList(arr: ReadableArray): List<ListPaymentsRequest> {
+    val list = ArrayList<ListPaymentsRequest>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asListPaymentsRequest(value)!!)
+            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+        }
+    }
+    return list
+}
+
 fun asLnPaymentDetails(data: ReadableMap): LnPaymentDetails? {
     if (!validateMandatoryFields(
             data,
@@ -673,7 +763,14 @@ fun asLnPaymentDetails(data: ReadableMap): LnPaymentDetails? {
     val paymentPreimage = data.getString("paymentPreimage")!!
     val keysend = data.getBoolean("keysend")
     val bolt11 = data.getString("bolt11")!!
-    val lnurlSuccessAction = if (hasNonNullKey(data, "lnurlSuccessAction")) data.getMap("lnurlSuccessAction")?.let { asSuccessActionProcessed(it) } else null
+    val lnurlSuccessAction =
+        if (hasNonNullKey(data, "lnurlSuccessAction")) {
+            data.getMap("lnurlSuccessAction")?.let {
+                asSuccessActionProcessed(it)
+            }
+        } else {
+            null
+        }
     val lnurlMetadata = if (hasNonNullKey(data, "lnurlMetadata")) data.getString("lnurlMetadata") else null
     val lnAddress = if (hasNonNullKey(data, "lnAddress")) data.getString("lnAddress") else null
     return LnPaymentDetails(
@@ -713,6 +810,7 @@ fun asLnPaymentDetailsList(arr: ReadableArray): List<LnPaymentDetails> {
     }
     return list
 }
+
 fun asLnUrlAuthRequestData(data: ReadableMap): LnUrlAuthRequestData? {
     if (!validateMandatoryFields(
             data,
@@ -756,6 +854,7 @@ fun asLnUrlAuthRequestDataList(arr: ReadableArray): List<LnUrlAuthRequestData> {
     }
     return list
 }
+
 fun asLnUrlErrorData(data: ReadableMap): LnUrlErrorData? {
     if (!validateMandatoryFields(
             data,
@@ -788,6 +887,7 @@ fun asLnUrlErrorDataList(arr: ReadableArray): List<LnUrlErrorData> {
     }
     return list
 }
+
 fun asLnUrlPayRequestData(data: ReadableMap): LnUrlPayRequestData? {
     if (!validateMandatoryFields(
             data,
@@ -843,6 +943,7 @@ fun asLnUrlPayRequestDataList(arr: ReadableArray): List<LnUrlPayRequestData> {
     }
     return list
 }
+
 fun asLnUrlWithdrawRequestData(data: ReadableMap): LnUrlWithdrawRequestData? {
     if (!validateMandatoryFields(
             data,
@@ -891,6 +992,7 @@ fun asLnUrlWithdrawRequestDataList(arr: ReadableArray): List<LnUrlWithdrawReques
     }
     return list
 }
+
 fun asLocaleOverrides(data: ReadableMap): LocaleOverrides? {
     if (!validateMandatoryFields(
             data,
@@ -930,6 +1032,7 @@ fun asLocaleOverridesList(arr: ReadableArray): List<LocaleOverrides> {
     }
     return list
 }
+
 fun asLocalizedName(data: ReadableMap): LocalizedName? {
     if (!validateMandatoryFields(
             data,
@@ -966,6 +1069,7 @@ fun asLocalizedNameList(arr: ReadableArray): List<LocalizedName> {
     }
     return list
 }
+
 fun asLogEntry(data: ReadableMap): LogEntry? {
     if (!validateMandatoryFields(
             data,
@@ -1002,6 +1106,7 @@ fun asLogEntryList(arr: ReadableArray): List<LogEntry> {
     }
     return list
 }
+
 fun asLspInformation(data: ReadableMap): LspInformation? {
     if (!validateMandatoryFields(
             data,
@@ -1082,6 +1187,7 @@ fun asLspInformationList(arr: ReadableArray): List<LspInformation> {
     }
     return list
 }
+
 fun asMessageSuccessActionData(data: ReadableMap): MessageSuccessActionData? {
     if (!validateMandatoryFields(
             data,
@@ -1114,6 +1220,7 @@ fun asMessageSuccessActionDataList(arr: ReadableArray): List<MessageSuccessActio
     }
     return list
 }
+
 fun asMetadataItem(data: ReadableMap): MetadataItem? {
     if (!validateMandatoryFields(
             data,
@@ -1150,6 +1257,7 @@ fun asMetadataItemList(arr: ReadableArray): List<MetadataItem> {
     }
     return list
 }
+
 fun asNodeState(data: ReadableMap): NodeState? {
     if (!validateMandatoryFields(
             data,
@@ -1222,6 +1330,7 @@ fun asNodeStateList(arr: ReadableArray): List<NodeState> {
     }
     return list
 }
+
 fun asOpenChannelFeeRequest(data: ReadableMap): OpenChannelFeeRequest? {
     if (!validateMandatoryFields(
             data,
@@ -1257,6 +1366,7 @@ fun asOpenChannelFeeRequestList(arr: ReadableArray): List<OpenChannelFeeRequest>
     }
     return list
 }
+
 fun asOpenChannelFeeResponse(data: ReadableMap): OpenChannelFeeResponse? {
     if (!validateMandatoryFields(
             data,
@@ -1292,6 +1402,7 @@ fun asOpenChannelFeeResponseList(arr: ReadableArray): List<OpenChannelFeeRespons
     }
     return list
 }
+
 fun asOpeningFeeParams(data: ReadableMap): OpeningFeeParams? {
     if (!validateMandatoryFields(
             data,
@@ -1344,6 +1455,7 @@ fun asOpeningFeeParamsList(arr: ReadableArray): List<OpeningFeeParams> {
     }
     return list
 }
+
 fun asOpeningFeeParamsMenu(data: ReadableMap): OpeningFeeParamsMenu? {
     if (!validateMandatoryFields(
             data,
@@ -1376,6 +1488,7 @@ fun asOpeningFeeParamsMenuList(arr: ReadableArray): List<OpeningFeeParamsMenu> {
     }
     return list
 }
+
 fun asPayment(data: ReadableMap): Payment? {
     if (!validateMandatoryFields(
             data,
@@ -1438,6 +1551,7 @@ fun asPaymentList(arr: ReadableArray): List<Payment> {
     }
     return list
 }
+
 fun asPaymentFailedData(data: ReadableMap): PaymentFailedData? {
     if (!validateMandatoryFields(
             data,
@@ -1477,6 +1591,7 @@ fun asPaymentFailedDataList(arr: ReadableArray): List<PaymentFailedData> {
     }
     return list
 }
+
 fun asRate(data: ReadableMap): Rate? {
     if (!validateMandatoryFields(
             data,
@@ -1513,11 +1628,23 @@ fun asRateList(arr: ReadableArray): List<Rate> {
     }
     return list
 }
+
 fun asReceiveOnchainRequest(data: ReadableMap): ReceiveOnchainRequest? {
-    if (!validateMandatoryFields(data, arrayOf())) {
+    if (!validateMandatoryFields(
+            data,
+            arrayOf(),
+        )
+    ) {
         return null
     }
-    val openingFeeParams = if (hasNonNullKey(data, "openingFeeParams")) data.getMap("openingFeeParams")?.let { asOpeningFeeParams(it) } else null
+    val openingFeeParams =
+        if (hasNonNullKey(data, "openingFeeParams")) {
+            data.getMap("openingFeeParams")?.let {
+                asOpeningFeeParams(it)
+            }
+        } else {
+            null
+        }
     return ReceiveOnchainRequest(
         openingFeeParams,
     )
@@ -1539,6 +1666,7 @@ fun asReceiveOnchainRequestList(arr: ReadableArray): List<ReceiveOnchainRequest>
     }
     return list
 }
+
 fun asReceivePaymentRequest(data: ReadableMap): ReceivePaymentRequest? {
     if (!validateMandatoryFields(
             data,
@@ -1553,7 +1681,14 @@ fun asReceivePaymentRequest(data: ReadableMap): ReceivePaymentRequest? {
     val amountSats = data.getDouble("amountSats").toULong()
     val description = data.getString("description")!!
     val preimage = if (hasNonNullKey(data, "preimage")) data.getArray("preimage")?.let { asUByteList(it) } else null
-    val openingFeeParams = if (hasNonNullKey(data, "openingFeeParams")) data.getMap("openingFeeParams")?.let { asOpeningFeeParams(it) } else null
+    val openingFeeParams =
+        if (hasNonNullKey(data, "openingFeeParams")) {
+            data.getMap("openingFeeParams")?.let {
+                asOpeningFeeParams(it)
+            }
+        } else {
+            null
+        }
     val useDescriptionHash = if (hasNonNullKey(data, "useDescriptionHash")) data.getBoolean("useDescriptionHash") else null
     val expiry = if (hasNonNullKey(data, "expiry")) data.getInt("expiry").toUInt() else null
     val cltv = if (hasNonNullKey(data, "cltv")) data.getInt("cltv").toUInt() else null
@@ -1590,6 +1725,7 @@ fun asReceivePaymentRequestList(arr: ReadableArray): List<ReceivePaymentRequest>
     }
     return list
 }
+
 fun asReceivePaymentResponse(data: ReadableMap): ReceivePaymentResponse? {
     if (!validateMandatoryFields(
             data,
@@ -1601,7 +1737,14 @@ fun asReceivePaymentResponse(data: ReadableMap): ReceivePaymentResponse? {
         return null
     }
     val lnInvoice = data.getMap("lnInvoice")?.let { asLnInvoice(it) }!!
-    val openingFeeParams = if (hasNonNullKey(data, "openingFeeParams")) data.getMap("openingFeeParams")?.let { asOpeningFeeParams(it) } else null
+    val openingFeeParams =
+        if (hasNonNullKey(data, "openingFeeParams")) {
+            data.getMap("openingFeeParams")?.let {
+                asOpeningFeeParams(it)
+            }
+        } else {
+            null
+        }
     val openingFeeMsat = if (hasNonNullKey(data, "openingFeeMsat")) data.getDouble("openingFeeMsat").toULong() else null
     return ReceivePaymentResponse(
         lnInvoice,
@@ -1628,6 +1771,7 @@ fun asReceivePaymentResponseList(arr: ReadableArray): List<ReceivePaymentRespons
     }
     return list
 }
+
 fun asRecommendedFees(data: ReadableMap): RecommendedFees? {
     if (!validateMandatoryFields(
             data,
@@ -1676,8 +1820,13 @@ fun asRecommendedFeesList(arr: ReadableArray): List<RecommendedFees> {
     }
     return list
 }
+
 fun asReverseSwapFeesRequest(data: ReadableMap): ReverseSwapFeesRequest? {
-    if (!validateMandatoryFields(data, arrayOf())) {
+    if (!validateMandatoryFields(
+            data,
+            arrayOf(),
+        )
+    ) {
         return null
     }
     val sendAmountSat = if (hasNonNullKey(data, "sendAmountSat")) data.getDouble("sendAmountSat").toULong() else null
@@ -1702,6 +1851,7 @@ fun asReverseSwapFeesRequestList(arr: ReadableArray): List<ReverseSwapFeesReques
     }
     return list
 }
+
 fun asReverseSwapInfo(data: ReadableMap): ReverseSwapInfo? {
     if (!validateMandatoryFields(
             data,
@@ -1746,6 +1896,7 @@ fun asReverseSwapInfoList(arr: ReadableArray): List<ReverseSwapInfo> {
     }
     return list
 }
+
 fun asReverseSwapPairInfo(data: ReadableMap): ReverseSwapPairInfo? {
     if (!validateMandatoryFields(
             data,
@@ -1801,6 +1952,7 @@ fun asReverseSwapPairInfoList(arr: ReadableArray): List<ReverseSwapPairInfo> {
     }
     return list
 }
+
 fun asRouteHint(data: ReadableMap): RouteHint? {
     if (!validateMandatoryFields(
             data,
@@ -1833,6 +1985,7 @@ fun asRouteHintList(arr: ReadableArray): List<RouteHint> {
     }
     return list
 }
+
 fun asRouteHintHop(data: ReadableMap): RouteHintHop? {
     if (!validateMandatoryFields(
             data,
@@ -1887,6 +2040,7 @@ fun asRouteHintHopList(arr: ReadableArray): List<RouteHintHop> {
     }
     return list
 }
+
 fun asSignMessageRequest(data: ReadableMap): SignMessageRequest? {
     if (!validateMandatoryFields(
             data,
@@ -1919,6 +2073,7 @@ fun asSignMessageRequestList(arr: ReadableArray): List<SignMessageRequest> {
     }
     return list
 }
+
 fun asSignMessageResponse(data: ReadableMap): SignMessageResponse? {
     if (!validateMandatoryFields(
             data,
@@ -1951,6 +2106,7 @@ fun asSignMessageResponseList(arr: ReadableArray): List<SignMessageResponse> {
     }
     return list
 }
+
 fun asStaticBackupRequest(data: ReadableMap): StaticBackupRequest? {
     if (!validateMandatoryFields(
             data,
@@ -1983,8 +2139,13 @@ fun asStaticBackupRequestList(arr: ReadableArray): List<StaticBackupRequest> {
     }
     return list
 }
+
 fun asStaticBackupResponse(data: ReadableMap): StaticBackupResponse? {
-    if (!validateMandatoryFields(data, arrayOf())) {
+    if (!validateMandatoryFields(
+            data,
+            arrayOf(),
+        )
+    ) {
         return null
     }
     val backup = if (hasNonNullKey(data, "backup")) data.getArray("backup")?.let { asStringList(it) } else null
@@ -2009,6 +2170,7 @@ fun asStaticBackupResponseList(arr: ReadableArray): List<StaticBackupResponse> {
     }
     return list
 }
+
 fun asSwapInfo(data: ReadableMap): SwapInfo? {
     if (!validateMandatoryFields(
             data,
@@ -2056,7 +2218,14 @@ fun asSwapInfo(data: ReadableMap): SwapInfo? {
     val minAllowedDeposit = data.getDouble("minAllowedDeposit").toLong()
     val maxAllowedDeposit = data.getDouble("maxAllowedDeposit").toLong()
     val lastRedeemError = if (hasNonNullKey(data, "lastRedeemError")) data.getString("lastRedeemError") else null
-    val channelOpeningFees = if (hasNonNullKey(data, "channelOpeningFees")) data.getMap("channelOpeningFees")?.let { asOpeningFeeParams(it) } else null
+    val channelOpeningFees =
+        if (hasNonNullKey(data, "channelOpeningFees")) {
+            data.getMap("channelOpeningFees")?.let {
+                asOpeningFeeParams(it)
+            }
+        } else {
+            null
+        }
     return SwapInfo(
         bitcoinAddress,
         createdAt,
@@ -2118,8 +2287,13 @@ fun asSwapInfoList(arr: ReadableArray): List<SwapInfo> {
     }
     return list
 }
+
 fun asSymbol(data: ReadableMap): Symbol? {
-    if (!validateMandatoryFields(data, arrayOf())) {
+    if (!validateMandatoryFields(
+            data,
+            arrayOf(),
+        )
+    ) {
         return null
     }
     val grapheme = if (hasNonNullKey(data, "grapheme")) data.getString("grapheme") else null
@@ -2153,6 +2327,7 @@ fun asSymbolList(arr: ReadableArray): List<Symbol> {
     }
     return list
 }
+
 fun asUnspentTransactionOutput(data: ReadableMap): UnspentTransactionOutput? {
     if (!validateMandatoryFields(
             data,
@@ -2205,6 +2380,7 @@ fun asUnspentTransactionOutputList(arr: ReadableArray): List<UnspentTransactionO
     }
     return list
 }
+
 fun asUrlSuccessActionData(data: ReadableMap): UrlSuccessActionData? {
     if (!validateMandatoryFields(
             data,
@@ -2423,7 +2599,9 @@ fun asLnUrlPayResult(data: ReadableMap): LnUrlPayResult? {
     val type = data.getString("type")
 
     if (type == "endpointSuccess") {
-        return LnUrlPayResult.EndpointSuccess(if (hasNonNullKey(data, "data")) data.getMap("data")?.let { asSuccessActionProcessed(it) } else null)
+        return LnUrlPayResult.EndpointSuccess(
+            if (hasNonNullKey(data, "data")) data.getMap("data")?.let { asSuccessActionProcessed(it) } else null,
+        )
     }
     if (type == "endpointError") {
         return LnUrlPayResult.EndpointError(data.getMap("data")?.let { asLnUrlErrorData(it) }!!)
@@ -2550,7 +2728,8 @@ fun readableMapOf(successActionProcessed: SuccessActionProcessed): ReadableMap? 
 fun asSwapStatus(type: String): SwapStatus {
     return SwapStatus.valueOf(type.uppercase())
 }
-    fun readableMapOf(vararg values: Pair<String, *>): ReadableMap {
+
+fun readableMapOf(vararg values: Pair<String, *>): ReadableMap {
     val map = Arguments.createMap()
     for ((key, value) in values) {
         pushToMap(map, key, value)
@@ -2558,11 +2737,17 @@ fun asSwapStatus(type: String): SwapStatus {
     return map
 }
 
-fun hasNonNullKey(map: ReadableMap, key: String): Boolean {
+fun hasNonNullKey(
+    map: ReadableMap,
+    key: String,
+): Boolean {
     return map.hasKey(key) && !map.isNull(key)
 }
 
-fun validateMandatoryFields(map: ReadableMap, keys: Array<String>): Boolean {
+fun validateMandatoryFields(
+    map: ReadableMap,
+    keys: Array<String>,
+): Boolean {
     for (k in keys) {
         if (!hasNonNullKey(map, k)) return false
     }
@@ -2570,7 +2755,10 @@ fun validateMandatoryFields(map: ReadableMap, keys: Array<String>): Boolean {
     return true
 }
 
-fun pushToArray(array: WritableArray, value: Any?) {
+fun pushToArray(
+    array: WritableArray,
+    value: Any?,
+) {
     when (value) {
         null -> array.pushNull()
         is FiatCurrency -> array.pushMap(readableMapOf(value))
@@ -2593,7 +2781,11 @@ fun pushToArray(array: WritableArray, value: Any?) {
     }
 }
 
-fun pushToMap(map: WritableMap, key: String, value: Any?) {
+fun pushToMap(
+    map: WritableMap,
+    key: String,
+    value: Any?,
+) {
     when (value) {
         null -> map.putNull(key)
         is Boolean -> map.putBoolean(key, value)

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -43,7 +43,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     fun removeListeners(count: Int) {}
 
     @ReactMethod
-    fun parseInvoice(invoice: String, promise: Promise) {
+    fun parseInvoice(
+        invoice: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = parseInvoice(invoice)
@@ -55,7 +58,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun parseInput(s: String, promise: Promise) {
+    fun parseInput(
+        s: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = parseInput(s)
@@ -67,7 +73,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun mnemonicToSeed(phrase: String, promise: Promise) {
+    fun mnemonicToSeed(
+        phrase: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = mnemonicToSeed(phrase)
@@ -79,7 +88,12 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun defaultConfig(envType: String, apiKey: String, nodeConfig: ReadableMap, promise: Promise) {
+    fun defaultConfig(
+        envType: String,
+        apiKey: String,
+        nodeConfig: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val envTypeTmp = asEnvironmentType(envType)
@@ -100,10 +114,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun staticBackup(request: ReadableMap, promise: Promise) {
+    fun staticBackup(
+        request: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val staticBackupRequest = asStaticBackupRequest(request) ?: run { throw SdkException.Generic("Missing mandatory field request of type StaticBackupRequest") }
+                val staticBackupRequest =
+                    asStaticBackupRequest(request) ?: run {
+                        throw SdkException.Generic("Missing mandatory field request of type StaticBackupRequest")
+                    }
                 val res = staticBackup(staticBackupRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -126,7 +146,11 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun connect(config: ReadableMap, seed: ReadableArray, promise: Promise) {
+    fun connect(
+        config: ReadableMap,
+        seed: ReadableArray,
+        promise: Promise,
+    ) {
         if (breezServices != null) {
             promise.reject(TAG, "BreezServices already initialized")
             return
@@ -157,7 +181,11 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun sendPayment(bolt11: String, amountSats: Double, promise: Promise) {
+    fun sendPayment(
+        bolt11: String,
+        amountSats: Double,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val amountSatsTmp = amountSats.toULong().takeUnless { it == 0UL }
@@ -170,7 +198,11 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun sendSpontaneousPayment(nodeId: String, amountSats: Double, promise: Promise) {
+    fun sendSpontaneousPayment(
+        nodeId: String,
+        amountSats: Double,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = getBreezServices().sendSpontaneousPayment(nodeId, amountSats.toULong())
@@ -182,10 +214,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun receivePayment(reqData: ReadableMap, promise: Promise) {
+    fun receivePayment(
+        reqData: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val receivePaymentRequest = asReceivePaymentRequest(reqData) ?: run { throw SdkException.Generic("Missing mandatory field reqData of type ReceivePaymentRequest") }
+                val receivePaymentRequest =
+                    asReceivePaymentRequest(reqData) ?: run {
+                        throw SdkException.Generic("Missing mandatory field reqData of type ReceivePaymentRequest")
+                    }
                 val res = getBreezServices().receivePayment(receivePaymentRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -195,10 +233,18 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun payLnurl(reqData: ReadableMap, amountSats: Double, comment: String, promise: Promise) {
+    fun payLnurl(
+        reqData: ReadableMap,
+        amountSats: Double,
+        comment: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val lnUrlPayRequestData = asLnUrlPayRequestData(reqData) ?: run { throw SdkException.Generic("Missing mandatory field reqData of type LnUrlPayRequestData") }
+                val lnUrlPayRequestData =
+                    asLnUrlPayRequestData(reqData) ?: run {
+                        throw SdkException.Generic("Missing mandatory field reqData of type LnUrlPayRequestData")
+                    }
                 val commentTmp = comment.takeUnless { it.isEmpty() }
                 val res = getBreezServices().payLnurl(lnUrlPayRequestData, amountSats.toULong(), commentTmp)
                 promise.resolve(readableMapOf(res))
@@ -209,10 +255,18 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun withdrawLnurl(reqData: ReadableMap, amountSats: Double, description: String, promise: Promise) {
+    fun withdrawLnurl(
+        reqData: ReadableMap,
+        amountSats: Double,
+        description: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val lnUrlWithdrawRequestData = asLnUrlWithdrawRequestData(reqData) ?: run { throw SdkException.Generic("Missing mandatory field reqData of type LnUrlWithdrawRequestData") }
+                val lnUrlWithdrawRequestData =
+                    asLnUrlWithdrawRequestData(reqData) ?: run {
+                        throw SdkException.Generic("Missing mandatory field reqData of type LnUrlWithdrawRequestData")
+                    }
                 val descriptionTmp = description.takeUnless { it.isEmpty() }
                 val res = getBreezServices().withdrawLnurl(lnUrlWithdrawRequestData, amountSats.toULong(), descriptionTmp)
                 promise.resolve(readableMapOf(res))
@@ -223,10 +277,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun lnurlAuth(reqData: ReadableMap, promise: Promise) {
+    fun lnurlAuth(
+        reqData: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val lnUrlAuthRequestData = asLnUrlAuthRequestData(reqData) ?: run { throw SdkException.Generic("Missing mandatory field reqData of type LnUrlAuthRequestData") }
+                val lnUrlAuthRequestData =
+                    asLnUrlAuthRequestData(reqData) ?: run {
+                        throw SdkException.Generic("Missing mandatory field reqData of type LnUrlAuthRequestData")
+                    }
                 val res = getBreezServices().lnurlAuth(lnUrlAuthRequestData)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -248,10 +308,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun signMessage(request: ReadableMap, promise: Promise) {
+    fun signMessage(
+        request: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val signMessageRequest = asSignMessageRequest(request) ?: run { throw SdkException.Generic("Missing mandatory field request of type SignMessageRequest") }
+                val signMessageRequest =
+                    asSignMessageRequest(request) ?: run {
+                        throw SdkException.Generic("Missing mandatory field request of type SignMessageRequest")
+                    }
                 val res = getBreezServices().signMessage(signMessageRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -261,10 +327,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun checkMessage(request: ReadableMap, promise: Promise) {
+    fun checkMessage(
+        request: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val checkMessageRequest = asCheckMessageRequest(request) ?: run { throw SdkException.Generic("Missing mandatory field request of type CheckMessageRequest") }
+                val checkMessageRequest =
+                    asCheckMessageRequest(request) ?: run {
+                        throw SdkException.Generic("Missing mandatory field request of type CheckMessageRequest")
+                    }
                 val res = getBreezServices().checkMessage(checkMessageRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -298,7 +370,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun paymentByHash(hash: String, promise: Promise) {
+    fun paymentByHash(
+        hash: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = getBreezServices().paymentByHash(hash)
@@ -310,13 +385,17 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun listPayments(filter: String, fromTimestamp: Double, toTimestamp: Double, promise: Promise) {
+    fun listPayments(
+        request: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val filterTmp = asPaymentTypeFilter(filter)
-                val fromTimestampTmp = fromTimestamp.toLong().takeUnless { it == 0L }
-                val toTimestampTmp = toTimestamp.toLong().takeUnless { it == 0L }
-                val res = getBreezServices().listPayments(filterTmp, fromTimestampTmp, toTimestampTmp)
+                val listPaymentsRequest =
+                    asListPaymentsRequest(request) ?: run {
+                        throw SdkException.Generic("Missing mandatory field request of type ListPaymentsRequest")
+                    }
+                val res = getBreezServices().listPayments(listPaymentsRequest)
                 promise.resolve(readableArrayOf(res))
             } catch (e: SdkException) {
                 promise.reject(e.javaClass.simpleName, e.message, e)
@@ -325,7 +404,11 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun sweep(toAddress: String, feeRateSatsPerVbyte: Double, promise: Promise) {
+    fun sweep(
+        toAddress: String,
+        feeRateSatsPerVbyte: Double,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 getBreezServices().sweep(toAddress, feeRateSatsPerVbyte.toULong())
@@ -373,7 +456,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun connectLsp(lspId: String, promise: Promise) {
+    fun connectLsp(
+        lspId: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 getBreezServices().connectLsp(lspId)
@@ -385,7 +471,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun fetchLspInfo(lspId: String, promise: Promise) {
+    fun fetchLspInfo(
+        lspId: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = getBreezServices().fetchLspInfo(lspId)
@@ -397,10 +486,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun openChannelFee(req: ReadableMap, promise: Promise) {
+    fun openChannelFee(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val openChannelFeeRequest = asOpenChannelFeeRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type OpenChannelFeeRequest") }
+                val openChannelFeeRequest =
+                    asOpenChannelFeeRequest(req) ?: run {
+                        throw SdkException.Generic("Missing mandatory field req of type OpenChannelFeeRequest")
+                    }
                 val res = getBreezServices().openChannelFee(openChannelFeeRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -446,10 +541,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun receiveOnchain(req: ReadableMap, promise: Promise) {
+    fun receiveOnchain(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val receiveOnchainRequest = asReceiveOnchainRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type ReceiveOnchainRequest") }
+                val receiveOnchainRequest =
+                    asReceiveOnchainRequest(req) ?: run {
+                        throw SdkException.Generic("Missing mandatory field req of type ReceiveOnchainRequest")
+                    }
                 val res = getBreezServices().receiveOnchain(receiveOnchainRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -483,7 +584,12 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun refund(swapAddress: String, toAddress: String, satPerVbyte: Int, promise: Promise) {
+    fun refund(
+        swapAddress: String,
+        toAddress: String,
+        satPerVbyte: Int,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = getBreezServices().refund(swapAddress, toAddress, satPerVbyte.toUInt())
@@ -495,10 +601,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun fetchReverseSwapFees(req: ReadableMap, promise: Promise) {
+    fun fetchReverseSwapFees(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val reverseSwapFeesRequest = asReverseSwapFeesRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type ReverseSwapFeesRequest") }
+                val reverseSwapFeesRequest =
+                    asReverseSwapFeesRequest(req) ?: run {
+                        throw SdkException.Generic("Missing mandatory field req of type ReverseSwapFeesRequest")
+                    }
                 val res = getBreezServices().fetchReverseSwapFees(reverseSwapFeesRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
@@ -520,7 +632,13 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun sendOnchain(amountSat: Double, onchainRecipientAddress: String, pairHash: String, satPerVbyte: Double, promise: Promise) {
+    fun sendOnchain(
+        amountSat: Double,
+        onchainRecipientAddress: String,
+        pairHash: String,
+        satPerVbyte: Double,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = getBreezServices().sendOnchain(amountSat.toULong(), onchainRecipientAddress, pairHash, satPerVbyte.toULong())
@@ -532,7 +650,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun executeDevCommand(command: String, promise: Promise) {
+    fun executeDevCommand(
+        command: String,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
                 val res = getBreezServices().executeDevCommand(command)
@@ -568,10 +689,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun buyBitcoin(req: ReadableMap, promise: Promise) {
+    fun buyBitcoin(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
         executor.execute {
             try {
-                val buyBitcoinRequest = asBuyBitcoinRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type BuyBitcoinRequest") }
+                val buyBitcoinRequest =
+                    asBuyBitcoinRequest(req) ?: run {
+                        throw SdkException.Generic("Missing mandatory field req of type BuyBitcoinRequest")
+                    }
                 val res = getBreezServices().buyBitcoin(buyBitcoinRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1335,9 +1335,10 @@ class BreezSDKMapper {
         let status = try asPaymentStatus(type: statusTmp)
 
         let description = data["description"] as? String
-        let lastError = data["lastError"] as? String
         guard let detailsTmp = data["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type Payment") }
         let details = try asPaymentDetails(data: detailsTmp)
+
+        let lastError = data["lastError"] as? String
 
         return Payment(
             id: id,
@@ -1347,8 +1348,8 @@ class BreezSDKMapper {
             feeMsat: feeMsat,
             status: status,
             description: description,
-            lastError: lastError,
-            details: details
+            details: details,
+            lastError: lastError
         )
     }
 
@@ -1361,8 +1362,8 @@ class BreezSDKMapper {
             "feeMsat": payment.feeMsat,
             "status": valueOf(paymentStatus: payment.status),
             "description": payment.description == nil ? nil : payment.description,
-            "lastError": payment.lastError == nil ? nil : payment.lastError,
             "details": dictionaryOf(paymentDetails: payment.details),
+            "lastError": payment.lastError == nil ? nil : payment.lastError,
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1380,8 +1380,6 @@ class BreezSDKMapper {
         guard let detailsTmp = data["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type Payment") }
         let details = try asPaymentDetails(data: detailsTmp)
 
-        let lastError = data["lastError"] as? String
-
         return Payment(
             id: id,
             paymentType: paymentType,
@@ -1390,8 +1388,7 @@ class BreezSDKMapper {
             feeMsat: feeMsat,
             status: status,
             description: description,
-            details: details,
-            lastError: lastError
+            details: details
         )
     }
 
@@ -1405,7 +1402,6 @@ class BreezSDKMapper {
             "status": valueOf(paymentStatus: payment.status),
             "description": payment.description == nil ? nil : payment.description,
             "details": dictionaryOf(paymentDetails: payment.details),
-            "lastError": payment.lastError == nil ? nil : payment.lastError,
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1331,8 +1331,11 @@ class BreezSDKMapper {
         guard let paymentTime = data["paymentTime"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field paymentTime for type Payment") }
         guard let amountMsat = data["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type Payment") }
         guard let feeMsat = data["feeMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field feeMsat for type Payment") }
-        guard let pending = data["pending"] as? Bool else { throw SdkError.Generic(message: "Missing mandatory field pending for type Payment") }
+        guard let statusTmp = data["status"] as? String else { throw SdkError.Generic(message: "Missing mandatory field status for type Payment") }
+        let status = try asPaymentStatus(type: statusTmp)
+
         let description = data["description"] as? String
+        let lastError = data["lastError"] as? String
         guard let detailsTmp = data["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type Payment") }
         let details = try asPaymentDetails(data: detailsTmp)
 
@@ -1342,8 +1345,9 @@ class BreezSDKMapper {
             paymentTime: paymentTime,
             amountMsat: amountMsat,
             feeMsat: feeMsat,
-            pending: pending,
+            status: status,
             description: description,
+            lastError: lastError,
             details: details
         )
     }
@@ -1355,8 +1359,9 @@ class BreezSDKMapper {
             "paymentTime": payment.paymentTime,
             "amountMsat": payment.amountMsat,
             "feeMsat": payment.feeMsat,
-            "pending": payment.pending,
+            "status": valueOf(paymentStatus: payment.status),
             "description": payment.description == nil ? nil : payment.description,
+            "lastError": payment.lastError == nil ? nil : payment.lastError,
             "details": dictionaryOf(paymentDetails: payment.details),
         ]
     }
@@ -2645,6 +2650,34 @@ class BreezSDKMapper {
                 "type": "closedChannel",
                 "data": dictionaryOf(closedChannelPaymentDetails: data),
             ]
+        }
+    }
+
+    static func asPaymentStatus(type: String) throws -> PaymentStatus {
+        switch type {
+        case "pending":
+            return PaymentStatus.pending
+
+        case "complete":
+            return PaymentStatus.complete
+
+        case "failed":
+            return PaymentStatus.failed
+
+        default: throw SdkError.Generic(message: "Invalid variant \(type) for enum PaymentStatus")
+        }
+    }
+
+    static func valueOf(paymentStatus: PaymentStatus) -> String {
+        switch paymentStatus {
+        case .pending:
+            return "pending"
+
+        case .complete:
+            return "complete"
+
+        case .failed:
+            return "failed"
         }
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -653,6 +653,48 @@ class BreezSDKMapper {
         return lnInvoiceList.map { v -> [String: Any?] in dictionaryOf(lnInvoice: v) }
     }
 
+    static func asListPaymentsRequest(data: [String: Any?]) throws -> ListPaymentsRequest {
+        guard let filterTmp = data["filter"] as? String else { throw SdkError.Generic(message: "Missing mandatory field filter for type ListPaymentsRequest") }
+        let filter = try asPaymentTypeFilter(type: filterTmp)
+
+        let fromTimestamp = data["fromTimestamp"] as? Int64
+        let toTimestamp = data["toTimestamp"] as? Int64
+        let includeFailures = data["includeFailures"] as? Bool
+
+        return ListPaymentsRequest(
+            filter: filter,
+            fromTimestamp: fromTimestamp,
+            toTimestamp: toTimestamp,
+            includeFailures: includeFailures
+        )
+    }
+
+    static func dictionaryOf(listPaymentsRequest: ListPaymentsRequest) -> [String: Any?] {
+        return [
+            "filter": valueOf(paymentTypeFilter: listPaymentsRequest.filter),
+            "fromTimestamp": listPaymentsRequest.fromTimestamp == nil ? nil : listPaymentsRequest.fromTimestamp,
+            "toTimestamp": listPaymentsRequest.toTimestamp == nil ? nil : listPaymentsRequest.toTimestamp,
+            "includeFailures": listPaymentsRequest.includeFailures == nil ? nil : listPaymentsRequest.includeFailures,
+        ]
+    }
+
+    static func asListPaymentsRequestList(arr: [Any]) throws -> [ListPaymentsRequest] {
+        var list = [ListPaymentsRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var listPaymentsRequest = try asListPaymentsRequest(data: val)
+                list.append(listPaymentsRequest)
+            } else {
+                throw SdkError.Generic(message: "Invalid element type ListPaymentsRequest")
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(listPaymentsRequestList: [ListPaymentsRequest]) -> [Any] {
+        return listPaymentsRequestList.map { v -> [String: Any?] in dictionaryOf(listPaymentsRequest: v) }
+    }
+
     static func asLnPaymentDetails(data: [String: Any?]) throws -> LnPaymentDetails {
         guard let paymentHash = data["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type LnPaymentDetails") }
         guard let label = data["label"] as? String else { throw SdkError.Generic(message: "Missing mandatory field label for type LnPaymentDetails") }

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -128,9 +128,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    listPayments: (NSString*)filter
-    fromTimestamp: (NSInteger*)fromTimestamp
-    toTimestamp: (NSInteger*)toTimestamp
+    listPayments: (NSDictionary*)request
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -263,13 +263,11 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
-    @objc(listPayments:fromTimestamp:toTimestamp:resolve:reject:)
-    func listPayments(_ filter: String, fromTimestamp: Int64, toTimestamp: Int64, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(listPayments:resolve:reject:)
+    func listPayments(_ request: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            let filterTmp = try BreezSDKMapper.asPaymentTypeFilter(type: filter)
-            let fromTimestampTmp = fromTimestamp == 0 ? nil : fromTimestamp
-            let toTimestampTmp = toTimestamp == 0 ? nil : toTimestamp
-            var res = try getBreezServices().listPayments(filter: filterTmp, fromTimestamp: fromTimestampTmp, toTimestamp: toTimestampTmp)
+            let listPaymentsRequest = try BreezSDKMapper.asListPaymentsRequest(data: request)
+            var res = try getBreezServices().listPayments(request: listPaymentsRequest)
             resolve(BreezSDKMapper.arrayOf(paymentList: res))
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -248,8 +248,9 @@ export type Payment = {
     paymentTime: number
     amountMsat: number
     feeMsat: number
-    pending: boolean
+    status: PaymentStatus
     description?: string
+    lastError?: string
     details: PaymentDetails
 }
 
@@ -533,6 +534,12 @@ export type PaymentDetails = {
 } | {
     type: PaymentDetailsVariant.CLOSED_CHANNEL,
     data: ClosedChannelPaymentDetails
+}
+
+export enum PaymentStatus {
+    PENDING = "pending",
+    COMPLETE = "complete",
+    FAILED = "failed"
 }
 
 export enum PaymentType {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -250,8 +250,8 @@ export type Payment = {
     feeMsat: number
     status: PaymentStatus
     description?: string
-    lastError?: string
     details: PaymentDetails
+    lastError?: string
 }
 
 export type PaymentFailedData = {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -123,6 +123,13 @@ export type LnInvoice = {
     paymentSecret: number[]
 }
 
+export type ListPaymentsRequest = {
+    filter: PaymentTypeFilter
+    fromTimestamp?: number
+    toTimestamp?: number
+    includeFailures?: boolean
+}
+
 export type LnPaymentDetails = {
     paymentHash: string
     label: string
@@ -692,8 +699,8 @@ export const paymentByHash = async (hash: string): Promise<Payment | null> => {
     return response
 }
 
-export const listPayments = async (filter: PaymentTypeFilter, fromTimestamp: number = 0, toTimestamp: number = 0): Promise<Payment[]> => {
-    const response = await BreezSDK.listPayments(filter, fromTimestamp, toTimestamp)
+export const listPayments = async (request: ListPaymentsRequest): Promise<Payment[]> => {
+    const response = await BreezSDK.listPayments(request)
     return response
 }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -258,7 +258,6 @@ export type Payment = {
     status: PaymentStatus
     description?: string
     details: PaymentDetails
-    lastError?: string
 }
 
 export type PaymentFailedData = {

--- a/tools/sdk-cli/.gitignore
+++ b/tools/sdk-cli/.gitignore
@@ -3,6 +3,7 @@ history.txt
 phrase
 storage.sql
 sync_storage.sql
+config.json
 creds
 
 *.log

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -5,8 +5,8 @@ use anyhow::{anyhow, Error, Result};
 use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
     parse, BreezEvent, BreezServices, BuyBitcoinRequest, CheckMessageRequest, EventListener,
-    GreenlightCredentials, PaymentTypeFilter, ReceiveOnchainRequest, ReceivePaymentRequest,
-    ReverseSwapFeesRequest, SignMessageRequest, StaticBackupRequest,
+    GreenlightCredentials, ListPaymentsRequest, PaymentTypeFilter, ReceiveOnchainRequest,
+    ReceivePaymentRequest, ReverseSwapFeesRequest, SignMessageRequest, StaticBackupRequest,
 };
 use breez_sdk_core::{Config, GreenlightNodeConfig, NodeConfig};
 use once_cell::sync::OnceCell;
@@ -169,9 +169,18 @@ pub(crate) async fn handle_command(
             let payment = sdk()?.send_spontaneous_payment(node_id, amount).await?;
             serde_json::to_string_pretty(&payment).map_err(|e| e.into())
         }
-        Commands::ListPayments {} => {
+        Commands::ListPayments {
+            from_timestamp,
+            to_timestamp,
+            include_failures,
+        } => {
             let payments = sdk()?
-                .list_payments(PaymentTypeFilter::All, None, None)
+                .list_payments(ListPaymentsRequest {
+                    filter: PaymentTypeFilter::All,
+                    from_timestamp,
+                    to_timestamp,
+                    include_failures: Some(include_failures),
+                })
                 .await?;
             serde_json::to_string_pretty(&payments).map_err(|e| e.into())
         }

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -111,7 +111,19 @@ pub(crate) enum Commands {
     },
 
     /// List all payments
-    ListPayments {},
+    ListPayments {
+        /// The optional from unix timestamp
+        #[clap(name = "from_timestamp", short = 'f', long = "from")]
+        from_timestamp: Option<i64>,
+
+        /// The optional to unix timestamp
+        #[clap(name = "to_timestamp", short = 't', long = "to")]
+        to_timestamp: Option<i64>,
+
+        /// Include failed payments
+        #[clap(short = 'i', long = "include_failures")]
+        include_failures: bool,
+    },
 
     /// Retrieve a payment by its hash
     PaymentByHash { hash: String },


### PR DESCRIPTION
This PR persists any payment failures when calling `send_payment`. Payments are stored by payment hash and as such the latest failed/completed attempt overwrites a previously stored payment. Failed payments can be retrieved using `payment_by_hash` or with `list_payments` using the `include_failures` parameter.

Fixes #446 

There is ongoing effort to improve the error codes returned in a payment failure cases addressed in issue #459.