### PR TITLE
Persist channel closed_at after lookup

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1225,38 +1225,49 @@ impl BreezServices {
     ) -> Result<Payment> {
         let now_epoch_sec = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
-        // If we don't have it, we look it up from the channel closing tx
-        let channel_closed_at = channel.closed_at.unwrap_or(
-            match channel.funding_outnum {
-                None => {
-                    warn!("No founding_outnum found for the closing tx, defaulting closed_at to epoch time");
-                    now_epoch_sec
-                }
-                Some(outnum) => {
-                    // Find the output tx that was used to fund the channel
-                    let outspends = self
-                        .chain_service
-                        .transaction_outspends(channel.funding_txid.clone())
-                        .await?;
-                    let maybe_block_time = outspends.get(outnum as usize)
-                        .and_then(|outspend| outspend.status.as_ref())
-                        .and_then(|status| status.block_time);
-
-                    match maybe_block_time {
-                        None => {
-                            warn!("Blocktime could not be determined for funding_outnum {outnum}, defaulting closed_at to epoch time");
-                            now_epoch_sec
-                        }
-                        Some(block_time) => block_time
+        let channel_closed_at = match channel.closed_at {
+            Some(closed_at) => closed_at,
+            None => {
+                // If we don't have it, we look it up from the channel closing tx
+                let looked_up_channel_closed_at = match channel.funding_outnum {
+                    None => {
+                        warn!("No founding_outnum found for the closing tx, defaulting closed_at to epoch time");
+                        now_epoch_sec
                     }
-                }
+                    Some(outnum) => {
+                        // Find the output tx that was used to fund the channel
+                        let outspends = self
+                            .chain_service
+                            .transaction_outspends(channel.funding_txid.clone())
+                            .await?;
+                        let maybe_block_time = outspends
+                            .get(outnum as usize)
+                            .and_then(|outspend| outspend.status.as_ref())
+                            .and_then(|status| status.block_time);
+
+                        match maybe_block_time {
+                            None => {
+                                warn!("Blocktime could not be determined for funding_outnum {outnum}, defaulting closed_at to epoch time");
+                                now_epoch_sec
+                            }
+                            Some(block_time) => block_time,
+                        }
+                    }
+                };
+
+                // Persist closed_at, if we had to look it up
+                let mut updated_channel = channel.clone();
+                updated_channel.closed_at = Some(looked_up_channel_closed_at);
+                self.persister.update_channels(&[updated_channel])?;
+
+                looked_up_channel_closed_at
             }
-        ) as i64;
+        };
 
         Ok(Payment {
             id: channel.funding_txid.clone(),
             payment_type: PaymentType::ClosedChannel,
-            payment_time: channel_closed_at,
+            payment_time: channel_closed_at as i64,
             amount_msat: channel.spendable_msat,
             fee_msat: 0,
             status: match channel.state {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1258,7 +1258,7 @@ impl BreezServices {
                 // Persist closed_at, if we had to look it up
                 let mut updated_channel = channel.clone();
                 updated_channel.closed_at = Some(looked_up_channel_closed_at);
-                self.persister.update_channels(&[updated_channel])?;
+                self.persister.insert_or_update_channel(updated_channel)?;
 
                 looked_up_channel_closed_at
             }

--- a/libs/sdk-core/src/persist/channels.rs
+++ b/libs/sdk-core/src/persist/channels.rs
@@ -75,9 +75,9 @@ impl SqliteStorage {
         Ok(channels)
     }
 
-    fn insert_or_update_channel(&self, c: Channel) -> Result<()> {
+    pub(crate) fn insert_or_update_channel(&self, c: Channel) -> Result<()> {
         self.get_connection()?.execute(
-            "INSERT INTO channels (
+            "INSERT OR REPLACE INTO channels (
                    funding_txid, 
                    short_channel_id,
                    state,
@@ -89,14 +89,6 @@ impl SqliteStorage {
                    alias_remote
                   )
                   VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
-                  ON CONFLICT(funding_txid) DO UPDATE SET
-                   short_channel_id=excluded.short_channel_id,
-                   state=excluded.state,
-                   spendable_msat=excluded.spendable_msat,
-                   receivable_msat=excluded.receivable_msat,
-                   funding_outnum=excluded.funding_outnum,                   
-                   alias_local=excluded.alias_local,
-                   alias_remote=excluded.alias_remote
                ",
             (
                 c.funding_txid,


### PR DESCRIPTION
If a closed channel's `closed_at` is unknown, and we have to look it up, we now persist it.