### PR TITLE
CLI: fix interactive prompt

### DIFF
--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -17,7 +17,7 @@ use rustyline::history::DefaultHistory;
 use crate::persist::CliPersistence;
 use crate::Commands;
 
-use std::borrow::Cow::{self, Borrowed, Owned};
+use std::borrow::Cow::{self, Owned};
 
 use rustyline::highlight::Highlighter;
 use rustyline::hint::HistoryHinter;
@@ -57,22 +57,9 @@ async fn connect(config: Config, seed: &[u8]) -> Result<()> {
 pub(crate) struct CliHelper {
     #[rustyline(Hinter)]
     pub(crate) hinter: HistoryHinter,
-    pub(crate) colored_prompt: String,
 }
 
 impl Highlighter for CliHelper {
-    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
-        &'s self,
-        prompt: &'p str,
-        default: bool,
-    ) -> Cow<'b, str> {
-        if default {
-            Borrowed(&self.colored_prompt)
-        } else {
-            Borrowed(prompt)
-        }
-    }
-
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
         Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
     }
@@ -370,8 +357,6 @@ pub(crate) async fn handle_command(
 
             match parse(lnurl_endpoint).await? {
                 LnUrlAuth { data: ad } => {
-                    println!("received {ad:?}");
-
                     let auth_res = sdk()?.lnurl_auth(ad).await?;
                     serde_json::to_string_pretty(&auth_res).map_err(|e| e.into())
                 }

--- a/tools/sdk-cli/src/main.rs
+++ b/tools/sdk-cli/src/main.rs
@@ -35,7 +35,6 @@ async fn main() -> Result<()> {
     let rl = &mut Editor::new()?;
     rl.set_helper(Some(CliHelper {
         hinter: HistoryHinter {},
-        colored_prompt: format!("\x1b[1;32m{}\x1b[0m", "sdk> "),
     }));
     if rl.load_history(history_file).is_err() {
         info!("No previous history.");


### PR DESCRIPTION
With the recent dependency update, the CLI interactive prompt was showing black text on black background (unusable).

This was the case for interactive prompts, so commands where the CLI asked for user input.

This PR removes prompt highlighting, which fixes it.