### PR TITLE
Properly handle new column for sync table

### DIFF
--- a/libs/sdk-core/src/persist/db.rs
+++ b/libs/sdk-core/src/persist/db.rs
@@ -44,8 +44,8 @@ impl SqliteStorage {
     }
 
     pub(crate) fn init(&self) -> SdkResult<()> {
-        Self::migrate_sync_db(self.sync_db_file.clone())?;
         self.migrate_main_db()?;
+        Self::migrate_sync_db(self.sync_db_file.clone())?;
         Ok(())
     }
 

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -460,6 +460,14 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
         channel_opening_fees TEXT NOT NULL
        ) STRICT;
        ",
+        "
+        CREATE TABLE IF NOT EXISTS payments_external_info (
+         payment_id TEXT NOT NULL PRIMARY KEY,
+         lnurl_success_action TEXT,
+         ln_address TEXT,
+         lnurl_metadata TEXT
+         ) STRICT;
+        ",
         "ALTER TABLE payments_external_info ADD COLUMN lnurl_withdraw_endpoint TEXT;",
     ]
 }

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -468,6 +468,28 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
          lnurl_metadata TEXT
          ) STRICT;
         ",
-        "ALTER TABLE payments_external_info ADD COLUMN lnurl_withdraw_endpoint TEXT;",
+        "
+        ALTER TABLE payments_external_info RENAME TO payments_external_info_old;
+
+        CREATE TABLE payments_external_info (
+         payment_id TEXT NOT NULL PRIMARY KEY,
+         lnurl_success_action TEXT,
+         ln_address TEXT,
+         lnurl_metadata TEXT,
+         lnurl_withdraw_endpoint TEXT
+        ) STRICT;
+
+        INSERT INTO payments_external_info
+         (payment_id, lnurl_success_action, ln_address, lnurl_metadata, lnurl_withdraw_endpoint)
+         SELECT
+          payment_id,
+          lnurl_success_action,
+          ln_address,
+          lnurl_metadata,
+          NULL
+         FROM payments_external_info_old;
+
+        DROP TABLE payments_external_info_old;
+        ",
     ]
 }

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -385,37 +385,10 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ) STRICT;
         ",
 
-        //sync & backup
+        //sync & backup (moved to sync migration function below)
         "
-        CREATE TABLE IF NOT EXISTS sync.sync_requests (
-         id INTEGER PRIMARY KEY AUTOINCREMENT,
-         changed_table TEXT NOT NULL
-        ) STRICT;
-
-        CREATE TRIGGER sync.sync_requests_swaps 
-         AFTER INSERT ON swaps         
-        BEGIN
-         INSERT INTO sync_requests(changed_table) VALUES('swaps');
-        END;
-
-        CREATE TRIGGER sync.sync_requests_swap_refunds 
-         AFTER INSERT ON swap_refunds        
-        BEGIN
-         INSERT INTO sync_requests(changed_table) VALUES('swap_refunds');
-        END;
-
-        CREATE TRIGGER sync.sync_requests_reverse_swaps
-         AFTER INSERT ON reverse_swaps        
-        BEGIN
-         INSERT INTO sync_requests(changed_table) VALUES('reverse_swaps');
-        END;
-
-        CREATE TRIGGER sync.sync_requests_payments_external_info
-         AFTER INSERT ON payments_external_info
-        BEGIN
-         INSERT INTO sync_requests(changed_table) VALUES('payments_external_info');
-        END;
-        ",       
+        SELECT 1;
+        ",
         "
         DROP TABLE sync_versions;
         CREATE TABLE IF NOT EXISTS sync_versions (

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -460,13 +460,76 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
         channel_opening_fees TEXT NOT NULL
        ) STRICT;
        ",
+        // Create all sync tables and triggers, if they don't already exist
         "
+        CREATE TABLE IF NOT EXISTS swaps (
+         bitcoin_address TEXT PRIMARY KEY NOT NULL,
+         created_at INTEGER DEFAULT CURRENT_TIMESTAMP,
+         lock_height INTEGER NOT NULL,
+         payment_hash BLOB NOT NULL UNIQUE,
+         preimage BLOB NOT NULL UNIQUE,
+         private_key BLOB NOT NULL UNIQUE,
+         public_key BLOB NOT NULL UNIQUE,
+         swapper_public_key BLOB NOT NULL UNIQUE,
+         script BLOB NOT NULL UNIQUE,
+         min_allowed_deposit INTEGER NOT NULL,
+         max_allowed_deposit INTEGER NOT NULL
+        ) STRICT;
+
+        CREATE TABLE IF NOT EXISTS swap_refunds (
+         bitcoin_address TEXT NOT NULL,
+         refund_tx_id TEXT NOT NULL,
+         PRIMARY KEY (bitcoin_address, refund_tx_id)
+        ) STRICT;
+
         CREATE TABLE IF NOT EXISTS payments_external_info (
          payment_id TEXT NOT NULL PRIMARY KEY,
          lnurl_success_action TEXT,
          ln_address TEXT,
          lnurl_metadata TEXT
-         ) STRICT;
+        ) STRICT;
+
+        CREATE TABLE IF NOT EXISTS reverse_swaps (
+         id TEXT PRIMARY KEY NOT NULL,
+         created_at_block_height INTEGER NOT NULL,
+         preimage BLOB NOT NULL UNIQUE,
+         private_key BLOB NOT NULL UNIQUE,
+         claim_pubkey TEXT NOT NULL,
+         timeout_block_height INTEGER NOT NULL,
+         invoice TEXT NOT NULL UNIQUE,
+         onchain_amount_sat INTEGER NOT NULL,
+         sat_per_vbyte INTEGER NOT NULL,
+         redeem_script TEXT NOT NULL
+        ) STRICT;
+
+        CREATE TABLE IF NOT EXISTS sync_requests (
+         id INTEGER PRIMARY KEY AUTOINCREMENT,
+         changed_table TEXT NOT NULL
+        ) STRICT;
+
+        CREATE TRIGGER IF NOT EXISTS sync_requests_swaps
+         AFTER INSERT ON swaps
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('swaps');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS sync_requests_swap_refunds
+         AFTER INSERT ON swap_refunds
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('swap_refunds');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS sync_requests_reverse_swaps
+         AFTER INSERT ON reverse_swaps
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('reverse_swaps');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS sync_requests_payments_external_info
+         AFTER INSERT ON payments_external_info
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('payments_external_info');
+        END;
         ",
         "
         ALTER TABLE payments_external_info RENAME TO payments_external_info_old;

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -411,7 +411,7 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         END;
 
         CREATE TRIGGER sync.sync_requests_payments_external_info
-         AFTER INSERT ON payments_external_info       
+         AFTER INSERT ON payments_external_info
         BEGIN
          INSERT INTO sync_requests(changed_table) VALUES('payments_external_info');
         END;
@@ -524,12 +524,6 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
         BEGIN
          INSERT INTO sync_requests(changed_table) VALUES('reverse_swaps');
         END;
-
-        CREATE TRIGGER IF NOT EXISTS sync_requests_payments_external_info
-         AFTER INSERT ON payments_external_info
-        BEGIN
-         INSERT INTO sync_requests(changed_table) VALUES('payments_external_info');
-        END;
         ",
         "
         ALTER TABLE payments_external_info RENAME TO payments_external_info_old;
@@ -553,6 +547,12 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
          FROM payments_external_info_old;
 
         DROP TABLE payments_external_info_old;
+
+        CREATE TRIGGER IF NOT EXISTS sync_requests_payments_external_info
+         AFTER INSERT ON payments_external_info
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('payments_external_info');
+        END;
         ",
     ]
 }

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -439,7 +439,7 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ALTER TABLE payments RENAME COLUMN pending TO status;
        UPDATE payments SET status = CASE WHEN status = 1 THEN 0 ELSE 1 END;
        ",
-       "ALTER TABLE sync.payments_external_info ADD COLUMN lnurl_withdraw_endpoint TEXT;",
+       "SELECT 1;", // Placeholder statement, to avoid that column is added twice (from sync fn below and here)
     ]
 }
 
@@ -460,5 +460,6 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
         channel_opening_fees TEXT NOT NULL
        ) STRICT;
        ",
+        "ALTER TABLE payments_external_info ADD COLUMN lnurl_withdraw_endpoint TEXT;",
     ]
 }


### PR DESCRIPTION
As discussed, moving the statement to the sync migrations function.

Even so, it fails with

```
Error: Failed to use the local DB for persistence: rusqlite_migrate error: RusqliteError { query: "ALTER TABLE payments_external_info ADD COLUMN lnurl_withdraw_endpoint TEXT;", err: SqliteFailure(Error { code: Unknown, extended_code: 1 }, Some("no such table: payments_external_info")) }
```

even after clearing the SQL files locally and trying again.

Could be an issue with my setup, so marking as draft until someone else can confirm it's working.