### PR TITLE
Fix issue with remote to local sync, affecting backup

### DIFF
--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -90,7 +90,7 @@ impl SqliteStorage {
     ) -> Result<()> {
         let sync_data_file = remote_storage.sync_db_path();
         match SqliteStorage::migrate_sync_db(sync_data_file.clone()) {
-            Ok(_) => {}
+            Ok(_) => debug!("Migrated sync db successfully, to_local={to_local}"),
             Err(e) => {
                 log::error!("Failed to migrate sync db, probably local db is older than remote, skipping migration: {}", e);
             }
@@ -156,7 +156,7 @@ impl SqliteStorage {
         )?;
 
         // sync remote payments_external_info table
-        tx.execute(
+        let _ = tx.execute(
             "
          INSERT into sync.payments_external_info
          SELECT
@@ -168,7 +168,7 @@ impl SqliteStorage {
          FROM remote_sync.payments_external_info
          WHERE payment_id NOT IN (SELECT payment_id FROM sync.payments_external_info);",
             [],
-        )?;
+        );
 
         // sync remote reverse_swaps table
         tx.execute(


### PR DESCRIPTION
When optimistic sync fails, we try a bidirectional sync, of which one step is to sync from remote to local.

I found that this particular tx failed because the remote schema did not have the new column, which caused the entire sync to abort by throwing the error.

The fix is to not throw the error if this discrepancy happens. The schema is apparently synchronized after this tx is executed, so on the next `backup` this tx won't throw an error.

I admit I don't fully understand yet the backup mechanism, so the explanation above may be incorrect. Therefore I'm marking this as draft for now.

If the explanation and solution makes sense, we should apply the same change to all `tx.commit(..)` that fall under the `if to_local` check.