### PR TITLE
Fix SDK panic caused by closing channels

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1220,18 +1220,17 @@ impl BreezServices {
                         .chain_service
                         .transaction_outspends(channel.funding_txid.clone())
                         .await?;
-                    match outspends.get(outnum as usize) {
+
+                    let maybe_block_time = outspends.get(outnum as usize)
+                        .and_then(|outspend| outspend.status.as_ref())
+                        .and_then(|status| status.block_time);
+
+                    match maybe_block_time {
                         None => {
-                            warn!("No funding tx outspend found at outnum {outnum}, defaulting closed_at to epoch time");
+                            warn!("Blocktime could not be determined for funding_outnum {outnum}, defaulting closed_at to epoch time");
                             now_epoch_sec
                         }
-                        Some(outspend) => match outspend.status.block_time {
-                            None => {
-                                warn!("No blocktime found for funding_outnum {outnum}, defaulting closed_at to epoch time");
-                                now_epoch_sec
-                            },
-                            Some(block_time) => block_time
-                        }
+                        Some(block_time) => block_time
                     }
                 }
             }

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -192,8 +192,8 @@ pub struct Vin {
 pub struct Outspend {
     pub spent: bool,
     pub txid: Option<String>,
-    pub vin: u32,
-    pub status: TxStatus,
+    pub vin: Option<u32>,
+    pub status: Option<TxStatus>,
 }
 
 impl Default for MempoolSpace {

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -187,7 +187,10 @@ pub struct Vin {
     pub sequence: u32,
 }
 
-/// Spending status of a transaction output
+/// Spending status of a transaction output.
+///
+/// If this is an outspend of a confirmed tx, `spent` is true and all other fields are set.
+/// If this is an outspend of an unconfirmed tx, `spent` is false and none of the other fields are set.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Outspend {
     pub spent: bool,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -189,13 +189,13 @@ impl ChainService for MockChainService {
         Ok(vec![Outspend {
             spent: true,
             txid: Some("test-tx-id".into()),
-            vin: 0,
-            status: TxStatus {
+            vin: Some(0),
+            status: Some(TxStatus {
                 confirmed: true,
                 block_height: Some(123),
                 block_hash: Some("test-hash".into()),
                 block_time: Some(123),
-            },
+            }),
         }])
     }
 


### PR DESCRIPTION
Calling `close_lsp_channels` would trigger a panic when trying to parse the mempool result, because the outspends do not always have `status` and `vin`.