### PR TITLE
Logging: allow modules to log on trace

### DIFF
--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -42,7 +42,7 @@ impl BindingLogger {
 impl log::Log for BindingLogger {
     fn enabled(&self, m: &Metadata) -> bool {
         // ignore the internal uniffi log to prevent infinite loop.
-        return m.level() <= Level::Debug && *m.target() != *"breez_sdk_bindings::uniffi_binding";
+        return m.level() <= Level::Trace && *m.target() != *"breez_sdk_bindings::uniffi_binding";
     }
 
     fn log(&self, record: &Record) {

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -438,7 +438,7 @@ impl BindingLogger {
 
 impl log::Log for BindingLogger {
     fn enabled(&self, m: &Metadata) -> bool {
-        m.level() <= Level::Debug
+        m.level() <= Level::Trace
     }
 
     fn log(&self, record: &Record) {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1267,7 +1267,7 @@ struct GlobalSdkLogger {
 }
 impl log::Log for GlobalSdkLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= log::Level::Debug
+        metadata.level() <= log::Level::Trace
     }
 
     fn log(&self, record: &Record) {


### PR DESCRIPTION
Our logging framework was only considering log levels at `debug` and up. This PR changes that to allow `trace` as well.

No modules currently log at `trace`, but with this PR, they could and their statements would land in the SDK log.