### PR TITLE
run max one pr ci at a time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   fmt:


### PR DESCRIPTION
Cancels in-progress CI runs for the same PR if an update is pushed, to save some concurrent jobs running.
