### PR TITLE
Consider only completed payments when

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1126,7 +1126,7 @@ impl TryFrom<ListpaysPays> for Payment {
         Ok(Payment {
             id: hex::encode(payment.payment_hash.clone()),
             payment_type: PaymentType::Sent,
-            payment_time: payment.created_at as i64,
+            payment_time: payment.completed_at.unwrap_or(payment.created_at) as i64,
             amount_msat: match status {
                 PaymentStatus::Failed => ln_invoice
                     .as_ref()

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -119,9 +119,11 @@ impl SqliteStorage {
 
     pub fn last_payment_timestamp(&self) -> Result<u64> {
         self.get_connection()?
-            .query_row("SELECT max(payment_time) FROM payments", [], |row| {
-                row.get(0)
-            })
+            .query_row(
+                "SELECT max(payment_time) FROM payments where status != ?1",
+                params![PaymentStatus::Pending],
+                |row| row.get(0),
+            )
             .map_err(anyhow::Error::msg)
     }
 


### PR DESCRIPTION
This PR fixes a race in the sync method.
When we pull changes from the node, we calculate the last synced timestamp (last payment time in the db) to determine which payments should be added. When investigating this issue #458  , I found that the pending payment time is equal to the completed payment time which means if there was a pending payment in the db the next sync won't fetch the completed payment as it is not above the "last sync timestamp".

This PR fixes two things:
1.  Pick the completed_at time as the payment time rather then the started_at (which is correct regardless of the issue). It also ensures the completed payment time will always be more than the pending one.
2. Don't consider pending payments when calculating the last sync timestamp as these are transient anyway.

I did manage to reproduce it with two simultaneous nodes and ensures the fix works. With one node this issue happens if there is a sync in between the payment start and its completion which may explain why it happens occasionally. 
I hope it Fixed #458 
