### PR TITLE
Error codes

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -11,14 +11,81 @@ dictionary RouteHintHop {
 [Error]
 enum SdkError {
     "Generic",
-    "InitFailed",
-    "NotReady",
-    "LspConnectFailed",
-    "LspOpenChannelNotSupported",
-    "PersistenceFailure",
-    "ReceivePaymentFailed",
-    "SendPaymentFailed",
-    "CalculateOpenChannelFeesFailed",
+    "ServiceConnectivity",
+};
+
+[Error]
+enum LnUrlAuthError {
+    "Generic",
+    "InvalidUri",
+    "ServiceConnectivity",
+};
+
+[Error]
+enum LnUrlPayError {
+    "AesDecryptionFailed",
+    "AlreadyPaid",
+    "Generic",
+    "InvalidAmount",
+    "InvalidInvoice",
+    "InvalidUri",
+    "InvoiceExpired",
+    "PaymentFailed",
+    "PaymentTimeout",
+    "RouteNotFound",
+    "RouteTooExpensive",
+    "ServiceConnectivity",
+};
+
+[Error]
+enum LnUrlWithdrawError {
+    "Generic",
+    "InvalidAmount",
+    "InvalidInvoice",
+    "InvalidUri",
+    "ServiceConnectivity",
+};
+
+[Error]
+enum ReceiveOnchainError {
+    "Generic",
+    "ServiceConnectivity",
+    "SwapInProgress",
+};
+
+[Error]
+enum ReceivePaymentError {
+    "Generic",
+    "InvalidAmount",
+    "InvalidInvoice",
+    "InvoiceExpired",
+    "InvoiceNoDescription",
+    "InvoicePreimageAlreadyExists",
+    "ServiceConnectivity",
+};
+
+[Error]
+enum SendOnchainError {
+    "Generic",
+    "InvalidDestinationAddress",
+    "PaymentFailed",
+    "PaymentTimeout",
+    "ReverseSwapInProgress",
+    "ServiceConnectivity",
+};
+
+[Error]
+enum SendPaymentError {
+    "AlreadyPaid",
+    "Generic",
+    "InvalidAmount",
+    "InvalidInvoice",
+    "InvoiceExpired",
+    "PaymentFailed",
+    "PaymentTimeout",
+    "RouteNotFound",
+    "RouteTooExpensive",
+    "ServiceConnectivity",
 };
 
 enum EnvironmentType {
@@ -606,22 +673,22 @@ interface BlockingBreezServices {
    [Throws=SdkError]
    void disconnect();
 
-   [Throws=SdkError]
+   [Throws=SendPaymentError]
    SendPaymentResponse send_payment(SendPaymentRequest req);
 
-   [Throws=SdkError]
+   [Throws=SendPaymentError]
    SendPaymentResponse send_spontaneous_payment(SendSpontaneousPaymentRequest req);
 
-   [Throws=SdkError]
+   [Throws=ReceivePaymentError]
    ReceivePaymentResponse receive_payment(ReceivePaymentRequest req);
 
-   [Throws=SdkError]
+   [Throws=LnUrlPayError]
    LnUrlPayResult pay_lnurl(LnUrlPayRequest req);
 
-   [Throws=SdkError]
+   [Throws=LnUrlWithdrawError]
    LnUrlWithdrawResult withdraw_lnurl(LnUrlWithdrawRequest request);
 
-   [Throws=SdkError]
+   [Throws=LnUrlAuthError]
    LnUrlCallbackStatus lnurl_auth(LnUrlAuthRequestData req_data);
 
    [Throws=SdkError]
@@ -675,7 +742,7 @@ interface BlockingBreezServices {
    [Throws=SdkError]
    void close_lsp_channels();
 
-   [Throws=SdkError]
+   [Throws=ReceiveOnchainError]
    SwapInfo receive_onchain(ReceiveOnchainRequest req);
 
    [Throws=SdkError]
@@ -696,7 +763,7 @@ interface BlockingBreezServices {
    [Throws=SdkError]
    sequence<ReverseSwapInfo> in_progress_reverse_swaps();
 
-   [Throws=SdkError]
+   [Throws=SendOnchainError]
    SendOnchainResponse send_onchain(SendOnchainRequest req);
 
    [Throws=SdkError]
@@ -708,7 +775,7 @@ interface BlockingBreezServices {
    [Throws=SdkError]
    RecommendedFees recommended_fees();
 
-   [Throws=SdkError]
+   [Throws=ReceiveOnchainError]
    BuyBitcoinResponse buy_bitcoin(BuyBitcoinRequest req);
 
    [Throws=SdkError]

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use breez_sdk_core::{
     error::*, mnemonic_to_seed as sdk_mnemonic_to_seed, parse as sdk_parse_input,
     parse_invoice as sdk_parse_invoice, AesSuccessActionDataDecrypted, BackupFailedData,
@@ -96,10 +96,10 @@ pub fn connect(
 }
 
 /// If used, this must be called before `connect`
-pub fn set_log_stream(log_stream: Box<dyn LogStream>) -> Result<()> {
-    LOG_INIT
-        .set(true)
-        .map_err(|_| anyhow!("log stream already created"))?;
+pub fn set_log_stream(log_stream: Box<dyn LogStream>) -> SdkResult<()> {
+    LOG_INIT.set(true).map_err(|_| SdkError::Generic {
+        err: "Log stream already created".into(),
+    })?;
     BindingLogger::init(log_stream);
     Ok(())
 }
@@ -109,22 +109,28 @@ pub struct BlockingBreezServices {
 }
 
 impl BlockingBreezServices {
-    pub fn disconnect(&self) -> Result<()> {
+    pub fn disconnect(&self) -> SdkResult<()> {
         rt().block_on(self.breez_services.disconnect())
     }
 
-    pub fn send_payment(&self, req: SendPaymentRequest) -> SdkResult<SendPaymentResponse> {
+    pub fn send_payment(
+        &self,
+        req: SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SendPaymentError> {
         rt().block_on(self.breez_services.send_payment(req))
     }
 
     pub fn send_spontaneous_payment(
         &self,
         req: SendSpontaneousPaymentRequest,
-    ) -> SdkResult<SendPaymentResponse> {
+    ) -> Result<SendPaymentResponse, SendPaymentError> {
         rt().block_on(self.breez_services.send_spontaneous_payment(req))
     }
 
-    pub fn receive_payment(&self, req: ReceivePaymentRequest) -> SdkResult<ReceivePaymentResponse> {
+    pub fn receive_payment(
+        &self,
+        req: ReceivePaymentRequest,
+    ) -> Result<ReceivePaymentResponse, ReceivePaymentError> {
         rt().block_on(self.breez_services.receive_payment(req))
     }
 
@@ -134,21 +140,18 @@ impl BlockingBreezServices {
 
     pub fn sign_message(&self, req: SignMessageRequest) -> SdkResult<SignMessageResponse> {
         rt().block_on(self.breez_services.sign_message(req))
-            .map_err(|e| e.into())
     }
 
     pub fn check_message(&self, req: CheckMessageRequest) -> SdkResult<CheckMessageResponse> {
         rt().block_on(self.breez_services.check_message(req))
-            .map_err(|e| e.into())
     }
 
     pub fn backup_status(&self) -> SdkResult<BackupStatus> {
-        self.breez_services.backup_status().map_err(|e| e.into())
+        self.breez_services.backup_status()
     }
 
     pub fn backup(&self) -> SdkResult<()> {
         rt().block_on(self.breez_services.backup())
-            .map_err(|e| e.into())
     }
 
     pub fn list_payments(&self, req: ListPaymentsRequest) -> SdkResult<Vec<Payment>> {
@@ -157,37 +160,36 @@ impl BlockingBreezServices {
 
     pub fn payment_by_hash(&self, hash: String) -> SdkResult<Option<Payment>> {
         rt().block_on(self.breez_services.payment_by_hash(hash))
-            .map_err(|e| e.into())
     }
 
-    pub fn pay_lnurl(&self, req: LnUrlPayRequest) -> SdkResult<LnUrlPayResult> {
+    pub fn pay_lnurl(&self, req: LnUrlPayRequest) -> Result<LnUrlPayResult, LnUrlPayError> {
         rt().block_on(self.breez_services.lnurl_pay(req))
-            .map_err(|e| e.into())
     }
 
-    pub fn withdraw_lnurl(&self, req: LnUrlWithdrawRequest) -> SdkResult<LnUrlWithdrawResult> {
+    pub fn withdraw_lnurl(
+        &self,
+        req: LnUrlWithdrawRequest,
+    ) -> Result<LnUrlWithdrawResult, LnUrlWithdrawError> {
         rt().block_on(self.breez_services.lnurl_withdraw(req))
-            .map_err(|e| e.into())
     }
 
-    pub fn lnurl_auth(&self, req_data: LnUrlAuthRequestData) -> SdkResult<LnUrlCallbackStatus> {
+    pub fn lnurl_auth(
+        &self,
+        req_data: LnUrlAuthRequestData,
+    ) -> Result<LnUrlCallbackStatus, LnUrlAuthError> {
         rt().block_on(self.breez_services.lnurl_auth(req_data))
-            .map_err(|e| e.into())
     }
 
     pub fn sweep(&self, req: SweepRequest) -> SdkResult<SweepResponse> {
         rt().block_on(self.breez_services.sweep(req))
-            .map_err(|e| e.into())
     }
 
     pub fn fetch_fiat_rates(&self) -> SdkResult<Vec<Rate>> {
         rt().block_on(self.breez_services.fetch_fiat_rates())
-            .map_err(|e| e.into())
     }
 
     pub fn list_fiat_currencies(&self) -> SdkResult<Vec<FiatCurrency>> {
         rt().block_on(self.breez_services.list_fiat_currencies())
-            .map_err(|e| e.into())
     }
 
     pub fn list_lsps(&self) -> SdkResult<Vec<LspInformation>> {
@@ -200,7 +202,6 @@ impl BlockingBreezServices {
 
     pub fn fetch_lsp_info(&self, lsp_id: String) -> SdkResult<Option<LspInformation>> {
         rt().block_on(self.breez_services.fetch_lsp_info(lsp_id))
-            .map_err(|e| e.into())
     }
 
     pub fn lsp_id(&self) -> SdkResult<Option<String>> {
@@ -209,7 +210,6 @@ impl BlockingBreezServices {
 
     pub fn lsp_info(&self) -> SdkResult<LspInformation> {
         rt().block_on(self.breez_services.lsp_info())
-            .map_err(|e: anyhow::Error| e.into())
     }
 
     pub fn open_channel_fee(
@@ -224,25 +224,24 @@ impl BlockingBreezServices {
             _ = self.breez_services.close_lsp_channels().await?;
             Ok(())
         })
-        .map_err(|e: anyhow::Error| e.into())
     }
 
     /// Onchain receive swap API
-    pub fn receive_onchain(&self, req: ReceiveOnchainRequest) -> SdkResult<SwapInfo> {
+    pub fn receive_onchain(
+        &self,
+        req: ReceiveOnchainRequest,
+    ) -> Result<SwapInfo, ReceiveOnchainError> {
         rt().block_on(self.breez_services.receive_onchain(req))
-            .map_err(|e| e.into())
     }
 
     /// Onchain receive swap API
     pub fn in_progress_swap(&self) -> SdkResult<Option<SwapInfo>> {
         rt().block_on(self.breez_services.in_progress_swap())
-            .map_err(|e| e.into())
     }
 
     /// list non-completed expired swaps that should be refunded by calling [BreezServices::refund]
     pub fn list_refundables(&self) -> SdkResult<Vec<SwapInfo>> {
         rt().block_on(self.breez_services.list_refundables())
-            .map_err(|e| e.into())
     }
 
     // prepare a refund transaction for a failed/expired swap
@@ -255,7 +254,6 @@ impl BlockingBreezServices {
     // construct and broadcast a refund transaction for a faile/expired swap
     pub fn refund(&self, req: RefundRequest) -> SdkResult<RefundResponse> {
         rt().block_on(self.breez_services.refund(req))
-            .map_err(|e| e.into())
     }
 
     pub fn fetch_reverse_swap_fees(
@@ -263,56 +261,53 @@ impl BlockingBreezServices {
         req: ReverseSwapFeesRequest,
     ) -> SdkResult<ReverseSwapPairInfo> {
         rt().block_on(self.breez_services.fetch_reverse_swap_fees(req))
-            .map_err(|e| e.into())
     }
 
     pub fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
         rt().block_on(self.breez_services.in_progress_reverse_swaps())
-            .map_err(|e| e.into())
     }
 
-    pub fn send_onchain(&self, req: SendOnchainRequest) -> SdkResult<SendOnchainResponse> {
+    pub fn send_onchain(
+        &self,
+        req: SendOnchainRequest,
+    ) -> Result<SendOnchainResponse, SendOnchainError> {
         rt().block_on(self.breez_services.send_onchain(req))
-            .map_err(|e| e.into())
     }
 
-    pub fn execute_dev_command(&self, command: String) -> Result<String> {
+    pub fn execute_dev_command(&self, command: String) -> SdkResult<String> {
         rt().block_on(self.breez_services.execute_dev_command(command))
     }
 
     pub fn sync(&self) -> SdkResult<()> {
         rt().block_on(self.breez_services.sync())
-            .map_err(|e| e.into())
     }
 
     pub fn recommended_fees(&self) -> SdkResult<RecommendedFees> {
         rt().block_on(self.breez_services.recommended_fees())
-            .map_err(|e| e.into())
     }
 
-    pub fn buy_bitcoin(&self, req: BuyBitcoinRequest) -> SdkResult<BuyBitcoinResponse> {
+    pub fn buy_bitcoin(
+        &self,
+        req: BuyBitcoinRequest,
+    ) -> Result<BuyBitcoinResponse, ReceiveOnchainError> {
         rt().block_on(self.breez_services.buy_bitcoin(req))
     }
 
-    pub fn prepare_sweep(
-        &self,
-        req: PrepareSweepRequest,
-    ) -> Result<PrepareSweepResponse, SdkError> {
+    pub fn prepare_sweep(&self, req: PrepareSweepRequest) -> SdkResult<PrepareSweepResponse> {
         rt().block_on(self.breez_services.prepare_sweep(req))
-            .map_err(|e| e.into())
     }
 }
 
 pub fn parse_invoice(invoice: String) -> SdkResult<LNInvoice> {
-    sdk_parse_invoice(&invoice).map_err(|e| e.into())
+    Ok(sdk_parse_invoice(&invoice)?)
 }
 
 pub fn parse_input(s: String) -> SdkResult<InputType> {
-    rt().block_on(sdk_parse_input(&s)).map_err(|e| e.into())
+    rt().block_on(async move { Ok(sdk_parse_input(&s).await?) })
 }
 
 pub fn mnemonic_to_seed(phrase: String) -> SdkResult<Vec<u8>> {
-    sdk_mnemonic_to_seed(phrase).map_err(|e| e.into())
+    Ok(sdk_mnemonic_to_seed(phrase)?)
 }
 
 fn rt() -> &'static tokio::runtime::Runtime {

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -1,5 +1,6 @@
 use crate::{
     breez_services::BackupFailedData,
+    error::SdkResult,
     persist::db::{HookEvent, SqliteStorage},
     BreezEvent, Config,
 };
@@ -63,8 +64,8 @@ pub struct BackupState {
 /// BackupTransport is the interface for syncing the sdk state between multiple apps.
 #[tonic::async_trait]
 pub trait BackupTransport: Send + Sync {
-    async fn pull(&self) -> Result<Option<BackupState>>;
-    async fn push(&self, version: Option<u64>, data: Vec<u8>) -> Result<u64>;
+    async fn pull(&self) -> SdkResult<Option<BackupState>>;
+    async fn push(&self, version: Option<u64>, data: Vec<u8>) -> SdkResult<u64>;
 }
 
 pub(crate) struct BackupWatcher {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -4,26 +4,30 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, Result};
 use bip39::*;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::util::bip32::ChildNumber;
 use chrono::Local;
+use futures::TryFutureExt;
 use log::{LevelFilter, Metadata, Record};
 use serde_json::json;
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::time::sleep;
 use tonic::codegen::InterceptedService;
+use tonic::metadata::errors::InvalidMetadataValue;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::service::Interceptor;
-use tonic::transport::{Channel, Uri};
+use tonic::transport::{Channel, Endpoint, Uri};
 use tonic::{Request, Status};
 
 use crate::backup::{BackupRequest, BackupTransport, BackupWatcher};
-use crate::boltzswap::BoltzApi;
 use crate::chain::{ChainService, MempoolSpace, Outspend, RecommendedFees};
-use crate::error::{SdkError, SdkResult};
+use crate::error::{
+    LnUrlAuthError, LnUrlPayError, LnUrlWithdrawError, ReceiveOnchainError, ReceivePaymentError,
+    SdkError, SdkResult, SendOnchainError, SendPaymentError,
+};
 use crate::fiat::{FiatCurrency, Rate};
 use crate::greenlight::{GLBackupTransport, Greenlight};
 use crate::grpc::channel_opener_client::ChannelOpenerClient;
@@ -43,14 +47,16 @@ use crate::lnurl::withdraw::validate_lnurl_withdraw;
 use crate::lsp::LspInformation;
 use crate::models::{
     parse_short_channel_id, ChannelState, ClosedChannelPaymentDetails, Config, EnvironmentType,
-    FiatAPI, LnUrlCallbackStatus, LspAPI, NodeAPI, NodeState, Payment, PaymentDetails, PaymentType,
+    FiatAPI, LnUrlCallbackStatus, LspAPI, NodeState, Payment, PaymentDetails, PaymentType,
     ReverseSwapPairInfo, ReverseSwapServiceAPI, SwapInfo, SwapperAPI,
     INVOICE_PAYMENT_FEE_EXPIRY_SECONDS,
 };
 use crate::moonpay::MoonPayApi;
+use crate::node_api::NodeAPI;
 use crate::persist::db::SqliteStorage;
-use crate::reverseswap::BTCSendSwap;
-use crate::swap::BTCReceiveSwap;
+use crate::swap_in::swap::BTCReceiveSwap;
+use crate::swap_out::boltzswap::BoltzApi;
+use crate::swap_out::reverseswap::BTCSendSwap;
 use crate::BuyBitcoinProvider::Moonpay;
 use crate::*;
 
@@ -192,12 +198,10 @@ impl BreezServices {
     ///
     /// It should be called only once when the app is started, regardless whether the app is sent to
     /// background and back.
-    async fn start(self: &Arc<BreezServices>) -> SdkResult<()> {
+    async fn start(self: &Arc<BreezServices>) -> Result<()> {
         let mut started = self.started.lock().await;
         if *started {
-            return Err(SdkError::InitFailed {
-                err: "BreezServices already started".into(),
-            });
+            return Err(anyhow!("BreezServices already started"));
         }
         let start = Instant::now();
         self.start_background_tasks().await?;
@@ -208,12 +212,18 @@ impl BreezServices {
     }
 
     /// Trigger the stopping of BreezServices background threads for this instance.
-    pub async fn disconnect(&self) -> Result<()> {
+    pub async fn disconnect(&self) -> SdkResult<()> {
         let mut started = self.started.lock().await;
         if !*started {
-            return Err(anyhow::Error::msg("BreezServices is not running"));
+            return Err(SdkError::Generic {
+                err: "BreezServices is not running".into(),
+            });
         }
-        self.shutdown_sender.send(()).map_err(anyhow::Error::msg)?;
+        self.shutdown_sender
+            .send(())
+            .map_err(|e| SdkError::Generic {
+                err: format!("Shutdown failed: {e}"),
+            })?;
         *started = false;
         Ok(())
     }
@@ -222,7 +232,10 @@ impl BreezServices {
     ///
     /// Calling `send_payment` ensures that the payment is not already completed, if so it will result in an error.
     /// If the invoice doesn't specify an amount, the amount is taken from the `amount_msat` arg.
-    pub async fn send_payment(&self, req: SendPaymentRequest) -> SdkResult<SendPaymentResponse> {
+    pub async fn send_payment(
+        &self,
+        req: SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SendPaymentError> {
         self.start_node().await?;
         let parsed_invoice = parse_invoice(req.bolt11.as_str())?;
         let invoice_amount_msat = parsed_invoice.amount_msat.unwrap_or_default();
@@ -230,15 +243,15 @@ impl BreezServices {
 
         // Ensure amount is provided for zero invoice
         if provided_amount_msat == 0 && invoice_amount_msat == 0 {
-            return Err(SdkError::SendPaymentFailed {
-                err: "amount must be provided when paying a zero invoice".into(),
+            return Err(SendPaymentError::InvalidAmount {
+                err: "Amount must be provided when paying a zero invoice".into(),
             });
         }
 
         // Ensure amount is not provided for invoice that contains amount
         if provided_amount_msat > 0 && invoice_amount_msat > 0 {
-            return Err(SdkError::SendPaymentFailed {
-                err: "amount should not be provided when paying a non zero invoice".into(),
+            return Err(SendPaymentError::InvalidAmount {
+                err: "Amount should not be provided when paying a non zero invoice".into(),
             });
         }
 
@@ -246,13 +259,12 @@ impl BreezServices {
             .persister
             .get_completed_payment_by_hash(&parsed_invoice.payment_hash)?
         {
-            Some(_) => Err(SdkError::SendPaymentFailed {
-                err: "Invoice already paid".into(),
-            }),
+            Some(_) => Err(SendPaymentError::AlreadyPaid),
             None => {
                 let payment_res = self
                     .node_api
                     .send_payment(req.bolt11.clone(), req.amount_msat)
+                    .map_err(Into::into)
                     .await;
                 let payment = self
                     .on_payment_completed(
@@ -270,11 +282,12 @@ impl BreezServices {
     pub async fn send_spontaneous_payment(
         &self,
         req: SendSpontaneousPaymentRequest,
-    ) -> SdkResult<SendPaymentResponse> {
+    ) -> Result<SendPaymentResponse, SendPaymentError> {
         self.start_node().await?;
         let payment_res = self
             .node_api
             .send_spontaneous_payment(req.node_id.clone(), req.amount_msat)
+            .map_err(Into::into)
             .await;
         let payment = self
             .on_payment_completed(req.node_id, None, payment_res)
@@ -290,7 +303,7 @@ impl BreezServices {
     /// is made.
     ///
     /// This method will return an [anyhow::Error] when any validation check fails.
-    pub async fn lnurl_pay(&self, req: LnUrlPayRequest) -> Result<LnUrlPayResult> {
+    pub async fn lnurl_pay(&self, req: LnUrlPayRequest) -> Result<LnUrlPayResult, LnUrlPayError> {
         match validate_lnurl_pay(req.amount_msat, req.comment, req.data.clone()).await? {
             ValidatedCallbackResponse::EndpointError { data: e } => {
                 Ok(LnUrlPayResult::EndpointError { data: e })
@@ -303,7 +316,9 @@ impl BreezServices {
                 let payment = self.send_payment(pay_req).await?.payment;
                 let details = match &payment.details {
                     PaymentDetails::ClosedChannel { .. } => {
-                        return Err(anyhow!("Payment lookup found unexpected payment type"));
+                        return Err(LnUrlPayError::Generic {
+                            err: "Payment lookup found unexpected payment type".into(),
+                        });
                     }
                     PaymentDetails::Ln { data } => data,
                 };
@@ -316,7 +331,11 @@ impl BreezServices {
                                 let preimage = sha256::Hash::from_str(&details.payment_preimage)?;
                                 let preimage_arr: [u8; 32] = preimage.into_inner();
 
-                                let decrypted = (data, &preimage_arr).try_into()?;
+                                let decrypted = (data, &preimage_arr).try_into().map_err(
+                                    |e: anyhow::Error| LnUrlPayError::AesDecryptionFailed {
+                                        err: e.to_string(),
+                                    },
+                                )?;
                                 SuccessActionProcessed::Aes { data: decrypted }
                             }
                             SuccessAction::Message(data) => {
@@ -351,7 +370,10 @@ impl BreezServices {
     /// This call will validate the given `amount_msat` against the parameters
     /// of the LNURL endpoint (`data`). If they match the endpoint requirements, the LNURL withdraw
     /// request is made. A successful result here means the endpoint started the payment.
-    pub async fn lnurl_withdraw(&self, req: LnUrlWithdrawRequest) -> Result<LnUrlWithdrawResult> {
+    pub async fn lnurl_withdraw(
+        &self,
+        req: LnUrlWithdrawRequest,
+    ) -> Result<LnUrlWithdrawResult, LnUrlWithdrawError> {
         let invoice = self
             .receive_payment(ReceivePaymentRequest {
                 amount_msat: req.amount_msat,
@@ -359,8 +381,7 @@ impl BreezServices {
                 use_description_hash: Some(false),
                 ..Default::default()
             })
-            .await
-            .map_err(|_| anyhow!("Failed to receive payment"))?
+            .await?
             .ln_invoice;
 
         let lnurl_w_endpoint = req.data.callback.clone();
@@ -385,8 +406,11 @@ impl BreezServices {
     ///
     /// This call will sign `k1` of the LNURL endpoint (`req_data`) on `secp256k1` using `linkingPrivKey` and DER-encodes the signature.
     /// If they match the endpoint requirements, the LNURL auth request is made. A successful result here means the client signature is verified.
-    pub async fn lnurl_auth(&self, req_data: LnUrlAuthRequestData) -> Result<LnUrlCallbackStatus> {
-        perform_lnurl_auth(self.node_api.clone(), req_data).await
+    pub async fn lnurl_auth(
+        &self,
+        req_data: LnUrlAuthRequestData,
+    ) -> Result<LnUrlCallbackStatus, LnUrlAuthError> {
+        Ok(perform_lnurl_auth(self.node_api.clone(), req_data).await?)
     }
 
     /// Creates an bolt11 payment request.
@@ -396,7 +420,7 @@ impl BreezServices {
     pub async fn receive_payment(
         &self,
         req: ReceivePaymentRequest,
-    ) -> SdkResult<ReceivePaymentResponse> {
+    ) -> Result<ReceivePaymentResponse, ReceivePaymentError> {
         self.payment_receiver.receive_payment(req).await
     }
 
@@ -404,23 +428,21 @@ impl BreezServices {
     ///
     /// Fail if it could not be retrieved or if `None` was found.
     pub fn node_info(&self) -> SdkResult<NodeState> {
-        self.persister
-            .get_node_state()?
-            .ok_or(SdkError::PersistenceFailure {
-                err: "No node info found".into(),
-            })
+        self.persister.get_node_state()?.ok_or(SdkError::Generic {
+            err: "Node info not found".into(),
+        })
     }
 
     /// Sign given message with the private key of the node id. Returns a zbase
     /// encoded signature.
-    pub async fn sign_message(&self, req: SignMessageRequest) -> Result<SignMessageResponse> {
+    pub async fn sign_message(&self, req: SignMessageRequest) -> SdkResult<SignMessageResponse> {
         let signature = self.node_api.sign_message(&req.message).await?;
         Ok(SignMessageResponse { signature })
     }
 
     /// Check whether given message was signed by the private key or the given
     /// pubkey and the signature (zbase encoded) is valid.
-    pub async fn check_message(&self, req: CheckMessageRequest) -> Result<CheckMessageResponse> {
+    pub async fn check_message(&self, req: CheckMessageRequest) -> SdkResult<CheckMessageResponse> {
         let is_valid = self
             .node_api
             .check_message(&req.message, &req.pubkey, &req.signature)
@@ -429,7 +451,7 @@ impl BreezServices {
     }
 
     /// Retrieve the node up to date BackupStatus
-    pub fn backup_status(&self) -> Result<BackupStatus> {
+    pub fn backup_status(&self) -> SdkResult<BackupStatus> {
         let backup_time = self.persister.get_last_backup_time()?;
         let sync_request = self.persister.get_last_sync_request()?;
         Ok(BackupStatus {
@@ -439,31 +461,33 @@ impl BreezServices {
     }
 
     /// Force running backup
-    pub async fn backup(&self) -> Result<()> {
+    pub async fn backup(&self) -> SdkResult<()> {
         let (on_complete, mut on_complete_receiver) = mpsc::channel::<Result<()>>(1);
         let req = BackupRequest::with(on_complete, true);
         self.backup_watcher.request_backup(req).await?;
 
         match on_complete_receiver.recv().await {
-            Some(res) => res,
-            None => Err(anyhow!("backup process failed to complete")),
+            Some(res) => res.map_err(|e| SdkError::Generic {
+                err: format!("Backup failed: {e}"),
+            }),
+            None => Err(SdkError::Generic {
+                err: "Backup process failed to complete".into(),
+            }),
         }
     }
 
     /// List payments matching the given filters, as retrieved from persistent storage
     pub async fn list_payments(&self, req: ListPaymentsRequest) -> SdkResult<Vec<Payment>> {
-        self.persister.list_payments(req)
+        Ok(self.persister.list_payments(req)?)
     }
 
     /// Fetch a specific payment by its hash.
-    pub async fn payment_by_hash(&self, hash: String) -> Result<Option<Payment>> {
-        self.persister
-            .get_payment_by_hash(&hash)
-            .map_err(|err| anyhow!(err))
+    pub async fn payment_by_hash(&self, hash: String) -> SdkResult<Option<Payment>> {
+        Ok(self.persister.get_payment_by_hash(&hash)?)
     }
 
     /// Sweep on-chain funds to the specified on-chain address, with the given feerate
-    pub async fn sweep(&self, req: SweepRequest) -> Result<SweepResponse> {
+    pub async fn sweep(&self, req: SweepRequest) -> SdkResult<SweepResponse> {
         self.start_node().await?;
         let txid = self
             .node_api
@@ -473,28 +497,25 @@ impl BreezServices {
         Ok(SweepResponse { txid })
     }
 
-    pub async fn prepare_sweep(&self, req: PrepareSweepRequest) -> Result<PrepareSweepResponse> {
+    pub async fn prepare_sweep(&self, req: PrepareSweepRequest) -> SdkResult<PrepareSweepResponse> {
         self.start_node().await?;
         let response = self.node_api.prepare_sweep(req).await?;
         Ok(response)
     }
 
     /// Fetch live rates of fiat currencies
-    pub async fn fetch_fiat_rates(&self) -> Result<Vec<Rate>> {
+    pub async fn fetch_fiat_rates(&self) -> SdkResult<Vec<Rate>> {
         self.fiat_api.fetch_fiat_rates().await
     }
 
     /// List all supported fiat currencies for which there is a known exchange rate.
-    pub async fn list_fiat_currencies(&self) -> Result<Vec<FiatCurrency>> {
+    pub async fn list_fiat_currencies(&self) -> SdkResult<Vec<FiatCurrency>> {
         self.fiat_api.list_fiat_currencies().await
     }
 
     /// List available LSPs that can be selected by the user
     pub async fn list_lsps(&self) -> SdkResult<Vec<LspInformation>> {
-        self.lsp_api
-            .list_lsps(self.node_info()?.id)
-            .await
-            .map_err(|e| SdkError::LspConnectFailed { err: e.to_string() })
+        self.lsp_api.list_lsps(self.node_info()?.id).await
     }
 
     /// Select the LSP to be used and provide inbound liquidity
@@ -505,7 +526,7 @@ impl BreezServices {
                 self.sync().await?;
                 Ok(())
             }
-            false => Err(SdkError::LspConnectFailed {
+            false => Err(SdkError::Generic {
                 err: format!("Unknown LSP: {lsp_id}"),
             }),
         }
@@ -513,12 +534,12 @@ impl BreezServices {
 
     /// Get the current LSP's ID
     pub async fn lsp_id(&self) -> SdkResult<Option<String>> {
-        self.persister.get_lsp_id()
+        Ok(self.persister.get_lsp_id()?)
     }
 
     /// Convenience method to look up [LspInformation] for a given LSP ID
-    pub async fn fetch_lsp_info(&self, id: String) -> Result<Option<LspInformation>> {
-        get_lsp_by_id(self.persister.clone(), self.lsp_api.clone(), id.as_str()).await
+    pub async fn fetch_lsp_info(&self, id: String) -> SdkResult<Option<LspInformation>> {
+        Ok(get_lsp_by_id(self.persister.clone(), self.lsp_api.clone(), id.as_str()).await?)
     }
 
     /// Gets the fees required to open a channel for a given amount.
@@ -530,8 +551,8 @@ impl BreezServices {
         req: OpenChannelFeeRequest,
     ) -> SdkResult<OpenChannelFeeResponse> {
         // get the node state to fetch the current inbound liquidity.
-        let node_state = self.persister.get_node_state()?.ok_or(SdkError::NotReady {
-            err: "Failed to read node state".to_string(),
+        let node_state = self.persister.get_node_state()?.ok_or(SdkError::Generic {
+            err: "Node info not found".into(),
         })?;
 
         // In case we have enough inbound liquidity we return zero fee.
@@ -557,7 +578,7 @@ impl BreezServices {
     /// Close all channels with the current LSP.
     ///
     /// Should be called  when the user wants to close all the channels.
-    pub async fn close_lsp_channels(&self) -> Result<Vec<String>> {
+    pub async fn close_lsp_channels(&self) -> SdkResult<Vec<String>> {
         self.start_node().await?;
         let lsp = self.lsp_info().await?;
         let tx_ids = self.node_api.close_peer_channels(lsp.pubkey).await?;
@@ -576,12 +597,15 @@ impl BreezServices {
     ///
     /// The returned [SwapInfo] contains the created swap details. The channel opening fees are
     /// available at [SwapInfo::channel_opening_fees].
-    pub async fn receive_onchain(&self, req: ReceiveOnchainRequest) -> Result<SwapInfo> {
+    pub async fn receive_onchain(
+        &self,
+        req: ReceiveOnchainRequest,
+    ) -> Result<SwapInfo, ReceiveOnchainError> {
         if let Some(in_progress) = self.in_progress_swap().await? {
-            return Err(anyhow!(format!(
-                  "Swap in progress was detected for address {}.Use in_progress_swap method to get the current swap state",
-                  in_progress.bitcoin_address
-              )));
+            return Err(ReceiveOnchainError::SwapInProgress{ err:format!(
+                    "A swap was detected for address {}. Use in_progress_swap method to get the current swap state",
+                    in_progress.bitcoin_address
+                )});
         }
         let channel_opening_fees = match req.opening_fee_params {
             Some(fee_params) => fee_params,
@@ -601,7 +625,7 @@ impl BreezServices {
 
     /// Returns an optional in-progress [SwapInfo].
     /// A [SwapInfo] is in-progress if it is waiting for confirmation to be redeemed and complete the swap.
-    pub async fn in_progress_swap(&self) -> Result<Option<SwapInfo>> {
+    pub async fn in_progress_swap(&self) -> SdkResult<Option<SwapInfo>> {
         let tip = self.chain_service.current_tip().await?;
         self.btc_receive_swapper.execute_pending_swaps(tip).await?;
         let in_progress = self.btc_receive_swapper.list_in_progress().await?;
@@ -625,13 +649,22 @@ impl BreezServices {
     pub async fn fetch_reverse_swap_fees(
         &self,
         req: ReverseSwapFeesRequest,
-    ) -> Result<ReverseSwapPairInfo> {
+    ) -> SdkResult<ReverseSwapPairInfo> {
         let mut res = self.btc_send_swapper.fetch_reverse_swap_fees().await?;
 
         if let Some(send_amount_sat) = req.send_amount_sat {
-            ensure!(send_amount_sat <= res.max, "Send amount is too high");
-            ensure!(send_amount_sat >= res.min, "Send amount is too low");
-
+            ensure_sdk!(
+                send_amount_sat <= res.max,
+                SdkError::Generic {
+                    err: "Send amount is too high".into()
+                }
+            );
+            ensure_sdk!(
+                send_amount_sat >= res.min,
+                SdkError::Generic {
+                    err: "Send amount is too low".into()
+                }
+            );
             let service_fee_sat = ((send_amount_sat as f64) * res.fees_percentage / 100.0) as u64;
             res.total_estimated_fees = Some(service_fee_sat + res.fees_lockup + res.fees_claim);
         }
@@ -640,11 +673,14 @@ impl BreezServices {
     }
 
     /// Creates a reverse swap and attempts to pay the HODL invoice
-    pub async fn send_onchain(&self, req: SendOnchainRequest) -> Result<SendOnchainResponse> {
-        ensure!(self.in_progress_reverse_swaps().await?.is_empty(),
-            "There already is at least one Reverse Swap in progress. You can only start a new one after after the ongoing ones finish. \
-            Use the in_progress_reverse_swaps method to get an overview of currently ongoing reverse swaps."
-        );
+    pub async fn send_onchain(
+        &self,
+        req: SendOnchainRequest,
+    ) -> Result<SendOnchainResponse, SendOnchainError> {
+        ensure_sdk!(self.in_progress_reverse_swaps().await?.is_empty(), SendOnchainError::ReverseSwapInProgress { err:
+            "You can only start a new one after after the ongoing ones finish. \
+            Use the in_progress_reverse_swaps method to get an overview of currently ongoing reverse swaps".into(), 
+        });
 
         let full_rsi = self.btc_send_swapper.create_reverse_swap(req).await?;
         let rsi = self
@@ -659,7 +695,7 @@ impl BreezServices {
     }
 
     /// Returns the blocking [ReverseSwapInfo]s that are in progress
-    pub async fn in_progress_reverse_swaps(&self) -> Result<Vec<ReverseSwapInfo>> {
+    pub async fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
         let full_rsis = self.btc_send_swapper.list_blocking().await?;
 
         let mut rsis = vec![];
@@ -675,8 +711,8 @@ impl BreezServices {
     }
 
     /// list non-completed expired swaps that should be refunded by calling [BreezServices::refund]
-    pub async fn list_refundables(&self) -> Result<Vec<SwapInfo>> {
-        self.btc_receive_swapper.list_refundables()
+    pub async fn list_refundables(&self) -> SdkResult<Vec<SwapInfo>> {
+        Ok(self.btc_receive_swapper.list_refundables()?)
     }
 
     /// Prepares a refund transaction for a failed/expired swap.
@@ -690,14 +726,14 @@ impl BreezServices {
     /// Construct and broadcast a refund transaction for a failed/expired swap
     ///
     /// Returns the txid of the refund transaction.
-    pub async fn refund(&self, req: RefundRequest) -> Result<RefundResponse> {
-        self.btc_receive_swapper.refund_swap(req).await
+    pub async fn refund(&self, req: RefundRequest) -> SdkResult<RefundResponse> {
+        Ok(self.btc_receive_swapper.refund_swap(req).await?)
     }
 
     /// Execute a command directly on the NodeAPI interface.
     /// Mainly used to debugging.
-    pub async fn execute_dev_command(&self, command: String) -> Result<String> {
-        self.node_api.execute_command(command).await
+    pub async fn execute_dev_command(&self, command: String) -> SdkResult<String> {
+        Ok(self.node_api.execute_command(command).await?)
     }
 
     /// This method sync the local state with the remote node state.
@@ -705,8 +741,8 @@ impl BreezServices {
     /// * node state - General information about the node and its liquidity status
     /// * channels - The list of channels and their status
     /// * payments - The incoming/outgoing payments
-    pub async fn sync(&self) -> Result<()> {
-        self.do_sync(false).await
+    pub async fn sync(&self) -> SdkResult<()> {
+        Ok(self.do_sync(false).await?)
     }
 
     async fn do_sync(&self, balance_changed: bool) -> Result<()> {
@@ -764,7 +800,7 @@ impl BreezServices {
     }
 
     /// Connects to the selected LSP, if any
-    async fn connect_lsp_peer(&self) -> Result<()> {
+    async fn connect_lsp_peer(&self) -> SdkResult<()> {
         if let Ok(lsp_info) = self.lsp_info().await {
             let node_id = lsp_info.pubkey;
             let address = lsp_info.host;
@@ -776,7 +812,9 @@ impl BreezServices {
                 self.node_api
                     .connect_peer(node_id.clone(), address.clone())
                     .await
-                    .map_err(anyhow::Error::msg)?;
+                    .map_err(|e| SdkError::ServiceConnectivity {
+                        err: format!("(LSP: {node_id}) Failed to connect: {e}"),
+                    })?;
             }
             debug!("connected to lsp {}@{}", node_id.clone(), address.clone());
         }
@@ -787,8 +825,8 @@ impl BreezServices {
         &self,
         node_id: String,
         invoice: Option<LNInvoice>,
-        payment_res: Result<PaymentResponse>,
-    ) -> SdkResult<Payment> {
+        payment_res: Result<PaymentResponse, SendPaymentError>,
+    ) -> Result<Payment, SendPaymentError> {
         self.do_sync(payment_res.is_ok()).await?;
 
         match payment_res {
@@ -798,7 +836,7 @@ impl BreezServices {
                         .await?;
                     Ok(p)
                 }
-                None => Err(SdkError::SendPaymentFailed {
+                None => Err(SendPaymentError::Generic {
                     err: "Payment not found".into(),
                 }),
             },
@@ -811,7 +849,7 @@ impl BreezServices {
                     },
                 })
                 .await?;
-                Err(SdkError::SendPaymentFailed { err: e.to_string() })
+                Err(e)
             }
         }
     }
@@ -842,17 +880,17 @@ impl BreezServices {
     }
 
     /// Convenience method to look up LSP info based on current LSP ID
-    pub async fn lsp_info(&self) -> Result<LspInformation> {
-        get_lsp(self.persister.clone(), self.lsp_api.clone()).await
+    pub async fn lsp_info(&self) -> SdkResult<LspInformation> {
+        Ok(get_lsp(self.persister.clone(), self.lsp_api.clone()).await?)
     }
 
     pub(crate) async fn start_node(&self) -> Result<()> {
-        self.node_api.start().await
+        Ok(self.node_api.start().await?)
     }
 
     /// Get the recommended fees for onchain transactions
-    pub async fn recommended_fees(&self) -> Result<RecommendedFees> {
-        self.chain_service.recommended_fees().await
+    pub async fn recommended_fees(&self) -> SdkResult<RecommendedFees> {
+        Ok(self.chain_service.recommended_fees().await?)
     }
 
     /// Get the full default config for a specific environment type
@@ -881,7 +919,10 @@ impl BreezServices {
     ///
     /// A user-selected [OpeningFeeParams] can be optionally set in the argument. If set, and the
     /// operation requires a new channel, the SDK will try to use the given fee params.
-    pub async fn buy_bitcoin(&self, req: BuyBitcoinRequest) -> SdkResult<BuyBitcoinResponse> {
+    pub async fn buy_bitcoin(
+        &self,
+        req: BuyBitcoinRequest,
+    ) -> Result<BuyBitcoinResponse, ReceiveOnchainError> {
         let swap_info = self
             .receive_onchain(ReceiveOnchainRequest {
                 opening_fee_params: req.opening_fee_params,
@@ -953,28 +994,22 @@ impl BreezServices {
         });
     }
 
-    async fn start_backup_watcher(self: &Arc<BreezServices>) -> SdkResult<()> {
+    async fn start_backup_watcher(self: &Arc<BreezServices>) -> Result<()> {
         self.backup_watcher
             .start(self.shutdown_receiver.clone())
             .await
-            .map_err(|e| SdkError::InitFailed {
-                err: format!("Failed to start backup watcher: {e}"),
-            })?;
+            .map_err(|e| anyhow!("Failed to start backup watcher: {e}"))?;
 
         // Restore backup state and request backup on start if needed
         let force_backup = self
             .persister
             .get_last_sync_version()
-            .map_err(|e| SdkError::InitFailed {
-                err: format!("Failed to read last sync version: {e}"),
-            })?
+            .map_err(|e| anyhow!("Failed to read last sync version: {e}"))?
             .is_none();
         self.backup_watcher
             .request_backup(BackupRequest::new(force_backup))
             .await
-            .map_err(|e| SdkError::InitFailed {
-                err: format!("Failed to request backup: {e}"),
-            })
+            .map_err(|e| anyhow!("Failed to request backup: {e}"))
     }
 
     async fn track_backup_events(self: &Arc<BreezServices>) {
@@ -1162,15 +1197,13 @@ impl BreezServices {
     /// An error is thrown if the log file cannot be created in the working directory.
     ///
     /// An error is thrown if a global logger is already configured.
-    pub fn init_logging(log_dir: &str, app_logger: Option<Box<dyn log::Log>>) -> SdkResult<()> {
+    pub fn init_logging(log_dir: &str, app_logger: Option<Box<dyn log::Log>>) -> Result<()> {
         let target_log_file = Box::new(
             OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(format!("{log_dir}/sdk.log"))
-                .map_err(|_| SdkError::InitFailed {
-                    err: "Can't create log file".into(),
-                })?,
+                .map_err(|e| anyhow!("Can't create log file: {e}"))?,
         );
         let logger = env_logger::Builder::new()
             .target(env_logger::Target::Pipe(target_log_file))
@@ -1209,9 +1242,8 @@ impl BreezServices {
             log_listener: app_logger,
         };
 
-        log::set_boxed_logger(Box::new(global_logger)).map_err(|e| SdkError::InitFailed {
-            err: format!("Failed to set global logger: {e}"),
-        })?;
+        log::set_boxed_logger(Box::new(global_logger))
+            .map_err(|e| anyhow!("Failed to set global logger: {e}"))?;
         log::set_max_level(LevelFilter::Trace);
 
         Ok(())
@@ -1429,7 +1461,7 @@ impl BreezServicesBuilder {
         event_listener: Option<Box<dyn EventListener>>,
     ) -> SdkResult<Arc<BreezServices>> {
         if self.node_api.is_none() && self.seed.is_none() {
-            return Err(SdkError::InitFailed {
+            return Err(SdkError::Generic {
                 err: "Either node_api or both credentials and seed should be provided".into(),
             });
         }
@@ -1455,8 +1487,8 @@ impl BreezServicesBuilder {
                 persister.clone(),
             )
             .await
-            .map_err(|e| SdkError::InitFailed {
-                err: format!("Failed to connect to Greenlight: {e}"),
+            .map_err(|e| SdkError::ServiceConnectivity {
+                err: format!("(Greenlight) Failed to connect: {e}"),
             })?;
             let gl_arc = Arc::new(greenlight);
             node_api = Some(gl_arc.clone());
@@ -1466,7 +1498,7 @@ impl BreezServicesBuilder {
         }
 
         if backup_transport.is_none() {
-            return Err(SdkError::InitFailed {
+            return Err(SdkError::Generic {
                 err: "State synchronizer should be provided".into(),
             });
         }
@@ -1475,33 +1507,17 @@ impl BreezServicesBuilder {
         let unwrapped_backup_transport = backup_transport.unwrap();
 
         // create the backup encryption key and then the backup watcher
-        let backup_encryption_key = unwrapped_node_api
-            .derive_bip32_key(vec![
-                ChildNumber::from_hardened_idx(139).map_err(|e| SdkError::InitFailed {
-                    err: format!(
-                        "Failed to get necessary child number to derive backup encryption key: {e}"
-                    ),
-                })?,
-                ChildNumber::from(0),
-            ])
-            .map_err(|e| SdkError::InitFailed {
-                err: format!("Failed to derive backup encryption key: {e}"),
-            })?;
+        let backup_encryption_key = unwrapped_node_api.derive_bip32_key(vec![
+            ChildNumber::from_hardened_idx(139)?,
+            ChildNumber::from(0),
+        ])?;
 
         // We calculate the legacy key as a fallback for the case where the backup is still
         // encrypted with the old key.
-        let legacy_backup_encryption_key = unwrapped_node_api
-            .legacy_derive_bip32_key(vec![
-                ChildNumber::from_hardened_idx(139).map_err(|e| SdkError::InitFailed {
-                    err: format!(
-                        "Failed to get necessary child number to derive backup encryption key: {e}"
-                    ),
-                })?,
-                ChildNumber::from(0),
-            ])
-            .map_err(|e| SdkError::InitFailed {
-                err: format!("Failed to derive backup encryption key: {e}"),
-            })?;
+        let legacy_backup_encryption_key = unwrapped_node_api.legacy_derive_bip32_key(vec![
+            ChildNumber::from_hardened_idx(139)?,
+            ChildNumber::from(0),
+        ])?;
         let backup_watcher = BackupWatcher::new(
             self.config.clone(),
             unwrapped_backup_transport.clone(),
@@ -1598,12 +1614,30 @@ impl BreezServer {
 
     pub(crate) async fn get_channel_opener_client(
         &self,
-    ) -> Result<ChannelOpenerClient<InterceptedService<Channel, ApiKeyInterceptor>>> {
+    ) -> SdkResult<ChannelOpenerClient<InterceptedService<Channel, ApiKeyInterceptor>>> {
         let s = self.server_url.clone();
-        let channel = Channel::from_shared(s)?.connect().await?;
+        let channel = Channel::from_shared(s)
+            .map_err(|e| SdkError::ServiceConnectivity {
+                err: format!("(Breez: {}) {e}", self.server_url.clone()),
+            })?
+            .connect()
+            .await
+            .map_err(|e| SdkError::ServiceConnectivity {
+                err: format!(
+                    "(Breez: {}) Failed to connect: {e}",
+                    self.server_url.clone()
+                ),
+            })?;
 
         let api_key_metadata: Option<MetadataValue<Ascii>> = match &self.api_key {
-            Some(key) => Some(format!("Bearer {key}").parse()?),
+            Some(key) => Some(format!("Bearer {key}").parse().map_err(
+                |e: InvalidMetadataValue| SdkError::ServiceConnectivity {
+                    err: format!(
+                        "(Breez: {}) Failed parse API key: {e}",
+                        self.server_url.clone()
+                    ),
+                },
+            )?),
             _ => None,
         };
         let client =
@@ -1611,32 +1645,32 @@ impl BreezServer {
         Ok(client)
     }
 
-    pub(crate) async fn get_information_client(&self) -> Result<InformationClient<Channel>> {
-        InformationClient::connect(Uri::from_str(&self.server_url)?)
-            .await
-            .map_err(|e| anyhow!(e))
+    pub(crate) async fn get_information_client(&self) -> SdkResult<InformationClient<Channel>> {
+        let url = Uri::from_str(&self.server_url).map_err(|e| SdkError::ServiceConnectivity {
+            err: format!("(Breez: {}) {e}", self.server_url.clone()),
+        })?;
+        Ok(InformationClient::connect(url).await?)
     }
 
-    pub(crate) async fn get_fund_manager_client(&self) -> Result<FundManagerClient<Channel>> {
-        FundManagerClient::connect(Uri::from_str(&self.server_url)?)
-            .await
-            .map_err(|e| anyhow!(e))
+    pub(crate) async fn get_fund_manager_client(&self) -> SdkResult<FundManagerClient<Channel>> {
+        let url = Uri::from_str(&self.server_url).map_err(|e| SdkError::ServiceConnectivity {
+            err: format!("(Breez: {}) {e}", self.server_url.clone()),
+        })?;
+        Ok(FundManagerClient::connect(url).await?)
     }
 
-    pub(crate) async fn get_signer_client(&self) -> Result<SignerClient<Channel>> {
-        Ok(SignerClient::new(
-            tonic::transport::Endpoint::new(Uri::from_str(&self.server_url)?)?
-                .connect()
-                .await?,
-        ))
+    pub(crate) async fn get_signer_client(&self) -> SdkResult<SignerClient<Channel>> {
+        let url = Uri::from_str(&self.server_url).map_err(|e| SdkError::ServiceConnectivity {
+            err: format!("(Breez: {}) {e}", self.server_url.clone()),
+        })?;
+        Ok(SignerClient::new(Endpoint::new(url)?.connect().await?))
     }
 
-    pub(crate) async fn get_swapper_client(&self) -> Result<SwapperClient<Channel>> {
-        Ok(SwapperClient::new(
-            tonic::transport::Endpoint::new(Uri::from_str(&self.server_url)?)?
-                .connect()
-                .await?,
-        ))
+    pub(crate) async fn get_swapper_client(&self) -> SdkResult<SwapperClient<Channel>> {
+        let url = Uri::from_str(&self.server_url).map_err(|e| SdkError::ServiceConnectivity {
+            err: format!("(Breez: {}) {e}", self.server_url.clone()),
+        })?;
+        Ok(SwapperClient::new(Endpoint::new(url)?.connect().await?))
     }
 }
 
@@ -1668,7 +1702,7 @@ pub trait Receiver: Send + Sync {
     async fn receive_payment(
         &self,
         req: ReceivePaymentRequest,
-    ) -> SdkResult<ReceivePaymentResponse>;
+    ) -> Result<ReceivePaymentResponse, ReceivePaymentError>;
 }
 
 pub(crate) struct PaymentReceiver {
@@ -1683,19 +1717,18 @@ impl Receiver for PaymentReceiver {
     async fn receive_payment(
         &self,
         req: ReceivePaymentRequest,
-    ) -> SdkResult<ReceivePaymentResponse> {
+    ) -> Result<ReceivePaymentResponse, ReceivePaymentError> {
         self.node_api.start().await?;
         let lsp_info = get_lsp(self.persister.clone(), self.lsp.clone()).await?;
         let node_state = self
             .persister
             .get_node_state()?
-            .ok_or("Failed to retrieve node state")
-            .map_err(|err| anyhow!(err))?;
+            .ok_or(anyhow!("Node info not found"))?;
         let expiry = req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS);
 
         ensure_sdk!(
             req.amount_msat > 0,
-            SdkError::ReceivePaymentFailed {
+            ReceivePaymentError::InvalidAmount {
                 err: "Receive amount must be more than 0".into()
             }
         );
@@ -1724,12 +1757,12 @@ impl Receiver for PaymentReceiver {
                     ofp.proportional, ofp.min_msat, channel_fees_msat);
 
                 if req.amount_msat < channel_fees_msat + 1000 {
-                    return Err(SdkError::ReceivePaymentFailed {
-                        err: format!(
-                            "requestPayment: Amount should be more than the minimum fees {channel_fees_msat} msat, but is {} msat",
+                    return Err(
+                        ReceivePaymentError::InvalidAmount{err: format!(
+                           "Amount should be more than the minimum fees {channel_fees_msat} msat, but is {} msat",
                             req.amount_msat
-                        ),
-                    });
+                        )}
+                    );
                 }
                 // remove the fees from the amount to get the small amount on the current node invoice.
                 destination_invoice_amount_msat = req.amount_msat - channel_fees_msat;
@@ -1743,9 +1776,7 @@ impl Receiver for PaymentReceiver {
                         .channels
                         .iter()
                         .find(|&c| c.state == ChannelState::Opened)
-                        .ok_or_else(|| SdkError::ReceivePaymentFailed {
-                            err: "No open channel found".into(),
-                        })?;
+                        .ok_or_else(|| anyhow!("No open channel found"))?;
                     let hint = active_channel
                         .clone()
                         .alias_remote
@@ -1821,7 +1852,7 @@ impl Receiver for PaymentReceiver {
             info!("Registering payment with LSP");
 
             if channel_opening_fee_params.is_none() {
-                return Err(SdkError::ReceivePaymentFailed {
+                return Err(ReceivePaymentError::Generic {
                     err: "We need to open a channel, but no channel opening fee params found"
                         .into(),
                 });
@@ -1835,17 +1866,11 @@ impl Receiver for PaymentReceiver {
                     lsp_info.id.clone(),
                     lsp_info.lsp_pubkey.clone(),
                     PaymentInformation {
-                        payment_hash: hex::decode(parsed_invoice.payment_hash.clone()).map_err(
-                            |e| SdkError::ReceivePaymentFailed {
-                                err: format!("Failed to decode hex payment hash: {e}"),
-                            },
-                        )?,
+                        payment_hash: hex::decode(parsed_invoice.payment_hash.clone())
+                            .map_err(|e| anyhow!("Failed to decode hex payment hash: {e}"))?,
                         payment_secret: parsed_invoice.payment_secret.clone(),
-                        destination: hex::decode(parsed_invoice.payee_pubkey.clone()).map_err(
-                            |e| SdkError::ReceivePaymentFailed {
-                                err: format!("Failed to decode hex payee pubkey: {e}"),
-                            },
-                        )?,
+                        destination: hex::decode(parsed_invoice.payee_pubkey.clone())
+                            .map_err(|e| anyhow!("Failed to decode hex payee pubkey: {e}"))?,
                         incoming_amount_msat: req.amount_msat as i64,
                         outgoing_amount_msat: destination_invoice_amount_msat as i64,
                         tag: json!({ "apiKeyHash": api_key_hash }).to_string(),
@@ -1870,14 +1895,11 @@ impl Receiver for PaymentReceiver {
 
 /// Convenience method to look up LSP info based on current LSP ID
 async fn get_lsp(persister: Arc<SqliteStorage>, lsp: Arc<dyn LspAPI>) -> Result<LspInformation> {
-    let lsp_id = persister
-        .get_lsp_id()?
-        .ok_or("No LSP ID found")
-        .map_err(|err| anyhow!(err))?;
+    let lsp_id = persister.get_lsp_id()?.ok_or(anyhow!("No LSP ID found"))?;
 
     get_lsp_by_id(persister, lsp, lsp_id.as_str())
         .await?
-        .ok_or_else(|| anyhow!("No LSP found for id {}", lsp_id))
+        .ok_or_else(|| anyhow!("No LSP found for id {lsp_id}"))
 }
 
 async fn get_lsp_by_id(
@@ -1887,8 +1909,7 @@ async fn get_lsp_by_id(
 ) -> Result<Option<LspInformation>> {
     let node_pubkey = persister
         .get_node_state()?
-        .ok_or("No NodeState found")
-        .map_err(|err| anyhow!(err))?
+        .ok_or(anyhow!("Node info not found"))?
         .id;
 
     Ok(lsp
@@ -1904,26 +1925,26 @@ pub(crate) mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use anyhow::Result;
+    use anyhow::{anyhow, Result};
     use regex::Regex;
     use reqwest::Url;
 
     use crate::breez_services::{BreezServices, BreezServicesBuilder};
-    use crate::error::{SdkError, SdkResult};
     use crate::fiat::Rate;
     use crate::lnurl::pay::model::MessageSuccessActionData;
     use crate::lnurl::pay::model::SuccessActionProcessed;
     use crate::models::{LnPaymentDetails, NodeState, Payment, PaymentDetails, PaymentTypeFilter};
+    use crate::node_api::NodeAPI;
+    use crate::PaymentType;
     use crate::{
         input_parser, parse_short_channel_id, test_utils::*, BuyBitcoinProvider, BuyBitcoinRequest,
         InputType, ListPaymentsRequest, PaymentStatus, ReceivePaymentRequest,
     };
-    use crate::{NodeAPI, PaymentType};
 
     use super::{PaymentReceiver, Receiver};
 
     #[tokio::test]
-    async fn test_node_state() -> SdkResult<()> {
+    async fn test_node_state() -> Result<()> {
         // let storage_path = format!("{}/storage.sql", get_test_working_dir());
         // std::fs::remove_file(storage_path).ok();
 
@@ -2090,7 +2111,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_receive_with_open_channel() -> SdkResult<()> {
+    async fn test_receive_with_open_channel() -> Result<()> {
         let config = create_test_config();
         let persister = Arc::new(create_test_persister(config.clone()));
         persister.init().unwrap();
@@ -2129,13 +2150,13 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_lsps() -> SdkResult<()> {
+    async fn test_list_lsps() -> Result<()> {
         let storage_path = format!("{}/storage.sql", get_test_working_dir());
         std::fs::remove_file(storage_path).ok();
 
-        let breez_services = breez_services().await.map_err(|e| SdkError::InitFailed {
-            err: format!("Failed to get the BreezServices: {e}"),
-        })?;
+        let breez_services = breez_services()
+            .await
+            .map_err(|e| anyhow!("Failed to get the BreezServices: {e}"))?;
         breez_services.sync().await?;
 
         let node_pubkey = breez_services.node_info()?.id;

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -1,5 +1,5 @@
 use crate::input_parser::get_parse_and_log_response;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::{OutPoint, Txid};
 use serde::{Deserialize, Serialize};
@@ -244,10 +244,9 @@ impl ChainService for MempoolSpace {
             .send()
             .await?
             .text()
-            .await
-            .map_err(anyhow::Error::msg)?;
+            .await?;
         match txid_or_error.contains("error") {
-            true => Err(anyhow::Error::msg(txid_or_error)),
+            true => Err(anyhow!("Error fetching tx: {txid_or_error}")),
             false => Ok(txid_or_error),
         }
     }

--- a/libs/sdk-core/src/crypt.rs
+++ b/libs/sdk-core/src/crypt.rs
@@ -1,9 +1,9 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 pub fn encrypt(key: Vec<u8>, msg: Vec<u8>) -> Result<Vec<u8>> {
     match ecies::encrypt(key.as_slice(), msg.as_slice()) {
         Ok(res) => Ok(res),
-        Err(err) => Err(anyhow!(err)),
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -11,6 +11,6 @@ pub fn encrypt(key: Vec<u8>, msg: Vec<u8>) -> Result<Vec<u8>> {
 pub fn decrypt(key: Vec<u8>, msg: Vec<u8>) -> Result<Vec<u8>> {
     match ecies::decrypt(key.as_slice(), msg.as_slice()) {
         Ok(res) => Ok(res),
-        Err(err) => Err(anyhow!(err)),
+        Err(err) => Err(err.into()),
     }
 }

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -1,60 +1,654 @@
+use anyhow::Result;
+use bitcoin::util::bip32;
 use thiserror::Error;
+
+use crate::{
+    invoice::InvoiceError, lnurl::error::LnUrlError, node_api::NodeError,
+    persist::error::PersistError, swap_in::error::SwapError, swap_out::error::ReverseSwapError,
+};
 
 pub type SdkResult<T, E = SdkError> = Result<T, E>;
 
-/// Type of error returned by the SDK
+/// Error returned by [BreezServices::lnurl_auth]
 #[derive(Debug, Error)]
-pub enum SdkError {
-    /// Generic error, that doesn't fit any of the other types
-    #[error("Breez SDK error: {err}")]
+pub enum LnUrlAuthError {
+    #[error("Generic: {err}")]
     Generic { err: String },
 
-    #[error("Failed to initialize the SDK: {err}")]
-    InitFailed { err: String },
+    #[error("Invalid uri: {err}")]
+    InvalidUri { err: String },
 
-    #[error("SDK is not ready: {err}")]
-    NotReady { err: String },
-
-    #[error("Failed to communicate with the LSP API: {err}")]
-    LspConnectFailed { err: String },
-
-    #[error("LSP doesn't support opening a new channel: {err}")]
-    LspOpenChannelNotSupported { err: String },
-
-    #[error("Failed to calculate channel opening fee: {err}")]
-    CalculateOpenChannelFeesFailed { err: String },
-
-    #[error("Failed to use the local DB for persistence: {err}")]
-    PersistenceFailure { err: String },
-
-    #[error("Failed to receive payment: {err}")]
-    ReceivePaymentFailed { err: String },
-
-    #[error("Failed to send payment: {err}")]
-    SendPaymentFailed { err: String },
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
 }
 
-impl From<rusqlite::Error> for SdkError {
-    fn from(value: rusqlite::Error) -> Self {
-        Self::PersistenceFailure {
-            err: value.to_string(),
+impl From<LnUrlError> for LnUrlAuthError {
+    fn from(value: LnUrlError) -> Self {
+        match value {
+            LnUrlError::InvalidUri(err) => Self::InvalidUri {
+                err: err.to_string(),
+            },
+            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
         }
     }
 }
 
-impl From<rusqlite_migration::Error> for SdkError {
-    fn from(value: rusqlite_migration::Error) -> Self {
-        Self::PersistenceFailure {
-            err: value.to_string(),
+impl From<SdkError> for LnUrlAuthError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
         }
     }
 }
 
-// TODO This won't be necessary when all service methods return SdkResult
-impl From<anyhow::Error> for SdkError {
-    fn from(value: anyhow::Error) -> Self {
+/// Error returned by [BreezServices::lnurl_pay]
+#[derive(Debug, Error)]
+pub enum LnUrlPayError {
+    #[error("Aes decryption failed: {err}")]
+    AesDecryptionFailed { err: String },
+
+    #[error("Invoice already paid")]
+    AlreadyPaid,
+
+    #[error("Generic: {err}")]
+    Generic { err: String },
+
+    #[error("Invalid amount: {err}")]
+    InvalidAmount { err: String },
+
+    #[error("Invalid invoice: {err}")]
+    InvalidInvoice { err: String },
+
+    #[error("Invalid uri: {err}")]
+    InvalidUri { err: String },
+
+    #[error("Invoice expired: {err}")]
+    InvoiceExpired { err: String },
+
+    #[error("Payment failed: {err}")]
+    PaymentFailed { err: String },
+
+    #[error("Payment timeout: {err}")]
+    PaymentTimeout { err: String },
+
+    #[error("Route not found: {err}")]
+    RouteNotFound { err: String },
+
+    #[error("Route too expensive: {err}")]
+    RouteTooExpensive { err: String },
+
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
+}
+
+impl From<anyhow::Error> for LnUrlPayError {
+    fn from(err: anyhow::Error) -> Self {
         Self::Generic {
-            err: value.to_string(),
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<bitcoin::hashes::hex::Error> for LnUrlPayError {
+    fn from(err: bitcoin::hashes::hex::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<LnUrlError> for LnUrlPayError {
+    fn from(value: LnUrlError) -> Self {
+        match value {
+            LnUrlError::InvalidUri(err) => Self::InvalidUri {
+                err: err.to_string(),
+            },
+            LnUrlError::InvalidInvoice(err) => Self::InvalidInvoice {
+                err: err.to_string(),
+            },
+            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<PersistError> for LnUrlPayError {
+    fn from(err: PersistError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<SdkError> for LnUrlPayError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<SendPaymentError> for LnUrlPayError {
+    fn from(value: SendPaymentError) -> Self {
+        match value {
+            SendPaymentError::AlreadyPaid => Self::AlreadyPaid,
+            SendPaymentError::InvalidAmount { err } => Self::InvalidAmount { err },
+            SendPaymentError::InvalidInvoice { err } => Self::InvalidInvoice { err },
+            SendPaymentError::InvoiceExpired { err } => Self::InvoiceExpired { err },
+            SendPaymentError::PaymentFailed { err } => Self::PaymentFailed { err },
+            SendPaymentError::PaymentTimeout { err } => Self::PaymentTimeout { err },
+            SendPaymentError::RouteNotFound { err } => Self::RouteNotFound { err },
+            SendPaymentError::RouteTooExpensive { err } => Self::RouteTooExpensive { err },
+            SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+/// Error returned by [BreezServices::lnurl_withdraw]
+#[derive(Debug, Error)]
+pub enum LnUrlWithdrawError {
+    #[error("Generic: {err}")]
+    Generic { err: String },
+
+    #[error("Invalid amount: {err}")]
+    InvalidAmount { err: String },
+
+    #[error("Invalid invoice: {err}")]
+    InvalidInvoice { err: String },
+
+    #[error("Invalid uri: {err}")]
+    InvalidUri { err: String },
+
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
+}
+
+impl From<LnUrlError> for LnUrlWithdrawError {
+    fn from(value: LnUrlError) -> Self {
+        match value {
+            LnUrlError::InvalidUri(err) => Self::InvalidUri {
+                err: err.to_string(),
+            },
+            LnUrlError::InvalidInvoice(err) => Self::InvalidInvoice {
+                err: err.to_string(),
+            },
+            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<PersistError> for LnUrlWithdrawError {
+    fn from(err: PersistError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<ReceivePaymentError> for LnUrlWithdrawError {
+    fn from(value: ReceivePaymentError) -> Self {
+        match value {
+            ReceivePaymentError::InvalidAmount { err } => Self::InvalidAmount { err },
+            ReceivePaymentError::InvalidInvoice { err } => Self::InvalidInvoice { err },
+            ReceivePaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<SdkError> for LnUrlWithdrawError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+/// Error returned by [BreezServices::receive_onchain] and [BreezServices::buy_bitcoin]
+#[derive(Debug, Error)]
+pub enum ReceiveOnchainError {
+    #[error("Generic: {err}")]
+    Generic { err: String },
+
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
+
+    #[error("Swap in progress: {err}")]
+    SwapInProgress { err: String },
+}
+
+impl From<anyhow::Error> for ReceiveOnchainError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<SdkError> for ReceiveOnchainError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<SwapError> for ReceiveOnchainError {
+    fn from(value: SwapError) -> Self {
+        match value {
+            SwapError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+/// Error returned by [BreezServices::receive_payment]
+#[derive(Debug, Error)]
+pub enum ReceivePaymentError {
+    #[error("Generic: {err}")]
+    Generic { err: String },
+
+    #[error("Invalid amount: {err}")]
+    InvalidAmount { err: String },
+
+    #[error("Invalid invoice: {err}")]
+    InvalidInvoice { err: String },
+
+    #[error("Invoice expired: {err}")]
+    InvoiceExpired { err: String },
+
+    #[error("Invoice no description: {err}")]
+    InvoiceNoDescription { err: String },
+
+    #[error("Invoice preimage already exists: {err}")]
+    InvoicePreimageAlreadyExists { err: String },
+
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
+}
+
+impl From<anyhow::Error> for ReceivePaymentError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<InvoiceError> for ReceivePaymentError {
+    fn from(err: InvoiceError) -> Self {
+        Self::InvalidInvoice {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<NodeError> for ReceivePaymentError {
+    fn from(value: NodeError) -> Self {
+        match value {
+            NodeError::InvoiceExpired(err) => Self::InvoiceExpired {
+                err: err.to_string(),
+            },
+            NodeError::InvoiceNoDescription(err) => Self::InvoiceNoDescription {
+                err: err.to_string(),
+            },
+            NodeError::InvoicePreimageAlreadyExists(err) => Self::InvoicePreimageAlreadyExists {
+                err: err.to_string(),
+            },
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<PersistError> for ReceivePaymentError {
+    fn from(err: PersistError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<SdkError> for ReceivePaymentError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+/// General error returned by the SDK
+#[derive(Debug, Error)]
+pub enum SdkError {
+    #[error("Generic: {err}")]
+    Generic { err: String },
+
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
+}
+
+impl From<anyhow::Error> for SdkError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<bitcoin::hashes::hex::Error> for SdkError {
+    fn from(err: bitcoin::hashes::hex::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<bip32::Error> for SdkError {
+    fn from(err: bip32::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<InvoiceError> for SdkError {
+    fn from(err: InvoiceError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<LnUrlError> for SdkError {
+    fn from(err: LnUrlError) -> Self {
+        SdkError::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<NodeError> for SdkError {
+    fn from(value: NodeError) -> Self {
+        match value {
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<PersistError> for SdkError {
+    fn from(err: PersistError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<ReverseSwapError> for SdkError {
+    fn from(value: ReverseSwapError) -> Self {
+        match value {
+            ReverseSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<serde_json::Error> for SdkError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<tonic::transport::Error> for SdkError {
+    fn from(err: tonic::transport::Error) -> Self {
+        Self::ServiceConnectivity {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<tonic::Status> for SdkError {
+    fn from(err: tonic::Status) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<SendPaymentError> for SdkError {
+    fn from(value: SendPaymentError) -> Self {
+        match value {
+            SendPaymentError::Generic { err } => Self::Generic { err },
+            SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+/// Error returned by [BreezServices::send_onchain]
+#[derive(Debug, Error)]
+pub enum SendOnchainError {
+    #[error("Generic: {err}")]
+    Generic { err: String },
+
+    #[error("Invalid destination address: {err}")]
+    InvalidDestinationAddress { err: String },
+
+    #[error("Payment failed: {err}")]
+    PaymentFailed { err: String },
+
+    #[error("Payment timeout: {err}")]
+    PaymentTimeout { err: String },
+
+    #[error("Reverse swap in progress: {err}")]
+    ReverseSwapInProgress { err: String },
+
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
+}
+
+impl From<anyhow::Error> for SendOnchainError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<NodeError> for SendOnchainError {
+    fn from(value: NodeError) -> Self {
+        match value {
+            NodeError::PaymentFailed(err) => Self::PaymentFailed {
+                err: err.to_string(),
+            },
+            NodeError::PaymentTimeout(err) => Self::PaymentTimeout {
+                err: err.to_string(),
+            },
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<SdkError> for SendOnchainError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<ReverseSwapError> for SendOnchainError {
+    fn from(value: ReverseSwapError) -> Self {
+        match value {
+            ReverseSwapError::InvalidDestinationAddress(err) => Self::InvalidDestinationAddress {
+                err: err.to_string(),
+            },
+            ReverseSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            ReverseSwapError::Node(err) => err.into(),
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+/// Error returned by [BreezServices::send_payment] and [BreezServices::send_spontaneous_payment]
+#[derive(Debug, Error)]
+pub enum SendPaymentError {
+    #[error("Invoice already paid")]
+    AlreadyPaid,
+
+    #[error("Generic: {err}")]
+    Generic { err: String },
+
+    #[error("Invalid amount: {err}")]
+    InvalidAmount { err: String },
+
+    #[error("Invalid invoice: {err}")]
+    InvalidInvoice { err: String },
+
+    #[error("Invoice expired: {err}")]
+    InvoiceExpired { err: String },
+
+    #[error("Payment failed: {err}")]
+    PaymentFailed { err: String },
+
+    #[error("Payment timeout: {err}")]
+    PaymentTimeout { err: String },
+
+    #[error("Route not found: {err}")]
+    RouteNotFound { err: String },
+
+    #[error("Route too expensive: {err}")]
+    RouteTooExpensive { err: String },
+
+    #[error("Service connectivity: {err}")]
+    ServiceConnectivity { err: String },
+}
+
+impl From<anyhow::Error> for SendPaymentError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<InvoiceError> for SendPaymentError {
+    fn from(err: InvoiceError) -> Self {
+        Self::InvalidInvoice {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<NodeError> for SendPaymentError {
+    fn from(value: NodeError) -> Self {
+        match value {
+            NodeError::InvoiceExpired(err) => Self::InvoiceExpired {
+                err: err.to_string(),
+            },
+            NodeError::PaymentFailed(err) => Self::PaymentFailed {
+                err: err.to_string(),
+            },
+            NodeError::PaymentTimeout(err) => Self::PaymentTimeout {
+                err: err.to_string(),
+            },
+            NodeError::RouteNotFound(err) => Self::RouteNotFound {
+                err: err.to_string(),
+            },
+            NodeError::RouteTooExpensive(err) => Self::RouteTooExpensive {
+                err: err.to_string(),
+            },
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
+                err: err.to_string(),
+            },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
+impl From<PersistError> for SendPaymentError {
+    fn from(err: PersistError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<SdkError> for SendPaymentError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
         }
     }
 }

--- a/libs/sdk-core/src/greenlight/error.rs
+++ b/libs/sdk-core/src/greenlight/error.rs
@@ -1,0 +1,213 @@
+use std::{num::TryFromIntError, time::SystemTimeError};
+
+use anyhow::{anyhow, Result};
+use bitcoin::secp256k1;
+use regex::Regex;
+use strum_macros::FromRepr;
+
+use crate::{invoice::InvoiceError, node_api::NodeError, persist::error::PersistError};
+
+#[derive(FromRepr, Debug, PartialEq)]
+#[repr(i16)]
+pub(crate) enum JsonRpcErrCode {
+    /* Errors from `pay`, `sendpay`, or `waitsendpay` commands */
+    PayInProgress = 200,
+    PayRhashAlreadyUsed = 201,
+    PayUnparseableOnion = 202,
+    PayDestinationPermFail = 203,
+    PayTryOtherRoute = 204,
+    PayRouteNotFound = 205,
+    PayRouteTooExpensive = 206,
+    PayInvoiceExpired = 207,
+    PayNoSuchPayment = 208,
+    PayUnspecifiedError = 209,
+    PayStoppedRetrying = 210,
+    PayStatusUnexpected = 211,
+    PayInvoiceRequestInvalid = 212,
+    PayInvoicePreapprovalDeclined = 213,
+    PayKeysendPreapprovalDeclined = 214,
+
+    /* `fundchannel` or `withdraw` errors */
+    FundMaxExceeded = 300,
+    FundCannotAfford = 301,
+    FundOutputIsDust = 302,
+    FundingBroadcastFail = 303,
+    FundingStillSyncingBitcoin = 304,
+    FundingPeerNotConnected = 305,
+    FundingUnknownPeer = 306,
+    FundingNothingToCancel = 307,
+    FundingCancelNotSafe = 308,
+    FundingPsbtInvalid = 309,
+    FundingV2NotSupported = 310,
+    FundingUnknownChannel = 311,
+    FundingStateInvalid = 312,
+    FundCannotAffordWithEmergency = 313,
+
+    /* Splice errors */
+    SpliceBroadcastFail = 350,
+    SpliceWrongOwner = 351,
+    SpliceUnknownChannel = 352,
+    SpliceInvalidChannelState = 353,
+    SpliceNotSupported = 354,
+    SpliceBusyError = 355,
+    SpliceInputError = 356,
+    SpliceFundingLow = 357,
+    SpliceStateError = 358,
+    SpliceLowFee = 359,
+    SpliceHighFee = 360,
+
+    /* `connect` errors */
+    ConnectNoKnownAddress = 400,
+    ConnectAllAddressesFailed = 401,
+    ConnectDisconnectedDuring = 402,
+
+    /* bitcoin-cli plugin errors */
+    BcliError = 500,
+    BcliNoFeeEstimates = 501,
+
+    /* Errors from `invoice` or `delinvoice` commands */
+    InvoiceLabelAlreadyExists = 900,
+    InvoicePreimageAlreadyExists = 901,
+    InvoiceHintsGaveNoRoutes = 902,
+    InvoiceExpiredDuringWait = 903,
+    InvoiceWaitTimedOut = 904,
+    InvoiceNotFound = 905,
+    InvoiceStatusUnexpected = 906,
+    InvoiceOfferInactive = 907,
+    InvoiceNoDescription = 908,
+
+    /* Errors from HSM crypto operations. */
+    HsmEcdhFailed = 800,
+
+    /* Errors from `offer` commands */
+    OfferAlreadyExists = 1000,
+    OfferAlreadyDisabled = 1001,
+    OfferExpired = 1002,
+    OfferRouteNotFound = 1003,
+    OfferBadInvreqReply = 1004,
+    OfferTimeout = 1005,
+
+    /* Errors from datastore command */
+    DatastoreDelDoesNotExist = 1200,
+    DatastoreDelWrongGeneration = 1201,
+    DatastoreUpdateAlreadyExists = 1202,
+    DatastoreUpdateDoesNotExist = 1203,
+    DatastoreUpdateWrongGeneration = 1204,
+    DatastoreUpdateHasChildren = 1205,
+    DatastoreUpdateNoChildren = 1206,
+
+    /* Errors from signmessage command */
+    SignmessagePubkeyNotFound = 1301,
+
+    /* Errors from delforward command */
+    DelforwardNotFound = 1401,
+
+    /* Errors from runes */
+    RuneNotAuthorized = 1501,
+    RuneNotPermitted = 1502,
+    RuneBlacklisted = 1503,
+
+    /* Errors from wait* commands */
+    WaitTimeout = 2000,
+}
+
+impl From<anyhow::Error> for NodeError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic(err)
+    }
+}
+
+impl From<bitcoin::util::address::Error> for NodeError {
+    fn from(err: bitcoin::util::address::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<bitcoin::util::bip32::Error> for NodeError {
+    fn from(err: bitcoin::util::bip32::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<hex::FromHexError> for NodeError {
+    fn from(err: hex::FromHexError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<InvoiceError> for NodeError {
+    fn from(err: InvoiceError) -> Self {
+        Self::InvalidInvoice(err)
+    }
+}
+
+impl From<PersistError> for NodeError {
+    fn from(err: PersistError) -> Self {
+        Self::Persistance(err)
+    }
+}
+
+impl From<secp256k1::Error> for NodeError {
+    fn from(err: secp256k1::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<SystemTimeError> for NodeError {
+    fn from(err: SystemTimeError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<tonic::Status> for NodeError {
+    fn from(status: tonic::Status) -> Self {
+        match parse_cln_error(status.clone()) {
+            Ok(code) => match code {
+                // Pay errors
+                JsonRpcErrCode::PayInvoiceExpired => Self::InvoiceExpired(status.into()),
+                JsonRpcErrCode::PayTryOtherRoute | JsonRpcErrCode::PayRouteNotFound => {
+                    Self::RouteNotFound(status.into())
+                }
+                JsonRpcErrCode::PayRouteTooExpensive => Self::RouteTooExpensive(status.into()),
+                JsonRpcErrCode::PayStoppedRetrying => Self::PaymentTimeout(status.into()),
+                JsonRpcErrCode::PayRhashAlreadyUsed
+                | JsonRpcErrCode::PayUnparseableOnion
+                | JsonRpcErrCode::PayDestinationPermFail
+                | JsonRpcErrCode::PayNoSuchPayment
+                | JsonRpcErrCode::PayUnspecifiedError
+                | JsonRpcErrCode::PayStatusUnexpected
+                | JsonRpcErrCode::PayInvoiceRequestInvalid
+                | JsonRpcErrCode::PayInvoicePreapprovalDeclined
+                | JsonRpcErrCode::PayKeysendPreapprovalDeclined => {
+                    Self::PaymentFailed(status.into())
+                }
+                // Invoice errors
+                JsonRpcErrCode::InvoiceExpiredDuringWait => Self::InvoiceExpired(status.into()),
+                JsonRpcErrCode::InvoiceNoDescription => Self::InvoiceNoDescription(status.into()),
+                JsonRpcErrCode::InvoicePreimageAlreadyExists => {
+                    Self::InvoicePreimageAlreadyExists(status.into())
+                }
+                _ => Self::Generic(status.into()),
+            },
+            _ => Self::Generic(status.into()),
+        }
+    }
+}
+
+impl From<TryFromIntError> for NodeError {
+    fn from(err: TryFromIntError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+#[allow(clippy::invalid_regex)]
+pub(crate) fn parse_cln_error(status: tonic::Status) -> Result<JsonRpcErrCode> {
+    let re: Regex = Regex::new(r"Some\((?<code>-?\d+)\)")?;
+    re.captures(status.message())
+        .and_then(|caps| {
+            caps["code"]
+                .parse::<i16>()
+                .map_or(None, JsonRpcErrCode::from_repr)
+        })
+        .ok_or(anyhow!("No code found"))
+}

--- a/libs/sdk-core/src/greenlight/mod.rs
+++ b/libs/sdk-core/src/greenlight/mod.rs
@@ -1,4 +1,5 @@
 mod backup_transport;
+pub(crate) mod error;
 mod node_api;
 pub(crate) use backup_transport::GLBackupTransport;
 pub(crate) use node_api::Greenlight;

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -39,8 +39,9 @@ use tokio::time::sleep;
 use tokio_stream::{Stream, StreamExt};
 use tonic::Streaming;
 
-use crate::invoice::parse_invoice;
+use crate::invoice::{parse_invoice, InvoiceError};
 use crate::models::*;
+use crate::node_api::{NodeAPI, NodeError, NodeResult};
 use crate::persist::db::SqliteStorage;
 use crate::{Channel, ChannelState, NodeConfig, PrepareSweepRequest, PrepareSweepResponse};
 use std::iter::Iterator;
@@ -187,20 +188,22 @@ impl Greenlight {
         network: Network,
         signer: &Signer,
         path: Vec<ChildNumber>,
-    ) -> Result<ExtendedPrivKey> {
-        ExtendedPrivKey::new_master(network.into(), &signer.bip32_ext_key())?
-            .derive_priv(&Secp256k1::new(), &path)
-            .map_err(|e| anyhow!(e))
+    ) -> NodeResult<ExtendedPrivKey> {
+        Ok(
+            ExtendedPrivKey::new_master(network.into(), &signer.bip32_ext_key())?
+                .derive_priv(&Secp256k1::new(), &path)?,
+        )
     }
 
     fn legacy_derive_bip32_key(
         network: Network,
         signer: &Signer,
         path: Vec<ChildNumber>,
-    ) -> Result<ExtendedPrivKey> {
-        ExtendedPrivKey::new_master(network.into(), &signer.legacy_bip32_ext_key())?
-            .derive_priv(&Secp256k1::new(), &path)
-            .map_err(|e| anyhow!(e))
+    ) -> NodeResult<ExtendedPrivKey> {
+        Ok(
+            ExtendedPrivKey::new_master(network.into(), &signer.legacy_bip32_ext_key())?
+                .derive_priv(&Secp256k1::new(), &path)?,
+        )
     }
 
     async fn register(
@@ -251,22 +254,34 @@ impl Greenlight {
         })
     }
 
-    async fn get_client(&self) -> Result<node::Client> {
+    async fn get_client(&self) -> NodeResult<node::Client> {
         let mut gl_client = self.gl_client.lock().await;
         if gl_client.is_none() {
-            let scheduler =
-                Scheduler::new(self.signer.node_id(), self.sdk_config.network.into()).await?;
-            *gl_client = Some(scheduler.schedule(self.tls_config.clone()).await?);
+            let scheduler = Scheduler::new(self.signer.node_id(), self.sdk_config.network.into())
+                .await
+                .map_err(NodeError::ServiceConnectivity)?;
+            *gl_client = Some(
+                scheduler
+                    .schedule(self.tls_config.clone())
+                    .await
+                    .map_err(NodeError::ServiceConnectivity)?,
+            );
         }
         Ok(gl_client.clone().unwrap())
     }
 
-    pub(crate) async fn get_node_client(&self) -> Result<node::ClnClient> {
+    pub(crate) async fn get_node_client(&self) -> NodeResult<node::ClnClient> {
         let mut node_client = self.node_client.lock().await;
         if node_client.is_none() {
-            let scheduler =
-                Scheduler::new(self.signer.node_id(), self.sdk_config.network.into()).await?;
-            *node_client = Some(scheduler.schedule(self.tls_config.clone()).await?);
+            let scheduler = Scheduler::new(self.signer.node_id(), self.sdk_config.network.into())
+                .await
+                .map_err(NodeError::ServiceConnectivity)?;
+            *node_client = Some(
+                scheduler
+                    .schedule(self.tls_config.clone())
+                    .await
+                    .map_err(NodeError::ServiceConnectivity)?,
+            );
         }
         Ok(node_client.clone().unwrap())
     }
@@ -275,7 +290,7 @@ impl Greenlight {
         cln_client: node::ClnClient,
         persister: Arc<SqliteStorage>,
         balance_changed: bool,
-    ) -> Result<(
+    ) -> NodeResult<(
         Vec<cln::ListpeersPeersChannels>,
         Vec<cln::ListpeersPeersChannels>,
         Vec<String>,
@@ -310,7 +325,7 @@ impl Greenlight {
 
     async fn fetch_channels_and_balance(
         mut cln_client: node::ClnClient,
-    ) -> Result<(
+    ) -> NodeResult<(
         Vec<cln::ListpeersPeersChannels>,
         Vec<cln::ListpeersPeersChannels>,
         Vec<String>,
@@ -406,7 +421,7 @@ impl NodeAPI for Greenlight {
         use_description_hash: Option<bool>,
         expiry: Option<u32>,
         cltv: Option<u32>,
-    ) -> Result<String> {
+    ) -> NodeResult<String> {
         let mut client = self.get_node_client().await?;
         let request = InvoiceRequest {
             amount_msat: Some(AmountOrAny {
@@ -435,7 +450,7 @@ impl NodeAPI for Greenlight {
         &self,
         since_timestamp: u64,
         balance_changed: bool,
-    ) -> Result<SyncResponse> {
+    ) -> NodeResult<SyncResponse> {
         info!("pull changed since {}", since_timestamp);
         let node_client = self.get_node_client().await?;
 
@@ -471,7 +486,7 @@ impl NodeAPI for Greenlight {
         let closed_channels = closed_channels_res?.into_inner().closedchannels;
         let (all_channels, opened_channels, connected_peers, channels_balance) = balance_res?;
 
-        let forgotten_closed_channels: Result<Vec<Channel>> = closed_channels
+        let forgotten_closed_channels: NodeResult<Vec<Channel>> = closed_channels
             .into_iter()
             .filter(|cc| {
                 all_channels
@@ -540,7 +555,7 @@ impl NodeAPI for Greenlight {
         &self,
         bolt11: String,
         amount_msat: Option<u64>,
-    ) -> Result<PaymentResponse> {
+    ) -> NodeResult<PaymentResponse> {
         let mut description = None;
         if !bolt11.is_empty() {
             description = parse_invoice(&bolt11)?.description;
@@ -570,7 +585,7 @@ impl NodeAPI for Greenlight {
         &self,
         node_id: String,
         amount_msat: u64,
-    ) -> Result<PaymentResponse> {
+    ) -> NodeResult<PaymentResponse> {
         let mut client: node::ClnClient = self.get_node_client().await?;
         let request = pb::cln::KeysendRequest {
             destination: hex::decode(node_id)?,
@@ -589,7 +604,7 @@ impl NodeAPI for Greenlight {
         client.key_send(request).await?.into_inner().try_into()
     }
 
-    async fn start(&self) -> Result<()> {
+    async fn start(&self) -> NodeResult<()> {
         self.get_node_client()
             .await?
             .getinfo(pb::cln::GetinfoRequest {})
@@ -597,7 +612,7 @@ impl NodeAPI for Greenlight {
         Ok(())
     }
 
-    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> Result<Vec<u8>> {
+    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> NodeResult<Vec<u8>> {
         let mut client = self.get_node_client().await?;
 
         let request = pb::cln::WithdrawRequest {
@@ -617,7 +632,7 @@ impl NodeAPI for Greenlight {
         Ok(client.withdraw(request).await?.into_inner().txid)
     }
 
-    async fn prepare_sweep(&self, req: PrepareSweepRequest) -> Result<PrepareSweepResponse> {
+    async fn prepare_sweep(&self, req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse> {
         let funds = self.list_funds().await?;
         let utxos = self.utxos(funds).await?;
 
@@ -659,7 +674,9 @@ impl NodeAPI for Greenlight {
             + witness_input_size * txins.len() as u64;
         let fee: u64 = tx_weight * req.sats_per_vbyte / WITNESS_SCALE_FACTOR as u64;
         if fee >= amount {
-            return Err(anyhow!("insufficient funds to pay fees"));
+            return Err(NodeError::Generic(anyhow!(
+                "Insufficient funds to pay fees"
+            )));
         }
         tx.output[0].value = amount - fee;
 
@@ -677,7 +694,7 @@ impl NodeAPI for Greenlight {
         }
     }
 
-    async fn list_peers(&self) -> Result<Vec<Peer>> {
+    async fn list_peers(&self) -> NodeResult<Vec<Peer>> {
         let mut client = self.get_node_client().await?;
 
         let res: cln::ListpeersResponse = client
@@ -689,7 +706,7 @@ impl NodeAPI for Greenlight {
         Ok(peers_models)
     }
 
-    async fn connect_peer(&self, id: String, addr: String) -> Result<()> {
+    async fn connect_peer(&self, id: String, addr: String) -> NodeResult<()> {
         let mut client = self.get_node_client().await?;
         let connect_req = pb::cln::ConnectRequest {
             id: format!("{id}@{addr}"),
@@ -700,19 +717,24 @@ impl NodeAPI for Greenlight {
         Ok(())
     }
 
-    async fn sign_message(&self, message: &str) -> Result<String> {
+    async fn sign_message(&self, message: &str) -> NodeResult<String> {
         let (sig, recovery_id) = self.signer.sign_message(message.as_bytes().to_vec())?;
         let mut complete_signature = vec![31 + recovery_id];
         complete_signature.extend_from_slice(&sig);
         Ok(zbase32::encode_full_bytes(&complete_signature))
     }
 
-    async fn check_message(&self, message: &str, pubkey: &str, signature: &str) -> Result<bool> {
+    async fn check_message(
+        &self,
+        message: &str,
+        pubkey: &str,
+        signature: &str,
+    ) -> NodeResult<bool> {
         let pk = PublicKey::from_str(pubkey)?;
         Ok(verify(message.as_bytes(), signature, &pk))
     }
 
-    fn sign_invoice(&self, invoice: RawInvoice) -> Result<String> {
+    fn sign_invoice(&self, invoice: RawInvoice) -> NodeResult<String> {
         let hrp_bytes = invoice.hrp.to_string().as_bytes().to_vec();
         let data_bytes = invoice.data.to_base32();
 
@@ -740,14 +762,13 @@ impl NodeAPI for Greenlight {
         // contruct the RecoveryId
         let rid = RecoveryId::from_i32(raw_result[64] as i32).expect("recovery ID");
         let sig = &raw_result[0..64];
-        let recoverable_sig =
-            RecoverableSignature::from_compact(sig, rid).map_err(|e| anyhow!(e))?;
+        let recoverable_sig = RecoverableSignature::from_compact(sig, rid)?;
 
         let signed_invoice: Result<SignedRawInvoice> = invoice.sign(|_| Ok(recoverable_sig));
         Ok(signed_invoice?.to_string())
     }
 
-    async fn close_peer_channels(&self, node_id: String) -> Result<Vec<String>> {
+    async fn close_peer_channels(&self, node_id: String) -> NodeResult<Vec<String>> {
         let mut client = self.get_node_client().await?;
         let closed_channels = client
             .list_peer_channels(ListpeerchannelsRequest {
@@ -773,7 +794,7 @@ impl NodeAPI for Greenlight {
             }
 
             if should_close {
-                let chan_id = channel.channel_id.ok_or(anyhow!("empty channel id"))?;
+                let chan_id = channel.channel_id.ok_or(anyhow!("Empty channel id"))?;
                 let response = client
                     .close(CloseRequest {
                         id: hex::encode(chan_id),
@@ -790,19 +811,19 @@ impl NodeAPI for Greenlight {
                         tx_ids.push(hex::encode(
                             res.into_inner()
                                 .txid
-                                .ok_or(anyhow!("empty txid in close response"))?,
+                                .ok_or(anyhow!("Empty txid in close response"))?,
                         ));
                     }
-                    Err(e) => {
-                        error!("error closing channel: {}", e);
-                    }
+                    Err(e) => Err(anyhow!("Empty closing channel: {e}"))?,
                 };
             }
         }
         Ok(tx_ids)
     }
 
-    async fn stream_incoming_payments(&self) -> Result<Streaming<gl_client::pb::IncomingPayment>> {
+    async fn stream_incoming_payments(
+        &self,
+    ) -> NodeResult<Streaming<gl_client::pb::IncomingPayment>> {
         let mut client = self.get_client().await?;
         let stream = client
             .stream_incoming(gl_client::pb::StreamIncomingFilter {})
@@ -811,7 +832,7 @@ impl NodeAPI for Greenlight {
         Ok(stream)
     }
 
-    async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>> {
+    async fn stream_log_messages(&self) -> NodeResult<Streaming<gl_client::pb::LogEntry>> {
         let mut client = self.get_client().await?;
         let stream = client
             .stream_log(gl_client::pb::StreamLogRequest {})
@@ -820,7 +841,7 @@ impl NodeAPI for Greenlight {
         Ok(stream)
     }
 
-    async fn static_backup(&self) -> Result<Vec<String>> {
+    async fn static_backup(&self) -> NodeResult<Vec<String>> {
         let mut client = self.get_node_client().await?;
         let res = client
             .static_backup(StaticbackupRequest {})
@@ -830,9 +851,9 @@ impl NodeAPI for Greenlight {
         Ok(hex_vec)
     }
 
-    async fn execute_command(&self, command: String) -> Result<String> {
-        let node_cmd = NodeCommand::from_str(&command)
-            .map_err(|_| anyhow!(format!("command not found: {command}")))?;
+    async fn execute_command(&self, command: String) -> NodeResult<String> {
+        let node_cmd =
+            NodeCommand::from_str(&command).map_err(|_| anyhow!("Command not found: {command}"))?;
         match node_cmd {
             NodeCommand::ListPeers => {
                 let resp = self
@@ -904,17 +925,17 @@ impl NodeAPI for Greenlight {
         }
     }
 
-    fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> Result<ExtendedPrivKey> {
+    fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey> {
         Self::derive_bip32_key(self.sdk_config.network, &self.signer, path)
     }
 
-    fn legacy_derive_bip32_key(&self, path: Vec<ChildNumber>) -> Result<ExtendedPrivKey> {
+    fn legacy_derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey> {
         Self::legacy_derive_bip32_key(self.sdk_config.network, &self.signer, path)
     }
 
     async fn stream_custom_messages(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<CustomMessage>> + Send>>> {
+    ) -> NodeResult<Pin<Box<dyn Stream<Item = Result<CustomMessage>> + Send>>> {
         let stream = {
             let mut client = match self.get_client().await {
                 Ok(c) => Ok(c),
@@ -955,7 +976,7 @@ impl NodeAPI for Greenlight {
         })))
     }
 
-    async fn send_custom_message(&self, message: CustomMessage) -> Result<()> {
+    async fn send_custom_message(&self, message: CustomMessage) -> NodeResult<()> {
         let mut msg = message.message_type.to_be_bytes().to_vec();
         msg.extend(message.payload);
         let resp = self
@@ -998,7 +1019,10 @@ enum NodeCommand {
 
 // pulls transactions from greenlight based on last sync timestamp.
 // greenlight gives us the payments via API and for received payments we are looking for settled invoices.
-async fn pull_transactions(since_timestamp: u64, client: node::ClnClient) -> Result<Vec<Payment>> {
+async fn pull_transactions(
+    since_timestamp: u64,
+    client: node::ClnClient,
+) -> NodeResult<Vec<Payment>> {
     let mut c = client.clone();
 
     // list invoices
@@ -1007,7 +1031,7 @@ async fn pull_transactions(since_timestamp: u64, client: node::ClnClient) -> Res
         .await?
         .into_inner();
     // construct the received transactions by filtering the invoices to those paid and beyond the filter timestamp
-    let received_transactions: Result<Vec<Payment>> = invoices
+    let received_transactions: NodeResult<Vec<Payment>> = invoices
         .invoices
         .into_iter()
         .filter(|i| {
@@ -1024,7 +1048,7 @@ async fn pull_transactions(since_timestamp: u64, client: node::ClnClient) -> Res
         .into_inner();
     debug!("list payments: {:?}", payments);
     // construct the payment transactions (pending and complete)
-    let outbound_transactions: Result<Vec<Payment>> = payments
+    let outbound_transactions: NodeResult<Vec<Payment>> = payments
         .pays
         .into_iter()
         .filter(|p| p.created_at > since_timestamp)
@@ -1040,7 +1064,7 @@ async fn pull_transactions(since_timestamp: u64, client: node::ClnClient) -> Res
 
 //pub(crate) fn offchain_payment_to_transaction
 impl TryFrom<OffChainPayment> for Payment {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
     fn try_from(p: OffChainPayment) -> std::result::Result<Self, Self::Error> {
         let ln_invoice = parse_invoice(&p.bolt11)?;
@@ -1075,7 +1099,7 @@ impl TryFrom<OffChainPayment> for Payment {
 
 /// Construct a lightning transaction from an invoice
 impl TryFrom<pb::Invoice> for Payment {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
     fn try_from(invoice: pb::Invoice) -> std::result::Result<Self, Self::Error> {
         let ln_invoice = parse_invoice(&invoice.bolt11)?;
@@ -1117,7 +1141,7 @@ impl From<PayStatus> for PaymentStatus {
 
 /// Construct a lightning transaction from an invoice
 impl TryFrom<pb::Payment> for Payment {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
     fn try_from(payment: pb::Payment) -> std::result::Result<Self, Self::Error> {
         let mut description = None;
@@ -1157,13 +1181,13 @@ impl TryFrom<pb::Payment> for Payment {
 
 /// Construct a lightning transaction from an invoice
 impl TryFrom<ListinvoicesInvoices> for Payment {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
     fn try_from(invoice: ListinvoicesInvoices) -> std::result::Result<Self, Self::Error> {
         let ln_invoice = invoice
             .bolt11
             .as_ref()
-            .ok_or(anyhow!("No bolt11 invoice"))
+            .ok_or(InvoiceError::Generic(anyhow!("No bolt11 invoice")))
             .and_then(|b| parse_invoice(b))?;
         Ok(Payment {
             id: hex::encode(invoice.payment_hash.clone()),
@@ -1205,13 +1229,13 @@ impl From<ListpaysPaysStatus> for PaymentStatus {
 }
 
 impl TryFrom<ListpaysPays> for Payment {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
-    fn try_from(payment: ListpaysPays) -> std::result::Result<Self, Self::Error> {
+    fn try_from(payment: ListpaysPays) -> NodeResult<Self, Self::Error> {
         let ln_invoice = payment
             .bolt11
             .as_ref()
-            .ok_or(anyhow!("No bolt11 invoice"))
+            .ok_or(InvoiceError::Generic(anyhow!("No bolt11 invoice")))
             .and_then(|b| parse_invoice(b));
         let payment_amount = payment
             .amount_msat
@@ -1257,7 +1281,7 @@ impl TryFrom<ListpaysPays> for Payment {
 }
 
 impl TryFrom<pb::cln::PayResponse> for PaymentResponse {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
     fn try_from(payment: pb::cln::PayResponse) -> std::result::Result<Self, Self::Error> {
         let payment_amount = payment.amount_msat.unwrap_or_default().msat;
@@ -1274,7 +1298,7 @@ impl TryFrom<pb::cln::PayResponse> for PaymentResponse {
 }
 
 impl TryFrom<pb::cln::KeysendResponse> for PaymentResponse {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
     fn try_from(payment: pb::cln::KeysendResponse) -> std::result::Result<Self, Self::Error> {
         let payment_amount = payment.amount_msat.unwrap_or_default().msat;
@@ -1343,7 +1367,7 @@ impl From<cln::ListpeersPeersChannels> for Channel {
 
 /// Conversion for a closed channel
 impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
-    type Error = anyhow::Error;
+    type Error = NodeError;
 
     fn try_from(c: ListclosedchannelsClosedchannels) -> std::result::Result<Self, Self::Error> {
         let (alias_remote, alias_local) = match c.alias {

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -1,5 +1,4 @@
-use anyhow::{anyhow, Result};
-use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::{self, PublicKey};
 use hex::ToHex;
 use lightning::routing::gossip::RoutingFees;
 use lightning::routing::*;
@@ -7,7 +6,54 @@ use lightning_invoice::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use std::time::UNIX_EPOCH;
+use std::time::{SystemTimeError, UNIX_EPOCH};
+
+pub type InvoiceResult<T, E = InvoiceError> = Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvoiceError {
+    #[error("Generic: {0}")]
+    Generic(#[from] anyhow::Error),
+
+    #[error("Validation: {0}")]
+    Validation(anyhow::Error),
+}
+
+impl From<lightning_invoice::CreationError> for InvoiceError {
+    fn from(err: lightning_invoice::CreationError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<lightning_invoice::ParseError> for InvoiceError {
+    fn from(err: lightning_invoice::ParseError) -> Self {
+        Self::Validation(anyhow::Error::new(err))
+    }
+}
+
+impl From<lightning_invoice::SemanticError> for InvoiceError {
+    fn from(err: lightning_invoice::SemanticError) -> Self {
+        Self::Validation(anyhow::Error::new(err))
+    }
+}
+
+impl From<regex::Error> for InvoiceError {
+    fn from(err: regex::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<secp256k1::Error> for InvoiceError {
+    fn from(err: secp256k1::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<SystemTimeError> for InvoiceError {
+    fn from(err: SystemTimeError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
 
 /// Wrapper for a BOLT11 LN invoice
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -50,7 +96,7 @@ pub struct RouteHint {
 }
 
 impl RouteHint {
-    pub fn to_ldk_hint(&self) -> Result<router::RouteHint> {
+    pub fn to_ldk_hint(&self) -> InvoiceResult<router::RouteHint> {
         let mut hops = Vec::new();
         for hop in self.hops.iter() {
             let pubkey_res = PublicKey::from_str(&hop.src_node_id)?;
@@ -95,7 +141,7 @@ pub fn add_lsp_routing_hints(
     invoice: String,
     lsp_hint: Option<RouteHint>,
     new_amount_msats: u64,
-) -> Result<RawInvoice> {
+) -> InvoiceResult<RawInvoice> {
     let signed = invoice.parse::<SignedRawInvoice>()?;
     let invoice = Invoice::from_signed(signed)?;
 
@@ -138,16 +184,11 @@ pub fn add_lsp_routing_hints(
         invoice_builder = invoice_builder.private_route(hint);
     }
 
-    let invoice_builder = invoice_builder.build_raw();
-
-    match invoice_builder {
-        Ok(invoice) => Ok(invoice),
-        Err(err) => Err(anyhow!(err)),
-    }
+    Ok(invoice_builder.build_raw()?)
 }
 
 /// Parse a BOLT11 payment request and return a structure contains the parsed fields.
-pub fn parse_invoice(bolt11: &str) -> Result<LNInvoice> {
+pub fn parse_invoice(bolt11: &str) -> InvoiceResult<LNInvoice> {
     let re = Regex::new(r"(?i)^lightning:")?;
     let bolt11 = re.replace_all(bolt11, "");
     let signed = bolt11.parse::<SignedRawInvoice>()?;

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -161,7 +161,6 @@ extern crate log;
 
 mod backup;
 pub mod binding;
-mod boltzswap;
 mod breez_services;
 mod chain;
 mod crypt;
@@ -180,9 +179,10 @@ mod lsps0;
 mod lsps2;
 mod models;
 mod moonpay;
+mod node_api;
 mod persist;
-mod reverseswap;
-mod swap;
+mod swap_in;
+mod swap_out;
 #[cfg(test)]
 mod test_utils;
 
@@ -202,4 +202,4 @@ pub use invoice::{parse_invoice, LNInvoice, RouteHint, RouteHintHop};
 pub use lnurl::pay::model::*;
 pub use lsp::LspInformation;
 pub use models::*;
-pub use reverseswap::{ESTIMATED_CLAIM_TX_VSIZE, ESTIMATED_LOCKUP_TX_VSIZE};
+pub use swap_out::reverseswap::{ESTIMATED_CLAIM_TX_VSIZE, ESTIMATED_LOCKUP_TX_VSIZE};

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -1,6 +1,6 @@
 use crate::input_parser::get_parse_and_log_response;
-use crate::{LnUrlAuthRequestData, LnUrlCallbackStatus, NodeAPI};
-use anyhow::{anyhow, Result};
+use crate::{node_api::NodeAPI, LnUrlAuthRequestData, LnUrlCallbackStatus};
+use anyhow::anyhow;
 use bitcoin::hashes::{hex::ToHex, sha256, Hash, HashEngine, Hmac, HmacEngine};
 use bitcoin::secp256k1::{Message, Secp256k1};
 use bitcoin::util::bip32::ChildNumber;
@@ -9,6 +9,8 @@ use reqwest::Url;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use super::error::{LnUrlError, LnUrlResult};
+
 /// Performs the third and last step of LNURL-auth, as per
 /// <https://github.com/lnurl/luds/blob/luds/04.md>
 ///
@@ -16,14 +18,20 @@ use std::sync::Arc;
 pub(crate) async fn perform_lnurl_auth(
     node_api: Arc<dyn NodeAPI>,
     req_data: LnUrlAuthRequestData,
-) -> Result<LnUrlCallbackStatus> {
-    let linking_keys = derive_linking_keys(node_api, Url::from_str(&req_data.url)?)?;
+) -> LnUrlResult<LnUrlCallbackStatus> {
+    let url =
+        Url::from_str(&req_data.url).map_err(|e| LnUrlError::InvalidUri(anyhow::Error::new(e)))?;
+    let linking_keys = derive_linking_keys(node_api, url)?;
 
-    let k1_to_sign = Message::from_slice(&hex::decode(req_data.k1)?)?;
+    let k1_to_sign = Message::from_slice(
+        &hex::decode(req_data.k1)
+            .map_err(|e| LnUrlError::Generic(anyhow!("Error decoding k1: {e}")))?,
+    )?;
     let sig = Secp256k1::new().sign_ecdsa(&k1_to_sign, &linking_keys.secret_key());
 
     // <LNURL_hostname_and_path>?<LNURL_existing_query_parameters>&sig=<hex(sign(utf8ToBytes(k1), linkingPrivKey))>&key=<hex(linkingKey)>
-    let mut callback_url = Url::from_str(&req_data.url)?;
+    let mut callback_url =
+        Url::from_str(&req_data.url).map_err(|e| LnUrlError::InvalidUri(anyhow::Error::new(e)))?;
     callback_url
         .query_pairs_mut()
         .append_pair("sig", &sig.serialize_der().to_hex());
@@ -31,35 +39,43 @@ pub(crate) async fn perform_lnurl_auth(
         .query_pairs_mut()
         .append_pair("key", &linking_keys.public_key().to_hex());
 
-    get_parse_and_log_response(callback_url.as_ref()).await
+    get_parse_and_log_response(callback_url.as_ref())
+        .await
+        .map_err(LnUrlError::ServiceConnectivity)
 }
 
 pub(crate) fn validate_request(
     domain: String,
     lnurl_endpoint: String,
-) -> Result<LnUrlAuthRequestData> {
-    let query = Url::from_str(&lnurl_endpoint)?;
+) -> LnUrlResult<LnUrlAuthRequestData> {
+    let query = Url::from_str(&lnurl_endpoint)
+        .map_err(|e| LnUrlError::InvalidUri(anyhow::Error::new(e)))?;
     let query_pairs = query.query_pairs();
 
     let k1 = query_pairs
         .into_iter()
         .find(|(key, _)| key == "k1")
         .map(|(_, v)| v.to_string())
-        .ok_or(anyhow!("LNURL-auth k1 arg not found"))?;
+        .ok_or(LnUrlError::Generic(anyhow!("LNURL-auth k1 arg not found")))?;
 
     let maybe_action = query_pairs
         .into_iter()
         .find(|(key, _)| key == "action")
         .map(|(_, v)| v.to_string());
 
-    let k1_bytes = hex::decode(&k1)?;
+    let k1_bytes =
+        hex::decode(&k1).map_err(|e| LnUrlError::Generic(anyhow!("Error decoding k1: {e}")))?;
     if k1_bytes.len() != 32 {
-        return Err(anyhow!("LNURL-auth k1 is of unexpected length"));
+        return Err(LnUrlError::Generic(anyhow!(
+            "LNURL-auth k1 is of unexpected length"
+        )));
     }
 
     if let Some(action) = &maybe_action {
         if !["register", "login", "link", "auth"].contains(&action.as_str()) {
-            return Err(anyhow!("LNURL-auth action is of unexpected type"));
+            return Err(LnUrlError::Generic(anyhow!(
+                "LNURL-auth action is of unexpected type"
+            )));
         }
     }
 
@@ -80,8 +96,10 @@ fn hmac_sha256(key: &[u8], input: &[u8]) -> Hmac<sha256::Hash> {
 /// Linking key is derived as per LUD-05
 ///
 /// https://github.com/lnurl/luds/blob/luds/05.md
-fn derive_linking_keys(node_api: Arc<dyn NodeAPI>, url: Url) -> Result<KeyPair> {
-    let domain = url.domain().ok_or(anyhow!("Could not determine domain"))?;
+fn derive_linking_keys(node_api: Arc<dyn NodeAPI>, url: Url) -> LnUrlResult<KeyPair> {
+    let domain = url.domain().ok_or(LnUrlError::InvalidUri(anyhow!(
+        "Could not determine domain"
+    )))?;
 
     // m/138'/0
     let hashing_key = node_api.derive_bip32_key(vec![

--- a/libs/sdk-core/src/lnurl/error.rs
+++ b/libs/sdk-core/src/lnurl/error.rs
@@ -1,0 +1,87 @@
+use std::{array::TryFromSliceError, string::FromUtf8Error};
+
+use anyhow::anyhow;
+use bitcoin::{bech32, secp256k1, util::bip32};
+
+use crate::{invoice::InvoiceError, node_api::NodeError};
+
+pub type LnUrlResult<T, E = LnUrlError> = Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LnUrlError {
+    #[error("Generic: {0}")]
+    Generic(#[from] anyhow::Error),
+
+    #[error(transparent)]
+    InvalidInvoice(#[from] InvoiceError),
+
+    #[error("Invalid uri: {0}")]
+    InvalidUri(anyhow::Error),
+
+    #[error("Service connectivity: {0}")]
+    ServiceConnectivity(anyhow::Error),
+}
+
+impl From<aes::cipher::InvalidLength> for LnUrlError {
+    fn from(err: aes::cipher::InvalidLength) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<aes::cipher::block_padding::UnpadError> for LnUrlError {
+    fn from(err: aes::cipher::block_padding::UnpadError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<base64::DecodeError> for LnUrlError {
+    fn from(err: base64::DecodeError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<bip32::Error> for LnUrlError {
+    fn from(err: bip32::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<bech32::Error> for LnUrlError {
+    fn from(err: bech32::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<FromUtf8Error> for LnUrlError {
+    fn from(err: FromUtf8Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<NodeError> for LnUrlError {
+    fn from(err: NodeError) -> Self {
+        match err {
+            NodeError::InvalidInvoice(err) => Self::InvalidInvoice(err),
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity(err),
+            _ => Self::Generic(anyhow!(err.to_string())),
+        }
+    }
+}
+
+impl From<secp256k1::Error> for LnUrlError {
+    fn from(err: secp256k1::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<serde_json::Error> for LnUrlError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::ServiceConnectivity(anyhow::Error::new(err))
+    }
+}
+
+impl From<TryFromSliceError> for LnUrlError {
+    fn from(err: TryFromSliceError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}

--- a/libs/sdk-core/src/lsps0/error.rs
+++ b/libs/sdk-core/src/lsps0/error.rs
@@ -1,5 +1,7 @@
 use anyhow::anyhow;
 
+use crate::node_api::NodeError;
+
 use super::jsonrpc::RpcError;
 
 #[derive(Debug, thiserror::Error)]
@@ -9,6 +11,9 @@ pub enum Error {
 
     #[error("Lsps0 deserialization error: {0}")]
     Deserialization(serde_json::Error),
+
+    #[error("Lsps0 node: {0}")]
+    Node(NodeError),
 
     #[error("Lsps0 request timed out")]
     Timeout,
@@ -20,6 +25,12 @@ pub enum Error {
 impl From<anyhow::Error> for Error {
     fn from(value: anyhow::Error) -> Self {
         Self::Local(value)
+    }
+}
+
+impl From<NodeError> for Error {
+    fn from(value: NodeError) -> Self {
+        Self::Node(value)
     }
 }
 

--- a/libs/sdk-core/src/lsps0/transport.rs
+++ b/libs/sdk-core/src/lsps0/transport.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::node_api::NodeAPI;
 use crate::CustomMessage;
-use crate::NodeAPI;
 use anyhow::{anyhow, Result};
 use rand::distributions::Alphanumeric;
 use rand::distributions::DistString;

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1,38 +1,33 @@
 use std::cmp::max;
 use std::ops::Add;
-use std::pin::Pin;
 use std::str::FromStr;
 
 use anyhow::{anyhow, ensure, Result};
 use bitcoin::blockdata::opcodes;
 use bitcoin::blockdata::script::Builder;
 use bitcoin::hashes::hex::{FromHex, ToHex};
-use bitcoin::hashes::Hash;
+use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
 use bitcoin::{Address, Script};
 use chrono::{DateTime, Duration, Utc};
-use lightning_invoice::RawInvoice;
 use ripemd::Digest;
 use ripemd::Ripemd160;
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef};
 use rusqlite::ToSql;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
-use tokio::sync::mpsc;
-use tokio_stream::Stream;
-use tonic::Streaming;
 
-use crate::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus};
+use crate::breez_services::BreezServer;
+use crate::error::SdkResult;
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{self, GetReverseRoutingNodeRequest, PaymentInformation, RegisterPaymentReply};
 use crate::lnurl::pay::model::SuccessActionProcessed;
 use crate::lsp::LspInformation;
 use crate::models::Network::*;
+use crate::swap_in::error::SwapResult;
+use crate::swap_out::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus};
+use crate::swap_out::error::{ReverseSwapError, ReverseSwapResult};
 use crate::{LNInvoice, LnUrlErrorData, LnUrlPayRequestData, LnUrlWithdrawRequestData};
-
-use crate::breez_services::BreezServer;
-use crate::error::{SdkError, SdkResult};
 
 pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
 pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 60 minutes
@@ -58,78 +53,26 @@ pub struct Peer {
     pub channels: Vec<Channel>,
 }
 
-/// Trait covering functions affecting the LN node
-#[tonic::async_trait]
-pub trait NodeAPI: Send + Sync {
-    async fn create_invoice(
-        &self,
-        amount_msat: u64,
-        description: String,
-        preimage: Option<Vec<u8>>,
-        use_description_hash: Option<bool>,
-        expiry: Option<u32>,
-        cltv: Option<u32>,
-    ) -> Result<String>;
-    async fn pull_changed(
-        &self,
-        since_timestamp: u64,
-        balance_changed: bool,
-    ) -> Result<SyncResponse>;
-    /// As per the `pb::PayRequest` docs, `amount_msat` is only needed when the invoice doesn't specify an amount
-    async fn send_payment(
-        &self,
-        bolt11: String,
-        amount_msat: Option<u64>,
-    ) -> Result<PaymentResponse>;
-    async fn send_spontaneous_payment(
-        &self,
-        node_id: String,
-        amount_msat: u64,
-    ) -> Result<PaymentResponse>;
-    async fn start(&self) -> Result<()>;
-    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> Result<Vec<u8>>;
-    async fn prepare_sweep(&self, req: PrepareSweepRequest) -> Result<PrepareSweepResponse>;
-    async fn start_signer(&self, shutdown: mpsc::Receiver<()>);
-    async fn list_peers(&self) -> Result<Vec<Peer>>;
-    async fn connect_peer(&self, node_id: String, addr: String) -> Result<()>;
-    fn sign_invoice(&self, invoice: RawInvoice) -> Result<String>;
-    async fn close_peer_channels(&self, node_id: String) -> Result<Vec<String>>;
-    async fn stream_incoming_payments(&self) -> Result<Streaming<gl_client::pb::IncomingPayment>>;
-    async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>>;
-    async fn static_backup(&self) -> Result<Vec<String>>;
-    async fn execute_command(&self, command: String) -> Result<String>;
-    async fn sign_message(&self, message: &str) -> Result<String>;
-    async fn check_message(&self, message: &str, pubkey: &str, signature: &str) -> Result<bool>;
-    async fn send_custom_message(&self, message: CustomMessage) -> Result<()>;
-    async fn stream_custom_messages(
-        &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<CustomMessage>> + Send>>>;
-
-    /// Gets the private key at the path specified
-    fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> Result<ExtendedPrivKey>;
-    fn legacy_derive_bip32_key(&self, path: Vec<ChildNumber>) -> Result<ExtendedPrivKey>;
-}
-
 /// Trait covering LSP-related functionality
 #[tonic::async_trait]
 pub trait LspAPI: Send + Sync {
-    async fn list_lsps(&self, node_pubkey: String) -> Result<Vec<LspInformation>>;
+    async fn list_lsps(&self, node_pubkey: String) -> SdkResult<Vec<LspInformation>>;
     async fn register_payment(
         &self,
         lsp_id: String,
         lsp_pubkey: Vec<u8>,
         payment_info: PaymentInformation,
-    ) -> Result<RegisterPaymentReply>;
+    ) -> SdkResult<RegisterPaymentReply>;
 }
 
 /// Trait covering fiat-related functionality
 #[tonic::async_trait]
 pub trait FiatAPI: Send + Sync {
     /// List all supported fiat currencies for which there is a known exchange rate.
-    async fn list_fiat_currencies(&self) -> Result<Vec<FiatCurrency>>;
+    async fn list_fiat_currencies(&self) -> SdkResult<Vec<FiatCurrency>>;
 
     /// Get the live rates from the server.
-    async fn fetch_fiat_rates(&self) -> Result<Vec<Rate>>;
+    async fn fetch_fiat_rates(&self) -> SdkResult<Vec<Rate>>;
 }
 
 /// Summary of an ongoing swap
@@ -151,7 +94,7 @@ pub trait SwapperAPI: Send + Sync {
         hash: Vec<u8>,
         payer_pubkey: Vec<u8>,
         node_pubkey: String,
-    ) -> Result<Swap>;
+    ) -> SwapResult<Swap>;
 
     async fn complete_swap(&self, bolt11: String) -> Result<()>;
 }
@@ -226,7 +169,7 @@ impl FullReverseSwapInfo {
         compressed_pub_key: Vec<u8>,
         sig: Vec<u8>,
         lock_height: u32,
-    ) -> Result<Script> {
+    ) -> ReverseSwapResult<Script> {
         let mut ripemd160_hasher = Ripemd160::new();
         ripemd160_hasher.update(preimage_hash);
         let ripemd160_hash = ripemd160_hasher.finalize();
@@ -266,7 +209,7 @@ impl FullReverseSwapInfo {
         &self,
         received_lockup_address: String,
         network: Network,
-    ) -> Result<()> {
+    ) -> ReverseSwapResult<()> {
         let redeem_script_received = Script::from_hex(&self.redeem_script)?;
         let asm = redeem_script_received.asm();
         debug!("received asm = {asm:?}");
@@ -295,10 +238,10 @@ impl FullReverseSwapInfo {
 
                 match lockup_addr_from_script == lockup_addr_expected {
                     true => Ok(()),
-                    false => Err(anyhow!("Unexpected lockup address")),
+                    false => Err(ReverseSwapError::UnexpectedLockupAddress),
                 }
             }
-            false => Err(anyhow!("Unexpected redeem script")),
+            false => Err(ReverseSwapError::UnexpectedRedeemScript),
         }
     }
 
@@ -307,19 +250,23 @@ impl FullReverseSwapInfo {
     /// - checks if amount matches the amount requested by the user
     /// - checks if the payment hash is the same preimage hash (derived from local secret bytes)
     /// included in the create request
-    pub(crate) fn validate_hodl_invoice(&self, amount_req_msat: u64) -> Result<()> {
+    pub(crate) fn validate_hodl_invoice(&self, amount_req_msat: u64) -> ReverseSwapResult<()> {
         let inv: lightning_invoice::Invoice = self.invoice.parse()?;
 
         // Validate if received invoice has the same amount as requested by the user
         let amount_from_invoice_msat = inv.amount_milli_satoshis().unwrap_or_default();
         match amount_from_invoice_msat == amount_req_msat {
-            false => Err(anyhow!("Invoice amount doesn't match the request")),
+            false => Err(ReverseSwapError::UnexpectedInvoiceAmount(anyhow!(
+                "Does not match the request"
+            ))),
             true => {
                 // Validate if received invoice has the same payment hash as the preimage hash in the request
                 let preimage_hash_from_invoice = inv.payment_hash();
                 let preimage_hash_from_req = &self.get_preimage_hash();
                 match preimage_hash_from_invoice == preimage_hash_from_req {
-                    false => Err(anyhow!("Invoice payment hash doesn't match the request")),
+                    false => Err(ReverseSwapError::UnexpectedPaymentHash(anyhow!(
+                        "Does not match the request"
+                    ))),
                     true => Ok(()),
                 }
             }
@@ -327,14 +274,14 @@ impl FullReverseSwapInfo {
     }
 
     /// Derives the lockup address from the redeem script
-    pub(crate) fn get_lockup_address(&self, network: Network) -> Result<Address> {
+    pub(crate) fn get_lockup_address(&self, network: Network) -> ReverseSwapResult<Address> {
         let redeem_script = Script::from_hex(&self.redeem_script)?;
         Ok(Address::p2wsh(&redeem_script, network.into()))
     }
 
     /// Get the preimage hash sent in the create request
-    pub(crate) fn get_preimage_hash(&self) -> bitcoin::hashes::sha256::Hash {
-        bitcoin::hashes::sha256::Hash::hash(&self.preimage)
+    pub(crate) fn get_preimage_hash(&self) -> sha256::Hash {
+        sha256::Hash::hash(&self.preimage)
     }
 }
 
@@ -412,18 +359,18 @@ impl TryFrom<i32> for ReverseSwapStatus {
 /// Trait covering Breez Server reverse swap functionality
 #[tonic::async_trait]
 pub(crate) trait ReverseSwapperRoutingAPI: Send + Sync {
-    async fn fetch_reverse_routing_node(&self) -> Result<Vec<u8>>;
+    async fn fetch_reverse_routing_node(&self) -> ReverseSwapResult<Vec<u8>>;
 }
 
 #[tonic::async_trait]
 impl ReverseSwapperRoutingAPI for BreezServer {
-    async fn fetch_reverse_routing_node(&self) -> Result<Vec<u8>> {
-        self.get_swapper_client()
+    async fn fetch_reverse_routing_node(&self) -> ReverseSwapResult<Vec<u8>> {
+        Ok(self
+            .get_swapper_client()
             .await?
             .get_reverse_routing_node(GetReverseRoutingNodeRequest::default())
             .await
-            .map(|reply| reply.into_inner().node_id)
-            .map_err(anyhow::Error::new)
+            .map(|reply| reply.into_inner().node_id)?)
     }
 }
 
@@ -432,7 +379,7 @@ impl ReverseSwapperRoutingAPI for BreezServer {
 pub(crate) trait ReverseSwapServiceAPI: Send + Sync {
     /// Lookup the most recent reverse swap pair info using the Boltz API. The fees are only valid
     /// for a set amount of time.
-    async fn fetch_reverse_swap_fees(&self) -> Result<ReverseSwapPairInfo>;
+    async fn fetch_reverse_swap_fees(&self) -> ReverseSwapResult<ReverseSwapPairInfo>;
 
     /// Creates a reverse submarine swap on the remote service (Boltz).
     ///
@@ -450,10 +397,10 @@ pub(crate) trait ReverseSwapServiceAPI: Send + Sync {
         claim_pubkey: String,
         pair_hash: String,
         routing_node: String,
-    ) -> Result<BoltzApiCreateReverseSwapResponse>;
+    ) -> ReverseSwapResult<BoltzApiCreateReverseSwapResponse>;
 
     /// Performs a live lookup of the reverse swap's status on the Boltz API
-    async fn get_boltz_status(&self, id: String) -> Result<BoltzApiReverseSwapStatus>;
+    async fn get_boltz_status(&self, id: String) -> ReverseSwapResult<BoltzApiReverseSwapStatus>;
 }
 
 /// Internal SDK log entry
@@ -884,9 +831,7 @@ pub struct OpeningFeeParams {
 
 impl OpeningFeeParams {
     pub(crate) fn valid_until_date(&self) -> Result<DateTime<Utc>> {
-        DateTime::parse_from_rfc3339(&self.valid_until)
-            .map_err(|e| anyhow!(e))
-            .map(|d| d.with_timezone(&Utc))
+        Ok(DateTime::parse_from_rfc3339(&self.valid_until).map(|d| d.with_timezone(&Utc))?)
     }
 
     pub(crate) fn valid_for(&self, expiry: u32) -> Result<bool> {
@@ -996,20 +941,13 @@ impl OpeningFeeParamsMenu {
         Ok(())
     }
 
-    pub fn get_cheapest_opening_fee_params(&self) -> SdkResult<OpeningFeeParams> {
-        self.values
-            .first()
-            .cloned()
-            .ok_or_else(|| {
-                SdkError::LspOpenChannelNotSupported {
-            err:
-                "The LSP doesn't support opening new channels: Dynamic fees menu contains no values"
-                    .into(),
-        }
-            })
+    pub fn get_cheapest_opening_fee_params(&self) -> Result<OpeningFeeParams> {
+        self.values.first().cloned().ok_or_else(|| {
+            anyhow!("The LSP doesn't support opening new channels: Dynamic fees menu contains no values")
+        })
     }
 
-    pub fn get_48h_opening_fee_params(&self) -> SdkResult<OpeningFeeParams> {
+    pub fn get_48h_opening_fee_params(&self) -> Result<OpeningFeeParams> {
         // Find the fee params that are valid for at least 48h
         let now = Utc::now();
         let duration_48h = chrono::Duration::hours(48);
@@ -1028,13 +966,9 @@ impl OpeningFeeParamsMenu {
 
         // Of those, return the first, which is the cheapest
         // (sorting order of fee params list was checked when the menu was initialized)
-        valid_min_48h
-            .first()
-            .cloned()
-            .ok_or_else(|| SdkError::LspOpenChannelNotSupported {
-                err: "The LSP doesn't support opening fees that are valid for at least 48 hours"
-                    .into(),
-            })
+        valid_min_48h.first().cloned().ok_or_else(|| {
+            anyhow!("The LSP doesn't support opening fees that are valid for at least 48 hours")
+        })
     }
 }
 

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,0 +1,104 @@
+use crate::{
+    invoice::InvoiceError, persist::error::PersistError, CustomMessage, PaymentResponse, Peer,
+    PrepareSweepRequest, PrepareSweepResponse, SyncResponse,
+};
+use anyhow::Result;
+use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
+use lightning_invoice::RawInvoice;
+use std::pin::Pin;
+use tokio::sync::mpsc;
+use tokio_stream::Stream;
+use tonic::Streaming;
+
+pub type NodeResult<T, E = NodeError> = Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NodeError {
+    #[error("Generic: {0}")]
+    Generic(anyhow::Error),
+
+    #[error(transparent)]
+    InvalidInvoice(InvoiceError),
+
+    #[error("Invoice expired: {0}")]
+    InvoiceExpired(anyhow::Error),
+
+    #[error("Invoice no description: {0}")]
+    InvoiceNoDescription(anyhow::Error),
+
+    #[error("Invoice preimage already exists: {0}")]
+    InvoicePreimageAlreadyExists(anyhow::Error),
+
+    #[error("Payment failed: {0}")]
+    PaymentFailed(anyhow::Error),
+
+    #[error("Payment timeout: {0}")]
+    PaymentTimeout(anyhow::Error),
+
+    #[error(transparent)]
+    Persistance(PersistError),
+
+    #[error("Route too expensive: {0}")]
+    RouteTooExpensive(anyhow::Error),
+
+    #[error("Route not found: {0}")]
+    RouteNotFound(anyhow::Error),
+
+    #[error("Service connectivity: {0}")]
+    ServiceConnectivity(anyhow::Error),
+}
+
+/// Trait covering functions affecting the LN node
+#[tonic::async_trait]
+pub trait NodeAPI: Send + Sync {
+    async fn create_invoice(
+        &self,
+        amount_msat: u64,
+        description: String,
+        preimage: Option<Vec<u8>>,
+        use_description_hash: Option<bool>,
+        expiry: Option<u32>,
+        cltv: Option<u32>,
+    ) -> NodeResult<String>;
+    async fn pull_changed(
+        &self,
+        since_timestamp: u64,
+        balance_changed: bool,
+    ) -> NodeResult<SyncResponse>;
+    /// As per the `pb::PayRequest` docs, `amount_msat` is only needed when the invoice doesn't specify an amount
+    async fn send_payment(
+        &self,
+        bolt11: String,
+        amount_msat: Option<u64>,
+    ) -> NodeResult<PaymentResponse>;
+    async fn send_spontaneous_payment(
+        &self,
+        node_id: String,
+        amount_msat: u64,
+    ) -> NodeResult<PaymentResponse>;
+    async fn start(&self) -> NodeResult<()>;
+    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> NodeResult<Vec<u8>>;
+    async fn prepare_sweep(&self, req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse>;
+    async fn start_signer(&self, shutdown: mpsc::Receiver<()>);
+    async fn list_peers(&self) -> NodeResult<Vec<Peer>>;
+    async fn connect_peer(&self, node_id: String, addr: String) -> NodeResult<()>;
+    fn sign_invoice(&self, invoice: RawInvoice) -> NodeResult<String>;
+    async fn close_peer_channels(&self, node_id: String) -> NodeResult<Vec<String>>;
+    async fn stream_incoming_payments(
+        &self,
+    ) -> NodeResult<Streaming<gl_client::pb::IncomingPayment>>;
+    async fn stream_log_messages(&self) -> NodeResult<Streaming<gl_client::pb::LogEntry>>;
+    async fn static_backup(&self) -> NodeResult<Vec<String>>;
+    async fn execute_command(&self, command: String) -> NodeResult<String>;
+    async fn sign_message(&self, message: &str) -> NodeResult<String>;
+    async fn check_message(&self, message: &str, pubkey: &str, signature: &str)
+        -> NodeResult<bool>;
+    async fn send_custom_message(&self, message: CustomMessage) -> NodeResult<()>;
+    async fn stream_custom_messages(
+        &self,
+    ) -> NodeResult<Pin<Box<dyn Stream<Item = Result<CustomMessage>> + Send>>>;
+
+    /// Gets the private key at the path specified
+    fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
+    fn legacy_derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
+}

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -1,11 +1,9 @@
 use crate::models::NodeState;
 
-use super::db::SqliteStorage;
-use crate::error::{SdkError, SdkResult};
-use anyhow::Result;
+use super::{db::SqliteStorage, error::PersistResult};
 
 impl SqliteStorage {
-    pub fn get_cached_item(&self, key: String) -> Result<Option<String>> {
+    pub fn get_cached_item(&self, key: String) -> PersistResult<Option<String>> {
         let res = self.get_connection()?.query_row(
             "SELECT value FROM cached_items WHERE key = ?1",
             [key],
@@ -14,7 +12,7 @@ impl SqliteStorage {
         Ok(res.ok())
     }
 
-    pub fn update_cached_item(&self, key: String, value: String) -> Result<()> {
+    pub fn update_cached_item(&self, key: String, value: String) -> PersistResult<()> {
         self.get_connection()?.execute(
             "INSERT OR REPLACE INTO cached_items (key, value) VALUES (?1,?2)",
             (key, value),
@@ -23,68 +21,60 @@ impl SqliteStorage {
     }
 
     #[allow(dead_code)]
-    pub fn delete_cached_item(&self, key: String) -> Result<()> {
+    pub fn delete_cached_item(&self, key: String) -> PersistResult<()> {
         self.get_connection()?
             .execute("DELETE FROM cached_items WHERE key = ?1", [key])?;
         Ok(())
     }
 
-    pub fn set_node_state(&self, state: &NodeState) -> Result<()> {
+    pub fn set_node_state(&self, state: &NodeState) -> PersistResult<()> {
         let serialized_state = serde_json::to_string(state)?;
         self.update_cached_item("node_state".to_string(), serialized_state)?;
         Ok(())
     }
 
-    pub fn get_node_state(&self) -> SdkResult<Option<NodeState>> {
+    pub fn get_node_state(&self) -> PersistResult<Option<NodeState>> {
         let state_str = self.get_cached_item("node_state".to_string())?;
         Ok(match state_str {
-            Some(str) => {
-                serde_json::from_str(str.as_str()).map_err(|e| SdkError::PersistenceFailure {
-                    err: format!("Failed to deserialize node state: {e}"),
-                })?
-            }
+            Some(str) => serde_json::from_str(str.as_str())?,
             None => None,
         })
     }
 
-    pub fn set_last_backup_time(&self, t: u64) -> Result<()> {
+    pub fn set_last_backup_time(&self, t: u64) -> PersistResult<()> {
         self.update_cached_item("last_backup_time".to_string(), t.to_string())?;
         Ok(())
     }
 
-    pub fn get_last_backup_time(&self) -> Result<Option<u64>> {
+    pub fn get_last_backup_time(&self) -> PersistResult<Option<u64>> {
         let state_str = self.get_cached_item("last_backup_time".to_string())?;
         Ok(match state_str {
             Some(str) => str.as_str().parse::<u64>().ok(),
             None => None,
         })
     }
-    pub fn set_gl_credentials(&self, creds: Vec<u8>) -> Result<()> {
+    pub fn set_gl_credentials(&self, creds: Vec<u8>) -> PersistResult<()> {
         self.update_cached_item("gl_credentials".to_string(), hex::encode(creds))?;
         Ok(())
     }
 
-    pub fn get_gl_credentials(&self) -> Result<Option<Vec<u8>>> {
+    pub fn get_gl_credentials(&self) -> PersistResult<Option<Vec<u8>>> {
         match self.get_cached_item("gl_credentials".to_string())? {
             Some(str) => Ok(Some(hex::decode(str)?)),
             None => Ok(None),
         }
     }
 
-    pub fn set_static_backup(&self, backup: Vec<String>) -> Result<()> {
+    pub fn set_static_backup(&self, backup: Vec<String>) -> PersistResult<()> {
         let serialized_state = serde_json::to_string(&backup)?;
         self.update_cached_item("static_backup".to_string(), serialized_state)?;
         Ok(())
     }
 
-    pub fn get_static_backup(&self) -> Result<Option<Vec<String>>> {
+    pub fn get_static_backup(&self) -> PersistResult<Option<Vec<String>>> {
         let backup_str = self.get_cached_item("static_backup".to_string())?;
         Ok(match backup_str {
-            Some(str) => {
-                serde_json::from_str(str.as_str()).map_err(|e| SdkError::PersistenceFailure {
-                    err: format!("Failed to deserialize static backup data: {e}"),
-                })?
-            }
+            Some(str) => serde_json::from_str(str.as_str())?,
             None => None,
         })
     }

--- a/libs/sdk-core/src/persist/channels.rs
+++ b/libs/sdk-core/src/persist/channels.rs
@@ -1,8 +1,7 @@
 use crate::models::*;
 use std::collections::HashMap;
 
-use super::db::SqliteStorage;
-use anyhow::Result;
+use super::{db::SqliteStorage, error::PersistResult};
 use std::str::FromStr;
 
 impl SqliteStorage {
@@ -12,7 +11,7 @@ impl SqliteStorage {
     /// closing-related fields `closed_at` and `closing_txid` are not set, because doing so would require
     /// a chain service lookup. Instead, they will be set on first lookup in
     /// [BreezServices::closed_channel_to_transaction]
-    pub(crate) fn update_channels(&self, fetched_channels: &[Channel]) -> Result<()> {
+    pub(crate) fn update_channels(&self, fetched_channels: &[Channel]) -> PersistResult<()> {
         // create a hash map of the channels before the update
         let channels_before_update = self
             .list_channels()?
@@ -63,7 +62,7 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub(crate) fn list_channels(&self) -> Result<Vec<Channel>> {
+    pub(crate) fn list_channels(&self) -> PersistResult<Vec<Channel>> {
         let con = self.get_connection()?;
         let mut stmt = con.prepare(
             "
@@ -104,7 +103,7 @@ impl SqliteStorage {
         Ok(channels)
     }
 
-    pub(crate) fn insert_or_update_channel(&self, c: Channel) -> Result<()> {
+    pub(crate) fn insert_or_update_channel(&self, c: Channel) -> PersistResult<()> {
         self.get_connection()?.execute(
             "INSERT OR REPLACE INTO channels (
                    funding_txid, 

--- a/libs/sdk-core/src/persist/error.rs
+++ b/libs/sdk-core/src/persist/error.rs
@@ -1,0 +1,25 @@
+pub type PersistResult<T, E = PersistError> = Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PersistError {
+    #[error("Generic: {0}")]
+    Generic(#[from] anyhow::Error),
+
+    #[error("Migration: {0}")]
+    Migration(#[from] rusqlite_migration::Error),
+
+    #[error("SQL: {0}")]
+    Sql(#[from] rusqlite::Error),
+}
+
+impl From<hex::FromHexError> for PersistError {
+    fn from(err: hex::FromHexError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<serde_json::Error> for PersistError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}

--- a/libs/sdk-core/src/persist/mod.rs
+++ b/libs/sdk-core/src/persist/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod cache;
 pub(crate) mod channels;
 pub(crate) mod db;
+pub(crate) mod error;
 pub(crate) mod migrations;
 pub(crate) mod reverseswap;
 pub(crate) mod settings;

--- a/libs/sdk-core/src/persist/reverseswap.rs
+++ b/libs/sdk-core/src/persist/reverseswap.rs
@@ -1,10 +1,9 @@
-use super::db::SqliteStorage;
+use super::{db::SqliteStorage, error::PersistResult};
 use crate::{FullReverseSwapInfo, ReverseSwapInfoCached, ReverseSwapStatus};
-use anyhow::Result;
 use rusqlite::{named_params, Row};
 
 impl SqliteStorage {
-    pub(crate) fn insert_reverse_swap(&self, rsi: &FullReverseSwapInfo) -> Result<()> {
+    pub(crate) fn insert_reverse_swap(&self, rsi: &FullReverseSwapInfo) -> PersistResult<()> {
         let mut con = self.get_connection()?;
         let tx = con.transaction()?;
 
@@ -42,7 +41,7 @@ impl SqliteStorage {
         &self,
         id: &str,
         status: &ReverseSwapStatus,
-    ) -> Result<()> {
+    ) -> PersistResult<()> {
         debug!("Persisting new status for reverse swap {id} to be {status:?}");
 
         self.get_connection()?.execute(
@@ -56,7 +55,7 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub(crate) fn list_reverse_swaps(&self) -> Result<Vec<FullReverseSwapInfo>> {
+    pub(crate) fn list_reverse_swaps(&self) -> PersistResult<Vec<FullReverseSwapInfo>> {
         let con = self.get_connection()?;
         let mut stmt = con.prepare(&self.select_reverse_swap_query())?;
 
@@ -68,7 +67,10 @@ impl SqliteStorage {
         Ok(vec)
     }
 
-    fn sql_row_to_reverse_swap(&self, row: &Row) -> Result<FullReverseSwapInfo, rusqlite::Error> {
+    fn sql_row_to_reverse_swap(
+        &self,
+        row: &Row,
+    ) -> PersistResult<FullReverseSwapInfo, rusqlite::Error> {
         Ok(FullReverseSwapInfo {
             id: row.get("id")?,
             created_at_block_height: row.get("created_at_block_height")?,

--- a/libs/sdk-core/src/persist/settings.rs
+++ b/libs/sdk-core/src/persist/settings.rs
@@ -1,6 +1,4 @@
-use super::db::SqliteStorage;
-use crate::error::SdkResult;
-use anyhow::Result;
+use super::{db::SqliteStorage, error::PersistResult};
 
 #[allow(dead_code)]
 pub struct SettingItem {
@@ -9,7 +7,7 @@ pub struct SettingItem {
 }
 
 impl SqliteStorage {
-    pub fn update_setting(&self, key: String, value: String) -> SdkResult<()> {
+    pub fn update_setting(&self, key: String, value: String) -> PersistResult<()> {
         self.get_connection()?.execute(
             "INSERT OR REPLACE INTO settings (key, value) VALUES (?1,?2)",
             (key, value),
@@ -17,7 +15,7 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub fn get_setting(&self, key: String) -> SdkResult<Option<String>> {
+    pub fn get_setting(&self, key: String) -> PersistResult<Option<String>> {
         let res = self.get_connection()?.query_row(
             "SELECT value FROM settings WHERE key = ?1",
             [key],
@@ -27,14 +25,14 @@ impl SqliteStorage {
     }
 
     #[allow(dead_code)]
-    pub fn delete_setting(&self, key: String) -> Result<()> {
+    pub fn delete_setting(&self, key: String) -> PersistResult<()> {
         self.get_connection()?
             .execute("DELETE FROM settings WHERE key = ?1", [key])?;
         Ok(())
     }
 
     #[allow(dead_code)]
-    pub fn list_settings(&self) -> Result<Vec<SettingItem>> {
+    pub fn list_settings(&self) -> PersistResult<Vec<SettingItem>> {
         let con = self.get_connection()?;
         let mut stmt = con.prepare("SELECT * FROM settings ORDER BY key")?;
         let vec = stmt
@@ -50,11 +48,11 @@ impl SqliteStorage {
         Ok(vec)
     }
 
-    pub fn set_lsp_id(&self, lsp_id: String) -> SdkResult<()> {
+    pub fn set_lsp_id(&self, lsp_id: String) -> PersistResult<()> {
         self.update_setting("lsp".to_string(), lsp_id)
     }
 
-    pub fn get_lsp_id(&self) -> SdkResult<Option<String>> {
+    pub fn get_lsp_id(&self) -> PersistResult<Option<String>> {
         self.get_setting("lsp".to_string())
     }
 }

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -1,0 +1,32 @@
+use anyhow::anyhow;
+
+use crate::{error::SdkError, persist::error::PersistError};
+
+pub type SwapResult<T, E = SwapError> = Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SwapError {
+    #[error("Generic: {0}")]
+    Generic(#[from] anyhow::Error),
+
+    #[error(transparent)]
+    Persistance(#[from] PersistError),
+
+    #[error("Service connectivity: {0}")]
+    ServiceConnectivity(anyhow::Error),
+}
+
+impl From<SdkError> for SwapError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::Generic { err } => Self::Generic(anyhow!(err)),
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity(anyhow!(err)),
+        }
+    }
+}
+
+impl From<tonic::Status> for SwapError {
+    fn from(err: tonic::Status) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}

--- a/libs/sdk-core/src/swap_in/mod.rs
+++ b/libs/sdk-core/src/swap_in/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod error;
+pub(crate) mod swap;

--- a/libs/sdk-core/src/swap_out/error.rs
+++ b/libs/sdk-core/src/swap_out/error.rs
@@ -1,0 +1,90 @@
+use anyhow::anyhow;
+use bitcoin::{hashes, secp256k1};
+
+use crate::{error::SdkError, node_api::NodeError, persist::error::PersistError};
+
+pub type ReverseSwapResult<T, E = ReverseSwapError> = Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReverseSwapError {
+    #[error("Generic: {0}")]
+    Generic(#[from] anyhow::Error),
+
+    #[error("Invalid destination address: {0}")]
+    InvalidDestinationAddress(anyhow::Error),
+
+    #[error(transparent)]
+    Node(#[from] NodeError),
+
+    #[error("Service connectivity: {0}")]
+    ServiceConnectivity(anyhow::Error),
+
+    #[error("Unexpected invoice amount: {0}")]
+    UnexpectedInvoiceAmount(anyhow::Error),
+
+    #[error("Unexpected lockup address")]
+    UnexpectedLockupAddress,
+
+    #[error("Unexpected payment hash: {0}")]
+    UnexpectedPaymentHash(anyhow::Error),
+
+    #[error("Unexpected redeem script")]
+    UnexpectedRedeemScript,
+}
+
+impl From<hashes::hex::Error> for ReverseSwapError {
+    fn from(err: hashes::hex::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<hex::FromHexError> for ReverseSwapError {
+    fn from(err: hex::FromHexError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<lightning_invoice::ParseOrSemanticError> for ReverseSwapError {
+    fn from(err: lightning_invoice::ParseOrSemanticError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<PersistError> for ReverseSwapError {
+    fn from(err: PersistError) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<reqwest::Error> for ReverseSwapError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<SdkError> for ReverseSwapError {
+    fn from(value: SdkError) -> Self {
+        match value {
+            SdkError::Generic { err } => Self::Generic(anyhow!(err)),
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity(anyhow!(err)),
+        }
+    }
+}
+
+impl From<secp256k1::Error> for ReverseSwapError {
+    fn from(err: secp256k1::Error) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}
+
+impl From<serde_json::Error> for ReverseSwapError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::ServiceConnectivity(anyhow::Error::new(err))
+    }
+}
+
+impl From<tonic::Status> for ReverseSwapError {
+    fn from(err: tonic::Status) -> Self {
+        Self::Generic(anyhow::Error::new(err))
+    }
+}

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod boltzswap;
+pub(crate) mod error;
+pub(crate) mod reverseswap;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 use std::{mem, vec};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Error, Result};
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::ecdsa::RecoverableSignature;
@@ -27,13 +27,16 @@ use tonic::Streaming;
 use crate::backup::{BackupState, BackupTransport};
 use crate::breez_services::Receiver;
 use crate::chain::{ChainService, OnchainTx, Outspend, RecommendedFees, TxStatus};
-use crate::error::SdkResult;
+use crate::error::{ReceivePaymentError, SdkError, SdkResult};
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentReply};
+use crate::invoice::{InvoiceError, InvoiceResult};
 use crate::lsp::LspInformation;
-use crate::models::{FiatAPI, LspAPI, NodeAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse};
+use crate::models::{FiatAPI, LspAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse};
 use crate::moonpay::MoonPayApi;
-use crate::swap::create_submarine_swap_script;
+use crate::node_api::{NodeAPI, NodeError, NodeResult};
+use crate::swap_in::error::SwapResult;
+use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
     parse_invoice, Config, CustomMessage, LNInvoice, PaymentResponse, Peer, PrepareSweepRequest,
     PrepareSweepResponse, RouteHint,
@@ -67,7 +70,7 @@ impl MockBackupTransport {
 
 #[tonic::async_trait]
 impl BackupTransport for MockBackupTransport {
-    async fn pull(&self) -> Result<Option<BackupState>> {
+    async fn pull(&self) -> SdkResult<Option<BackupState>> {
         sleep(Duration::from_millis(10)).await;
         *self.num_pulled.lock().unwrap() += 1;
         let current_state = self.state.lock().unwrap();
@@ -77,14 +80,16 @@ impl BackupTransport for MockBackupTransport {
             None => Ok(None),
         }
     }
-    async fn push(&self, version: Option<u64>, data: Vec<u8>) -> Result<u64> {
+    async fn push(&self, version: Option<u64>, data: Vec<u8>) -> SdkResult<u64> {
         sleep(Duration::from_millis(10)).await;
         let mut remote_version = self.remote_version.lock().unwrap();
         let mut numpushed = self.num_pushed.lock().unwrap();
         *numpushed += 1;
 
         if !remote_version.is_none() && *remote_version != version {
-            return Err(anyhow!("version mismatch"));
+            return Err(SdkError::Generic {
+                err: "version mismatch".into(),
+            });
         }
         let next_version = match version {
             Some(v) => v + 1,
@@ -108,7 +113,7 @@ impl SwapperAPI for MockSwapperAPI {
         hash: Vec<u8>,
         payer_pubkey: Vec<u8>,
         _node_pubkey: String,
-    ) -> Result<Swap> {
+    ) -> SwapResult<Swap> {
         let mut swapper_priv_key_raw = [2; 32];
         rand::thread_rng().fill(&mut swapper_priv_key_raw);
 
@@ -249,7 +254,7 @@ impl Receiver for MockReceiver {
     async fn receive_payment(
         &self,
         _request: ReceivePaymentRequest,
-    ) -> SdkResult<crate::ReceivePaymentResponse> {
+    ) -> Result<crate::ReceivePaymentResponse, ReceivePaymentError> {
         Ok(crate::ReceivePaymentResponse {
             ln_invoice: parse_invoice(&self.bolt11)?,
             opening_fee_params: _request.opening_fee_params,
@@ -266,7 +271,7 @@ pub struct MockNodeAPI {
     /// added test payments
     cloud_payments: Mutex<Vec<gl_client::pb::Payment>>,
     node_state: NodeState,
-    on_send_custom_message: Box<dyn Fn(CustomMessage) -> Result<()> + Sync + Send>,
+    on_send_custom_message: Box<dyn Fn(CustomMessage) -> NodeResult<()> + Sync + Send>,
     on_stream_custom_messages: Mutex<mpsc::Receiver<CustomMessage>>,
 }
 
@@ -280,7 +285,7 @@ impl NodeAPI for MockNodeAPI {
         _use_description_hash: Option<bool>,
         _expiry: Option<u32>,
         _cltv: Option<u32>,
-    ) -> Result<String> {
+    ) -> NodeResult<String> {
         let invoice = create_invoice(description, amount_sats * 1000, vec![], preimage);
         Ok(invoice.bolt11)
     }
@@ -289,7 +294,7 @@ impl NodeAPI for MockNodeAPI {
         &self,
         _since_timestamp: u64,
         _balance_changed: bool,
-    ) -> Result<SyncResponse> {
+    ) -> NodeResult<SyncResponse> {
         Ok(SyncResponse {
             node_state: self.node_state.clone(),
             payments: self
@@ -308,88 +313,100 @@ impl NodeAPI for MockNodeAPI {
         &self,
         bolt11: String,
         _amount_msat: Option<u64>,
-    ) -> Result<PaymentResponse> {
+    ) -> NodeResult<PaymentResponse> {
         let payment = self.add_dummy_payment_for(bolt11, None, None).await?;
-        payment.try_into()
+        Ok(payment.try_into()?)
     }
 
     async fn send_spontaneous_payment(
         &self,
         _node_id: String,
         _amount_msat: u64,
-    ) -> Result<PaymentResponse> {
+    ) -> NodeResult<PaymentResponse> {
         let payment = self.add_dummy_payment_rand().await?;
-        payment.try_into()
+        Ok(payment.try_into()?)
     }
 
-    async fn start(&self) -> Result<()> {
+    async fn start(&self) -> NodeResult<()> {
         Ok(())
     }
 
-    async fn sweep(&self, _to_address: String, _fee_rate_sats_per_vbyte: u32) -> Result<Vec<u8>> {
+    async fn sweep(
+        &self,
+        _to_address: String,
+        _fee_rate_sats_per_vbyte: u32,
+    ) -> NodeResult<Vec<u8>> {
         Ok(rand_vec_u8(32))
     }
 
-    async fn prepare_sweep(&self, _req: PrepareSweepRequest) -> Result<PrepareSweepResponse> {
-        Err(anyhow!("Not implemented"))
+    async fn prepare_sweep(&self, _req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse> {
+        Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
     async fn start_signer(&self, _shutdown: mpsc::Receiver<()>) {}
 
-    async fn list_peers(&self) -> Result<Vec<Peer>> {
+    async fn list_peers(&self) -> NodeResult<Vec<Peer>> {
         Ok(vec![])
     }
 
-    async fn connect_peer(&self, _node_id: String, _addr: String) -> Result<()> {
+    async fn connect_peer(&self, _node_id: String, _addr: String) -> NodeResult<()> {
         Ok(())
     }
 
-    async fn sign_message(&self, _message: &str) -> Result<String> {
+    async fn sign_message(&self, _message: &str) -> NodeResult<String> {
         Ok("".to_string())
     }
 
-    async fn check_message(&self, _message: &str, _pubkey: &str, _signature: &str) -> Result<bool> {
+    async fn check_message(
+        &self,
+        _message: &str,
+        _pubkey: &str,
+        _signature: &str,
+    ) -> NodeResult<bool> {
         Ok(true)
     }
 
-    fn sign_invoice(&self, invoice: RawInvoice) -> Result<String> {
+    fn sign_invoice(&self, invoice: RawInvoice) -> NodeResult<String> {
         Ok(sign_invoice(invoice))
     }
 
-    async fn close_peer_channels(&self, _node_id: String) -> Result<Vec<String>> {
+    async fn close_peer_channels(&self, _node_id: String) -> NodeResult<Vec<String>> {
         Ok(vec![])
     }
-    async fn stream_incoming_payments(&self) -> Result<Streaming<gl_client::pb::IncomingPayment>> {
-        Err(anyhow!("Not implemented"))
+    async fn stream_incoming_payments(
+        &self,
+    ) -> NodeResult<Streaming<gl_client::pb::IncomingPayment>> {
+        Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
-    async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>> {
-        Err(anyhow!("Not implemented"))
+    async fn stream_log_messages(&self) -> NodeResult<Streaming<gl_client::pb::LogEntry>> {
+        Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
-    async fn static_backup(&self) -> Result<Vec<String>> {
+    async fn static_backup(&self) -> NodeResult<Vec<String>> {
         Ok(Vec::new())
     }
 
-    async fn execute_command(&self, _command: String) -> Result<String> {
-        Err(anyhow!("Not implemented"))
+    async fn execute_command(&self, _command: String) -> NodeResult<String> {
+        Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
-    fn derive_bip32_key(&self, _path: Vec<ChildNumber>) -> Result<ExtendedPrivKey> {
+    fn derive_bip32_key(&self, _path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey> {
         Ok(ExtendedPrivKey::new_master(Network::Bitcoin, &[])?)
     }
 
-    fn legacy_derive_bip32_key(&self, _path: Vec<ChildNumber>) -> Result<ExtendedPrivKey> {
+    fn legacy_derive_bip32_key(&self, _path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey> {
         Ok(ExtendedPrivKey::new_master(Network::Bitcoin, &[])?)
     }
 
-    async fn send_custom_message(&self, message: CustomMessage) -> Result<()> {
+    async fn send_custom_message(&self, message: CustomMessage) -> NodeResult<()> {
         (self.on_send_custom_message)(message)
     }
 
     async fn stream_custom_messages(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<CustomMessage>> + Send>>> {
+    ) -> NodeResult<Pin<Box<dyn Stream<Item = core::result::Result<CustomMessage, Error>> + Send>>>
+    {
         let (_, next_rx) = mpsc::channel(1);
         let mut guard = self.on_stream_custom_messages.lock().await;
         let rx = mem::replace(&mut *guard, next_rx);
@@ -421,14 +438,16 @@ impl MockNodeAPI {
         bolt11: String,
         preimage: Option<sha256::Hash>,
         status: Option<PayStatus>,
-    ) -> Result<Payment> {
-        let inv = bolt11.parse::<lightning_invoice::Invoice>()?;
+    ) -> NodeResult<Payment> {
+        let inv = bolt11
+            .parse::<lightning_invoice::Invoice>()
+            .map_err(|e| NodeError::Generic(anyhow::Error::new(e)))?;
 
         self.add_dummy_payment(inv, preimage, status).await
     }
 
     /// Adds a dummy payment with random attributes.
-    pub(crate) async fn add_dummy_payment_rand(&self) -> Result<Payment> {
+    pub(crate) async fn add_dummy_payment_rand(&self) -> NodeResult<Payment> {
         let preimage = sha256::Hash::hash(&rand_vec_u8(10));
         let inv = rand_invoice_with_description_hash_and_preimage("test".into(), preimage)?;
 
@@ -441,7 +460,7 @@ impl MockNodeAPI {
         inv: lightning_invoice::Invoice,
         preimage: Option<sha256::Hash>,
         status: Option<PayStatus>,
-    ) -> Result<Payment> {
+    ) -> NodeResult<Payment> {
         let gl_payment = gl_client::pb::Payment {
             payment_hash: hex::decode(inv.payment_hash().to_hex())?,
             bolt11: inv.to_string(),
@@ -473,7 +492,7 @@ impl MockNodeAPI {
     async fn save_payment_for_future_sync_updates(
         &self,
         gl_payment: gl_client::pb::Payment,
-    ) -> Result<Payment> {
+    ) -> NodeResult<Payment> {
         let mut cloud_payments = self.cloud_payments.lock().await;
 
         // Only store it if a payment with the same ID doesn't already exist
@@ -502,7 +521,7 @@ impl MockNodeAPI {
 
     pub fn set_on_send_custom_message(
         &mut self,
-        f: Box<dyn Fn(CustomMessage) -> Result<()> + Sync + Send>,
+        f: Box<dyn Fn(CustomMessage) -> NodeResult<()> + Sync + Send>,
     ) {
         self.on_send_custom_message = f;
     }
@@ -525,7 +544,7 @@ impl MockBreezServer {
 
 #[tonic::async_trait]
 impl LspAPI for MockBreezServer {
-    async fn list_lsps(&self, _node_pubkey: String) -> Result<Vec<LspInformation>> {
+    async fn list_lsps(&self, _node_pubkey: String) -> SdkResult<Vec<LspInformation>> {
         Ok(vec![LspInformation {
             id: self.lsp_id(),
             name: "test lsp".to_string(),
@@ -553,18 +572,18 @@ impl LspAPI for MockBreezServer {
         _lsp_id: String,
         _lsp_pubkey: Vec<u8>,
         _payment_info: PaymentInformation,
-    ) -> Result<RegisterPaymentReply> {
+    ) -> SdkResult<RegisterPaymentReply> {
         Ok(RegisterPaymentReply {})
     }
 }
 
 #[tonic::async_trait]
 impl FiatAPI for MockBreezServer {
-    async fn list_fiat_currencies(&self) -> Result<Vec<FiatCurrency>> {
+    async fn list_fiat_currencies(&self) -> SdkResult<Vec<FiatCurrency>> {
         Ok(vec![])
     }
 
-    async fn fetch_fiat_rates(&self) -> Result<Vec<Rate>> {
+    async fn fetch_fiat_rates(&self) -> SdkResult<Vec<Rate>> {
         Ok(vec![Rate {
             coin: "USD".to_string(),
             value: 20_000.00,
@@ -585,7 +604,7 @@ impl MoonPayApi for MockBreezServer {
 
 pub(crate) fn rand_invoice_with_description_hash(
     expected_desc: String,
-) -> Result<lightning_invoice::Invoice> {
+) -> InvoiceResult<lightning_invoice::Invoice> {
     let preimage = sha256::Hash::hash(&rand_vec_u8(10));
 
     rand_invoice_with_description_hash_and_preimage(expected_desc, preimage)
@@ -594,7 +613,7 @@ pub(crate) fn rand_invoice_with_description_hash(
 pub(crate) fn rand_invoice_with_description_hash_and_preimage(
     expected_desc: String,
     preimage: sha256::Hash,
-) -> Result<lightning_invoice::Invoice> {
+) -> InvoiceResult<lightning_invoice::Invoice> {
     let expected_desc_hash = Hash::hash(expected_desc.as_bytes());
 
     let hashed_preimage = Message::from_hashed_data::<sha256::Hash>(&preimage[..]);
@@ -606,15 +625,17 @@ pub(crate) fn rand_invoice_with_description_hash_and_preimage(
     let key_pair = KeyPair::new(&secp, &mut rand::thread_rng());
     let private_key = key_pair.secret_key();
 
-    InvoiceBuilder::new(Currency::Bitcoin)
+    Ok(InvoiceBuilder::new(Currency::Bitcoin)
         .description_hash(expected_desc_hash)
         .amount_milli_satoshis(50 * 1000)
-        .payment_hash(Hash::from_slice(payment_hash)?)
+        .payment_hash(
+            Hash::from_slice(payment_hash)
+                .map_err(|e| InvoiceError::Generic(anyhow::Error::new(e)))?,
+        )
         .payment_secret(payment_secret)
         .current_timestamp()
         .min_final_cltv_expiry_delta(144)
-        .build_signed(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
-        .map_err(|err| anyhow!(err))
+        .build_signed(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))?)
 }
 
 pub fn rand_string(len: usize) -> String {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1422,7 +1422,7 @@ class SendPaymentRequest {
   /// The bolt11 invoice
   final String bolt11;
 
-  /// The amount to pay in millisatoshis
+  /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
   final int? amountMsat;
 
   const SendPaymentRequest({

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -34,7 +34,7 @@ fun asAesSuccessActionDataDecryptedList(arr: ReadableArray): List<AesSuccessActi
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asAesSuccessActionDataDecrypted(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -67,7 +67,7 @@ fun asBackupFailedDataList(arr: ReadableArray): List<BackupFailedData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBackupFailedData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -103,7 +103,7 @@ fun asBackupStatusList(arr: ReadableArray): List<BackupStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBackupStatus(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -149,7 +149,7 @@ fun asBitcoinAddressDataList(arr: ReadableArray): List<BitcoinAddressData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBitcoinAddressData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -192,7 +192,7 @@ fun asBuyBitcoinRequestList(arr: ReadableArray): List<BuyBitcoinRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBuyBitcoinRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -235,7 +235,7 @@ fun asBuyBitcoinResponseList(arr: ReadableArray): List<BuyBitcoinResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBuyBitcoinResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -276,7 +276,7 @@ fun asCheckMessageRequestList(arr: ReadableArray): List<CheckMessageRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -309,7 +309,7 @@ fun asCheckMessageResponseList(arr: ReadableArray): List<CheckMessageResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -362,7 +362,7 @@ fun asClosedChannelPaymentDetailsList(arr: ReadableArray): List<ClosedChannelPay
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asClosedChannelPaymentDetails(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -429,7 +429,7 @@ fun asConfigList(arr: ReadableArray): List<Config> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asConfig(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -495,7 +495,7 @@ fun asCurrencyInfoList(arr: ReadableArray): List<CurrencyInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asCurrencyInfo(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -532,7 +532,7 @@ fun asFiatCurrencyList(arr: ReadableArray): List<FiatCurrency> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asFiatCurrency(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -569,7 +569,7 @@ fun asGreenlightCredentialsList(arr: ReadableArray): List<GreenlightCredentials>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asGreenlightCredentials(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -614,7 +614,7 @@ fun asGreenlightNodeConfigList(arr: ReadableArray): List<GreenlightNodeConfig> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asGreenlightNodeConfig(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -651,7 +651,7 @@ fun asInvoicePaidDetailsList(arr: ReadableArray): List<InvoicePaidDetails> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asInvoicePaidDetails(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -717,7 +717,7 @@ fun asLnInvoiceList(arr: ReadableArray): List<LnInvoice> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnInvoice(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -788,7 +788,7 @@ fun asListPaymentsRequestList(arr: ReadableArray): List<ListPaymentsRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asListPaymentsRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -869,7 +869,7 @@ fun asLnPaymentDetailsList(arr: ReadableArray): List<LnPaymentDetails> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnPaymentDetails(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -913,7 +913,7 @@ fun asLnUrlAuthRequestDataList(arr: ReadableArray): List<LnUrlAuthRequestData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlAuthRequestData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -946,7 +946,7 @@ fun asLnUrlErrorDataList(arr: ReadableArray): List<LnUrlErrorData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlErrorData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -986,7 +986,7 @@ fun asLnUrlPayRequestList(arr: ReadableArray): List<LnUrlPayRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1042,7 +1042,7 @@ fun asLnUrlPayRequestDataList(arr: ReadableArray): List<LnUrlPayRequestData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequestData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1082,7 +1082,7 @@ fun asLnUrlWithdrawRequestList(arr: ReadableArray): List<LnUrlWithdrawRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1131,7 +1131,7 @@ fun asLnUrlWithdrawRequestDataList(arr: ReadableArray): List<LnUrlWithdrawReques
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequestData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1164,7 +1164,7 @@ fun asLnUrlWithdrawSuccessDataList(arr: ReadableArray): List<LnUrlWithdrawSucces
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawSuccessData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1204,7 +1204,7 @@ fun asLocaleOverridesList(arr: ReadableArray): List<LocaleOverrides> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLocaleOverrides(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1241,7 +1241,7 @@ fun asLocalizedNameList(arr: ReadableArray): List<LocalizedName> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLocalizedName(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1278,7 +1278,7 @@ fun asLogEntryList(arr: ReadableArray): List<LogEntry> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLogEntry(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1359,7 +1359,7 @@ fun asLspInformationList(arr: ReadableArray): List<LspInformation> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLspInformation(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1392,7 +1392,7 @@ fun asMessageSuccessActionDataList(arr: ReadableArray): List<MessageSuccessActio
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asMessageSuccessActionData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1429,7 +1429,7 @@ fun asMetadataItemList(arr: ReadableArray): List<MetadataItem> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asMetadataItem(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1502,7 +1502,7 @@ fun asNodeStateList(arr: ReadableArray): List<NodeState> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asNodeState(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1538,7 +1538,7 @@ fun asOpenChannelFeeRequestList(arr: ReadableArray): List<OpenChannelFeeRequest>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpenChannelFeeRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1581,7 +1581,7 @@ fun asOpenChannelFeeResponseList(arr: ReadableArray): List<OpenChannelFeeRespons
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpenChannelFeeResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1634,7 +1634,7 @@ fun asOpeningFeeParamsList(arr: ReadableArray): List<OpeningFeeParams> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpeningFeeParams(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1667,7 +1667,7 @@ fun asOpeningFeeParamsMenuList(arr: ReadableArray): List<OpeningFeeParamsMenu> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpeningFeeParamsMenu(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1727,7 +1727,7 @@ fun asPaymentList(arr: ReadableArray): List<Payment> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPayment(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1767,7 +1767,7 @@ fun asPaymentFailedDataList(arr: ReadableArray): List<PaymentFailedData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPaymentFailedData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1808,7 +1808,7 @@ fun asPrepareRefundRequestList(arr: ReadableArray): List<PrepareRefundRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1845,7 +1845,7 @@ fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1882,7 +1882,7 @@ fun asPrepareSweepRequestList(arr: ReadableArray): List<PrepareSweepRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSweepRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1919,7 +1919,7 @@ fun asPrepareSweepResponseList(arr: ReadableArray): List<PrepareSweepResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSweepResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1956,7 +1956,7 @@ fun asRateList(arr: ReadableArray): List<Rate> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRate(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -1998,7 +1998,7 @@ fun asReceiveOnchainRequestList(arr: ReadableArray): List<ReceiveOnchainRequest>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReceiveOnchainRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2077,7 +2077,7 @@ fun asReceivePaymentRequestList(arr: ReadableArray): List<ReceivePaymentRequest>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2136,7 +2136,7 @@ fun asReceivePaymentResponseList(arr: ReadableArray): List<ReceivePaymentRespons
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2185,7 +2185,7 @@ fun asRecommendedFeesList(arr: ReadableArray): List<RecommendedFees> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRecommendedFees(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2226,7 +2226,7 @@ fun asRefundRequestList(arr: ReadableArray): List<RefundRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRefundRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2259,7 +2259,7 @@ fun asRefundResponseList(arr: ReadableArray): List<RefundResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRefundResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2299,7 +2299,7 @@ fun asReverseSwapFeesRequestList(arr: ReadableArray): List<ReverseSwapFeesReques
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReverseSwapFeesRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2350,7 +2350,7 @@ fun asReverseSwapInfoList(arr: ReadableArray): List<ReverseSwapInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReverseSwapInfo(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2415,7 +2415,7 @@ fun asReverseSwapPairInfoList(arr: ReadableArray): List<ReverseSwapPairInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReverseSwapPairInfo(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2448,7 +2448,7 @@ fun asRouteHintList(arr: ReadableArray): List<RouteHint> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRouteHint(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2503,7 +2503,7 @@ fun asRouteHintHopList(arr: ReadableArray): List<RouteHintHop> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRouteHintHop(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2548,7 +2548,7 @@ fun asSendOnchainRequestList(arr: ReadableArray): List<SendOnchainRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendOnchainRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2581,7 +2581,7 @@ fun asSendOnchainResponseList(arr: ReadableArray): List<SendOnchainResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendOnchainResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2617,7 +2617,7 @@ fun asSendPaymentRequestList(arr: ReadableArray): List<SendPaymentRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2650,7 +2650,7 @@ fun asSendPaymentResponseList(arr: ReadableArray): List<SendPaymentResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2687,7 +2687,7 @@ fun asSendSpontaneousPaymentRequestList(arr: ReadableArray): List<SendSpontaneou
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendSpontaneousPaymentRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2720,7 +2720,7 @@ fun asSignMessageRequestList(arr: ReadableArray): List<SignMessageRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2753,7 +2753,7 @@ fun asSignMessageResponseList(arr: ReadableArray): List<SignMessageResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2786,7 +2786,7 @@ fun asStaticBackupRequestList(arr: ReadableArray): List<StaticBackupRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asStaticBackupRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2826,7 +2826,7 @@ fun asStaticBackupResponseList(arr: ReadableArray): List<StaticBackupResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asStaticBackupResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2943,7 +2943,7 @@ fun asSwapInfoList(arr: ReadableArray): List<SwapInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSwapInfo(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -2980,7 +2980,7 @@ fun asSweepRequestList(arr: ReadableArray): List<SweepRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSweepRequest(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3013,7 +3013,7 @@ fun asSweepResponseList(arr: ReadableArray): List<SweepResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSweepResponse(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3053,7 +3053,7 @@ fun asSymbolList(arr: ReadableArray): List<Symbol> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSymbol(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3102,7 +3102,7 @@ fun asUnspentTransactionOutputList(arr: ReadableArray): List<UnspentTransactionO
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asUnspentTransactionOutput(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3139,7 +3139,7 @@ fun asUrlSuccessActionDataList(arr: ReadableArray): List<UrlSuccessActionData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asUrlSuccessActionData(value)!!)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3216,7 +3216,7 @@ fun asBreezEventList(arr: ReadableArray): List<BreezEvent> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBreezEvent(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3231,7 +3231,7 @@ fun asBuyBitcoinProviderList(arr: ReadableArray): List<BuyBitcoinProvider> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asBuyBitcoinProvider(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3246,7 +3246,7 @@ fun asChannelStateList(arr: ReadableArray): List<ChannelState> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asChannelState(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3261,7 +3261,7 @@ fun asEnvironmentTypeList(arr: ReadableArray): List<EnvironmentType> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asEnvironmentType(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3276,7 +3276,7 @@ fun asFeeratePresetList(arr: ReadableArray): List<FeeratePreset> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asFeeratePreset(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3356,7 +3356,7 @@ fun asInputTypeList(arr: ReadableArray): List<InputType> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asInputType(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3393,7 +3393,7 @@ fun asLnUrlCallbackStatusList(arr: ReadableArray): List<LnUrlCallbackStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlCallbackStatus(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3439,7 +3439,7 @@ fun asLnUrlPayResultList(arr: ReadableArray): List<LnUrlPayResult> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayResult(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3477,7 +3477,7 @@ fun asLnUrlWithdrawResultList(arr: ReadableArray): List<LnUrlWithdrawResult> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawResult(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3492,7 +3492,7 @@ fun asNetworkList(arr: ReadableArray): List<Network> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asNetwork(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3523,7 +3523,7 @@ fun asNodeConfigList(arr: ReadableArray): List<NodeConfig> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asNodeConfig(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3561,7 +3561,7 @@ fun asPaymentDetailsList(arr: ReadableArray): List<PaymentDetails> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPaymentDetails(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3576,7 +3576,7 @@ fun asPaymentStatusList(arr: ReadableArray): List<PaymentStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asPaymentStatus(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3591,7 +3591,7 @@ fun asPaymentTypeList(arr: ReadableArray): List<PaymentType> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asPaymentType(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3606,7 +3606,7 @@ fun asPaymentTypeFilterList(arr: ReadableArray): List<PaymentTypeFilter> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asPaymentTypeFilter(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3621,7 +3621,7 @@ fun asReverseSwapStatusList(arr: ReadableArray): List<ReverseSwapStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asReverseSwapStatus(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3666,7 +3666,7 @@ fun asSuccessActionProcessedList(arr: ReadableArray): List<SuccessActionProcesse
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSuccessActionProcessed(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3681,7 +3681,7 @@ fun asSwapStatusList(arr: ReadableArray): List<SwapStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asSwapStatus(value)!!)
-            else -> throw IllegalArgumentException("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list
@@ -3736,7 +3736,7 @@ fun pushToArray(
         is UnspentTransactionOutput -> array.pushMap(readableMapOf(value))
         is Array<*> -> array.pushArray(readableArrayOf(value.asIterable()))
         is List<*> -> array.pushArray(readableArrayOf(value))
-        else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+        else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
     }
 }
 
@@ -3761,7 +3761,7 @@ fun pushToMap(
         is ULong -> map.putDouble(key, value.toDouble())
         is Array<*> -> map.putArray(key, readableArrayOf(value.asIterable()))
         is List<*> -> map.putArray(key, readableArrayOf(value))
-        else -> throw IllegalArgumentException("Unsupported value type ${value::class.java.name} for key [$key]")
+        else -> throw SdkException.Generic("Unexpected type ${value::class.java.name} for key [$key]")
     }
 }
 
@@ -3783,7 +3783,7 @@ fun asUByteList(arr: ReadableArray): List<UByte> {
             is Double -> list.add(value.toInt().toUByte())
             is Int -> list.add(value.toUByte())
             is UByte -> list.add(value)
-            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
     return list

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -14,7 +14,6 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
 
     companion object {
         const val TAG = "RNBreezSDK"
-        const val GENERIC_CODE = "Generic"
     }
 
     override fun initialize() {
@@ -51,8 +50,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = parseInvoice(invoice)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -66,8 +65,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = parseInput(s)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -81,8 +80,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = mnemonicToSeed(phrase)
                 promise.resolve(readableArrayOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -107,8 +106,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
 
                 res.workingDir = workingDir.absolutePath
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -126,8 +125,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = staticBackup(staticBackupRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -139,9 +138,9 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
 
             setLogStream(BreezSDKLogStream(emitter))
             promise.resolve(readableMapOf("status" to "ok"))
-        } catch (e: SdkException) {
+        } catch (e: Exception) {
             e.printStackTrace()
-            promise.reject(e.javaClass.simpleName, e.message, e)
+            promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
         }
     }
 
@@ -152,7 +151,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         promise: Promise,
     ) {
         if (breezServices != null) {
-            promise.reject(TAG, "BreezServices already initialized")
+            promise.reject("Generic", "BreezServices already initialized")
             return
         }
 
@@ -162,9 +161,9 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
 
             breezServices = connect(configTmp, asUByteList(seed), BreezSDKListener(emitter))
             promise.resolve(readableMapOf("status" to "ok"))
-        } catch (e: SdkException) {
+        } catch (e: Exception) {
             e.printStackTrace()
-            promise.reject(e.javaClass.simpleName, e.message, e)
+            promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
         }
     }
 
@@ -174,8 +173,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 getBreezServices().disconnect()
                 promise.resolve(readableMapOf("status" to "ok"))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -193,8 +192,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().sendPayment(sendPaymentRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -212,8 +211,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().sendSpontaneousPayment(sendSpontaneousPaymentRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -231,8 +230,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().receivePayment(receivePaymentRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -247,8 +246,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 val lnUrlPayRequest = asLnUrlPayRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type LnUrlPayRequest") }
                 val res = getBreezServices().payLnurl(lnUrlPayRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -266,8 +265,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().withdrawLnurl(lnUrlWithdrawRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -285,8 +284,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().lnurlAuth(lnUrlAuthRequestData)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -297,8 +296,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().nodeInfo()
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -316,8 +315,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().signMessage(signMessageRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -335,8 +334,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().checkMessage(checkMessageRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -347,8 +346,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().backupStatus()
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -359,8 +358,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 getBreezServices().backup()
                 promise.resolve(readableMapOf("status" to "ok"))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -374,8 +373,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().paymentByHash(hash)
                 promise.resolve(res?.let { readableMapOf(res) })
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -393,8 +392,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().listPayments(listPaymentsRequest)
                 promise.resolve(readableArrayOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -409,8 +408,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 val sweepRequest = asSweepRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type SweepRequest") }
                 val res = getBreezServices().sweep(sweepRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -421,8 +420,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().fetchFiatRates()
                 promise.resolve(readableArrayOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -433,8 +432,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().listFiatCurrencies()
                 promise.resolve(readableArrayOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -445,8 +444,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().listLsps()
                 promise.resolve(readableArrayOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -460,8 +459,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 getBreezServices().connectLsp(lspId)
                 promise.resolve(readableMapOf("status" to "ok"))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -475,8 +474,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().fetchLspInfo(lspId)
                 promise.resolve(res?.let { readableMapOf(res) })
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -494,8 +493,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().openChannelFee(openChannelFeeRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -506,8 +505,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().lspId()
                 promise.resolve(res?.let { res })
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -518,8 +517,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().lspInfo()
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -530,8 +529,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 getBreezServices().closeLspChannels()
                 promise.resolve(readableMapOf("status" to "ok"))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -549,8 +548,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().receiveOnchain(receiveOnchainRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -561,8 +560,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().inProgressSwap()
                 promise.resolve(res?.let { readableMapOf(res) })
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -573,8 +572,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().listRefundables()
                 promise.resolve(readableArrayOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -592,8 +591,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().prepareRefund(prepareRefundRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -608,8 +607,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 val refundRequest = asRefundRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type RefundRequest") }
                 val res = getBreezServices().refund(refundRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -627,8 +626,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().fetchReverseSwapFees(reverseSwapFeesRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -639,8 +638,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().inProgressReverseSwaps()
                 promise.resolve(readableArrayOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -658,8 +657,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().sendOnchain(sendOnchainRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -673,8 +672,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().executeDevCommand(command)
                 promise.resolve(res)
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -685,8 +684,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 getBreezServices().sync()
                 promise.resolve(readableMapOf("status" to "ok"))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -697,8 +696,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val res = getBreezServices().recommendedFees()
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -716,8 +715,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().buyBitcoin(buyBitcoinRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }
@@ -735,8 +734,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                     }
                 val res = getBreezServices().prepareSweep(prepareSweepRequest)
                 promise.resolve(readableMapOf(res))
-            } catch (e: SdkException) {
-                promise.reject(e.javaClass.simpleName, e.message, e)
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }
         }
     }

--- a/libs/sdk-react-native/example/App.js
+++ b/libs/sdk-react-native/example/App.js
@@ -146,6 +146,7 @@ const App = () => {
                 addLine("backupStatus", JSON.stringify(await backupStatus()))
             } catch (e) {
                 addLine("error", e.toString())
+                console.log(`Error: ${JSON.stringify(e)}`)
             }
         }
         asyncFn()

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -26,7 +26,7 @@ class BreezSDKMapper {
                 var aesSuccessActionDataDecrypted = try asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: val)
                 list.append(aesSuccessActionDataDecrypted)
             } else {
-                throw SdkError.Generic(message: "Invalid element type AesSuccessActionDataDecrypted")
+                throw SdkError.Generic(message: "Unexpected type AesSuccessActionDataDecrypted")
             }
         }
         return list
@@ -56,7 +56,7 @@ class BreezSDKMapper {
                 var backupFailedData = try asBackupFailedData(backupFailedData: val)
                 list.append(backupFailedData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type BackupFailedData")
+                throw SdkError.Generic(message: "Unexpected type BackupFailedData")
             }
         }
         return list
@@ -90,7 +90,7 @@ class BreezSDKMapper {
                 var backupStatus = try asBackupStatus(backupStatus: val)
                 list.append(backupStatus)
             } else {
-                throw SdkError.Generic(message: "Invalid element type BackupStatus")
+                throw SdkError.Generic(message: "Unexpected type BackupStatus")
             }
         }
         return list
@@ -135,7 +135,7 @@ class BreezSDKMapper {
                 var bitcoinAddressData = try asBitcoinAddressData(bitcoinAddressData: val)
                 list.append(bitcoinAddressData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type BitcoinAddressData")
+                throw SdkError.Generic(message: "Unexpected type BitcoinAddressData")
             }
         }
         return list
@@ -174,7 +174,7 @@ class BreezSDKMapper {
                 var buyBitcoinRequest = try asBuyBitcoinRequest(buyBitcoinRequest: val)
                 list.append(buyBitcoinRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type BuyBitcoinRequest")
+                throw SdkError.Generic(message: "Unexpected type BuyBitcoinRequest")
             }
         }
         return list
@@ -211,7 +211,7 @@ class BreezSDKMapper {
                 var buyBitcoinResponse = try asBuyBitcoinResponse(buyBitcoinResponse: val)
                 list.append(buyBitcoinResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type BuyBitcoinResponse")
+                throw SdkError.Generic(message: "Unexpected type BuyBitcoinResponse")
             }
         }
         return list
@@ -248,7 +248,7 @@ class BreezSDKMapper {
                 var checkMessageRequest = try asCheckMessageRequest(checkMessageRequest: val)
                 list.append(checkMessageRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type CheckMessageRequest")
+                throw SdkError.Generic(message: "Unexpected type CheckMessageRequest")
             }
         }
         return list
@@ -278,7 +278,7 @@ class BreezSDKMapper {
                 var checkMessageResponse = try asCheckMessageResponse(checkMessageResponse: val)
                 list.append(checkMessageResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type CheckMessageResponse")
+                throw SdkError.Generic(message: "Unexpected type CheckMessageResponse")
             }
         }
         return list
@@ -320,7 +320,7 @@ class BreezSDKMapper {
                 var closedChannelPaymentDetails = try asClosedChannelPaymentDetails(closedChannelPaymentDetails: val)
                 list.append(closedChannelPaymentDetails)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ClosedChannelPaymentDetails")
+                throw SdkError.Generic(message: "Unexpected type ClosedChannelPaymentDetails")
             }
         }
         return list
@@ -381,7 +381,7 @@ class BreezSDKMapper {
                 var config = try asConfig(config: val)
                 list.append(config)
             } else {
-                throw SdkError.Generic(message: "Invalid element type Config")
+                throw SdkError.Generic(message: "Unexpected type Config")
             }
         }
         return list
@@ -445,7 +445,7 @@ class BreezSDKMapper {
                 var currencyInfo = try asCurrencyInfo(currencyInfo: val)
                 list.append(currencyInfo)
             } else {
-                throw SdkError.Generic(message: "Invalid element type CurrencyInfo")
+                throw SdkError.Generic(message: "Unexpected type CurrencyInfo")
             }
         }
         return list
@@ -480,7 +480,7 @@ class BreezSDKMapper {
                 var fiatCurrency = try asFiatCurrency(fiatCurrency: val)
                 list.append(fiatCurrency)
             } else {
-                throw SdkError.Generic(message: "Invalid element type FiatCurrency")
+                throw SdkError.Generic(message: "Unexpected type FiatCurrency")
             }
         }
         return list
@@ -514,7 +514,7 @@ class BreezSDKMapper {
                 var greenlightCredentials = try asGreenlightCredentials(greenlightCredentials: val)
                 list.append(greenlightCredentials)
             } else {
-                throw SdkError.Generic(message: "Invalid element type GreenlightCredentials")
+                throw SdkError.Generic(message: "Unexpected type GreenlightCredentials")
             }
         }
         return list
@@ -552,7 +552,7 @@ class BreezSDKMapper {
                 var greenlightNodeConfig = try asGreenlightNodeConfig(greenlightNodeConfig: val)
                 list.append(greenlightNodeConfig)
             } else {
-                throw SdkError.Generic(message: "Invalid element type GreenlightNodeConfig")
+                throw SdkError.Generic(message: "Unexpected type GreenlightNodeConfig")
             }
         }
         return list
@@ -586,7 +586,7 @@ class BreezSDKMapper {
                 var invoicePaidDetails = try asInvoicePaidDetails(invoicePaidDetails: val)
                 list.append(invoicePaidDetails)
             } else {
-                throw SdkError.Generic(message: "Invalid element type InvoicePaidDetails")
+                throw SdkError.Generic(message: "Unexpected type InvoicePaidDetails")
             }
         }
         return list
@@ -646,7 +646,7 @@ class BreezSDKMapper {
                 var lnInvoice = try asLnInvoice(lnInvoice: val)
                 list.append(lnInvoice)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnInvoice")
+                throw SdkError.Generic(message: "Unexpected type LnInvoice")
             }
         }
         return list
@@ -696,7 +696,7 @@ class BreezSDKMapper {
                 var listPaymentsRequest = try asListPaymentsRequest(listPaymentsRequest: val)
                 list.append(listPaymentsRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ListPaymentsRequest")
+                throw SdkError.Generic(message: "Unexpected type ListPaymentsRequest")
             }
         }
         return list
@@ -758,7 +758,7 @@ class BreezSDKMapper {
                 var lnPaymentDetails = try asLnPaymentDetails(lnPaymentDetails: val)
                 list.append(lnPaymentDetails)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnPaymentDetails")
+                throw SdkError.Generic(message: "Unexpected type LnPaymentDetails")
             }
         }
         return list
@@ -798,7 +798,7 @@ class BreezSDKMapper {
                 var lnUrlAuthRequestData = try asLnUrlAuthRequestData(lnUrlAuthRequestData: val)
                 list.append(lnUrlAuthRequestData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnUrlAuthRequestData")
+                throw SdkError.Generic(message: "Unexpected type LnUrlAuthRequestData")
             }
         }
         return list
@@ -828,7 +828,7 @@ class BreezSDKMapper {
                 var lnUrlErrorData = try asLnUrlErrorData(lnUrlErrorData: val)
                 list.append(lnUrlErrorData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnUrlErrorData")
+                throw SdkError.Generic(message: "Unexpected type LnUrlErrorData")
             }
         }
         return list
@@ -867,7 +867,7 @@ class BreezSDKMapper {
                 var lnUrlPayRequest = try asLnUrlPayRequest(lnUrlPayRequest: val)
                 list.append(lnUrlPayRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnUrlPayRequest")
+                throw SdkError.Generic(message: "Unexpected type LnUrlPayRequest")
             }
         }
         return list
@@ -916,7 +916,7 @@ class BreezSDKMapper {
                 var lnUrlPayRequestData = try asLnUrlPayRequestData(lnUrlPayRequestData: val)
                 list.append(lnUrlPayRequestData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnUrlPayRequestData")
+                throw SdkError.Generic(message: "Unexpected type LnUrlPayRequestData")
             }
         }
         return list
@@ -955,7 +955,7 @@ class BreezSDKMapper {
                 var lnUrlWithdrawRequest = try asLnUrlWithdrawRequest(lnUrlWithdrawRequest: val)
                 list.append(lnUrlWithdrawRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnUrlWithdrawRequest")
+                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawRequest")
             }
         }
         return list
@@ -998,7 +998,7 @@ class BreezSDKMapper {
                 var lnUrlWithdrawRequestData = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: val)
                 list.append(lnUrlWithdrawRequestData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnUrlWithdrawRequestData")
+                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawRequestData")
             }
         }
         return list
@@ -1029,7 +1029,7 @@ class BreezSDKMapper {
                 var lnUrlWithdrawSuccessData = try asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: val)
                 list.append(lnUrlWithdrawSuccessData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LnUrlWithdrawSuccessData")
+                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawSuccessData")
             }
         }
         return list
@@ -1067,7 +1067,7 @@ class BreezSDKMapper {
                 var localeOverrides = try asLocaleOverrides(localeOverrides: val)
                 list.append(localeOverrides)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LocaleOverrides")
+                throw SdkError.Generic(message: "Unexpected type LocaleOverrides")
             }
         }
         return list
@@ -1101,7 +1101,7 @@ class BreezSDKMapper {
                 var localizedName = try asLocalizedName(localizedName: val)
                 list.append(localizedName)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LocalizedName")
+                throw SdkError.Generic(message: "Unexpected type LocalizedName")
             }
         }
         return list
@@ -1135,7 +1135,7 @@ class BreezSDKMapper {
                 var logEntry = try asLogEntry(logEntry: val)
                 list.append(logEntry)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LogEntry")
+                throw SdkError.Generic(message: "Unexpected type LogEntry")
             }
         }
         return list
@@ -1203,7 +1203,7 @@ class BreezSDKMapper {
                 var lspInformation = try asLspInformation(lspInformation: val)
                 list.append(lspInformation)
             } else {
-                throw SdkError.Generic(message: "Invalid element type LspInformation")
+                throw SdkError.Generic(message: "Unexpected type LspInformation")
             }
         }
         return list
@@ -1233,7 +1233,7 @@ class BreezSDKMapper {
                 var messageSuccessActionData = try asMessageSuccessActionData(messageSuccessActionData: val)
                 list.append(messageSuccessActionData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type MessageSuccessActionData")
+                throw SdkError.Generic(message: "Unexpected type MessageSuccessActionData")
             }
         }
         return list
@@ -1267,7 +1267,7 @@ class BreezSDKMapper {
                 var metadataItem = try asMetadataItem(metadataItem: val)
                 list.append(metadataItem)
             } else {
-                throw SdkError.Generic(message: "Invalid element type MetadataItem")
+                throw SdkError.Generic(message: "Unexpected type MetadataItem")
             }
         }
         return list
@@ -1330,7 +1330,7 @@ class BreezSDKMapper {
                 var nodeState = try asNodeState(nodeState: val)
                 list.append(nodeState)
             } else {
-                throw SdkError.Generic(message: "Invalid element type NodeState")
+                throw SdkError.Generic(message: "Unexpected type NodeState")
             }
         }
         return list
@@ -1364,7 +1364,7 @@ class BreezSDKMapper {
                 var openChannelFeeRequest = try asOpenChannelFeeRequest(openChannelFeeRequest: val)
                 list.append(openChannelFeeRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type OpenChannelFeeRequest")
+                throw SdkError.Generic(message: "Unexpected type OpenChannelFeeRequest")
             }
         }
         return list
@@ -1401,7 +1401,7 @@ class BreezSDKMapper {
                 var openChannelFeeResponse = try asOpenChannelFeeResponse(openChannelFeeResponse: val)
                 list.append(openChannelFeeResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type OpenChannelFeeResponse")
+                throw SdkError.Generic(message: "Unexpected type OpenChannelFeeResponse")
             }
         }
         return list
@@ -1447,7 +1447,7 @@ class BreezSDKMapper {
                 var openingFeeParams = try asOpeningFeeParams(openingFeeParams: val)
                 list.append(openingFeeParams)
             } else {
-                throw SdkError.Generic(message: "Invalid element type OpeningFeeParams")
+                throw SdkError.Generic(message: "Unexpected type OpeningFeeParams")
             }
         }
         return list
@@ -1478,7 +1478,7 @@ class BreezSDKMapper {
                 var openingFeeParamsMenu = try asOpeningFeeParamsMenu(openingFeeParamsMenu: val)
                 list.append(openingFeeParamsMenu)
             } else {
-                throw SdkError.Generic(message: "Invalid element type OpeningFeeParamsMenu")
+                throw SdkError.Generic(message: "Unexpected type OpeningFeeParamsMenu")
             }
         }
         return list
@@ -1535,7 +1535,7 @@ class BreezSDKMapper {
                 var payment = try asPayment(payment: val)
                 list.append(payment)
             } else {
-                throw SdkError.Generic(message: "Invalid element type Payment")
+                throw SdkError.Generic(message: "Unexpected type Payment")
             }
         }
         return list
@@ -1575,7 +1575,7 @@ class BreezSDKMapper {
                 var paymentFailedData = try asPaymentFailedData(paymentFailedData: val)
                 list.append(paymentFailedData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type PaymentFailedData")
+                throw SdkError.Generic(message: "Unexpected type PaymentFailedData")
             }
         }
         return list
@@ -1612,7 +1612,7 @@ class BreezSDKMapper {
                 var prepareRefundRequest = try asPrepareRefundRequest(prepareRefundRequest: val)
                 list.append(prepareRefundRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type PrepareRefundRequest")
+                throw SdkError.Generic(message: "Unexpected type PrepareRefundRequest")
             }
         }
         return list
@@ -1646,7 +1646,7 @@ class BreezSDKMapper {
                 var prepareRefundResponse = try asPrepareRefundResponse(prepareRefundResponse: val)
                 list.append(prepareRefundResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type PrepareRefundResponse")
+                throw SdkError.Generic(message: "Unexpected type PrepareRefundResponse")
             }
         }
         return list
@@ -1680,7 +1680,7 @@ class BreezSDKMapper {
                 var prepareSweepRequest = try asPrepareSweepRequest(prepareSweepRequest: val)
                 list.append(prepareSweepRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type PrepareSweepRequest")
+                throw SdkError.Generic(message: "Unexpected type PrepareSweepRequest")
             }
         }
         return list
@@ -1714,7 +1714,7 @@ class BreezSDKMapper {
                 var prepareSweepResponse = try asPrepareSweepResponse(prepareSweepResponse: val)
                 list.append(prepareSweepResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type PrepareSweepResponse")
+                throw SdkError.Generic(message: "Unexpected type PrepareSweepResponse")
             }
         }
         return list
@@ -1748,7 +1748,7 @@ class BreezSDKMapper {
                 var rate = try asRate(rate: val)
                 list.append(rate)
             } else {
-                throw SdkError.Generic(message: "Invalid element type Rate")
+                throw SdkError.Generic(message: "Unexpected type Rate")
             }
         }
         return list
@@ -1781,7 +1781,7 @@ class BreezSDKMapper {
                 var receiveOnchainRequest = try asReceiveOnchainRequest(receiveOnchainRequest: val)
                 list.append(receiveOnchainRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ReceiveOnchainRequest")
+                throw SdkError.Generic(message: "Unexpected type ReceiveOnchainRequest")
             }
         }
         return list
@@ -1834,7 +1834,7 @@ class BreezSDKMapper {
                 var receivePaymentRequest = try asReceivePaymentRequest(receivePaymentRequest: val)
                 list.append(receivePaymentRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ReceivePaymentRequest")
+                throw SdkError.Generic(message: "Unexpected type ReceivePaymentRequest")
             }
         }
         return list
@@ -1877,7 +1877,7 @@ class BreezSDKMapper {
                 var receivePaymentResponse = try asReceivePaymentResponse(receivePaymentResponse: val)
                 list.append(receivePaymentResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ReceivePaymentResponse")
+                throw SdkError.Generic(message: "Unexpected type ReceivePaymentResponse")
             }
         }
         return list
@@ -1920,7 +1920,7 @@ class BreezSDKMapper {
                 var recommendedFees = try asRecommendedFees(recommendedFees: val)
                 list.append(recommendedFees)
             } else {
-                throw SdkError.Generic(message: "Invalid element type RecommendedFees")
+                throw SdkError.Generic(message: "Unexpected type RecommendedFees")
             }
         }
         return list
@@ -1957,7 +1957,7 @@ class BreezSDKMapper {
                 var refundRequest = try asRefundRequest(refundRequest: val)
                 list.append(refundRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type RefundRequest")
+                throw SdkError.Generic(message: "Unexpected type RefundRequest")
             }
         }
         return list
@@ -1987,7 +1987,7 @@ class BreezSDKMapper {
                 var refundResponse = try asRefundResponse(refundResponse: val)
                 list.append(refundResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type RefundResponse")
+                throw SdkError.Generic(message: "Unexpected type RefundResponse")
             }
         }
         return list
@@ -2017,7 +2017,7 @@ class BreezSDKMapper {
                 var reverseSwapFeesRequest = try asReverseSwapFeesRequest(reverseSwapFeesRequest: val)
                 list.append(reverseSwapFeesRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ReverseSwapFeesRequest")
+                throw SdkError.Generic(message: "Unexpected type ReverseSwapFeesRequest")
             }
         }
         return list
@@ -2064,7 +2064,7 @@ class BreezSDKMapper {
                 var reverseSwapInfo = try asReverseSwapInfo(reverseSwapInfo: val)
                 list.append(reverseSwapInfo)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ReverseSwapInfo")
+                throw SdkError.Generic(message: "Unexpected type ReverseSwapInfo")
             }
         }
         return list
@@ -2113,7 +2113,7 @@ class BreezSDKMapper {
                 var reverseSwapPairInfo = try asReverseSwapPairInfo(reverseSwapPairInfo: val)
                 list.append(reverseSwapPairInfo)
             } else {
-                throw SdkError.Generic(message: "Invalid element type ReverseSwapPairInfo")
+                throw SdkError.Generic(message: "Unexpected type ReverseSwapPairInfo")
             }
         }
         return list
@@ -2144,7 +2144,7 @@ class BreezSDKMapper {
                 var routeHint = try asRouteHint(routeHint: val)
                 list.append(routeHint)
             } else {
-                throw SdkError.Generic(message: "Invalid element type RouteHint")
+                throw SdkError.Generic(message: "Unexpected type RouteHint")
             }
         }
         return list
@@ -2193,7 +2193,7 @@ class BreezSDKMapper {
                 var routeHintHop = try asRouteHintHop(routeHintHop: val)
                 list.append(routeHintHop)
             } else {
-                throw SdkError.Generic(message: "Invalid element type RouteHintHop")
+                throw SdkError.Generic(message: "Unexpected type RouteHintHop")
             }
         }
         return list
@@ -2233,7 +2233,7 @@ class BreezSDKMapper {
                 var sendOnchainRequest = try asSendOnchainRequest(sendOnchainRequest: val)
                 list.append(sendOnchainRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SendOnchainRequest")
+                throw SdkError.Generic(message: "Unexpected type SendOnchainRequest")
             }
         }
         return list
@@ -2264,7 +2264,7 @@ class BreezSDKMapper {
                 var sendOnchainResponse = try asSendOnchainResponse(sendOnchainResponse: val)
                 list.append(sendOnchainResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SendOnchainResponse")
+                throw SdkError.Generic(message: "Unexpected type SendOnchainResponse")
             }
         }
         return list
@@ -2298,7 +2298,7 @@ class BreezSDKMapper {
                 var sendPaymentRequest = try asSendPaymentRequest(sendPaymentRequest: val)
                 list.append(sendPaymentRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SendPaymentRequest")
+                throw SdkError.Generic(message: "Unexpected type SendPaymentRequest")
             }
         }
         return list
@@ -2329,7 +2329,7 @@ class BreezSDKMapper {
                 var sendPaymentResponse = try asSendPaymentResponse(sendPaymentResponse: val)
                 list.append(sendPaymentResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SendPaymentResponse")
+                throw SdkError.Generic(message: "Unexpected type SendPaymentResponse")
             }
         }
         return list
@@ -2363,7 +2363,7 @@ class BreezSDKMapper {
                 var sendSpontaneousPaymentRequest = try asSendSpontaneousPaymentRequest(sendSpontaneousPaymentRequest: val)
                 list.append(sendSpontaneousPaymentRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SendSpontaneousPaymentRequest")
+                throw SdkError.Generic(message: "Unexpected type SendSpontaneousPaymentRequest")
             }
         }
         return list
@@ -2393,7 +2393,7 @@ class BreezSDKMapper {
                 var signMessageRequest = try asSignMessageRequest(signMessageRequest: val)
                 list.append(signMessageRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SignMessageRequest")
+                throw SdkError.Generic(message: "Unexpected type SignMessageRequest")
             }
         }
         return list
@@ -2423,7 +2423,7 @@ class BreezSDKMapper {
                 var signMessageResponse = try asSignMessageResponse(signMessageResponse: val)
                 list.append(signMessageResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SignMessageResponse")
+                throw SdkError.Generic(message: "Unexpected type SignMessageResponse")
             }
         }
         return list
@@ -2453,7 +2453,7 @@ class BreezSDKMapper {
                 var staticBackupRequest = try asStaticBackupRequest(staticBackupRequest: val)
                 list.append(staticBackupRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type StaticBackupRequest")
+                throw SdkError.Generic(message: "Unexpected type StaticBackupRequest")
             }
         }
         return list
@@ -2483,7 +2483,7 @@ class BreezSDKMapper {
                 var staticBackupResponse = try asStaticBackupResponse(staticBackupResponse: val)
                 list.append(staticBackupResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type StaticBackupResponse")
+                throw SdkError.Generic(message: "Unexpected type StaticBackupResponse")
             }
         }
         return list
@@ -2579,7 +2579,7 @@ class BreezSDKMapper {
                 var swapInfo = try asSwapInfo(swapInfo: val)
                 list.append(swapInfo)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SwapInfo")
+                throw SdkError.Generic(message: "Unexpected type SwapInfo")
             }
         }
         return list
@@ -2613,7 +2613,7 @@ class BreezSDKMapper {
                 var sweepRequest = try asSweepRequest(sweepRequest: val)
                 list.append(sweepRequest)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SweepRequest")
+                throw SdkError.Generic(message: "Unexpected type SweepRequest")
             }
         }
         return list
@@ -2643,7 +2643,7 @@ class BreezSDKMapper {
                 var sweepResponse = try asSweepResponse(sweepResponse: val)
                 list.append(sweepResponse)
             } else {
-                throw SdkError.Generic(message: "Invalid element type SweepResponse")
+                throw SdkError.Generic(message: "Unexpected type SweepResponse")
             }
         }
         return list
@@ -2683,7 +2683,7 @@ class BreezSDKMapper {
                 var symbol = try asSymbol(symbol: val)
                 list.append(symbol)
             } else {
-                throw SdkError.Generic(message: "Invalid element type Symbol")
+                throw SdkError.Generic(message: "Unexpected type Symbol")
             }
         }
         return list
@@ -2726,7 +2726,7 @@ class BreezSDKMapper {
                 var unspentTransactionOutput = try asUnspentTransactionOutput(unspentTransactionOutput: val)
                 list.append(unspentTransactionOutput)
             } else {
-                throw SdkError.Generic(message: "Invalid element type UnspentTransactionOutput")
+                throw SdkError.Generic(message: "Unexpected type UnspentTransactionOutput")
             }
         }
         return list
@@ -2760,7 +2760,7 @@ class BreezSDKMapper {
                 var urlSuccessActionData = try asUrlSuccessActionData(urlSuccessActionData: val)
                 list.append(urlSuccessActionData)
             } else {
-                throw SdkError.Generic(message: "Invalid element type UrlSuccessActionData")
+                throw SdkError.Generic(message: "Unexpected type UrlSuccessActionData")
             }
         }
         return list
@@ -2810,7 +2810,7 @@ class BreezSDKMapper {
             return BreezEvent.backupFailed(details: _details)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum BreezEvent")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum BreezEvent")
     }
 
     static func dictionaryOf(breezEvent: BreezEvent) -> [String: Any?] {
@@ -2883,7 +2883,7 @@ class BreezSDKMapper {
                 var breezEvent = try asBreezEvent(breezEvent: val)
                 list.append(breezEvent)
             } else {
-                throw NSError(domain: "Unexpected type BreezEvent", code: 0)
+                throw SdkError.Generic(message: "Unexpected type BreezEvent")
             }
         }
         return list
@@ -2916,7 +2916,7 @@ class BreezSDKMapper {
                 var buyBitcoinProvider = try asBuyBitcoinProvider(buyBitcoinProvider: val)
                 list.append(buyBitcoinProvider)
             } else {
-                throw NSError(domain: "Unexpected type BuyBitcoinProvider", code: 0)
+                throw SdkError.Generic(message: "Unexpected type BuyBitcoinProvider")
             }
         }
         return list
@@ -2967,7 +2967,7 @@ class BreezSDKMapper {
                 var channelState = try asChannelState(channelState: val)
                 list.append(channelState)
             } else {
-                throw NSError(domain: "Unexpected type ChannelState", code: 0)
+                throw SdkError.Generic(message: "Unexpected type ChannelState")
             }
         }
         return list
@@ -3006,7 +3006,7 @@ class BreezSDKMapper {
                 var environmentType = try asEnvironmentType(environmentType: val)
                 list.append(environmentType)
             } else {
-                throw NSError(domain: "Unexpected type EnvironmentType", code: 0)
+                throw SdkError.Generic(message: "Unexpected type EnvironmentType")
             }
         }
         return list
@@ -3051,7 +3051,7 @@ class BreezSDKMapper {
                 var feeratePreset = try asFeeratePreset(feeratePreset: val)
                 list.append(feeratePreset)
             } else {
-                throw NSError(domain: "Unexpected type FeeratePreset", code: 0)
+                throw SdkError.Generic(message: "Unexpected type FeeratePreset")
             }
         }
         return list
@@ -3104,7 +3104,7 @@ class BreezSDKMapper {
             return InputType.lnUrlError(data: _data)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum InputType")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum InputType")
     }
 
     static func dictionaryOf(inputType: InputType) -> [String: Any?] {
@@ -3186,7 +3186,7 @@ class BreezSDKMapper {
                 var inputType = try asInputType(inputType: val)
                 list.append(inputType)
             } else {
-                throw NSError(domain: "Unexpected type InputType", code: 0)
+                throw SdkError.Generic(message: "Unexpected type InputType")
             }
         }
         return list
@@ -3204,7 +3204,7 @@ class BreezSDKMapper {
             return LnUrlCallbackStatus.errorStatus(data: _data)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum LnUrlCallbackStatus")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlCallbackStatus")
     }
 
     static func dictionaryOf(lnUrlCallbackStatus: LnUrlCallbackStatus) -> [String: Any?] {
@@ -3235,7 +3235,7 @@ class BreezSDKMapper {
                 var lnUrlCallbackStatus = try asLnUrlCallbackStatus(lnUrlCallbackStatus: val)
                 list.append(lnUrlCallbackStatus)
             } else {
-                throw NSError(domain: "Unexpected type LnUrlCallbackStatus", code: 0)
+                throw SdkError.Generic(message: "Unexpected type LnUrlCallbackStatus")
             }
         }
         return list
@@ -3258,7 +3258,7 @@ class BreezSDKMapper {
             return LnUrlPayResult.endpointError(data: _data)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum LnUrlPayResult")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlPayResult")
     }
 
     static func dictionaryOf(lnUrlPayResult: LnUrlPayResult) -> [String: Any?] {
@@ -3292,7 +3292,7 @@ class BreezSDKMapper {
                 var lnUrlPayResult = try asLnUrlPayResult(lnUrlPayResult: val)
                 list.append(lnUrlPayResult)
             } else {
-                throw NSError(domain: "Unexpected type LnUrlPayResult", code: 0)
+                throw SdkError.Generic(message: "Unexpected type LnUrlPayResult")
             }
         }
         return list
@@ -3313,7 +3313,7 @@ class BreezSDKMapper {
             return LnUrlWithdrawResult.errorStatus(data: _data)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum LnUrlWithdrawResult")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlWithdrawResult")
     }
 
     static func dictionaryOf(lnUrlWithdrawResult: LnUrlWithdrawResult) -> [String: Any?] {
@@ -3347,7 +3347,7 @@ class BreezSDKMapper {
                 var lnUrlWithdrawResult = try asLnUrlWithdrawResult(lnUrlWithdrawResult: val)
                 list.append(lnUrlWithdrawResult)
             } else {
-                throw NSError(domain: "Unexpected type LnUrlWithdrawResult", code: 0)
+                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawResult")
             }
         }
         return list
@@ -3398,7 +3398,7 @@ class BreezSDKMapper {
                 var network = try asNetwork(network: val)
                 list.append(network)
             } else {
-                throw NSError(domain: "Unexpected type Network", code: 0)
+                throw SdkError.Generic(message: "Unexpected type Network")
             }
         }
         return list
@@ -3413,7 +3413,7 @@ class BreezSDKMapper {
             return NodeConfig.greenlight(config: _config)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum NodeConfig")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum NodeConfig")
     }
 
     static func dictionaryOf(nodeConfig: NodeConfig) -> [String: Any?] {
@@ -3439,7 +3439,7 @@ class BreezSDKMapper {
                 var nodeConfig = try asNodeConfig(nodeConfig: val)
                 list.append(nodeConfig)
             } else {
-                throw NSError(domain: "Unexpected type NodeConfig", code: 0)
+                throw SdkError.Generic(message: "Unexpected type NodeConfig")
             }
         }
         return list
@@ -3460,7 +3460,7 @@ class BreezSDKMapper {
             return PaymentDetails.closedChannel(data: _data)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum PaymentDetails")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
     }
 
     static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {
@@ -3494,7 +3494,7 @@ class BreezSDKMapper {
                 var paymentDetails = try asPaymentDetails(paymentDetails: val)
                 list.append(paymentDetails)
             } else {
-                throw NSError(domain: "Unexpected type PaymentDetails", code: 0)
+                throw SdkError.Generic(message: "Unexpected type PaymentDetails")
             }
         }
         return list
@@ -3539,7 +3539,7 @@ class BreezSDKMapper {
                 var paymentStatus = try asPaymentStatus(paymentStatus: val)
                 list.append(paymentStatus)
             } else {
-                throw NSError(domain: "Unexpected type PaymentStatus", code: 0)
+                throw SdkError.Generic(message: "Unexpected type PaymentStatus")
             }
         }
         return list
@@ -3584,7 +3584,7 @@ class BreezSDKMapper {
                 var paymentType = try asPaymentType(paymentType: val)
                 list.append(paymentType)
             } else {
-                throw NSError(domain: "Unexpected type PaymentType", code: 0)
+                throw SdkError.Generic(message: "Unexpected type PaymentType")
             }
         }
         return list
@@ -3629,7 +3629,7 @@ class BreezSDKMapper {
                 var paymentTypeFilter = try asPaymentTypeFilter(paymentTypeFilter: val)
                 list.append(paymentTypeFilter)
             } else {
-                throw NSError(domain: "Unexpected type PaymentTypeFilter", code: 0)
+                throw SdkError.Generic(message: "Unexpected type PaymentTypeFilter")
             }
         }
         return list
@@ -3686,7 +3686,7 @@ class BreezSDKMapper {
                 var reverseSwapStatus = try asReverseSwapStatus(reverseSwapStatus: val)
                 list.append(reverseSwapStatus)
             } else {
-                throw NSError(domain: "Unexpected type ReverseSwapStatus", code: 0)
+                throw SdkError.Generic(message: "Unexpected type ReverseSwapStatus")
             }
         }
         return list
@@ -3713,7 +3713,7 @@ class BreezSDKMapper {
             return SuccessActionProcessed.url(data: _data)
         }
 
-        throw SdkError.Generic(message: "Invalid enum variant \(type) for enum SuccessActionProcessed")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum SuccessActionProcessed")
     }
 
     static func dictionaryOf(successActionProcessed: SuccessActionProcessed) -> [String: Any?] {
@@ -3755,7 +3755,7 @@ class BreezSDKMapper {
                 var successActionProcessed = try asSuccessActionProcessed(successActionProcessed: val)
                 list.append(successActionProcessed)
             } else {
-                throw NSError(domain: "Unexpected type SuccessActionProcessed", code: 0)
+                throw SdkError.Generic(message: "Unexpected type SuccessActionProcessed")
             }
         }
         return list
@@ -3794,7 +3794,7 @@ class BreezSDKMapper {
                 var swapStatus = try asSwapStatus(swapStatus: val)
                 list.append(swapStatus)
             } else {
-                throw NSError(domain: "Unexpected type SwapStatus", code: 0)
+                throw SdkError.Generic(message: "Unexpected type SwapStatus")
             }
         }
         return list

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -107,7 +107,7 @@ class RNBreezSDK: RCTEventEmitter {
     @objc(connect:seed:resolve:reject:)
     func connect(_ config: [String: Any], seed: [UInt8], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         if breezServices != nil {
-            reject(RNBreezSDK.TAG, "BreezServices already initialized", nil)
+            reject("Generic", "BreezServices already initialized", nil)
             return
         }
 
@@ -525,15 +525,14 @@ class RNBreezSDK: RCTEventEmitter {
     }
 
     func rejectErr(err: Error, reject: @escaping RCTPromiseRejectBlock) {
-        var errorCode = "Generic"
+        var errorName = "Generic"
         var message = "\(err)"
-        if let sdkErr = err as? SdkError {
-            if let sdkErrAssociated = Mirror(reflecting: sdkErr).children.first {
-                if let associatedMessage = Mirror(reflecting: sdkErrAssociated.value).children.first {
-                    message = associatedMessage.value as! String
-                }
+        if let errAssociated = Mirror(reflecting: err).children.first {
+            errorName = errAssociated.label ?? errorName
+            if let associatedMessage = Mirror(reflecting: errAssociated.value).children.first {
+                message = associatedMessage.value as! String
             }
         }
-        reject(errorCode, message, err)
+        reject(errorName, message, err)
     }
 }

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -50,7 +50,7 @@ async fn connect(config: Config, seed: &[u8]) -> Result<()> {
 
     BREEZ_SERVICES
         .set(service)
-        .map_err(|_| anyhow!("Failed to set Breez Service"))?;
+        .map_err(|_| anyhow!("Breez Services already initialized"))?;
 
     Ok(())
 }


### PR DESCRIPTION
Structures the code in such a way as an error enum can be constructed per SDK interface method that needs one.

Accompanying PRs:
- [x] breez/breez-sdk-rn-generator#9
- [x] ~update c-breez error handling~

```
Err(SendPaymentError::AlreadyPaid)
```

Fixes #459 