### PR TITLE
Send onchain the largest amount possible

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -143,6 +143,7 @@ dictionary LNInvoice {
     u64 expiry;
     sequence<RouteHint> routing_hints;
     sequence<u8> payment_secret;
+    u64 min_final_cltv_expiry_delta;
 };
 
 dictionary UnspentTransactionOutput {
@@ -647,6 +648,10 @@ dictionary SendPaymentResponse {
     Payment payment;
 };
 
+dictionary MaxReverseSwapAmountResponse {
+    u64 total_msat;
+};
+
 dictionary SendOnchainRequest {
     u64 amount_sat;
     string onchain_recipient_address;
@@ -773,6 +778,9 @@ interface BlockingBreezServices {
 
    [Throws=SdkError]
    sequence<ReverseSwapInfo> in_progress_reverse_swaps();
+   
+   [Throws=SdkError]
+   MaxReverseSwapAmountResponse max_reverse_swap_amount();
 
    [Throws=SendOnchainError]
    SendOnchainResponse send_onchain(SendOnchainRequest req);

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -649,7 +649,7 @@ dictionary SendPaymentResponse {
 };
 
 dictionary MaxReverseSwapAmountResponse {
-    u64 total_msat;
+    u64 total_sat;
 };
 
 dictionary SendOnchainRequest {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -10,11 +10,11 @@ use breez_sdk_core::{
     LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayErrorData, LnUrlPayRequest, LnUrlPayRequestData,
     LnUrlPayResult, LnUrlPaySuccessData, LnUrlWithdrawRequest, LnUrlWithdrawRequestData,
     LnUrlWithdrawResult, LnUrlWithdrawSuccessData, LocaleOverrides, LocalizedName, LogEntry,
-    LogStream, LspInformation, MessageSuccessActionData, MetadataItem, Network, NodeConfig,
-    NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse, OpeningFeeParams,
-    OpeningFeeParamsMenu, Payment, PaymentDetails, PaymentFailedData, PaymentStatus, PaymentType,
-    PaymentTypeFilter, PrepareRefundRequest, PrepareRefundResponse, PrepareSweepRequest,
-    PrepareSweepResponse, Rate, ReceiveOnchainRequest, ReceivePaymentRequest,
+    LogStream, LspInformation, MaxReverseSwapAmountResponse, MessageSuccessActionData,
+    MetadataItem, Network, NodeConfig, NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse,
+    OpeningFeeParams, OpeningFeeParamsMenu, Payment, PaymentDetails, PaymentFailedData,
+    PaymentStatus, PaymentType, PaymentTypeFilter, PrepareRefundRequest, PrepareRefundResponse,
+    PrepareSweepRequest, PrepareSweepResponse, Rate, ReceiveOnchainRequest, ReceivePaymentRequest,
     ReceivePaymentResponse, RecommendedFees, RefundRequest, RefundResponse, ReverseSwapFeesRequest,
     ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop,
     SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
@@ -265,6 +265,10 @@ impl BlockingBreezServices {
 
     pub fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
         rt().block_on(self.breez_services.in_progress_reverse_swaps())
+    }
+
+    pub fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
+        rt().block_on(self.breez_services.max_reverse_swap_amount())
     }
 
     pub fn send_onchain(

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -307,7 +307,7 @@ impl BackupWorker {
                 Ok((new_version, data))
             }
             Err(e) => {
-                debug!("Optimistic sync failed, trying to sync remote changes {e}");
+                info!("Optimistic sync failed, trying to sync remote changes {e}");
                 // We need to sync remote changes and then retry the push
                 self.sync_remote_and_push(sync_dir, data, &mut last_sync_request_id)
                     .await

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -34,13 +34,13 @@ use crate::models::{Config, LogEntry, NodeState, Payment, SwapInfo};
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     EnvironmentType, ListPaymentsRequest, LnUrlCallbackStatus, LnUrlPayRequest,
-    LnUrlWithdrawRequest, LnUrlWithdrawResult, NodeConfig, OpenChannelFeeRequest,
-    OpenChannelFeeResponse, PrepareRefundRequest, PrepareRefundResponse, PrepareSweepRequest,
-    PrepareSweepResponse, ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse,
-    RefundRequest, RefundResponse, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
-    SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
-    SendSpontaneousPaymentRequest, SignMessageRequest, SignMessageResponse, StaticBackupRequest,
-    StaticBackupResponse, SweepRequest, SweepResponse,
+    LnUrlWithdrawRequest, LnUrlWithdrawResult, MaxReverseSwapAmountResponse, NodeConfig,
+    OpenChannelFeeRequest, OpenChannelFeeResponse, PrepareRefundRequest, PrepareRefundResponse,
+    PrepareSweepRequest, PrepareSweepResponse, ReceiveOnchainRequest, ReceivePaymentRequest,
+    ReceivePaymentResponse, RefundRequest, RefundResponse, ReverseSwapFeesRequest, ReverseSwapInfo,
+    ReverseSwapPairInfo, SendOnchainRequest, SendOnchainResponse, SendPaymentRequest,
+    SendPaymentResponse, SendSpontaneousPaymentRequest, SignMessageRequest, SignMessageResponse,
+    StaticBackupRequest, StaticBackupResponse, SweepRequest, SweepResponse,
 };
 
 /*
@@ -299,6 +299,11 @@ pub fn list_fiat_currencies() -> Result<Vec<FiatCurrency>> {
 }
 
 /*  On-Chain Swap API's */
+
+pub fn max_reverse_swap_amount() -> Result<MaxReverseSwapAmountResponse> {
+    block_on(async { get_breez_services().await?.max_reverse_swap_amount().await })
+        .map_err(anyhow::Error::new::<SdkError>)
+}
 
 /// See [BreezServices::send_onchain]
 pub fn send_onchain(req: SendOnchainRequest) -> Result<SendOnchainResponse> {

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -300,6 +300,7 @@ pub fn list_fiat_currencies() -> Result<Vec<FiatCurrency>> {
 
 /*  On-Chain Swap API's */
 
+/// See [BreezServices::max_reverse_swap_amount]
 pub fn max_reverse_swap_amount() -> Result<MaxReverseSwapAmountResponse> {
     block_on(async { get_breez_services().await?.max_reverse_swap_amount().await })
         .map_err(anyhow::Error::new::<SdkError>)

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -707,7 +707,7 @@ impl BreezServices {
         // User Node -> LSP Node -> Routing Node -> Swapper Node
         let (max_to_pay, _) = self
             .node_api
-            .max_amount_to_send(
+            .max_sendable_amount(
                 Some(
                     hex::decode(&last_hop.src_node_id)
                         .map_err(|e| anyhow!("Failed to decode hex node_id: {e}"))?,
@@ -718,9 +718,9 @@ impl BreezServices {
             .await?;
 
         // Sum the max amount per channel and return the result
-        let total_msat = max_to_pay.into_iter().map(|m| m.amount_msat).sum();
-
-        Ok(MaxReverseSwapAmountResponse { total_msat })
+        let total_msat: u64 = max_to_pay.into_iter().map(|m| m.amount_msat).sum();
+        let total_sat = total_msat / 1000;
+        Ok(MaxReverseSwapAmountResponse { total_sat })
     }
 
     /// Creates a reverse swap and attempts to pay the HODL invoice

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -702,8 +702,9 @@ impl BreezServices {
         // fetch the last hop hints from the swapper
         let last_hop = self.btc_send_swapper.last_hop_for_payment().await?;
         let lsp = self.lsp_info().await?;
-        let lsp_pubkey =
-            hex::decode(lsp.pubkey).map_err(|e| anyhow!("Failed to decode lsp pubkey: {e}"))?;
+        let lsp_pubkey = hex::decode(lsp.pubkey).map_err(|e| SdkError::Generic {
+            err: format!("Failed to decode lsp pubkey: {e}"),
+        })?;
         // calculate the largest payment we can send over this route using maximum 3 hops
         // as follows:
         // User Node -> LSP Node -> Routing Node -> Swapper Node
@@ -712,8 +713,9 @@ impl BreezServices {
             .max_sendable_amount(
                 lsp_pubkey,
                 Some(
-                    hex::decode(&last_hop.src_node_id)
-                        .map_err(|e| anyhow!("Failed to decode hex node_id: {e}"))?,
+                    hex::decode(&last_hop.src_node_id).map_err(|e| SdkError::Generic {
+                        err: format!("Failed to decode hex node_id: {e}"),
+                    })?,
                 ),
                 swap_out::reverseswap::MAX_PAYMENT_PATH_HOPS,
                 Some(&last_hop),
@@ -737,8 +739,9 @@ impl BreezServices {
         });
 
         let lsp_info = self.lsp_info().await?;
-        let lsp_pubkey = hex::decode(lsp_info.pubkey)
-            .map_err(|e| anyhow!("Failed to decode lsp pubkey: {e}"))?;
+        let lsp_pubkey = hex::decode(lsp_info.pubkey).map_err(|e| SendOnchainError::Generic {
+            err: format!("Failed to decode lsp pubkey: {e}"),
+        })?;
 
         let full_rsi = self
             .btc_send_swapper

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -696,7 +696,7 @@ impl BreezServices {
     /// Returns the max amount that can be sent on-chain using the send_onchain method.
     /// The returned amount is the sum of the max amount that can be sent on each channel
     /// minus the expected fees.
-    /// This is possible since the route to the swapper node is known in advance ans is expected
+    /// This is possible since the route to the swapper node is known in advance and is expected
     /// to consist of maximum 3 hops.
     pub async fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
         // fetch the last hop hints from the swapper

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -701,13 +701,16 @@ impl BreezServices {
     pub async fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
         // fetch the last hop hints from the swapper
         let last_hop = self.btc_send_swapper.last_hop_for_payment().await?;
-
+        let lsp = self.lsp_info().await?;
+        let lsp_pubkey =
+            hex::decode(lsp.pubkey).map_err(|e| anyhow!("Failed to decode lsp pubkey: {e}"))?;
         // calculate the largest payment we can send over this route using maximum 3 hops
         // as follows:
         // User Node -> LSP Node -> Routing Node -> Swapper Node
-        let (max_to_pay, _) = self
+        let max_to_pay = self
             .node_api
             .max_sendable_amount(
+                lsp_pubkey,
                 Some(
                     hex::decode(&last_hop.src_node_id)
                         .map_err(|e| anyhow!("Failed to decode hex node_id: {e}"))?,
@@ -733,7 +736,14 @@ impl BreezServices {
             Use the in_progress_reverse_swaps method to get an overview of currently ongoing reverse swaps".into(), 
         });
 
-        let full_rsi = self.btc_send_swapper.create_reverse_swap(req).await?;
+        let lsp_info = self.lsp_info().await?;
+        let lsp_pubkey = hex::decode(lsp_info.pubkey)
+            .map_err(|e| anyhow!("Failed to decode lsp pubkey: {e}"))?;
+
+        let full_rsi = self
+            .btc_send_swapper
+            .create_reverse_swap(req, lsp_pubkey)
+            .await?;
         let rsi = self
             .btc_send_swapper
             .convert_reverse_swap_info(full_rsi)

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -693,6 +693,36 @@ impl BreezServices {
         Ok(res)
     }
 
+    /// Returns the max amount that can be sent on-chain using the send_onchain method.
+    /// The returned amount is the sum of the max amount that can be sent on each channel
+    /// minus the expected fees.
+    /// This is possible since the route to the swapper node is known in advance ans is expected
+    /// to consist of maximum 3 hops.
+    pub async fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
+        // fetch the last hop hints from the swapper
+        let last_hop = self.btc_send_swapper.last_hop_for_payment().await?;
+
+        // calculate the largest payment we can send over this route using maximum 3 hops
+        // as follows:
+        // User Node -> LSP Node -> Routing Node -> Swapper Node
+        let (max_to_pay, _) = self
+            .node_api
+            .max_amount_to_send(
+                Some(
+                    hex::decode(&last_hop.src_node_id)
+                        .map_err(|e| anyhow!("Failed to decode hex node_id: {e}"))?,
+                ),
+                swap_out::reverseswap::MAX_PAYMENT_PATH_HOPS,
+                Some(&last_hop),
+            )
+            .await?;
+
+        // Sum the max amount per channel and return the result
+        let total_msat = max_to_pay.into_iter().map(|m| m.amount_msat).sum();
+
+        Ok(MaxReverseSwapAmountResponse { total_msat })
+    }
+
     /// Creates a reverse swap and attempts to pay the HODL invoice
     pub async fn send_onchain(
         &self,

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -170,6 +170,11 @@ pub extern "C" fn wire_list_fiat_currencies(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_max_reverse_swap_amount(port_: i64) {
+    wire_max_reverse_swap_amount_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_send_onchain(port_: i64, req: *mut wire_SendOnchainRequest) {
     wire_send_onchain_impl(port_, req)
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -70,6 +70,7 @@ use crate::models::LnUrlWithdrawRequest;
 use crate::models::LnUrlWithdrawResult;
 use crate::models::LnUrlWithdrawSuccessData;
 use crate::models::LogEntry;
+use crate::models::MaxReverseSwapAmountResponse;
 use crate::models::Network;
 use crate::models::NodeConfig;
 use crate::models::NodeState;
@@ -517,6 +518,16 @@ fn wire_list_fiat_currencies_impl(port_: MessagePort) {
             mode: FfiCallMode::Normal,
         },
         move || move |task_callback| list_fiat_currencies(),
+    )
+}
+fn wire_max_reverse_swap_amount_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, MaxReverseSwapAmountResponse>(
+        WrapInfo {
+            debug_name: "max_reverse_swap_amount",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| max_reverse_swap_amount(),
     )
 }
 fn wire_send_onchain_impl(port_: MessagePort, req: impl Wire2Api<SendOnchainRequest> + UnwindSafe) {
@@ -1117,6 +1128,9 @@ impl support::IntoDart for LNInvoice {
             self.expiry.into_into_dart().into_dart(),
             self.routing_hints.into_into_dart().into_dart(),
             self.payment_secret.into_into_dart().into_dart(),
+            self.min_final_cltv_expiry_delta
+                .into_into_dart()
+                .into_dart(),
         ]
         .into_dart()
     }
@@ -1388,6 +1402,18 @@ impl support::IntoDart for LspInformation {
 }
 impl support::IntoDartExceptPrimitive for LspInformation {}
 impl rust2dart::IntoIntoDart<LspInformation> for LspInformation {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for MaxReverseSwapAmountResponse {
+    fn into_dart(self) -> support::DartAbi {
+        vec![self.total_msat.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for MaxReverseSwapAmountResponse {}
+impl rust2dart::IntoIntoDart<MaxReverseSwapAmountResponse> for MaxReverseSwapAmountResponse {
     fn into_into_dart(self) -> Self {
         self
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1409,7 +1409,7 @@ impl rust2dart::IntoIntoDart<LspInformation> for LspInformation {
 
 impl support::IntoDart for MaxReverseSwapAmountResponse {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.total_msat.into_into_dart().into_dart()].into_dart()
+        vec![self.total_sat.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MaxReverseSwapAmountResponse {}

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -456,14 +456,14 @@ impl Greenlight {
         via_peer_channels: Vec<ListpeersPeersChannels>,
         payee_node_id: Option<Vec<u8>>,
         max_hops: u32,
-        last_hop_hints: Option<&RouteHintHop>,
+        last_hop_hint: Option<&RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>> {
         let mut client = self.get_node_client().await?;
 
         // Consider the hints as part of the route. If there is a routing hint we will
         // attempt to calculate the path until the last hop in the hint and then add
         // the last hop to the path.
-        let (last_node, max_hops) = match last_hop_hints {
+        let (last_node, max_hops) = match last_hop_hint {
             Some(hop) => (hex::decode(&hop.src_node_id)?, max_hops - 1),
             None => match payee_node_id.clone() {
                 Some(node_id) => (node_id, max_hops),
@@ -544,7 +544,7 @@ impl Greenlight {
                 .await?;
 
             // Add the last hop hints (if any) to the route
-            if let Some(hint) = last_hop_hints {
+            if let Some(hint) = last_hop_hint {
                 payment_path.edges.extend(vec![PaymentPathEdge {
                     base_fee_msat: hint.fees_base_msat as u64,
                     fee_per_millionth: hint.fees_proportional_millionths as u64,
@@ -1198,7 +1198,7 @@ impl NodeAPI for Greenlight {
         &self,
         payee_node_id: Option<Vec<u8>>,
         max_hops: u32,
-        last_hop_hints: Option<&RouteHintHop>,
+        last_hop_hint: Option<&RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>> {
         let mut client = self.get_node_client().await?;
 
@@ -1215,7 +1215,7 @@ impl NodeAPI for Greenlight {
                     peer.channels,
                     payee_node_id.clone(),
                     max_hops,
-                    last_hop_hints,
+                    last_hop_hint,
                 )
                 .await?;
             max_channel_amounts.extend_from_slice(max_amounts_for_peer.as_slice());

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1103,7 +1103,7 @@ impl NodeAPI for Greenlight {
                 Some(node_id) => (node_id, max_hops),
                 None => {
                     return Err(NodeError::RouteNotFound(anyhow!(
-                        "no payee node id or last hop hints provided, cannot calculate max amount"
+                        "No payee node id or last hop hints provided, cannot calculate max amount"
                     )));
                 }
             },
@@ -1119,7 +1119,7 @@ impl NodeAPI for Greenlight {
                 fromid: Some(via_peer_id.clone()),
                 fuzzpercent: Some(0),
                 exclude: vec![],
-                // we reduce the first hope that we calculate manually
+                // we deduct the first hop that we calculate manually
                 maxhops: Some(max_hops - 1),
             })
             .await?
@@ -1175,7 +1175,7 @@ impl NodeAPI for Greenlight {
             let chan_id = c
                 .clone()
                 .channel_id
-                .ok_or(NodeError::Generic(anyhow!("empty channel id")))?;
+                .ok_or(NodeError::Generic(anyhow!("Empty channel id")))?;
 
             // First hop is forwarding so no fees and delays.
             let first_edge = PaymentPathEdge {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -32,6 +32,7 @@ use gl_client::tls::TlsConfig;
 use gl_client::{node, utils};
 use lightning::util::message_signing::verify;
 use lightning_invoice::{RawInvoice, SignedRawInvoice};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use tokio::sync::{mpsc, Mutex};
@@ -753,6 +754,8 @@ impl NodeAPI for Greenlight {
         let mut amount_sent_msat = 0;
         // The total amount received by the recipient
         let mut amount_received_msat = 0;
+        // Generate a random group_id for the payment
+        let group_id = rand::random::<u64>();
 
         // The algorithm goes over each channel and drains it until the received amount
         // equals to the amount to pay defined in the bolt11 invoice.
@@ -805,7 +808,7 @@ impl NodeAPI for Greenlight {
                 payment_hash: hex::decode(invoice.payment_hash.clone())?,
                 partid: Some(1),
                 timeout: Some(self.sdk_config.payment_timeout_sec),
-                groupid: None,
+                groupid: Some(group_id),
             })
             .await?
             .into_inner();

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -435,8 +435,8 @@ impl Greenlight {
 
             info!("found channel in route: {:?}", first_channel);
             hops.push(PaymentPathEdge {
-                base_fee_msat: first_channel.base_fee_millisatoshi,
-                fee_per_millionth: first_channel.fee_per_millionth,
+                base_fee_msat: first_channel.base_fee_millisatoshi as u64,
+                fee_per_millionth: first_channel.fee_per_millionth as u64,
                 node_id: hop.id.clone(),
                 short_channel_id: hop.channel.clone(),
                 channel_delay: first_channel.delay as u64,
@@ -1126,8 +1126,8 @@ impl NodeAPI for Greenlight {
         // Add the last hop hints (if any) to the route
         if let Some(hint) = last_hop_hints {
             payment_path.edges.extend(vec![PaymentPathEdge {
-                base_fee_msat: hint.fees_base_msat,
-                fee_per_millionth: hint.fees_proportional_millionths,
+                base_fee_msat: hint.fees_base_msat as u64,
+                fee_per_millionth: hint.fees_proportional_millionths as u64,
                 node_id: payee_node_id.unwrap_or_default(),
                 short_channel_id: format_short_channel_id(hint.short_channel_id),
                 channel_delay: hint.cltv_expiry_delta,

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1113,7 +1113,7 @@ impl NodeAPI for Greenlight {
         let route_response = client
             .get_route(GetrouteRequest {
                 id: last_node.clone(),
-                amount_msat: Some(Amount { msat: 1_000 }),
+                amount_msat: Some(Amount { msat: 0 }),
                 riskfactor: 0,
                 cltv: None,
                 fromid: Some(via_peer_id.clone()),

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -507,20 +507,11 @@ impl Greenlight {
         );
 
         // We fetch the opened channels so can calculate max amount to send for each channel
-        let mut opened_channels: Vec<cln::ListpeersPeersChannels> = via_peer_channels
+        let opened_channels: Vec<cln::ListpeersPeersChannels> = via_peer_channels
             .iter()
             .cloned()
             .filter(|c| c.state() == ChanneldNormal)
             .collect();
-
-        // opened_channels.into_iter().filter(|c: &cln::ListpeersPeersChannels|c)
-        opened_channels.sort_by(|c1, c2| {
-            c2.spendable_msat
-                .clone()
-                .unwrap_or_default()
-                .msat
-                .cmp(&c1.spendable_msat.clone().unwrap_or_default().msat)
-        });
 
         let mut max_per_channel = vec![];
         for c in opened_channels {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -32,7 +32,6 @@ use gl_client::tls::TlsConfig;
 use gl_client::{node, utils};
 use lightning::util::message_signing::verify;
 use lightning_invoice::{RawInvoice, SignedRawInvoice};
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use tokio::sync::{mpsc, Mutex};

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -645,7 +645,7 @@ impl NodeAPI for Greenlight {
         // The total amount received by the recipient
         let mut amount_received_msat = 0;
 
-        // The algorithm goes over each channel and drains it until the recived amount
+        // The algorithm goes over each channel and drains it until the received amount
         // equals to the amount to pay defined in the bolt11 invoice.
         for max in max_amount_per_channel {
             // calculating the incoming amount for the remaining amount to pay.

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1,4 +1,4 @@
-use std::cmp::{max, min};
+use std::cmp::{max, min, Reverse};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -617,7 +617,7 @@ impl NodeAPI for Greenlight {
 
         // Sort the channels by max amount descending so we can build the route in a way that it
         // drains the largest channels first
-        max_amount_per_channel.sort_by(|m1, m2| m2.amount_msat.cmp(&m1.amount_msat));
+        max_amount_per_channel.sort_by_key(|m| Reverse(m.amount_msat));
 
         let amount_to_pay_msat = match invoice.amount_msat {
             Some(amount) => Ok(amount),

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -69,6 +69,7 @@ pub struct LNInvoice {
     pub expiry: u64,
     pub routing_hints: Vec<RouteHint>,
     pub payment_secret: Vec<u8>,
+    pub min_final_cltv_expiry_delta: u64,
 }
 
 /// Details of a specific hop in a larger route hint
@@ -235,6 +236,7 @@ pub fn parse_invoice(bolt11: &str) -> InvoiceResult<LNInvoice> {
             InvoiceDescription::Direct(_) => None,
             InvoiceDescription::Hash(h) => Some(h.0.to_string()),
         },
+        min_final_cltv_expiry_delta: invoice.min_final_cltv_expiry_delta(),
     };
     Ok(ln_invoice)
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -697,7 +697,7 @@ pub struct MaxChannelAmount {
     pub channel_id: String,
     /// The max amount can be sent from this channel.
     pub amount_msat: u64,
-    /// The payment path to be used for thte maximum amount.
+    /// The payment path to be used for the maximum amount.
     pub path: PaymentPath,
 }
 
@@ -1275,7 +1275,7 @@ pub struct PaymentPathEdge {
 
 impl PaymentPathEdge {
     pub(crate) fn amount_to_forward(&self, in_amount_msat: u64) -> u64 {
-        let amount_to_forward = Self::devide_ceil(
+        let amount_to_forward = Self::divide_ceil(
             1_000_000 * (in_amount_msat - self.base_fee_msat),
             1_000_000 + self.fee_per_millionth,
         );
@@ -1292,7 +1292,7 @@ impl PaymentPathEdge {
         in_amount_msat
     }
 
-    fn devide_ceil(dividend: u64, factor: u64) -> u64 {
+    fn divide_ceil(dividend: u64, factor: u64) -> u64 {
         (dividend + factor - 1) / factor
     }
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1125,7 +1125,7 @@ pub(crate) fn parse_short_channel_id(id_str: &str) -> Result<u64> {
 pub(crate) fn format_short_channel_id(id: u64) -> String {
     let block_num = (id >> 40) as u32;
     let tx_num = ((id >> 16) & 0xFFFFFF) as u32;
-    let tx_out = id as u16;
+    let tx_out = (id & 0xFFFF) as u16;
     format!("{block_num}x{tx_num}x{tx_out}")
 }
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -687,7 +687,7 @@ pub struct ReverseSwapFeesRequest {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MaxReverseSwapAmountResponse {
-    pub total_msat: u64,
+    pub total_sat: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1271,18 +1271,17 @@ pub struct PaymentPathEdge {
 impl PaymentPathEdge {
     pub(crate) fn amount_to_forward(&self, in_amount_msat: u64) -> u64 {
         let forward = (in_amount_msat - self.base_fee_msat as u64) as f64
-            / (1f64 + self.fee_per_millionth as f64 / 1000000f64);
+            / (1f64 + self.fee_per_millionth as f64 / 1_000_000f64);
 
         let amount_to_forward = forward.floor() as u64;
         info!("amount_to_forward: in_amount_msat = {in_amount_msat},base_fee_msat={}, fee_per_millionth={}  amount_to_forward: {}", self.base_fee_msat, self.fee_per_millionth, amount_to_forward);
         amount_to_forward
     }
-
-    // forward_amount_msat * (1000000 + self.fee_per_millionth)/1000000 + self.base_fee_msat = x
+    
     pub(crate) fn amount_from_forward(&self, forward_amount_msat: u64) -> u64 {
         let in_amount_msat = self.base_fee_msat as f64
-            + forward_amount_msat as f64 * (1000000f64 + self.fee_per_millionth as f64)
-                / 1000000f64;
+            + forward_amount_msat as f64 * (1_000_000f64 + self.fee_per_millionth as f64)
+                / 1_000_000f64;
         print!("amount_from_forward: in_amount_msat = {in_amount_msat},base_fee_msat={}, fee_per_millionth={}  amount_to_forward: {}", self.base_fee_msat, self.fee_per_millionth, forward_amount_msat);
         in_amount_msat.ceil() as u64
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -694,6 +694,7 @@ pub struct MaxReverseSwapAmountResponse {
 pub struct MaxChannelAmount {
     pub channel_id: String,
     pub amount_msat: u64,
+    pub path: PaymentPath,
 }
 
 /// Represents a receive payment request.
@@ -1236,7 +1237,7 @@ impl FromStr for BuyBitcoinProvider {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct PaymentPath {
     pub edges: Vec<PaymentPathEdge>,
 }
@@ -1259,7 +1260,7 @@ impl PaymentPath {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct PaymentPathEdge {
     pub node_id: Vec<u8>,
     pub short_channel_id: String,
@@ -1292,7 +1293,7 @@ impl PaymentPathEdge {
     }
 
     fn devide_ceil(dividend: u64, factor: u64) -> u64 {
-        return (dividend + factor - 1) / factor;
+        (dividend + factor - 1) / factor
     }
 }
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1275,13 +1275,9 @@ pub struct PaymentPathEdge {
 
 impl PaymentPathEdge {
     pub(crate) fn amount_to_forward(&self, in_amount_msat: u64) -> u64 {
-        // return incomingAmt - divideCeil(
-        //     feeRateParts*(incomingAmt-c.FeeBaseMSat),
-        //     feeRateParts+c.FeeProportionalMillionths,
-        // )
         let amount_to_forward = Self::devide_ceil(
             1_000_000 * (in_amount_msat - self.base_fee_msat),
-            1000000 + self.fee_per_millionth,
+            1_000_000 + self.fee_per_millionth,
         );
 
         info!("amount_to_forward: in_amount_msat = {in_amount_msat},base_fee_msat={}, fee_per_millionth={}  amount_to_forward: {}", self.base_fee_msat, self.fee_per_millionth, amount_to_forward);

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -687,13 +687,17 @@ pub struct ReverseSwapFeesRequest {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MaxReverseSwapAmountResponse {
+    /// The total sats that can be sent onchain.
     pub total_sat: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MaxChannelAmount {
+    /// The channel id.
     pub channel_id: String,
+    /// The max amount can be sent from this channel.
     pub amount_msat: u64,
+    /// The payment path to be used for thte maximum amount.
     pub path: PaymentPath,
 }
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1277,7 +1277,7 @@ impl PaymentPathEdge {
         info!("amount_to_forward: in_amount_msat = {in_amount_msat},base_fee_msat={}, fee_per_millionth={}  amount_to_forward: {}", self.base_fee_msat, self.fee_per_millionth, amount_to_forward);
         amount_to_forward
     }
-    
+
     pub(crate) fn amount_from_forward(&self, forward_amount_msat: u64) -> u64 {
         let in_amount_msat = self.base_fee_msat as f64
             + forward_amount_msat as f64 * (1_000_000f64 + self.fee_per_millionth as f64)

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -81,7 +81,7 @@ pub trait NodeAPI: Send + Sync {
 
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain
     /// Large channels first.
-    /// This is useful function to send the largest anount possible to a node.
+    /// This is useful function to send the largest amount possible to a node.
     async fn send_pay(&self, bolt11: String, max_hops: u32) -> NodeResult<PaymentResponse>;
 
     /// Calculates the maximum amount that can be sent to a node.

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,7 +1,6 @@
 use crate::{
     invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
-    PaymentPath, PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse, RouteHintHop,
-    SyncResponse,
+    PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse, RouteHintHop, SyncResponse,
 };
 use anyhow::Result;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
@@ -82,15 +81,21 @@ pub trait NodeAPI: Send + Sync {
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain
     /// Large channels first.
     /// This is useful function to send the largest amount possible to a node.
-    async fn send_pay(&self, bolt11: String, max_hops: u32) -> NodeResult<PaymentResponse>;
+    async fn send_pay(
+        &self,
+        via_peer_id: Vec<u8>,
+        bolt11: String,
+        max_hops: u32,
+    ) -> NodeResult<PaymentResponse>;
 
     /// Calculates the maximum amount that can be sent to a node.
     async fn max_sendable_amount(
         &self,
+        via_peer_id: Vec<u8>,
         payee_node_id: Option<Vec<u8>>,
         max_hops: u32,
         last_hop: Option<&RouteHintHop>,
-    ) -> NodeResult<(Vec<MaxChannelAmount>, PaymentPath)>;
+    ) -> NodeResult<Vec<MaxChannelAmount>>;
     async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> NodeResult<Vec<u8>>;
     async fn prepare_sweep(&self, req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse>;
     async fn start_signer(&self, shutdown: mpsc::Receiver<()>);

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -84,7 +84,7 @@ pub trait NodeAPI: Send + Sync {
     /// This is useful function to send the largest anount possible to a node.
     async fn send_pay(&self, bolt11: String, max_hops: u32) -> NodeResult<PaymentResponse>;
 
-    /// Calcualtes the maximum amount that can be sent to a node.
+    /// Calculates the maximum amount that can be sent to a node.
     async fn max_amount_to_send(
         &self,
         payee_node_id: Option<Vec<u8>>,

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -85,7 +85,7 @@ pub trait NodeAPI: Send + Sync {
     async fn send_pay(&self, bolt11: String, max_hops: u32) -> NodeResult<PaymentResponse>;
 
     /// Calculates the maximum amount that can be sent to a node.
-    async fn max_amount_to_send(
+    async fn max_sendable_amount(
         &self,
         payee_node_id: Option<Vec<u8>>,
         max_hops: u32,

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,6 +1,7 @@
 use crate::{
-    invoice::InvoiceError, persist::error::PersistError, CustomMessage, PaymentResponse, Peer,
-    PrepareSweepRequest, PrepareSweepResponse, SyncResponse,
+    invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
+    PaymentPath, PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse, RouteHintHop,
+    SyncResponse,
 };
 use anyhow::Result;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
@@ -77,6 +78,19 @@ pub trait NodeAPI: Send + Sync {
         amount_msat: u64,
     ) -> NodeResult<PaymentResponse>;
     async fn start(&self) -> NodeResult<String>;
+
+    /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain
+    /// Large channels first.
+    /// This is useful function to send the largest anount possible to a node.
+    async fn send_pay(&self, bolt11: String, max_hops: u32) -> NodeResult<PaymentResponse>;
+
+    /// Calcualtes the maximum amount that can be sent to a node.
+    async fn max_amount_to_send(
+        &self,
+        payee_node_id: Option<Vec<u8>>,
+        max_hops: u32,
+        last_hop: Option<&RouteHintHop>,
+    ) -> NodeResult<(Vec<MaxChannelAmount>, PaymentPath)>;
     async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> NodeResult<Vec<u8>>;
     async fn prepare_sweep(&self, req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse>;
     async fn start_signer(&self, shutdown: mpsc::Receiver<()>);

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -81,17 +81,11 @@ pub trait NodeAPI: Send + Sync {
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain
     /// Large channels first.
     /// This is useful function to send the largest amount possible to a node.
-    async fn send_pay(
-        &self,
-        via_peer_id: Vec<u8>,
-        bolt11: String,
-        max_hops: u32,
-    ) -> NodeResult<PaymentResponse>;
+    async fn send_pay(&self, bolt11: String, max_hops: u32) -> NodeResult<PaymentResponse>;
 
     /// Calculates the maximum amount that can be sent to a node.
     async fn max_sendable_amount(
         &self,
-        via_peer_id: Vec<u8>,
         payee_node_id: Option<Vec<u8>>,
         max_hops: u32,
         last_hop: Option<&RouteHintHop>,

--- a/libs/sdk-core/src/swap_out/boltzswap.rs
+++ b/libs/sdk-core/src/swap_out/boltzswap.rs
@@ -21,7 +21,7 @@ use super::error::{ReverseSwapError, ReverseSwapResult};
 const BOLTZ_API_URL: &str = "https://api.boltz.exchange/";
 const GET_PAIRS_ENDPOINT: &str = concatcp!(BOLTZ_API_URL, "getpairs");
 const GET_SWAP_STATUS_ENDPOINT: &str = concatcp!(BOLTZ_API_URL, "swapstatus");
-const GET_ROUTE_HINTS_ENDPIONT: &str = concatcp!(BOLTZ_API_URL, "routinghints");
+const GET_ROUTE_HINTS_ENDPOINT: &str = concatcp!(BOLTZ_API_URL, "routinghints");
 pub(crate) const CREATE_REVERSE_SWAP_ENDPOINT: &str = concatcp!(BOLTZ_API_URL, "createswap");
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -308,7 +308,7 @@ impl ReverseSwapServiceAPI for BoltzApi {
 
     async fn get_route_hints(&self, routing_node_id: String) -> ReverseSwapResult<Vec<RouteHint>> {
         Client::new()
-            .post(GET_ROUTE_HINTS_ENDPIONT)
+            .post(GET_ROUTE_HINTS_ENDPOINT)
             .header(CONTENT_TYPE, "application/json")
             .body(Body::from(
                 json!({ "routingNode": routing_node_id, "symbol": "BTC" }).to_string(),
@@ -319,7 +319,7 @@ impl ReverseSwapServiceAPI for BoltzApi {
             .await
             .map_err(|e| {
                 ReverseSwapError::ServiceConnectivity(anyhow!(
-                    "(Boltz {GET_ROUTE_HINTS_ENDPIONT}) Failed to get routing hints: {e}"
+                    "(Boltz {GET_ROUTE_HINTS_ENDPOINT}) Failed to get routing hints: {e}"
                 ))
             })
             .and_then(|res| {
@@ -330,7 +330,7 @@ impl ReverseSwapServiceAPI for BoltzApi {
                 serde_json::from_str::<BoltzRouteHints>(&res)
                 .map_err(|e| {
                     ReverseSwapError::ServiceConnectivity(anyhow!(
-                        "(Boltz {GET_ROUTE_HINTS_ENDPIONT}) Failed to parse get route hints response: {e}"
+                        "(Boltz {GET_ROUTE_HINTS_ENDPOINT}) Failed to parse get route hints response: {e}"
                     ))
                 })
             })

--- a/libs/sdk-core/src/swap_out/error.rs
+++ b/libs/sdk-core/src/swap_out/error.rs
@@ -30,6 +30,9 @@ pub enum ReverseSwapError {
 
     #[error("Unexpected redeem script")]
     UnexpectedRedeemScript,
+
+    #[error("Route not found: {0}")]
+    RouteNotFound(anyhow::Error),
 }
 
 impl From<hashes::hex::Error> for ReverseSwapError {

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -127,7 +127,6 @@ impl BTCSendSwap {
     pub(crate) async fn create_reverse_swap(
         &self,
         req: SendOnchainRequest,
-        via_peer_id: Vec<u8>,
     ) -> ReverseSwapResult<FullReverseSwapInfo> {
         Self::validate_rev_swap_args(&req.onchain_recipient_address)?;
 
@@ -149,7 +148,7 @@ impl BTCSendSwap {
         let res = tokio::select! {
             pay_thread_res = tokio::time::timeout(
                 Duration::from_secs(self.config.payment_timeout_sec as u64),
-                self.node_api.send_pay(via_peer_id, created_rsi.invoice.clone(), MAX_PAYMENT_PATH_HOPS)
+                self.node_api.send_pay(created_rsi.invoice.clone(), MAX_PAYMENT_PATH_HOPS)
             ) => {
                 // TODO It doesn't fail when trying to pay more sats than max_payable?
                 match pay_thread_res {

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -116,7 +116,7 @@ impl BTCSendSwap {
             .first()
             .ok_or_else(|| {
                 ReverseSwapError::Generic(anyhow!(
-                    "No route hints found for reverse routing node {reverse_routing_node:?}"
+                    "No hops found for reverse routing node {reverse_routing_node:?}"
                 ))
             })
             .map(|r| r.clone())

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -127,6 +127,7 @@ impl BTCSendSwap {
     pub(crate) async fn create_reverse_swap(
         &self,
         req: SendOnchainRequest,
+        via_peer_id: Vec<u8>,
     ) -> ReverseSwapResult<FullReverseSwapInfo> {
         Self::validate_rev_swap_args(&req.onchain_recipient_address)?;
 
@@ -148,7 +149,7 @@ impl BTCSendSwap {
         let res = tokio::select! {
             pay_thread_res = tokio::time::timeout(
                 Duration::from_secs(self.config.payment_timeout_sec as u64),
-                self.node_api.send_pay(created_rsi.invoice.clone(), MAX_PAYMENT_PATH_HOPS)
+                self.node_api.send_pay(via_peer_id, created_rsi.invoice.clone(), MAX_PAYMENT_PATH_HOPS)
             ) => {
                 // TODO It doesn't fail when trying to pay more sats than max_payable?
                 match pay_thread_res {

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -108,14 +108,14 @@ impl BTCSendSwap {
         routing_hints
             .first()
             .ok_or_else(|| {
-                ReverseSwapError::Generic(anyhow!(
+                ReverseSwapError::RouteNotFound(anyhow!(
                     "No route hints found for reverse routing node {reverse_routing_node:?}"
                 ))
             })?
             .hops
             .first()
             .ok_or_else(|| {
-                ReverseSwapError::Generic(anyhow!(
+                ReverseSwapError::RouteNotFound(anyhow!(
                     "No hops found for reverse routing node {reverse_routing_node:?}"
                 ))
             })

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -11,7 +11,7 @@ use crate::{
     BreezEvent, Config, FullReverseSwapInfo, PaymentStatus, ReverseSwapInfo, ReverseSwapInfoCached,
     ReverseSwapPairInfo, ReverseSwapStatus,
 };
-use crate::{ReverseSwapStatus::*, SendOnchainRequest};
+use crate::{ReverseSwapStatus::*, RouteHintHop, SendOnchainRequest};
 use anyhow::{anyhow, ensure, Result};
 use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
 use bitcoin::consensus::serialize;
@@ -28,6 +28,7 @@ use tokio::time::{sleep, Duration};
 // Estimates based on https://github.com/BoltzExchange/boltz-backend/blob/master/lib/rates/FeeProvider.ts#L31-L42
 pub const ESTIMATED_CLAIM_TX_VSIZE: u64 = 138;
 pub const ESTIMATED_LOCKUP_TX_VSIZE: u64 = 153;
+pub(crate) const MAX_PAYMENT_PATH_HOPS: u32 = 3;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -95,6 +96,32 @@ impl BTCSendSwap {
             .map_err(|e| ReverseSwapError::InvalidDestinationAddress(anyhow::Error::new(e)))
     }
 
+    pub(crate) async fn last_hop_for_payment(&self) -> ReverseSwapResult<RouteHintHop> {
+        let reverse_routing_node = self
+            .reverse_swapper_api
+            .fetch_reverse_routing_node()
+            .await?;
+        let routing_hints = self
+            .reverse_swap_service_api
+            .get_route_hints(hex::encode(reverse_routing_node.clone()))
+            .await?;
+        routing_hints
+            .first()
+            .ok_or_else(|| {
+                ReverseSwapError::Generic(anyhow!(
+                    "No route hints found for reverse routing node {reverse_routing_node:?}"
+                ))
+            })?
+            .hops
+            .first()
+            .ok_or_else(|| {
+                ReverseSwapError::Generic(anyhow!(
+                    "No route hints found for reverse routing node {reverse_routing_node:?}"
+                ))
+            })
+            .map(|r| r.clone())
+    }
+
     /// Creates and persists a reverse swap. If the initial payment fails, the reverse swap has the new
     /// status persisted.
     pub(crate) async fn create_reverse_swap(
@@ -121,7 +148,7 @@ impl BTCSendSwap {
         let res = tokio::select! {
             pay_thread_res = tokio::time::timeout(
                 Duration::from_secs(self.config.payment_timeout_sec as u64),
-                self.node_api.send_payment(created_rsi.invoice.clone(), None)
+                self.node_api.send_pay(created_rsi.invoice.clone(), MAX_PAYMENT_PATH_HOPS)
             ) => {
                 // TODO It doesn't fail when trying to pay more sats than max_payable?
                 match pay_thread_res {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -310,12 +310,7 @@ impl NodeAPI for MockNodeAPI {
         })
     }
 
-    async fn send_pay(
-        &self,
-        _from_node_id: Vec<u8>,
-        _bolt11: String,
-        _max_hops: u32,
-    ) -> NodeResult<PaymentResponse> {
+    async fn send_pay(&self, _bolt11: String, _max_hops: u32) -> NodeResult<PaymentResponse> {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
@@ -405,7 +400,6 @@ impl NodeAPI for MockNodeAPI {
 
     async fn max_sendable_amount(
         &self,
-        _from_node_id: Vec<u8>,
         _payee_node_id: Option<Vec<u8>>,
         _max_hops: u32,
         _last_hop: Option<&RouteHintHop>,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -39,8 +39,8 @@ use crate::node_api::{NodeAPI, NodeError, NodeResult};
 use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
-    parse_invoice, Config, CustomMessage, LNInvoice, PaymentResponse, Peer, PrepareSweepRequest,
-    PrepareSweepResponse, RouteHint,
+    parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, PaymentPath,
+    PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse, RouteHint, RouteHintHop,
 };
 use crate::{OpeningFeeParams, OpeningFeeParamsMenu};
 use crate::{ReceivePaymentRequest, SwapInfo};
@@ -310,6 +310,10 @@ impl NodeAPI for MockNodeAPI {
         })
     }
 
+    async fn send_pay(&self, _bolt11: String, _max_hops: u32) -> NodeResult<PaymentResponse> {
+        Err(NodeError::Generic(anyhow!("Not implemented")))
+    }
+
     async fn send_payment(
         &self,
         bolt11: String,
@@ -391,6 +395,15 @@ impl NodeAPI for MockNodeAPI {
     }
 
     async fn execute_command(&self, _command: String) -> NodeResult<String> {
+        Err(NodeError::Generic(anyhow!("Not implemented")))
+    }
+
+    async fn max_amount_to_send(
+        &self,
+        _payee_node_id: Option<Vec<u8>>,
+        _max_hops: u32,
+        _last_hop: Option<&RouteHintHop>,
+    ) -> NodeResult<(Vec<MaxChannelAmount>, PaymentPath)> {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -398,7 +398,7 @@ impl NodeAPI for MockNodeAPI {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
-    async fn max_amount_to_send(
+    async fn max_sendable_amount(
         &self,
         _payee_node_id: Option<Vec<u8>>,
         _max_hops: u32,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -39,8 +39,8 @@ use crate::node_api::{NodeAPI, NodeError, NodeResult};
 use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
-    parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, PaymentPath,
-    PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse, RouteHint, RouteHintHop,
+    parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, PaymentResponse, Peer,
+    PrepareSweepRequest, PrepareSweepResponse, RouteHint, RouteHintHop,
 };
 use crate::{OpeningFeeParams, OpeningFeeParamsMenu};
 use crate::{ReceivePaymentRequest, SwapInfo};
@@ -310,7 +310,12 @@ impl NodeAPI for MockNodeAPI {
         })
     }
 
-    async fn send_pay(&self, _bolt11: String, _max_hops: u32) -> NodeResult<PaymentResponse> {
+    async fn send_pay(
+        &self,
+        _from_node_id: Vec<u8>,
+        _bolt11: String,
+        _max_hops: u32,
+    ) -> NodeResult<PaymentResponse> {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
@@ -400,10 +405,11 @@ impl NodeAPI for MockNodeAPI {
 
     async fn max_sendable_amount(
         &self,
+        _from_node_id: Vec<u8>,
         _payee_node_id: Option<Vec<u8>>,
         _max_hops: u32,
         _last_hop: Option<&RouteHintHop>,
-    ) -> NodeResult<(Vec<MaxChannelAmount>, PaymentPath)> {
+    ) -> NodeResult<Vec<MaxChannelAmount>> {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -278,6 +278,8 @@ void wire_fetch_fiat_rates(int64_t port_);
 
 void wire_list_fiat_currencies(int64_t port_);
 
+void wire_max_reverse_swap_amount(int64_t port_);
+
 void wire_send_onchain(int64_t port_, struct wire_SendOnchainRequest *req);
 
 void wire_receive_onchain(int64_t port_, struct wire_ReceiveOnchainRequest *req);
@@ -404,6 +406,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_lnurl_auth);
     dummy_var ^= ((int64_t) (void*) wire_fetch_fiat_rates);
     dummy_var ^= ((int64_t) (void*) wire_list_fiat_currencies);
+    dummy_var ^= ((int64_t) (void*) wire_max_reverse_swap_amount);
     dummy_var ^= ((int64_t) (void*) wire_send_onchain);
     dummy_var ^= ((int64_t) (void*) wire_receive_onchain);
     dummy_var ^= ((int64_t) (void*) wire_buy_bitcoin);

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -286,6 +286,10 @@ class BreezSDK {
 
   /* On-Chain Swap API's */
 
+  Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount() async {
+    return await _lnToolkit.maxReverseSwapAmount();
+  }
+
   /// Creates a reverse swap and attempts to pay the HODL invoice
   Future<SendOnchainResponse> sendOnchain({
     required SendOnchainRequest req,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -968,6 +968,7 @@ class LspInformation {
 }
 
 class MaxReverseSwapAmountResponse {
+  /// The total sats that can be sent onchain.
   final int totalSat;
 
   const MaxReverseSwapAmountResponse({

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -177,6 +177,7 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta;
 
+  /// See [BreezServices::max_reverse_swap_amount]
   Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kMaxReverseSwapAmountConstMeta;

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -968,10 +968,10 @@ class LspInformation {
 }
 
 class MaxReverseSwapAmountResponse {
-  final int totalMsat;
+  final int totalSat;
 
   const MaxReverseSwapAmountResponse({
-    required this.totalMsat,
+    required this.totalSat,
   });
 }
 
@@ -3036,7 +3036,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     final arr = raw as List<dynamic>;
     if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MaxReverseSwapAmountResponse(
-      totalMsat: _wire2api_u64(arr[0]),
+      totalSat: _wire2api_u64(arr[0]),
     );
   }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -177,6 +177,10 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta;
 
+  Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kMaxReverseSwapAmountConstMeta;
+
   /// See [BreezServices::send_onchain]
   Future<SendOnchainResponse> sendOnchain({required SendOnchainRequest req, dynamic hint});
 
@@ -616,6 +620,7 @@ class LNInvoice {
   final int expiry;
   final List<RouteHint> routingHints;
   final Uint8List paymentSecret;
+  final int minFinalCltvExpiryDelta;
 
   const LNInvoice({
     required this.bolt11,
@@ -628,6 +633,7 @@ class LNInvoice {
     required this.expiry,
     required this.routingHints,
     required this.paymentSecret,
+    required this.minFinalCltvExpiryDelta,
   });
 }
 
@@ -958,6 +964,14 @@ class LspInformation {
     required this.minHtlcMsat,
     required this.lspPubkey,
     required this.openingFeeParamsList,
+  });
+}
+
+class MaxReverseSwapAmountResponse {
+  final int totalMsat;
+
+  const MaxReverseSwapAmountResponse({
+    required this.totalMsat,
   });
 }
 
@@ -2184,6 +2198,21 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
+  Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_max_reverse_swap_amount(port_),
+      parseSuccessData: _wire2api_max_reverse_swap_amount_response,
+      constMeta: kMaxReverseSwapAmountConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kMaxReverseSwapAmountConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "max_reverse_swap_amount",
+        argNames: [],
+      );
+
   Future<SendOnchainResponse> sendOnchain({required SendOnchainRequest req, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_send_onchain_request(req);
     return _platform.executeNormal(FlutterRustBridgeTask(
@@ -2804,7 +2833,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LNInvoice _wire2api_ln_invoice(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return LNInvoice(
       bolt11: _wire2api_String(arr[0]),
       payeePubkey: _wire2api_String(arr[1]),
@@ -2816,6 +2845,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       expiry: _wire2api_u64(arr[7]),
       routingHints: _wire2api_list_route_hint(arr[8]),
       paymentSecret: _wire2api_uint_8_list(arr[9]),
+      minFinalCltvExpiryDelta: _wire2api_u64(arr[10]),
     );
   }
 
@@ -2999,6 +3029,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       minHtlcMsat: _wire2api_i64(arr[10]),
       lspPubkey: _wire2api_uint_8_list(arr[11]),
       openingFeeParamsList: _wire2api_opening_fee_params_menu(arr[12]),
+    );
+  }
+
+  MaxReverseSwapAmountResponse _wire2api_max_reverse_swap_amount_response(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return MaxReverseSwapAmountResponse(
+      totalMsat: _wire2api_u64(arr[0]),
     );
   }
 
@@ -4628,6 +4666,19 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_list_fiat_currenciesPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_fiat_currencies');
   late final _wire_list_fiat_currencies = _wire_list_fiat_currenciesPtr.asFunction<void Function(int)>();
+
+  void wire_max_reverse_swap_amount(
+    int port_,
+  ) {
+    return _wire_max_reverse_swap_amount(
+      port_,
+    );
+  }
+
+  late final _wire_max_reverse_swap_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_max_reverse_swap_amount');
+  late final _wire_max_reverse_swap_amount =
+      _wire_max_reverse_swap_amountPtr.asFunction<void Function(int)>();
 
   void wire_send_onchain(
     int port_,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1453,21 +1453,21 @@ fun asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: ReadableMap): M
     if (!validateMandatoryFields(
             maxReverseSwapAmountResponse,
             arrayOf(
-                "totalMsat",
+                "totalSat",
             ),
         )
     ) {
         return null
     }
-    val totalMsat = maxReverseSwapAmountResponse.getDouble("totalMsat").toULong()
+    val totalSat = maxReverseSwapAmountResponse.getDouble("totalSat").toULong()
     return MaxReverseSwapAmountResponse(
-        totalMsat,
+        totalSat,
     )
 }
 
 fun readableMapOf(maxReverseSwapAmountResponse: MaxReverseSwapAmountResponse): ReadableMap {
     return readableMapOf(
-        "totalMsat" to maxReverseSwapAmountResponse.totalMsat,
+        "totalSat" to maxReverseSwapAmountResponse.totalSat,
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -668,6 +668,7 @@ fun asLnInvoice(lnInvoice: ReadableMap): LnInvoice? {
                 "expiry",
                 "routingHints",
                 "paymentSecret",
+                "minFinalCltvExpiryDelta",
             ),
         )
     ) {
@@ -683,6 +684,7 @@ fun asLnInvoice(lnInvoice: ReadableMap): LnInvoice? {
     val expiry = lnInvoice.getDouble("expiry").toULong()
     val routingHints = lnInvoice.getArray("routingHints")?.let { asRouteHintList(it) }!!
     val paymentSecret = lnInvoice.getArray("paymentSecret")?.let { asUByteList(it) }!!
+    val minFinalCltvExpiryDelta = lnInvoice.getDouble("minFinalCltvExpiryDelta").toULong()
     return LnInvoice(
         bolt11,
         payeePubkey,
@@ -694,6 +696,7 @@ fun asLnInvoice(lnInvoice: ReadableMap): LnInvoice? {
         expiry,
         routingHints,
         paymentSecret,
+        minFinalCltvExpiryDelta,
     )
 }
 
@@ -709,6 +712,7 @@ fun readableMapOf(lnInvoice: LnInvoice): ReadableMap {
         "expiry" to lnInvoice.expiry,
         "routingHints" to readableArrayOf(lnInvoice.routingHints),
         "paymentSecret" to readableArrayOf(lnInvoice.paymentSecret),
+        "minFinalCltvExpiryDelta" to lnInvoice.minFinalCltvExpiryDelta,
     )
 }
 
@@ -1439,6 +1443,39 @@ fun asLspInformationList(arr: ReadableArray): List<LspInformation> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLspInformation(value)!!)
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+        }
+    }
+    return list
+}
+
+fun asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: ReadableMap): MaxReverseSwapAmountResponse? {
+    if (!validateMandatoryFields(
+            maxReverseSwapAmountResponse,
+            arrayOf(
+                "totalMsat",
+            ),
+        )
+    ) {
+        return null
+    }
+    val totalMsat = maxReverseSwapAmountResponse.getDouble("totalMsat").toULong()
+    return MaxReverseSwapAmountResponse(
+        totalMsat,
+    )
+}
+
+fun readableMapOf(maxReverseSwapAmountResponse: MaxReverseSwapAmountResponse): ReadableMap {
+    return readableMapOf(
+        "totalMsat" to maxReverseSwapAmountResponse.totalMsat,
+    )
+}
+
+fun asMaxReverseSwapAmountResponseList(arr: ReadableArray): List<MaxReverseSwapAmountResponse> {
+    val list = ArrayList<MaxReverseSwapAmountResponse>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asMaxReverseSwapAmountResponse(value)!!)
             else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -645,6 +645,18 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
+    fun maxReverseSwapAmount(promise: Promise) {
+        executor.execute {
+            try {
+                val res = getBreezServices().maxReverseSwapAmount()
+                promise.resolve(readableMapOf(res))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun sendOnchain(
         req: ReadableMap,
         promise: Promise,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1289,15 +1289,15 @@ class BreezSDKMapper {
     }
 
     static func asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: [String: Any?]) throws -> MaxReverseSwapAmountResponse {
-        guard let totalMsat = maxReverseSwapAmountResponse["totalMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field totalMsat for type MaxReverseSwapAmountResponse") }
+        guard let totalSat = maxReverseSwapAmountResponse["totalSat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field totalSat for type MaxReverseSwapAmountResponse") }
 
         return MaxReverseSwapAmountResponse(
-            totalMsat: totalMsat)
+            totalSat: totalSat)
     }
 
     static func dictionaryOf(maxReverseSwapAmountResponse: MaxReverseSwapAmountResponse) -> [String: Any?] {
         return [
-            "totalMsat": maxReverseSwapAmountResponse.totalMsat,
+            "totalSat": maxReverseSwapAmountResponse.totalSat,
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -609,6 +609,7 @@ class BreezSDKMapper {
         let routingHints = try asRouteHintList(arr: routingHintsTmp)
 
         guard let paymentSecret = lnInvoice["paymentSecret"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field paymentSecret for type LnInvoice") }
+        guard let minFinalCltvExpiryDelta = lnInvoice["minFinalCltvExpiryDelta"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field minFinalCltvExpiryDelta for type LnInvoice") }
 
         return LnInvoice(
             bolt11: bolt11,
@@ -620,7 +621,8 @@ class BreezSDKMapper {
             timestamp: timestamp,
             expiry: expiry,
             routingHints: routingHints,
-            paymentSecret: paymentSecret
+            paymentSecret: paymentSecret,
+            minFinalCltvExpiryDelta: minFinalCltvExpiryDelta
         )
     }
 
@@ -636,6 +638,7 @@ class BreezSDKMapper {
             "expiry": lnInvoice.expiry,
             "routingHints": arrayOf(routeHintList: lnInvoice.routingHints),
             "paymentSecret": lnInvoice.paymentSecret,
+            "minFinalCltvExpiryDelta": lnInvoice.minFinalCltvExpiryDelta,
         ]
     }
 
@@ -1283,6 +1286,36 @@ class BreezSDKMapper {
 
     static func arrayOf(lspInformationList: [LspInformation]) -> [Any] {
         return lspInformationList.map { v -> [String: Any?] in dictionaryOf(lspInformation: v) }
+    }
+
+    static func asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: [String: Any?]) throws -> MaxReverseSwapAmountResponse {
+        guard let totalMsat = maxReverseSwapAmountResponse["totalMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field totalMsat for type MaxReverseSwapAmountResponse") }
+
+        return MaxReverseSwapAmountResponse(
+            totalMsat: totalMsat)
+    }
+
+    static func dictionaryOf(maxReverseSwapAmountResponse: MaxReverseSwapAmountResponse) -> [String: Any?] {
+        return [
+            "totalMsat": maxReverseSwapAmountResponse.totalMsat,
+        ]
+    }
+
+    static func asMaxReverseSwapAmountResponseList(arr: [Any]) throws -> [MaxReverseSwapAmountResponse] {
+        var list = [MaxReverseSwapAmountResponse]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var maxReverseSwapAmountResponse = try asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: val)
+                list.append(maxReverseSwapAmountResponse)
+            } else {
+                throw SdkError.Generic(message: "Unexpected type MaxReverseSwapAmountResponse")
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(maxReverseSwapAmountResponseList: [MaxReverseSwapAmountResponse]) -> [Any] {
+        return maxReverseSwapAmountResponseList.map { v -> [String: Any?] in dictionaryOf(maxReverseSwapAmountResponse: v) }
     }
 
     static func asMessageSuccessActionData(messageSuccessActionData: [String: Any?]) throws -> MessageSuccessActionData {

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -221,6 +221,11 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    maxReverseSwapAmount: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     sendOnchain: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -461,6 +461,16 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
+    @objc(maxReverseSwapAmount:reject:)
+    func maxReverseSwapAmount(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            var res = try getBreezServices().maxReverseSwapAmount()
+            resolve(BreezSDKMapper.dictionaryOf(maxReverseSwapAmountResponse: res))
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(sendOnchain:resolve:reject:)
     func sendOnchain(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -122,6 +122,7 @@ export type LnInvoice = {
     expiry: number
     routingHints: RouteHint[]
     paymentSecret: number[]
+    minFinalCltvExpiryDelta: number
 }
 
 export type ListPaymentsRequest = {
@@ -231,6 +232,10 @@ export type LspInformation = {
     minHtlcMsat: number
     lspPubkey: number[]
     openingFeeParamsList: OpeningFeeParamsMenu
+}
+
+export type MaxReverseSwapAmountResponse = {
+    totalMsat: number
 }
 
 export type MessageSuccessActionData = {
@@ -896,6 +901,11 @@ export const fetchReverseSwapFees = async (req: ReverseSwapFeesRequest): Promise
 
 export const inProgressReverseSwaps = async (): Promise<ReverseSwapInfo[]> => {
     const response = await BreezSDK.inProgressReverseSwaps()
+    return response
+}
+
+export const maxReverseSwapAmount = async (): Promise<MaxReverseSwapAmountResponse> => {
+    const response = await BreezSDK.maxReverseSwapAmount()
     return response
 }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -235,7 +235,7 @@ export type LspInformation = {
 }
 
 export type MaxReverseSwapAmountResponse = {
-    totalMsat: number
+    totalSat: number
 }
 
 export type MessageSuccessActionData = {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -47,7 +47,6 @@ impl EventListener for CliEventListener {
 async fn connect(config: Config, seed: &[u8]) -> Result<()> {
     let service =
         BreezServices::connect(config, seed.to_vec(), Box::new(CliEventListener {})).await?;
-
     BREEZ_SERVICES
         .set(service)
         .map_err(|_| anyhow!("Breez Services already initialized"))?;
@@ -162,6 +161,10 @@ pub(crate) async fn handle_command(
                 })
                 .await?;
             serde_json::to_string_pretty(&rev_swap_res.reverse_swap_info).map_err(|e| e.into())
+        }
+        Commands::MaxOnchainPayment {} => {
+            let response = sdk()?.max_reverse_swap_amount().await?;
+            serde_json::to_string_pretty(&response).map_err(|e| e.into())
         }
         Commands::FetchOnchainFees { send_amount_sat } => {
             let pair_info = sdk()?

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -162,7 +162,7 @@ pub(crate) async fn handle_command(
                 .await?;
             serde_json::to_string_pretty(&rev_swap_res.reverse_swap_info).map_err(|e| e.into())
         }
-        Commands::MaxOnchainPayment {} => {
+        Commands::MaxReverseSwapAmount {} => {
             let response = sdk()?.max_reverse_swap_amount().await?;
             serde_json::to_string_pretty(&response).map_err(|e| e.into())
         }

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -86,7 +86,7 @@ pub(crate) enum Commands {
         sat_per_vbyte: u32,
     },
 
-    MaxOnchainPayment {},
+    MaxReverseSwapAmount {},
 
     /// Get the current fees for a potential new reverse swap
     FetchOnchainFees {

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -64,13 +64,19 @@ pub(crate) enum Commands {
     },
 
     /// Pay using lnurl pay
-    LnurlPay { lnurl: String },
+    LnurlPay {
+        lnurl: String,
+    },
 
     /// Withdraw using lnurl withdraw
-    LnurlWithdraw { lnurl: String },
+    LnurlWithdraw {
+        lnurl: String,
+    },
 
     /// Authenticate using lnurl auth
-    LnurlAuth { lnurl: String },
+    LnurlAuth {
+        lnurl: String,
+    },
 
     /// Send on-chain using a reverse swap
     SendOnchain {
@@ -79,6 +85,8 @@ pub(crate) enum Commands {
         /// The fee rate for the claim transaction
         sat_per_vbyte: u32,
     },
+
+    MaxOnchainPayment {},
 
     /// Get the current fees for a potential new reverse swap
     FetchOnchainFees {
@@ -98,10 +106,15 @@ pub(crate) enum Commands {
     },
 
     /// Send a spontaneous (keysend) payment
-    SendSpontaneousPayment { node_id: String, amount_msat: u64 },
+    SendSpontaneousPayment {
+        node_id: String,
+        amount_msat: u64,
+    },
 
     /// Sign a message with the node's private key
-    SignMessage { message: String },
+    SignMessage {
+        message: String,
+    },
 
     /// Verify a message with a node's public key
     CheckMessage {
@@ -134,7 +147,9 @@ pub(crate) enum Commands {
     },
 
     /// Retrieve a payment by its hash
-    PaymentByHash { hash: String },
+    PaymentByHash {
+        hash: String,
+    },
 
     /// Send on-chain funds to an external address
     Sweep {
@@ -213,8 +228,12 @@ pub(crate) enum Commands {
     },
 
     /// Execute a low level node command (used for debugging)
-    ExecuteDevCommand { command: String },
+    ExecuteDevCommand {
+        command: String,
+    },
 
     /// Generates an URL to buy bitcoin from a 3rd party provider
-    BuyBitcoin { provider: BuyBitcoinProvider },
+    BuyBitcoin {
+        provider: BuyBitcoinProvider,
+    },
 }


### PR DESCRIPTION
This PR is to supports the use case of sending the maximum amount to an on chain address (send_onchain).
Since this operation is a reverse swap where the user node sends over lightning we need to calculate the shortest stable route to the swapper node and find the maximum amount to forward for each channel while making sure we have enough fees to pay over lightning.
There are two parts to achieve the above:

## Calculating the max amount to send to the swapper node
For this purpose one API method was added: `max_reverse_swap_amount` which returns the maximum amount to send to the reverse swapper. This is possible due to the following two assumption that the sdk has:
1. The reverse swapper node can provide us with the routing hints to its private node.
2. The path to the reverse swapper consists mostly 3 hops and has enough liquidity to route all funds.

## Sending the amount while draining the channels
For this purpose we needed to implement another way of sending (send_pay) in the NodeAPI trait where we can control the internal htlc splitting.
The `send_pay` (sdk method) behaves as follows:
1. For a given invoice finds the path to the destination node (payee)  that is no longer than 3 hops (including the routing hints).
2. Calculates the route (including fees and cltv delta expiries).
3. Using the greenlight `send_pay` to send each htlc (one per channel).


- [x] Implement `max_reverse_swap_payment`
- [x] Implement `send_onchain` using a predefined route, emptying all channels.