### PR TITLE
update flutter readme

### DIFF
--- a/libs/sdk-flutter/README.md
+++ b/libs/sdk-flutter/README.md
@@ -45,9 +45,8 @@ make android
 
 ### Generated artifacts:
 * Android libraries
- >* android/src/main/jniLibs/arm64-v8a/libbreez_sdk_core.so
- >* android/src/main/jniLibs/armeabi-v7a/libbreez_core_sdk.so
- >* android/src/main/jniLibs/x86/libbreez_sdk_core.so
- >* android/src/main/jniLibs/x86_64/libbreez_sdk_core.so
-* iOS library
- >* ios/libbreez_sdk_core.a
+ >* ./android/src/main/jniLibs/arm64-v8a/libbreez_sdk_bindings.so
+ >* ./android/src/main/jniLibs/armeabi-v7a/libbreez_sdk_bindings.so
+ >* ./android/src/main/jniLibs/x86/libbreez_sdk_bindings.so
+ >* ./android/src/main/jniLibs/x86_64/libbreez_sdk_bindings.so
+* iOS library is imported through libs/sdk-bindings/bindings-swift

--- a/libs/sdk-flutter/makefile
+++ b/libs/sdk-flutter/makefile
@@ -30,8 +30,8 @@ ios-dev: ios
 .PHONY: android
 android: $(SOURCES) flutter_rust_bridge
 	cd ../sdk-bindings && make android
-	mkdir -p ./android/src/main
-	cp -r ../sdk-bindings/ffi/kotlin/jniLibs ./android/src/main/jniLibs
+	mkdir -p ./android/src/main/jniLibs
+	cp -r ../sdk-bindings/ffi/kotlin/jniLibs/* ./android/src/main/jniLibs
 
 ## desktop: compiles for x86_64-unknown-linux-gnu by default, other targets can be specified
 ## with the TARGET variable eg. make desktop TARGET=aarch64-unknown-linux-gnu


### PR DESCRIPTION
Update flutter readme to include the proper binaries.

Also copy the *contents* of the jniLibs folder and not the jniLibs folder itself.
Problem was if you ran `make android` twice, there would be a `jniLibs` folder inside the `jniLibs` folder.