### PR TITLE
Fix rev swap state transitions

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1182,10 +1182,12 @@ impl BreezServices {
                 r#"
                 info,
                 breez_sdk_core::input_parser=warn,
+                breez_sdk_core::backup=info,
+                breez_sdk_core::persist::reverseswap=info,
+                breez_sdk_core::reverseswap=info,
                 gl_client=warn,
                 h2=warn,
                 hyper=warn,
-                breez_sdk_core::reverseswap=info,
                 lightning_signer=warn,
                 reqwest=warn,
                 rustls=warn,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -364,6 +364,8 @@ impl From<FullReverseSwapInfo> for ReverseSwapInfo {
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum ReverseSwapStatus {
     /// HODL invoice payment is not completed yet
+    ///
+    /// This is also the temporary status of a reverse swap when restoring a node, until `sync` finishes.
     Initial = 0,
 
     /// HODL invoice payment was successfully triggered and confirmed by Boltz, but the reverse swap


### PR DESCRIPTION
This PR fixes the handling of the initial reverse swap state, when a node is restored.

It also handles two more edge cases in state transition that result in state Cancelled.