### PR TITLE
Simple lsps2 client

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
+ "serde_with 3.3.0",
  "strum",
  "strum_macros",
  "tempfile",
@@ -693,7 +694,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -1002,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,7 +1297,7 @@ dependencies = [
  "serde",
  "serde_bolt 0.2.4",
  "serde_json",
- "serde_with",
+ "serde_with 2.3.3",
  "sha256",
  "tempfile",
  "thiserror",
@@ -1336,7 +1343,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1622,6 +1629,17 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
  "serde",
 ]
 
@@ -2165,7 +2183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -2848,10 +2866,27 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 2.3.3",
+ "time 0.3.22",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.3.0",
  "time 0.3.22",
 ]
 
@@ -2860,6 +2895,18 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3331,7 +3378,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand",
@@ -3663,7 +3710,7 @@ dependencies = [
  "serde",
  "serde_bolt 0.3.1",
  "serde_derive",
- "serde_with",
+ "serde_with 2.3.3",
  "txoo",
 ]
 
@@ -3676,7 +3723,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.3.3",
  "vls-core",
 ]
 

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -61,6 +61,7 @@ thiserror = "1"
 const_format = "0.2"
 miniz_oxide = "0.7.1"
 tokio-stream = "0.1.14"
+serde_with = "3.3.0"
 
 [dev-dependencies]
 mockito = "1"

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -177,6 +177,7 @@ mod invoice;
 mod lnurl;
 mod lsp;
 mod lsps0;
+mod lsps2;
 mod models;
 mod moonpay;
 mod persist;

--- a/libs/sdk-core/src/lsps0/client.rs
+++ b/libs/sdk-core/src/lsps0/client.rs
@@ -28,7 +28,6 @@ impl Client {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn call<TRequest, TResponse>(
         &self,
         method: String,

--- a/libs/sdk-core/src/lsps0/mod.rs
+++ b/libs/sdk-core/src/lsps0/mod.rs
@@ -3,11 +3,8 @@ pub(crate) mod error;
 pub(crate) mod jsonrpc;
 pub(crate) mod transport;
 
-#[allow(unused_imports)]
 pub(crate) use client::Client;
 
+pub(crate) use error::Error;
 #[allow(unused_imports)]
 pub(crate) use transport::Transport;
-
-#[allow(unused_imports)]
-pub(crate) use error::Error;

--- a/libs/sdk-core/src/lsps2/client.rs
+++ b/libs/sdk-core/src/lsps2/client.rs
@@ -1,0 +1,339 @@
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+use crate::lsps0;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct GetVersionsRequest {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetVersionsResponse {
+    pub versions: Vec<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetInfoRequest {
+    pub version: i32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct GetInfoResponse {
+    pub opening_fee_params_menu: Vec<OpeningFeeParams>,
+
+    #[serde_as(as = "DisplayFromStr")]
+    pub min_payment_size_msat: u64,
+
+    #[serde_as(as = "DisplayFromStr")]
+    pub max_payment_size_msat: u64,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct OpeningFeeParams {
+    #[serde_as(as = "DisplayFromStr")]
+    pub min_fee_msat: u64,
+    pub proportional: u32,
+    pub valid_until: String,
+    pub min_lifetime: u32,
+    pub max_client_to_self_delay: u32,
+    pub promise: String,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BuyRequest {
+    pub version: i32,
+    pub opening_fee_params: OpeningFeeParams,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub payment_size_msat: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct BuyResponse {
+    pub jit_channel_scid: String,
+    pub lsp_cltv_expiry_delta: u32,
+
+    #[serde(default)]
+    pub client_trusts_lsp: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetInfoError {
+    #[error("lsps2.get_info unsupported_version error: {0:?}")]
+    UnsupportedVersion(lsps0::jsonrpc::RpcError),
+    #[error("lsps2.get_info unrecognized_or_stale_token error: {0:?}")]
+    UnrecognizedOrStaleToken(lsps0::jsonrpc::RpcError),
+    #[error("lsps2.get_info general error: {0}")]
+    Lsps0(lsps0::Error),
+}
+
+impl From<lsps0::Error> for GetInfoError {
+    fn from(value: lsps0::Error) -> Self {
+        match value {
+            lsps0::Error::Remote(e) => match e.code {
+                1 => Self::UnsupportedVersion(e),
+                2 => Self::UnrecognizedOrStaleToken(e),
+                _ => Self::Lsps0(lsps0::Error::Remote(e)),
+            },
+            _ => Self::Lsps0(value),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuyError {
+    #[error("lsps2.buy unsupported_version error: {0:?}")]
+    UnsupportedVersion(lsps0::jsonrpc::RpcError),
+
+    #[error("lsps2.buy invalid_opening_fee_params error: {0:?}")]
+    InvalidOpeningFeeParams(lsps0::jsonrpc::RpcError),
+
+    #[error("lsps2.buy payment_size_too_small error: {0:?}")]
+    PaymentSizeTooSmall(lsps0::jsonrpc::RpcError),
+
+    #[error("lsps2.buy payment_size_too_large error: {0:?}")]
+    PaymentSizeTooLarge(lsps0::jsonrpc::RpcError),
+
+    #[error("lsps2.buy general error: {0}")]
+    Lsps0(lsps0::Error),
+}
+
+impl From<lsps0::Error> for BuyError {
+    fn from(value: lsps0::Error) -> Self {
+        match value {
+            lsps0::Error::Remote(e) => match e.code {
+                1 => Self::UnsupportedVersion(e),
+                2 => Self::InvalidOpeningFeeParams(e),
+                3 => Self::PaymentSizeTooSmall(e),
+                4 => Self::PaymentSizeTooLarge(e),
+                _ => Self::Lsps0(lsps0::Error::Remote(e)),
+            },
+            _ => Self::Lsps0(value),
+        }
+    }
+}
+pub struct Client {
+    client: lsps0::Client,
+}
+
+impl Client {
+    #[allow(dead_code)]
+    pub fn new(client: lsps0::Client) -> Self {
+        Self { client }
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_versions(&self) -> Result<GetVersionsResponse, lsps0::Error> {
+        self.client
+            .call(String::from("lsps2.get_versions"), GetVersionsRequest {})
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_info(&self, req: GetInfoRequest) -> Result<GetInfoResponse, GetInfoError> {
+        match self.client.call(String::from("lsps2.get_info"), req).await {
+            Ok(v) => Ok(v),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn buy(&self, req: BuyRequest) -> Result<BuyResponse, BuyError> {
+        match self.client.call(String::from("lsps2.buy"), req).await {
+            Ok(v) => Ok(v),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lsps2::client::{
+        BuyRequest, BuyResponse, GetInfoRequest, GetInfoResponse, GetVersionsResponse,
+        OpeningFeeParams,
+    };
+
+    #[test]
+    fn test_get_versions_response_deserialize() {
+        let json = r#"{"versions":[1]}"#;
+        let result = serde_json::from_str::<GetVersionsResponse>(json).unwrap();
+        assert_eq!(vec![1], result.versions)
+    }
+
+    #[test]
+    fn test_get_info_request_serialize_with_token() {
+        let req = GetInfoRequest {
+            token: Some(String::from("token")),
+            version: 1,
+        };
+        let result = serde_json::to_string(&req).unwrap();
+        assert_eq!(r#"{"version":1,"token":"token"}"#, result)
+    }
+
+    #[test]
+    fn test_get_info_request_serialize_without_token() {
+        let req = GetInfoRequest {
+            token: None,
+            version: 1,
+        };
+        let result = serde_json::to_string(&req).unwrap();
+        assert_eq!(r#"{"version":1}"#, result)
+    }
+
+    #[test]
+    fn test_get_info_response_deserialize() {
+        let json = r#"{
+            "opening_fee_params_menu": [
+                {
+                    "min_fee_msat": "546000",
+                    "proportional": 1200,
+                    "valid_until": "2023-02-23T08:47:30.511Z",
+                    "min_lifetime": 1008,
+                    "max_client_to_self_delay": 2016,
+                    "promise": "abcdefghijklmnopqrstuvwxyz"
+                },
+                {
+                    "min_fee_msat": "1092000",
+                    "proportional": 2400,
+                    "valid_until": "2023-02-27T21:23:57.984Z",
+                    "min_lifetime": 1008,
+                    "max_client_to_self_delay": 2016,
+                    "promise": "abcdefghijklmnopqrstuvwxyz"
+                }
+            ],
+            "min_payment_size_msat": "1000",
+            "max_payment_size_msat": "1000000"
+        }"#;
+
+        let result = serde_json::from_str::<GetInfoResponse>(json).unwrap();
+        assert_eq!(
+            result,
+            GetInfoResponse {
+                max_payment_size_msat: 1000000,
+                min_payment_size_msat: 1000,
+                opening_fee_params_menu: vec![
+                    OpeningFeeParams {
+                        min_fee_msat: 546000,
+                        proportional: 1200,
+                        valid_until: String::from("2023-02-23T08:47:30.511Z"),
+                        min_lifetime: 1008,
+                        max_client_to_self_delay: 2016,
+                        promise: String::from("abcdefghijklmnopqrstuvwxyz")
+                    },
+                    OpeningFeeParams {
+                        min_fee_msat: 1092000,
+                        proportional: 2400,
+                        valid_until: String::from("2023-02-27T21:23:57.984Z"),
+                        min_lifetime: 1008,
+                        max_client_to_self_delay: 2016,
+                        promise: String::from("abcdefghijklmnopqrstuvwxyz")
+                    },
+                ]
+            }
+        )
+    }
+
+    #[test]
+    fn test_buy_request_serialize_with_payment_size() {
+        let req = BuyRequest {
+            version: 1,
+            opening_fee_params: OpeningFeeParams {
+                min_fee_msat: 546000,
+                proportional: 1200,
+                valid_until: String::from("2023-02-23T08:47:30.511Z"),
+                min_lifetime: 1008,
+                max_client_to_self_delay: 2016,
+                promise: String::from("abcdefghijklmnopqrstuvwxyz"),
+            },
+            payment_size_msat: Some(42000),
+        };
+        let result = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            r#"{"version":1,"opening_fee_params":{"min_fee_msat":"546000","proportional":1200,"valid_until":"2023-02-23T08:47:30.511Z","min_lifetime":1008,"max_client_to_self_delay":2016,"promise":"abcdefghijklmnopqrstuvwxyz"},"payment_size_msat":"42000"}"#,
+            result
+        )
+    }
+
+    #[test]
+    fn test_buy_request_serialize_without_payment_size() {
+        let req = BuyRequest {
+            version: 1,
+            opening_fee_params: OpeningFeeParams {
+                min_fee_msat: 546000,
+                proportional: 1200,
+                valid_until: String::from("2023-02-23T08:47:30.511Z"),
+                min_lifetime: 1008,
+                max_client_to_self_delay: 2016,
+                promise: String::from("abcdefghijklmnopqrstuvwxyz"),
+            },
+            payment_size_msat: None,
+        };
+        let result = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            r#"{"version":1,"opening_fee_params":{"min_fee_msat":"546000","proportional":1200,"valid_until":"2023-02-23T08:47:30.511Z","min_lifetime":1008,"max_client_to_self_delay":2016,"promise":"abcdefghijklmnopqrstuvwxyz"}}"#,
+            result
+        )
+    }
+
+    #[test]
+    fn test_buy_response_deserialize_with_client_trusts_lsp_false() {
+        let json = r#"{
+            "jit_channel_scid": "1x4815x29451",
+            "lsp_cltv_expiry_delta" : 144,
+            "client_trusts_lsp": false
+        }"#;
+
+        let result = serde_json::from_str::<BuyResponse>(json).unwrap();
+        assert_eq!(
+            result,
+            BuyResponse {
+                client_trusts_lsp: false,
+                jit_channel_scid: String::from("1x4815x29451"),
+                lsp_cltv_expiry_delta: 144
+            }
+        );
+    }
+
+    #[test]
+    fn test_buy_response_deserialize_with_client_trusts_lsp_true() {
+        let json = r#"{
+            "jit_channel_scid": "1x4815x29451",
+            "lsp_cltv_expiry_delta" : 144,
+            "client_trusts_lsp": true
+        }"#;
+
+        let result = serde_json::from_str::<BuyResponse>(json).unwrap();
+        assert_eq!(
+            result,
+            BuyResponse {
+                client_trusts_lsp: true,
+                jit_channel_scid: String::from("1x4815x29451"),
+                lsp_cltv_expiry_delta: 144
+            }
+        );
+    }
+
+    #[test]
+    fn test_buy_response_deserialize_without_client_trusts_lsp() {
+        let json = r#"{
+            "jit_channel_scid": "1x4815x29451",
+            "lsp_cltv_expiry_delta": 144
+        }"#;
+
+        let result = serde_json::from_str::<BuyResponse>(json).unwrap();
+        assert_eq!(
+            result,
+            BuyResponse {
+                client_trusts_lsp: false,
+                jit_channel_scid: String::from("1x4815x29451"),
+                lsp_cltv_expiry_delta: 144
+            }
+        );
+    }
+}

--- a/libs/sdk-core/src/lsps2/mod.rs
+++ b/libs/sdk-core/src/lsps2/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod client;
+
+#[allow(unused_imports)]
+pub(crate) use client::Client;

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
+ "serde_with 3.3.0",
  "strum",
  "strum_macros",
  "tempfile",
@@ -954,6 +955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,7 +1264,7 @@ dependencies = [
  "serde",
  "serde_bolt 0.2.4",
  "serde_json",
- "serde_with",
+ "serde_with 2.3.3",
  "sha256",
  "tempfile",
  "thiserror",
@@ -1286,7 +1293,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1317,6 +1324,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hashlink"
@@ -1561,6 +1574,17 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
  "serde",
 ]
 
@@ -2078,7 +2102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -2749,10 +2773,27 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 2.3.3",
+ "time 0.3.21",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.3.0",
  "time 0.3.21",
 ]
 
@@ -2761,6 +2802,18 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3204,7 +3257,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand",
@@ -3409,7 +3462,7 @@ dependencies = [
  "serde",
  "serde_bolt 0.3.1",
  "serde_derive",
- "serde_with",
+ "serde_with 2.3.3",
  "txoo",
 ]
 
@@ -3422,7 +3475,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.3.3",
  "vls-core",
 ]
 


### PR DESCRIPTION
A simple lsps2 client, just a wrapper for the rpc functions defined in the LSPS2 spec. Depends on https://github.com/breez/breez-sdk/pull/470