### PR TITLE
workaround for x86_64-android

### DIFF
--- a/libs/sdk-bindings/build.rs
+++ b/libs/sdk-bindings/build.rs
@@ -1,6 +1,42 @@
 use anyhow::*;
+use std::env;
+use std::path::Path;
+
+const DEFAULT_CLANG_VERSION: &str = "14.0.7";
+
+/// Adds a temporary workaround for an issue with the Rust compiler and Android
+/// in x86_64 devices: https://github.com/rust-lang/rust/issues/109717.
+/// The workaround comes from: https://github.com/smartvaults/smartvaults/blob/827805a989561b78c0ea5b41f2c1c9e9e59545e0/bindings/smartvaults-sdk-ffi/build.rs
+fn setup_x86_64_android_workaround() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
+    if target_arch == "x86_64" && target_os == "android" {
+        let android_ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
+        let build_os = match env::consts::OS {
+            "linux" => "linux",
+            "macos" => "darwin",
+            "windows" => "windows",
+            _ => panic!(
+                "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
+            ),
+        };
+        let clang_version =
+            env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
+        let linux_x86_64_lib_dir = format!(
+            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
+        );
+        let linkpath = format!("{android_ndk_home}/{linux_x86_64_lib_dir}");
+        if Path::new(&linkpath).exists() {
+            println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
+            println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
+        } else {
+            panic!("Path {linkpath} not exists");
+        }
+    }
+}
 
 fn main() -> Result<()> {
+    setup_x86_64_android_workaround();
     uniffi_build::generate_scaffolding("./src/breez_sdk.udl").unwrap();
     Ok(())
 }


### PR DESCRIPTION
A workaround that fixes https://github.com/breez/c-breez/issues/553
Recommended by @yukibtc here https://github.com/breez/c-breez/issues/553#issuecomment-1731477289

Flutter uses sdk-core for Android, that's why this build script is put in sdk-core. It may be necessary to put it in sdk-bindings as well, for bindings for other languages that work on android, not sure.

Did a testrun with a breez-sdk-flutter release from the CI: https://github.com/breez/breez-sdk/suites/16489120334/artifacts/942132999
The testrun worked.