### PR TITLE
Cln API

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -521,7 +521,7 @@ enum BuyBitcoinProvider {
 
 dictionary SweepRequest {
     string to_address;
-    u64 fee_rate_sats_per_vbyte;
+    u32 fee_rate_sats_per_vbyte;
 };
 
 dictionary SweepResponse {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -83,8 +83,7 @@ dictionary UnspentTransactionOutput {
     u32 outnum;
     u64 amount_millisatoshi;
     string address;
-    boolean reserved;
-    u32 reserved_to_block;
+    boolean reserved;  
 };
 
 dictionary NodeState {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1235,13 +1235,13 @@ impl BreezServices {
                     let outspends = self
                         .chain_service
                         .transaction_outspends(channel.funding_txid.clone())
-                        .await?;                    
+                        .await?;
                     let maybe_block_time = outspends.get(outnum as usize)
                         .and_then(|outspend| outspend.status.as_ref())
                         .and_then(|status| status.block_time);
 
                     match maybe_block_time {
-                        None => {                            
+                        None => {
                             warn!("Blocktime could not be determined for funding_outnum {outnum}, defaulting closed_at to epoch time");
                             now_epoch_sec
                         }

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -857,7 +857,7 @@ pub struct wire_StaticBackupRequest {
 #[derive(Clone)]
 pub struct wire_SweepRequest {
     to_address: *mut wire_uint_8_list,
-    fee_rate_sats_per_vbyte: u64,
+    fee_rate_sats_per_vbyte: u32,
 }
 
 #[repr(C)]

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1489,7 +1489,6 @@ impl support::IntoDart for UnspentTransactionOutput {
             self.amount_millisatoshi.into_dart(),
             self.address.into_dart(),
             self.reserved.into_dart(),
-            self.reserved_to_block.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -558,13 +558,13 @@ impl NodeAPI for Greenlight {
         Ok(())
     }
 
-    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u64) -> Result<Vec<u8>> {
+    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> Result<Vec<u8>> {
         let mut client = self.get_node_client().await?;
 
         let request = pb::cln::WithdrawRequest {
             feerate: Some(pb::cln::Feerate {
                 style: Some(pb::cln::feerate::Style::Perkw(
-                    fee_rate_sats_per_vbyte as u32 * 250,
+                    fee_rate_sats_per_vbyte * 250,
                 )),
             }),
             satoshi: Some(pb::cln::AmountOrAll {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -12,7 +12,6 @@ use bitcoin::secp256k1::Secp256k1;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
 use ecies::utils::{aes_decrypt, aes_encrypt};
 use gl_client::node::ClnClient;
-use gl_client::pb::amount::Unit;
 use gl_client::pb::cln::listinvoices_invoices::ListinvoicesInvoicesStatus;
 use gl_client::pb::cln::listpays_pays::ListpaysPaysStatus;
 use gl_client::pb::cln::{
@@ -21,7 +20,7 @@ use gl_client::pb::cln::{
     StaticbackupRequest,
 };
 use gl_client::pb::cln::{AmountOrAny, InvoiceRequest};
-use gl_client::pb::{Amount, OffChainPayment, PayStatus, Peer, WithdrawResponse};
+use gl_client::pb::{OffChainPayment, PayStatus};
 
 use gl_client::pb::cln::listpeers_peers_channels::ListpeersPeersChannelsState::*;
 use gl_client::scheduler::Scheduler;
@@ -362,18 +361,17 @@ impl NodeAPI for Greenlight {
         balance_changed: bool,
     ) -> Result<SyncResponse> {
         info!("pull changed since {}", since_timestamp);
-        let mut client = self.get_client().await?;
         let mut node_client = self.get_node_client().await?;
 
         // get node info
-        let node_info = client
-            .get_info(pb::GetInfoRequest::default())
+        let node_info = node_client
+            .getinfo(pb::cln::GetinfoRequest::default())
             .await?
             .into_inner();
 
         // list both off chain funds and on chain fudns
-        let funds = client
-            .list_funds(pb::ListFundsRequest::default())
+        let funds: pb::cln::ListfundsResponse = node_client
+            .list_funds(pb::cln::ListfundsRequest::default())
             .await?
             .into_inner();
         let onchain_funds = funds.outputs;
@@ -433,28 +431,22 @@ impl NodeAPI for Greenlight {
             if b.reserved {
                 return a;
             }
-            a + amount_to_msat(&b.amount.clone().unwrap_or_default())
+            a + b.amount_msat.clone().unwrap_or_default().msat
         });
 
         // Collect utxos from onchain funds
         let utxos = onchain_funds
             .iter()
-            .filter_map(|list_funds_output| {
-                list_funds_output
-                    .output
+            .map(|output| UnspentTransactionOutput {
+                txid: output.txid.clone(),
+                outnum: output.output,
+                amount_millisatoshi: output
+                    .amount_msat
                     .as_ref()
-                    .map(|output| UnspentTransactionOutput {
-                        txid: output.txid.clone(),
-                        outnum: output.outnum,
-                        amount_millisatoshi: list_funds_output
-                            .amount
-                            .as_ref()
-                            .map(amount_to_msat)
-                            .unwrap_or_default(),
-                        address: list_funds_output.address.clone(),
-                        reserved: list_funds_output.reserved,
-                        reserved_to_block: list_funds_output.reserved_to_block,
-                    })
+                    .map(|a| a.msat)
+                    .unwrap_or_default(),
+                address: output.address.clone().unwrap_or_default(),
+                reserved: output.reserved,
             })
             .collect();
 
@@ -479,7 +471,7 @@ impl NodeAPI for Greenlight {
         })?;
 
         let max_allowed_to_receive_msats = max(MAX_INBOUND_LIQUIDITY_MSAT - channels_balance, 0);
-        let node_pubkey = hex::encode(node_info.node_id);
+        let node_pubkey = hex::encode(node_info.id);
 
         // construct the node state
         let node_state = NodeState {
@@ -566,26 +558,24 @@ impl NodeAPI for Greenlight {
         Ok(())
     }
 
-    async fn sweep(
-        &self,
-        to_address: String,
-        fee_rate_sats_per_vbyte: u64,
-    ) -> Result<WithdrawResponse> {
-        let mut client = self.get_client().await?;
+    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u64) -> Result<Vec<u8>> {
+        let mut client = self.get_node_client().await?;
 
-        let request = pb::WithdrawRequest {
-            feerate: Some(pb::Feerate {
-                value: Some(pb::feerate::Value::Perkw(fee_rate_sats_per_vbyte * 250)),
+        let request = pb::cln::WithdrawRequest {
+            feerate: Some(pb::cln::Feerate {
+                style: Some(pb::cln::feerate::Style::Perkw(
+                    fee_rate_sats_per_vbyte as u32 * 250,
+                )),
             }),
-            amount: Some(Amount {
-                unit: Some(Unit::All(true)),
+            satoshi: Some(pb::cln::AmountOrAll {
+                value: Some(pb::cln::amount_or_all::Value::All(true)),
             }),
             destination: to_address,
             minconf: None,
             utxos: vec![],
         };
 
-        Ok(client.withdraw(request).await?.into_inner())
+        Ok(client.withdraw(request).await?.into_inner().txid)
     }
 
     /// Starts the signer that listens in a loop until the shutdown signal is received
@@ -597,17 +587,24 @@ impl NodeAPI for Greenlight {
     }
 
     async fn list_peers(&self) -> Result<Vec<Peer>> {
-        let mut client = self.get_client().await?;
-        Ok(client
-            .list_peers(pb::ListPeersRequest::default())
+        let mut client = self.get_node_client().await?;
+
+        let res: cln::ListpeersResponse = client
+            .list_peers(cln::ListpeersRequest::default())
             .await?
-            .into_inner()
-            .peers)
+            .into_inner();
+
+        let peers_models: Vec<Peer> = res.peers.into_iter().map(|p| p.into()).collect();
+        Ok(peers_models)
     }
 
-    async fn connect_peer(&self, node_id: String, addr: String) -> Result<()> {
-        let mut client = self.get_client().await?;
-        let connect_req = pb::ConnectRequest { node_id, addr };
+    async fn connect_peer(&self, id: String, addr: String) -> Result<()> {
+        let mut client = self.get_node_client().await?;
+        let connect_req = pb::cln::ConnectRequest {
+            id: format!("{id}@{addr}"),
+            host: None,
+            port: None,
+        };
         client.connect_peer(connect_req).await?;
         Ok(())
     }
@@ -748,9 +745,9 @@ impl NodeAPI for Greenlight {
         match node_cmd {
             NodeCommand::ListPeers => {
                 let resp = self
-                    .get_client()
+                    .get_node_client()
                     .await?
-                    .list_peers(pb::ListPeersRequest::default())
+                    .list_peers(pb::cln::ListpeersRequest::default())
                     .await?
                     .into_inner();
                 Ok(format!("{resp:?}"))
@@ -766,36 +763,36 @@ impl NodeAPI for Greenlight {
             }
             NodeCommand::ListFunds => {
                 let resp = self
-                    .get_client()
+                    .get_node_client()
                     .await?
-                    .list_funds(pb::ListFundsRequest::default())
+                    .list_funds(pb::cln::ListfundsRequest::default())
                     .await?
                     .into_inner();
                 Ok(format!("{resp:?}"))
             }
             NodeCommand::ListPayments => {
                 let resp = self
-                    .get_client()
+                    .get_node_client()
                     .await?
-                    .list_payments(pb::ListPaymentsRequest::default())
+                    .list_pays(pb::cln::ListpaysRequest::default())
                     .await?
                     .into_inner();
                 Ok(format!("{resp:?}"))
             }
             NodeCommand::ListInvoices => {
                 let resp = self
-                    .get_client()
+                    .get_node_client()
                     .await?
-                    .list_invoices(pb::ListInvoicesRequest::default())
+                    .list_invoices(pb::cln::ListinvoicesRequest::default())
                     .await?
                     .into_inner();
                 Ok(format!("{resp:?}"))
             }
             NodeCommand::CloseAllChannels => {
                 let peers_res = self
-                    .get_client()
+                    .get_node_client()
                     .await?
-                    .list_peers(pb::ListPeersRequest::default())
+                    .list_peers(pb::cln::ListpeersRequest::default())
                     .await?
                     .into_inner();
                 for p in peers_res.peers {
@@ -1201,6 +1198,15 @@ fn amount_to_msat(amount: &pb::Amount) -> u64 {
     }
 }
 
+impl From<cln::ListpeersPeers> for Peer {
+    fn from(c: cln::ListpeersPeers) -> Self {
+        Peer {
+            id: c.id,
+            channels: c.channels.into_iter().map(|c| c.into()).collect(),
+        }
+    }
+}
+
 impl From<cln::ListpeersPeersChannels> for Channel {
     fn from(c: cln::ListpeersPeersChannels) -> Self {
         let state = match c.state() {
@@ -1212,6 +1218,11 @@ impl From<cln::ListpeersPeersChannels> for Channel {
             _ => ChannelState::PendingClose,
         };
 
+        let (alias_remote, alias_local) = match c.alias {
+            Some(a) => (a.remote, a.local),
+            None => (None, None),
+        };
+
         Channel {
             short_channel_id: c.short_channel_id.unwrap_or_default(),
             state,
@@ -1220,6 +1231,8 @@ impl From<cln::ListpeersPeersChannels> for Channel {
             receivable_msat: c.receivable_msat.unwrap_or_default().msat,
             closed_at: None,
             funding_outnum: c.funding_outnum,
+            alias_remote,
+            alias_local,
         }
     }
 }
@@ -1228,6 +1241,10 @@ impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
     type Error = anyhow::Error;
 
     fn try_from(c: ListclosedchannelsClosedchannels) -> std::result::Result<Self, Self::Error> {
+        let (alias_remote, alias_local) = match c.alias {
+            Some(a) => (a.remote, a.local),
+            None => (None, None),
+        };
         Ok(Channel {
             short_channel_id: c
                 .short_channel_id
@@ -1241,6 +1258,8 @@ impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
             receivable_msat: 0,
             closed_at: None, // Don't fill at his time, because it involves a chain_service lookup
             funding_outnum: Some(c.funding_outnum),
+            alias_remote,
+            alias_local,
         })
     }
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -87,7 +87,7 @@ pub trait NodeAPI: Send + Sync {
         amount_sats: u64,
     ) -> Result<crate::models::PaymentResponse>;
     async fn start(&self) -> Result<()>;
-    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u64) -> Result<Vec<u8>>;
+    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> Result<Vec<u8>>;
     async fn start_signer(&self, shutdown: mpsc::Receiver<()>);
     async fn list_peers(&self) -> Result<Vec<Peer>>;
     async fn connect_peer(&self, node_id: String, addr: String) -> Result<()>;
@@ -798,7 +798,7 @@ pub struct BuyBitcoinResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SweepRequest {
     pub to_address: String,
-    pub fee_rate_sats_per_vbyte: u64,
+    pub fee_rate_sats_per_vbyte: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/sdk-core/src/persist/channels.rs
+++ b/libs/sdk-core/src/persist/channels.rs
@@ -84,19 +84,17 @@ impl SqliteStorage {
                    spendable_msat, 
                    receivable_msat,
                    closed_at,
-                   funding_outnum,
-                   closed_at,
+                   funding_outnum,                   
                    alias_local,
                    alias_remote
                   )
-                  VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)
+                  VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
                   ON CONFLICT(funding_txid) DO UPDATE SET
                    short_channel_id=excluded.short_channel_id,
                    state=excluded.state,
                    spendable_msat=excluded.spendable_msat,
                    receivable_msat=excluded.receivable_msat,
-                   funding_outnum=excluded.funding_outnum,
-                   closed_at=excluded.closed_at,
+                   funding_outnum=excluded.funding_outnum,                   
                    alias_local=excluded.alias_local,
                    alias_remote=excluded.alias_remote
                ",
@@ -111,7 +109,6 @@ impl SqliteStorage {
                     _ => c.closed_at,
                 },
                 c.funding_outnum,
-                c.closed_at,
                 c.alias_local,
                 c.alias_remote,
             ),

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -413,6 +413,8 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        UPDATE payments SET status = CASE WHEN status = 1 THEN 0 ELSE 1 END;
        ",
        "SELECT 1;", // Placeholder statement, to avoid that column is added twice (from sync fn below and here)
+       "ALTER TABLE channels ADD COLUMN alias_local TEXT;",
+       "ALTER TABLE channels ADD COLUMN alias_remote TEXT;"
     ]
 }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -323,7 +323,7 @@ impl NodeAPI for MockNodeAPI {
         Ok(())
     }
 
-    async fn sweep(&self, _to_address: String, _fee_rate_sats_per_vbyte: u64) -> Result<Vec<u8>> {
+    async fn sweep(&self, _to_address: String, _fee_rate_sats_per_vbyte: u32) -> Result<Vec<u8>> {
         Ok(rand_vec_u8(32))
     }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -12,7 +12,7 @@ use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
 use bitcoin::Network;
 use chrono::{SecondsFormat, Utc};
 use gl_client::pb::amount::Unit;
-use gl_client::pb::{Amount, PayStatus, Peer, WithdrawResponse};
+use gl_client::pb::{Amount, PayStatus};
 use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, InvoiceBuilder, RawInvoice};
 use rand::distributions::{Alphanumeric, DistString, Standard};
@@ -34,7 +34,7 @@ use crate::lsp::LspInformation;
 use crate::models::{FiatAPI, LspAPI, NodeAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse};
 use crate::moonpay::MoonPayApi;
 use crate::swap::create_submarine_swap_script;
-use crate::{parse_invoice, Config, CustomMessage, LNInvoice, PaymentResponse, RouteHint};
+use crate::{parse_invoice, Config, CustomMessage, LNInvoice, PaymentResponse, Peer, RouteHint};
 use crate::{OpeningFeeParams, OpeningFeeParamsMenu};
 use crate::{ReceivePaymentRequest, SwapInfo};
 
@@ -323,15 +323,8 @@ impl NodeAPI for MockNodeAPI {
         Ok(())
     }
 
-    async fn sweep(
-        &self,
-        _to_address: String,
-        _fee_rate_sats_per_vbyte: u64,
-    ) -> Result<WithdrawResponse> {
-        Ok(WithdrawResponse {
-            tx: rand_vec_u8(32),
-            txid: rand_vec_u8(32),
-        })
+    async fn sweep(&self, _to_address: String, _fee_rate_sats_per_vbyte: u64) -> Result<Vec<u8>> {
+        Ok(rand_vec_u8(32))
     }
 
     async fn start_signer(&self, _shutdown: mpsc::Receiver<()>) {}

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -134,7 +134,7 @@ typedef struct wire_BuyBitcoinRequest {
 
 typedef struct wire_SweepRequest {
   struct wire_uint_8_list *to_address;
-  uint64_t fee_rate_sats_per_vbyte;
+  uint32_t fee_rate_sats_per_vbyte;
 } wire_SweepRequest;
 
 typedef struct wire_OpenChannelFeeRequest {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -3644,7 +3644,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_sweep_request(SweepRequest apiObj, wire_SweepRequest wireObj) {
     wireObj.to_address = api2wire_String(apiObj.toAddress);
-    wireObj.fee_rate_sats_per_vbyte = api2wire_u64(apiObj.feeRateSatsPerVbyte);
+    wireObj.fee_rate_sats_per_vbyte = api2wire_u32(apiObj.feeRateSatsPerVbyte);
   }
 }
 
@@ -4839,7 +4839,7 @@ class wire_BuyBitcoinRequest extends ffi.Struct {
 class wire_SweepRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> to_address;
 
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int fee_rate_sats_per_vbyte;
 }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1437,7 +1437,6 @@ class UnspentTransactionOutput {
   final int amountMillisatoshi;
   final String address;
   final bool reserved;
-  final int reservedToBlock;
 
   const UnspentTransactionOutput({
     required this.txid,
@@ -1445,7 +1444,6 @@ class UnspentTransactionOutput {
     required this.amountMillisatoshi,
     required this.address,
     required this.reserved,
-    required this.reservedToBlock,
   });
 }
 
@@ -3121,14 +3119,13 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   UnspentTransactionOutput _wire2api_unspent_transaction_output(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return UnspentTransactionOutput(
       txid: _wire2api_uint_8_list(arr[0]),
       outnum: _wire2api_u32(arr[1]),
       amountMillisatoshi: _wire2api_u64(arr[2]),
       address: _wire2api_String(arr[3]),
       reserved: _wire2api_bool(arr[4]),
-      reservedToBlock: _wire2api_u32(arr[5]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -2440,7 +2440,6 @@ fun asUnspentTransactionOutput(data: ReadableMap): UnspentTransactionOutput? {
                 "amountMillisatoshi",
                 "address",
                 "reserved",
-                "reservedToBlock",
             ),
         )
     ) {
@@ -2451,14 +2450,12 @@ fun asUnspentTransactionOutput(data: ReadableMap): UnspentTransactionOutput? {
     val amountMillisatoshi = data.getDouble("amountMillisatoshi").toULong()
     val address = data.getString("address")!!
     val reserved = data.getBoolean("reserved")
-    val reservedToBlock = data.getInt("reservedToBlock").toUInt()
     return UnspentTransactionOutput(
         txid,
         outnum,
         amountMillisatoshi,
         address,
         reserved,
-        reservedToBlock,
     )
 }
 
@@ -2469,7 +2466,6 @@ fun readableMapOf(unspentTransactionOutput: UnspentTransactionOutput): ReadableM
         "amountMillisatoshi" to unspentTransactionOutput.amountMillisatoshi,
         "address" to unspentTransactionOutput.address,
         "reserved" to unspentTransactionOutput.reserved,
-        "reservedToBlock" to unspentTransactionOutput.reservedToBlock,
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -2333,7 +2333,7 @@ fun asSweepRequest(data: ReadableMap): SweepRequest? {
         return null
     }
     val toAddress = data.getString("toAddress")!!
-    val feeRateSatsPerVbyte = data.getDouble("feeRateSatsPerVbyte").toULong()
+    val feeRateSatsPerVbyte = data.getInt("feeRateSatsPerVbyte").toUInt()
     return SweepRequest(
         toAddress,
         feeRateSatsPerVbyte,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2228,15 +2228,13 @@ class BreezSDKMapper {
         guard let amountMillisatoshi = data["amountMillisatoshi"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMillisatoshi for type UnspentTransactionOutput") }
         guard let address = data["address"] as? String else { throw SdkError.Generic(message: "Missing mandatory field address for type UnspentTransactionOutput") }
         guard let reserved = data["reserved"] as? Bool else { throw SdkError.Generic(message: "Missing mandatory field reserved for type UnspentTransactionOutput") }
-        guard let reservedToBlock = data["reservedToBlock"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field reservedToBlock for type UnspentTransactionOutput") }
 
         return UnspentTransactionOutput(
             txid: txid,
             outnum: outnum,
             amountMillisatoshi: amountMillisatoshi,
             address: address,
-            reserved: reserved,
-            reservedToBlock: reservedToBlock
+            reserved: reserved
         )
     }
 
@@ -2247,7 +2245,6 @@ class BreezSDKMapper {
             "amountMillisatoshi": unspentTransactionOutput.amountMillisatoshi,
             "address": unspentTransactionOutput.address,
             "reserved": unspentTransactionOutput.reserved,
-            "reservedToBlock": unspentTransactionOutput.reservedToBlock,
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2120,7 +2120,7 @@ class BreezSDKMapper {
 
     static func asSweepRequest(data: [String: Any?]) throws -> SweepRequest {
         guard let toAddress = data["toAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field toAddress for type SweepRequest") }
-        guard let feeRateSatsPerVbyte = data["feeRateSatsPerVbyte"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field feeRateSatsPerVbyte for type SweepRequest") }
+        guard let feeRateSatsPerVbyte = data["feeRateSatsPerVbyte"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field feeRateSatsPerVbyte for type SweepRequest") }
 
         return SweepRequest(
             toAddress: toAddress,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -401,7 +401,6 @@ export type UnspentTransactionOutput = {
     amountMillisatoshi: number
     address: string
     reserved: boolean
-    reservedToBlock: number
 }
 
 export type UrlSuccessActionData = {

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -134,7 +134,7 @@ pub(crate) enum Commands {
         to_address: String,
 
         /// The fee rate for the sweep transaction
-        sat_per_vbyte: u64,
+        sat_per_vbyte: u32,
     },
 
     /// List available LSPs


### PR DESCRIPTION
This PR moves from the greenlight.proto deprecated API and uses the node.proto instead.
Greenlight are going to retire the greenlight.proto very soon: https://github.com/Blockstream/greenlight/pull/279