### PR TITLE
Lsps0 implementation

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "thiserror",
  "tiny-bip39",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
  "zbase32",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -60,6 +60,7 @@ tempfile = "3"
 thiserror = "1"
 const_format = "0.2"
 miniz_oxide = "0.7.1"
+tokio-stream = "0.1.14"
 
 [dev-dependencies]
 mockito = "1"

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -176,6 +176,7 @@ pub mod input_parser;
 mod invoice;
 mod lnurl;
 mod lsp;
+mod lsps0;
 mod models;
 mod moonpay;
 mod persist;

--- a/libs/sdk-core/src/lsps0/client.rs
+++ b/libs/sdk-core/src/lsps0/client.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::mpsc;
+
+use super::{error::Error, transport::Transport};
+
+#[derive(Debug, Serialize)]
+pub struct ListProtocolsRequest {}
+
+#[derive(Debug, Deserialize)]
+pub struct ListProtocolsResponse {
+    pub protocols: Vec<i32>,
+}
+
+pub struct Client {
+    transport: Arc<Transport>,
+    peer_id: Vec<u8>,
+    timeout: Duration,
+}
+
+impl Client {
+    #[allow(dead_code)]
+    pub fn new(transport: Arc<Transport>, peer_id: Vec<u8>, timeout: Duration) -> Self {
+        Self {
+            transport,
+            peer_id,
+            timeout,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn call<TRequest, TResponse>(
+        &self,
+        method: String,
+        req: TRequest,
+    ) -> Result<TResponse, Error>
+    where
+        TRequest: serde::Serialize,
+        TResponse: serde::de::DeserializeOwned,
+    {
+        self.transport
+            .request_response(method, self.peer_id.clone(), &req, self.timeout)
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn stream_notifications<TNotification>(
+        &self,
+        method: String,
+    ) -> Result<mpsc::Receiver<TNotification>, Error>
+    where
+        TNotification: serde::de::DeserializeOwned + std::marker::Send + 'static,
+    {
+        self.transport
+            .stream_notifications(method, self.peer_id.clone())
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn list_protocols(&self) -> Result<ListProtocolsResponse, Error> {
+        self.call(
+            String::from("lsps0.list_protocols"),
+            ListProtocolsRequest {},
+        )
+        .await
+    }
+}

--- a/libs/sdk-core/src/lsps0/error.rs
+++ b/libs/sdk-core/src/lsps0/error.rs
@@ -1,0 +1,42 @@
+use anyhow::anyhow;
+
+use super::jsonrpc::RpcError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Local lsps0 error: {0}")]
+    Local(anyhow::Error),
+
+    #[error("Lsps0 deserialization error: {0}")]
+    Deserialization(serde_json::Error),
+
+    #[error("Lsps0 request timed out")]
+    Timeout,
+
+    #[error("Lsps0 remote error: {0:?}")]
+    Remote(RpcError),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Local(value)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Deserialization(value)
+    }
+}
+
+impl From<tokio::sync::oneshot::error::RecvError> for Error {
+    fn from(_value: tokio::sync::oneshot::error::RecvError) -> Self {
+        Self::Local(anyhow!("server lost"))
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(_value: tokio::time::error::Elapsed) -> Self {
+        Self::Timeout
+    }
+}

--- a/libs/sdk-core/src/lsps0/jsonrpc.rs
+++ b/libs/sdk-core/src/lsps0/jsonrpc.rs
@@ -1,0 +1,75 @@
+extern crate serde;
+extern crate serde_json;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcServerMessage {
+    pub jsonrpc: String,
+
+    #[serde(flatten)]
+    pub body: RpcServerMessageBody,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RpcServerMessageBody {
+    Notification { method: String, params: Value },
+    Response { id: String, result: Value },
+    Error { id: String, error: RpcError },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcRequest<TParams> {
+    pub id: String,
+    pub jsonrpc: String,
+    pub method: String,
+    pub params: TParams,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcError {
+    pub code: i64,
+    pub message: String,
+    pub data: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lsps0::jsonrpc::{RpcServerMessage, RpcServerMessageBody};
+
+    #[test]
+    fn test_deserialize_notification() {
+        let json = r#"{"jsonrpc":"2.0","method":"test","params":{}}"#;
+        let notification = serde_json::from_str::<RpcServerMessage>(json).unwrap();
+        assert!(matches!(
+            notification.body,
+            RpcServerMessageBody::Notification { .. }
+        ))
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let json = r#"{"jsonrpc":"2.0","id":"test","result":{}}"#;
+        let notification = serde_json::from_str::<RpcServerMessage>(json).unwrap();
+        assert!(matches!(
+            notification.body,
+            RpcServerMessageBody::Response { .. }
+        ))
+    }
+
+    #[test]
+    fn test_deserialize_error() {
+        let json = r#"{"jsonrpc":"2.0","id":"test","error":{"code":1,"message":"test","data":{}}}"#;
+        let error = serde_json::from_str::<RpcServerMessage>(json).unwrap();
+        assert!(matches!(error.body, RpcServerMessageBody::Error { .. }))
+    }
+
+    #[test]
+    fn test_deserialize_error_without_data() {
+        let json = r#"{"jsonrpc":"2.0","id":"test","error":{"code":1,"message":"test"}}"#;
+        let error = serde_json::from_str::<RpcServerMessage>(json).unwrap();
+        assert!(matches!(error.body, RpcServerMessageBody::Error { .. }))
+    }
+}

--- a/libs/sdk-core/src/lsps0/mod.rs
+++ b/libs/sdk-core/src/lsps0/mod.rs
@@ -1,0 +1,9 @@
+pub(crate) mod error;
+pub(crate) mod jsonrpc;
+pub(crate) mod transport;
+
+#[allow(unused_imports)]
+pub(crate) use transport::Transport;
+
+#[allow(unused_imports)]
+pub(crate) use error::Error;

--- a/libs/sdk-core/src/lsps0/mod.rs
+++ b/libs/sdk-core/src/lsps0/mod.rs
@@ -1,6 +1,10 @@
+pub(crate) mod client;
 pub(crate) mod error;
 pub(crate) mod jsonrpc;
 pub(crate) mod transport;
+
+#[allow(unused_imports)]
+pub(crate) use client::Client;
 
 #[allow(unused_imports)]
 pub(crate) use transport::Transport;

--- a/libs/sdk-core/src/lsps0/transport.rs
+++ b/libs/sdk-core/src/lsps0/transport.rs
@@ -1,0 +1,748 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::CustomMessage;
+use crate::NodeAPI;
+use anyhow::{anyhow, Result};
+use rand::distributions::Alphanumeric;
+use rand::distributions::DistString;
+use serde::de::DeserializeOwned;
+use tokio::sync::watch;
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
+use tokio::time::sleep;
+use tokio_stream::StreamExt;
+
+use super::error::Error;
+use super::jsonrpc::RpcServerMessageBody;
+use super::jsonrpc::{RpcError, RpcRequest, RpcServerMessage};
+
+const LSPS0_MESSAGE_TYPE: u16 = 37913;
+const JSONRPC_VERSION: &str = "2.0";
+
+#[tonic::async_trait]
+trait NotificationSender: Send + Sync {
+    async fn send(&self, params: serde_json::Value) -> Result<(), Error>;
+}
+struct NotificationHandler<TNotification>
+where
+    TNotification: DeserializeOwned + Send,
+{
+    tx: mpsc::Sender<TNotification>,
+}
+
+#[tonic::async_trait]
+impl<TNotification> NotificationSender for NotificationHandler<TNotification>
+where
+    TNotification: DeserializeOwned + Send,
+{
+    async fn send(&self, params: serde_json::Value) -> Result<(), Error> {
+        let n = match serde_json::from_value::<TNotification>(params) {
+            Ok(n) => n,
+            Err(e) => return Err(Error::Deserialization(e)),
+        };
+
+        match self.tx.send(n).await {
+            Ok(_) => Ok(()),
+            Err(_) => Err(Error::Local(anyhow!("receiver dropped"))),
+        }
+    }
+}
+
+struct ResponseOrError {
+    response: Option<serde_json::Value>,
+    error: Option<RpcError>,
+}
+
+/// Transport sends and receives LSPS0 messages to/from remote nodes. One
+/// user node has one Transport.
+pub struct Transport {
+    node: Arc<dyn NodeAPI>,
+    reconnect_interval: Duration,
+    response_handlers: Mutex<HashMap<String, oneshot::Sender<ResponseOrError>>>,
+    notification_handlers: RwLock<HashMap<String, Box<dyn NotificationSender>>>,
+}
+
+impl Transport {
+    #[allow(dead_code)]
+    pub fn new(node: Arc<dyn NodeAPI>) -> Transport {
+        Transport {
+            node,
+            response_handlers: Mutex::new(HashMap::new()),
+            notification_handlers: RwLock::new(HashMap::new()),
+            reconnect_interval: Duration::from_secs(1),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn start(self: &Arc<Transport>, cancel: watch::Receiver<()>) {
+        debug!("starting lsps0 transport.");
+        let cloned = self.clone();
+        tokio::spawn(async move {
+            loop {
+                let mut cancel = cancel.clone();
+                if cancel.has_changed().map_or(true, |c| c) {
+                    return;
+                }
+
+                debug!("lsps0 transport connecting to custom message stream.");
+                let mut stream = match cloned.node.stream_custom_messages().await {
+                    Ok(s) => s,
+                    Err(err) => {
+                        warn!(
+                            "lsps0 transport failed to connect to custom message stream: {}. Retrying in {:?}", 
+                            err,
+                            cloned.reconnect_interval);
+                        break;
+                    }
+                };
+                loop {
+                    tokio::select! {
+                        _ = cancel.changed() => {
+                            debug!("lsps0 tranport cancelled.");
+                            return;
+                        }
+                        msg = stream.next() => {
+                            let msg = match msg {
+                                Some(msg) => match msg {
+                                    Ok(msg) => msg,
+                                    Err(e) => {
+                                        warn!("connection to custom message stream errored: {}", e);
+                                        break;
+                                    }
+                                },
+                                None => {
+                                    warn!("connection to custom message stream dropped");
+                                    break
+                                }
+                            };
+
+                            cloned.handle_message(msg).await;
+                        }
+                    }
+                }
+
+                sleep(cloned.reconnect_interval).await;
+            }
+        });
+    }
+
+    async fn handle_message(&self, msg: CustomMessage) {
+        if msg.message_type != LSPS0_MESSAGE_TYPE {
+            debug!("received custom message that was not lsps0: {:?}", msg);
+            return;
+        }
+
+        let v: RpcServerMessage = match serde_json::from_slice(&msg.payload) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    "error deserializing lsps0 payload {:?}: {}",
+                    &msg.payload, e
+                );
+                return;
+            }
+        };
+
+        if v.jsonrpc != JSONRPC_VERSION {
+            warn!(
+                "error deserializing lsps0 payload {:?}: Invalid jsonrpc version. Expected {:?}.",
+                &msg.payload, JSONRPC_VERSION
+            );
+            return;
+        }
+
+        match v.body {
+            RpcServerMessageBody::Notification { method, params } => {
+                let id = get_notification_handler_id(&method, msg.peer_id.clone());
+                if let Some(tx) = (*self.notification_handlers.read().await).get(&id) {
+                    match tx.send(params).await {
+                        Ok(_) => (),
+                        Err(e) => match e {
+                            Error::Deserialization(e) => {
+                                // TODO: Drop connection to LSP?
+                                warn!(
+                                    "LSPS0: Got invalid notification {:?} for id {}: {}",
+                                    msg, id, e
+                                );
+                            }
+                            _ => {
+                                debug!("LSPS0: Notification listener dropped for id {}", id);
+                                let mut notification_handlers =
+                                    self.notification_handlers.write().await;
+                                (*notification_handlers).remove(&id);
+                            }
+                        },
+                    }
+                } else {
+                    info!(
+                        "LSPS0: got notification without listener: method: {}, params: {:?}",
+                        method, params
+                    );
+                }
+            }
+            RpcServerMessageBody::Response { id, result } => {
+                let handler_id = get_request_handler_id(&id, msg.peer_id);
+                if let Some(tx) = (*self.response_handlers.lock().await).remove(&handler_id) {
+                    if tx
+                        .send(ResponseOrError {
+                            response: Some(result),
+                            error: None,
+                        })
+                        .is_err()
+                    {
+                        debug!("LSPS0: got response, but listener dropped");
+                    }
+                } else {
+                    debug!(
+                        "LSPS0: got response without listener: id: {}, result: {:?}",
+                        id, result
+                    );
+                }
+            }
+            RpcServerMessageBody::Error { id, error } => {
+                let handler_id = get_request_handler_id(&id, msg.peer_id);
+                if let Some(tx) = (*self.response_handlers.lock().await).remove(&handler_id) {
+                    if tx
+                        .send(ResponseOrError {
+                            response: None,
+                            error: Some(error),
+                        })
+                        .is_err()
+                    {
+                        debug!("LSPS0: got error response, but listener dropped");
+                    }
+                } else {
+                    debug!(
+                        "LSPS0: got error without listener: id: {}, error: {:?}",
+                        id, error
+                    );
+                }
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn request_response<TRequest, TResponse>(
+        &self,
+        method: String,
+        peer_id: Vec<u8>,
+        req: &TRequest,
+        timeout: Duration,
+    ) -> Result<TResponse, Error>
+    where
+        TRequest: serde::Serialize,
+        TResponse: serde::de::DeserializeOwned,
+    {
+        let request_id = generate_request_id();
+        let wrapped_req = RpcRequest {
+            id: request_id.clone(),
+            jsonrpc: String::from(JSONRPC_VERSION),
+            method,
+            params: req,
+        };
+        let payload = serde_json::to_vec(&wrapped_req)?;
+        let (tx, rx) = oneshot::channel();
+        let handler_id = get_request_handler_id(&request_id, peer_id.clone());
+        (*self.response_handlers.lock().await).insert(handler_id.clone(), tx);
+
+        if let Err(e) = self
+            .node
+            .send_custom_message(CustomMessage {
+                peer_id,
+                message_type: LSPS0_MESSAGE_TYPE,
+                payload,
+            })
+            .await
+        {
+            (*self.response_handlers.lock().await).remove(&handler_id);
+            return Err(e.into());
+        }
+
+        let result_or = tokio::time::timeout(timeout, rx).await?;
+        let response_or_error = result_or?;
+        if let Some(response) = response_or_error.response {
+            let resp = serde_json::from_value::<TResponse>(response)?;
+            Ok(resp)
+        } else if let Some(error) = response_or_error.error {
+            Err(Error::Remote(error))
+        } else {
+            Err(Error::Local(anyhow!("did not get response or error")))
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn stream_notifications<TNotification>(
+        &self,
+        method: String,
+        node_id: Vec<u8>,
+    ) -> Result<mpsc::Receiver<TNotification>, Error>
+    where
+        TNotification: serde::de::DeserializeOwned + std::marker::Send + 'static,
+    {
+        let (tx, rx) = mpsc::channel(100);
+        let id = get_notification_handler_id(&method, node_id);
+        (*self.notification_handlers.write().await)
+            .insert(id, Box::new(NotificationHandler::<TNotification> { tx }));
+
+        Ok(rx)
+    }
+}
+
+fn generate_request_id() -> String {
+    Alphanumeric.sample_string(&mut rand::thread_rng(), 21)
+}
+
+fn get_request_handler_id(request_id: &str, node_id: Vec<u8>) -> String {
+    let mut id = hex::encode(node_id);
+    id.push('|');
+    id.push_str(request_id);
+    id
+}
+
+fn get_notification_handler_id(method: &str, node_id: Vec<u8>) -> String {
+    let mut id = hex::encode(node_id);
+    id.push('|');
+    id.push_str(method);
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use std::{sync::Arc, time::Duration};
+    use tokio::sync::{mpsc, watch};
+
+    use crate::{
+        breez_services::tests::get_dummy_node_state,
+        lsps0::{
+            error::Error,
+            jsonrpc::{RpcError, RpcRequest, RpcServerMessage, RpcServerMessageBody},
+            transport::LSPS0_MESSAGE_TYPE,
+        },
+        test_utils::MockNodeAPI,
+        CustomMessage,
+    };
+
+    use super::Transport;
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Request {}
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Response {}
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Notification {}
+
+    #[tokio::test]
+    async fn test_request_response_success() {
+        let peer_id = vec![21];
+        let peer_id_clone = peer_id.clone();
+        let (tx, rx) = mpsc::channel(1);
+        let tx_arc = Arc::new(tx);
+        let on_send_request = move |message: CustomMessage| {
+            let req = serde_json::from_slice::<RpcRequest<Request>>(&message.payload).unwrap();
+            let resp = RpcServerMessage {
+                jsonrpc: req.jsonrpc,
+                body: RpcServerMessageBody::Response {
+                    id: req.id,
+                    result: json!({}),
+                },
+            };
+            let raw_resp = serde_json::to_vec(&resp).unwrap();
+            let tx_arc = tx_arc.clone();
+            let peer_id = peer_id_clone.clone();
+            tokio::spawn(async move {
+                tx_arc
+                    .send(CustomMessage {
+                        message_type: LSPS0_MESSAGE_TYPE,
+                        payload: raw_resp,
+                        peer_id,
+                    })
+                    .await
+                    .unwrap();
+            });
+            Ok(())
+        };
+
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_send_custom_message(Box::new(on_send_request));
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let timeout = Duration::from_millis(10);
+        transport
+            .request_response::<Request, Response>(
+                String::from("test"),
+                peer_id.clone(),
+                &Request {},
+                timeout,
+            )
+            .await
+            .unwrap();
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_request_response_timeout() {
+        let peer_id = vec![21];
+        let node_api = MockNodeAPI::new(get_dummy_node_state());
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let timeout = Duration::from_millis(10);
+        let result = transport
+            .request_response::<Request, Response>(
+                String::from("test"),
+                peer_id.clone(),
+                &Request {},
+                timeout,
+            )
+            .await;
+
+        assert!(matches!(result.err().unwrap(), Error::Timeout));
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_response_from_different_node() {
+        let (tx, rx) = mpsc::channel(1);
+        let tx_arc = Arc::new(tx);
+        let on_send_request = move |message: CustomMessage| {
+            let req = serde_json::from_slice::<RpcRequest<Request>>(&message.payload).unwrap();
+            let resp = RpcServerMessage {
+                jsonrpc: req.jsonrpc,
+                body: RpcServerMessageBody::Response {
+                    id: req.id,
+                    result: json!({}),
+                },
+            };
+            let raw_resp = serde_json::to_vec(&resp).unwrap();
+            let tx_arc = tx_arc.clone();
+            tokio::spawn(async move {
+                tx_arc
+                    .send(CustomMessage {
+                        message_type: LSPS0_MESSAGE_TYPE,
+                        payload: raw_resp,
+                        peer_id: vec![22],
+                    })
+                    .await
+                    .unwrap();
+            });
+            Ok(())
+        };
+
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_send_custom_message(Box::new(on_send_request));
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let timeout = Duration::from_millis(10);
+        let result = transport
+            .request_response::<Request, Response>(
+                String::from("test"),
+                vec![21],
+                &Request {},
+                timeout,
+            )
+            .await;
+
+        assert!(matches!(result.err().unwrap(), Error::Timeout));
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_request_response_remote_error() {
+        let peer_id = vec![21];
+        let peer_id_clone = peer_id.clone();
+        let (tx, rx) = mpsc::channel(1);
+        let tx_arc = Arc::new(tx);
+        let on_send_request = move |message: CustomMessage| {
+            let req = serde_json::from_slice::<RpcRequest<Request>>(&message.payload).unwrap();
+            let resp = RpcServerMessage {
+                jsonrpc: req.jsonrpc,
+                body: RpcServerMessageBody::Error {
+                    id: req.id,
+                    error: RpcError {
+                        code: 1,
+                        data: Some(json!({})),
+                        message: String::from("error occurred"),
+                    },
+                },
+            };
+            let raw_resp = serde_json::to_vec(&resp).unwrap();
+            let tx_arc = tx_arc.clone();
+            let peer_id = peer_id_clone.clone();
+            tokio::spawn(async move {
+                tx_arc
+                    .send(CustomMessage {
+                        message_type: LSPS0_MESSAGE_TYPE,
+                        payload: raw_resp,
+                        peer_id,
+                    })
+                    .await
+                    .unwrap();
+            });
+            Ok(())
+        };
+
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_send_custom_message(Box::new(on_send_request));
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let timeout = Duration::from_millis(10);
+        let result = transport
+            .request_response::<Request, Response>(
+                String::from("test"),
+                peer_id.clone(),
+                &Request {},
+                timeout,
+            )
+            .await;
+
+        let err = result.err().unwrap();
+        assert!(matches!(err, Error::Remote { .. }));
+        match err {
+            Error::Remote(e) => {
+                assert_eq!(e.code, 1);
+                assert_eq!(e.message, String::from("error occurred"));
+                assert_eq!(e.data, Some(json!({})));
+            }
+            _ => unreachable!(),
+        };
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_request_response_deserialization_error() {
+        let peer_id = vec![21];
+        let peer_id_clone = peer_id.clone();
+        let (tx, rx) = mpsc::channel(1);
+        let tx_arc = Arc::new(tx);
+        let on_send_request = move |message: CustomMessage| {
+            let req = serde_json::from_slice::<RpcRequest<Request>>(&message.payload).unwrap();
+            let resp = RpcServerMessage {
+                jsonrpc: req.jsonrpc,
+                body: RpcServerMessageBody::Response {
+                    id: req.id,
+                    result: json!("cannot deserialize this"),
+                },
+            };
+            let raw_resp = serde_json::to_vec(&resp).unwrap();
+            let tx_arc = tx_arc.clone();
+            let peer_id = peer_id_clone.clone();
+            tokio::spawn(async move {
+                tx_arc
+                    .send(CustomMessage {
+                        message_type: LSPS0_MESSAGE_TYPE,
+                        payload: raw_resp,
+                        peer_id,
+                    })
+                    .await
+                    .unwrap();
+            });
+            Ok(())
+        };
+
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_send_custom_message(Box::new(on_send_request));
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let timeout = Duration::from_millis(10);
+        let result = transport
+            .request_response::<Request, Response>(
+                String::from("test"),
+                peer_id.clone(),
+                &Request {},
+                timeout,
+            )
+            .await;
+
+        let err = result.err().unwrap();
+        assert!(matches!(err, Error::Deserialization { .. }));
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_request_response_different_id() {
+        let peer_id = vec![21];
+        let peer_id_clone = peer_id.clone();
+        let (tx, rx) = mpsc::channel(1);
+        let tx_arc = Arc::new(tx);
+        let on_send_request = move |message: CustomMessage| {
+            let req = serde_json::from_slice::<RpcRequest<Request>>(&message.payload).unwrap();
+            let resp = RpcServerMessage {
+                jsonrpc: req.jsonrpc,
+                body: RpcServerMessageBody::Response {
+                    id: String::from("different id"),
+                    result: json!({}),
+                },
+            };
+            let raw_resp = serde_json::to_vec(&resp).unwrap();
+            let tx_arc = tx_arc.clone();
+            let peer_id = peer_id_clone.clone();
+            tokio::spawn(async move {
+                tx_arc
+                    .send(CustomMessage {
+                        message_type: LSPS0_MESSAGE_TYPE,
+                        payload: raw_resp,
+                        peer_id,
+                    })
+                    .await
+                    .unwrap();
+            });
+            Ok(())
+        };
+
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_send_custom_message(Box::new(on_send_request));
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let timeout = Duration::from_millis(10);
+        let result = transport
+            .request_response::<Request, Response>(
+                String::from("test"),
+                peer_id.clone(),
+                &Request {},
+                timeout,
+            )
+            .await;
+        assert!(matches!(result.err().unwrap(), Error::Timeout));
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_request_response_not_lsps0() {
+        let peer_id = vec![21];
+        let peer_id_clone = peer_id.clone();
+        let (tx, rx) = mpsc::channel(1);
+        let tx_arc = Arc::new(tx);
+        let on_send_request = move |message: CustomMessage| {
+            let req = serde_json::from_slice::<RpcRequest<Request>>(&message.payload).unwrap();
+            let resp = RpcServerMessage {
+                jsonrpc: req.jsonrpc,
+                body: RpcServerMessageBody::Response {
+                    id: req.id,
+                    result: json!({}),
+                },
+            };
+            let raw_resp = serde_json::to_vec(&resp).unwrap();
+            let tx_arc = tx_arc.clone();
+            let peer_id = peer_id_clone.clone();
+            tokio::spawn(async move {
+                tx_arc
+                    .send(CustomMessage {
+                        message_type: LSPS0_MESSAGE_TYPE + 1,
+                        payload: raw_resp,
+                        peer_id,
+                    })
+                    .await
+                    .unwrap();
+            });
+            Ok(())
+        };
+
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_send_custom_message(Box::new(on_send_request));
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let timeout = Duration::from_millis(10);
+        let result = transport
+            .request_response::<Request, Response>(
+                String::from("test"),
+                peer_id.clone(),
+                &Request {},
+                timeout,
+            )
+            .await;
+        assert!(matches!(result.err().unwrap(), Error::Timeout));
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_notification_success() {
+        let method = String::from("test");
+        let peer_id = vec![21];
+        let (tx, rx) = mpsc::channel(1);
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let mut stream = transport
+            .stream_notifications::<Notification>(method, peer_id.clone())
+            .await
+            .unwrap();
+        let payload = RpcServerMessage {
+            jsonrpc: String::from("2.0"),
+            body: RpcServerMessageBody::Notification {
+                method: String::from("test"),
+                params: json!({}),
+            },
+        };
+        let raw_payload = serde_json::to_vec(&payload).unwrap();
+        tx.send(CustomMessage {
+            message_type: LSPS0_MESSAGE_TYPE,
+            payload: raw_payload,
+            peer_id: peer_id.clone(),
+        })
+        .await
+        .unwrap();
+        stream.recv().await.unwrap();
+        let _ = stop.send(());
+    }
+
+    #[tokio::test]
+    async fn test_notification_different_node() {
+        let method = String::from("test");
+        let peer_id = vec![21];
+        let (tx, rx) = mpsc::channel(1);
+        let mut node_api = MockNodeAPI::new(get_dummy_node_state());
+        node_api.set_on_stream_custom_messages(rx).await;
+
+        let transport = Arc::new(Transport::new(Arc::new(node_api)));
+        let (stop, cancel) = watch::channel(());
+        transport.start(cancel);
+        let mut stream = transport
+            .stream_notifications::<Notification>(method, peer_id.clone())
+            .await
+            .unwrap();
+        let payload = RpcServerMessage {
+            jsonrpc: String::from("2.0"),
+            body: RpcServerMessageBody::Notification {
+                method: String::from("test"),
+                params: json!({}),
+            },
+        };
+        let raw_payload = serde_json::to_vec(&payload).unwrap();
+        tx.send(CustomMessage {
+            message_type: LSPS0_MESSAGE_TYPE,
+            payload: raw_payload,
+            peer_id: vec![22],
+        })
+        .await
+        .unwrap();
+        let a = stream.try_recv();
+        assert!(a.is_err());
+        let _ = stop.send(());
+    }
+}

--- a/libs/sdk-core/src/lsps0/transport.rs
+++ b/libs/sdk-core/src/lsps0/transport.rs
@@ -222,7 +222,6 @@ impl Transport {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn request_response<TRequest, TResponse>(
         &self,
         method: String,
@@ -271,7 +270,6 @@ impl Transport {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn stream_notifications<TNotification>(
         &self,
         method: String,

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "thiserror",
  "tiny-bip39",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
  "zbase32",


### PR DESCRIPTION
Adds a basic LSPS0 client implementation. With support for request/response messages to the LSPS0 server, and support for receiving LSPS0 notifications (this is a different kind of notification than the notification in our offline receive milestone).

The idea is:
- Every user node (greenlight node) initializes a single `lsps0::Transport`. You start the transport in a thread. That makes it start listening to LSPS0 messages from any remote node, and allows sending request/response messages to any remote node.
- You initialize a `lsps0::Client` to interact with a specific remote node. There can be many `lsps0::Client`s.
