### PR TITLE
CI: build kotlin mpp on macOS

### DIFF
--- a/.github/workflows/publish-kotlin-mpp.yml
+++ b/.github/workflows/publish-kotlin-mpp.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build-package:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Linux ignores ios targets for kotlin-mpp. Build on ios to include all targets.