### PR TITLE
Add closing_txid to Channel, ClosedChannelPaymentDetails

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -198,6 +198,7 @@ dictionary ClosedChannelPaymentDetails {
     string short_channel_id;
     ChannelState state;
     string funding_txid;
+    string closing_txid;
 };
 
 enum ChannelState {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -198,7 +198,7 @@ dictionary ClosedChannelPaymentDetails {
     string short_channel_id;
     ChannelState state;
     string funding_txid;
-    string closing_txid;
+    string? closing_txid;
 };
 
 enum ChannelState {

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -898,6 +898,7 @@ impl support::IntoDart for ClosedChannelPaymentDetails {
             self.short_channel_id.into_dart(),
             self.state.into_dart(),
             self.funding_txid.into_dart(),
+            self.closing_txid.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1219,6 +1219,7 @@ impl From<cln::ListpeersPeers> for Peer {
     }
 }
 
+/// Conversion for an open channel
 impl From<cln::ListpeersPeersChannels> for Channel {
     fn from(c: cln::ListpeersPeersChannels) -> Self {
         let state = match c.state() {
@@ -1245,10 +1246,12 @@ impl From<cln::ListpeersPeersChannels> for Channel {
             funding_outnum: c.funding_outnum,
             alias_remote,
             alias_local,
+            closing_txid: None,
         }
     }
 }
 
+/// Conversion for a closed channel
 impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
     type Error = anyhow::Error;
 
@@ -1257,6 +1260,9 @@ impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
             Some(a) => (a.remote, a.local),
             None => (None, None),
         };
+
+        // To keep the conversion simple and fast, some closing-related fields (closed_at, closing_txid)
+        // are left empty here in the conversion, but populated later (via chain service lookup, or DB lookup)
         Ok(Channel {
             short_channel_id: c
                 .short_channel_id
@@ -1268,10 +1274,11 @@ impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
                 .ok_or(anyhow!("final_to_us_msat is missing"))?
                 .msat,
             receivable_msat: 0,
-            closed_at: None, // Don't fill at his time, because it involves a chain_service lookup
+            closed_at: None,
             funding_outnum: Some(c.funding_outnum),
             alias_remote,
             alias_local,
+            closing_txid: None,
         })
     }
 }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -724,7 +724,7 @@ pub struct ClosedChannelPaymentDetails {
     pub state: ChannelState,
     pub funding_txid: String,
     /// Can be empty for older closed channels.
-    pub closing_txid: String,
+    pub closing_txid: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -723,6 +723,8 @@ pub struct ClosedChannelPaymentDetails {
     pub short_channel_id: String,
     pub state: ChannelState,
     pub funding_txid: String,
+    /// Can be empty for older closed channels.
+    pub closing_txid: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -995,6 +997,10 @@ pub struct Channel {
     pub funding_outnum: Option<u32>,
     pub alias_local: Option<String>,
     pub alias_remote: Option<String>,
+    /// Only set for closed channels.
+    ///
+    /// This may be empty for older closed channels, if it was not possible to retrieve the closing txid.
+    pub closing_txid: Option<String>,
 }
 
 /// State of a Lightning channel

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -414,7 +414,8 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ",
        "SELECT 1;", // Placeholder statement, to avoid that column is added twice (from sync fn below and here)
        "ALTER TABLE channels ADD COLUMN alias_local TEXT;",
-       "ALTER TABLE channels ADD COLUMN alias_remote TEXT;"
+       "ALTER TABLE channels ADD COLUMN alias_remote TEXT;",
+       "ALTER TABLE channels ADD COLUMN closing_txid TEXT;"
     ]
 }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -402,10 +402,14 @@ class ClosedChannelPaymentDetails {
   final ChannelState state;
   final String fundingTxid;
 
+  /// Can be empty for older closed channels.
+  final String? closingTxid;
+
   const ClosedChannelPaymentDetails({
     required this.shortChannelId,
     required this.state,
     required this.fundingTxid,
+    this.closingTxid,
   });
 }
 
@@ -2396,11 +2400,12 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   ClosedChannelPaymentDetails _wire2api_closed_channel_payment_details(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ClosedChannelPaymentDetails(
       shortChannelId: _wire2api_String(arr[0]),
       state: _wire2api_channel_state(arr[1]),
       fundingTxid: _wire2api_String(arr[2]),
+      closingTxid: _wire2api_opt_String(arr[3]),
     );
   }
 

--- a/libs/sdk-flutter/lib/native_toolkit.dart
+++ b/libs/sdk-flutter/lib/native_toolkit.dart
@@ -19,8 +19,7 @@ BreezSdkCore getNativeToolkit() {
       // iOS and macOS are statically linked
       _breezSDK = BreezSdkCoreImpl(DynamicLibrary.process());
     } else {
-      throw UnsupportedPlatform(
-          '${Platform.operatingSystem} is not yet supported!');
+      throw UnsupportedPlatform('${Platform.operatingSystem} is not yet supported!');
     }
   }
   return _breezSDK!;

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -322,6 +322,7 @@ fun asClosedChannelPaymentDetails(data: ReadableMap): ClosedChannelPaymentDetail
                 "shortChannelId",
                 "state",
                 "fundingTxid",
+                "closingTxid",
             ),
         )
     ) {
@@ -330,10 +331,12 @@ fun asClosedChannelPaymentDetails(data: ReadableMap): ClosedChannelPaymentDetail
     val shortChannelId = data.getString("shortChannelId")!!
     val state = data.getString("state")?.let { asChannelState(it) }!!
     val fundingTxid = data.getString("fundingTxid")!!
+    val closingTxid = data.getString("closingTxid")!!
     return ClosedChannelPaymentDetails(
         shortChannelId,
         state,
         fundingTxid,
+        closingTxid,
     )
 }
 
@@ -342,6 +345,7 @@ fun readableMapOf(closedChannelPaymentDetails: ClosedChannelPaymentDetails): Rea
         "shortChannelId" to closedChannelPaymentDetails.shortChannelId,
         "state" to closedChannelPaymentDetails.state.name.lowercase(),
         "fundingTxid" to closedChannelPaymentDetails.fundingTxid,
+        "closingTxid" to closedChannelPaymentDetails.closingTxid,
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -322,7 +322,6 @@ fun asClosedChannelPaymentDetails(data: ReadableMap): ClosedChannelPaymentDetail
                 "shortChannelId",
                 "state",
                 "fundingTxid",
-                "closingTxid",
             ),
         )
     ) {
@@ -331,7 +330,7 @@ fun asClosedChannelPaymentDetails(data: ReadableMap): ClosedChannelPaymentDetail
     val shortChannelId = data.getString("shortChannelId")!!
     val state = data.getString("state")?.let { asChannelState(it) }!!
     val fundingTxid = data.getString("fundingTxid")!!
-    val closingTxid = data.getString("closingTxid")!!
+    val closingTxid = if (hasNonNullKey(data, "closingTxid")) data.getString("closingTxid") else null
     return ClosedChannelPaymentDetails(
         shortChannelId,
         state,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -294,11 +294,13 @@ class BreezSDKMapper {
         let state = try asChannelState(type: stateTmp)
 
         guard let fundingTxid = data["fundingTxid"] as? String else { throw SdkError.Generic(message: "Missing mandatory field fundingTxid for type ClosedChannelPaymentDetails") }
+        guard let closingTxid = data["closingTxid"] as? String else { throw SdkError.Generic(message: "Missing mandatory field closingTxid for type ClosedChannelPaymentDetails") }
 
         return ClosedChannelPaymentDetails(
             shortChannelId: shortChannelId,
             state: state,
-            fundingTxid: fundingTxid
+            fundingTxid: fundingTxid,
+            closingTxid: closingTxid
         )
     }
 
@@ -307,6 +309,7 @@ class BreezSDKMapper {
             "shortChannelId": closedChannelPaymentDetails.shortChannelId,
             "state": valueOf(channelState: closedChannelPaymentDetails.state),
             "fundingTxid": closedChannelPaymentDetails.fundingTxid,
+            "closingTxid": closedChannelPaymentDetails.closingTxid,
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -294,7 +294,7 @@ class BreezSDKMapper {
         let state = try asChannelState(type: stateTmp)
 
         guard let fundingTxid = data["fundingTxid"] as? String else { throw SdkError.Generic(message: "Missing mandatory field fundingTxid for type ClosedChannelPaymentDetails") }
-        guard let closingTxid = data["closingTxid"] as? String else { throw SdkError.Generic(message: "Missing mandatory field closingTxid for type ClosedChannelPaymentDetails") }
+        let closingTxid = data["closingTxid"] as? String
 
         return ClosedChannelPaymentDetails(
             shortChannelId: shortChannelId,
@@ -309,7 +309,7 @@ class BreezSDKMapper {
             "shortChannelId": closedChannelPaymentDetails.shortChannelId,
             "state": valueOf(channelState: closedChannelPaymentDetails.state),
             "fundingTxid": closedChannelPaymentDetails.fundingTxid,
-            "closingTxid": closedChannelPaymentDetails.closingTxid,
+            "closingTxid": closedChannelPaymentDetails.closingTxid == nil ? nil : closedChannelPaymentDetails.closingTxid,
         ]
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -65,7 +65,7 @@ export type ClosedChannelPaymentDetails = {
     shortChannelId: string
     state: ChannelState
     fundingTxid: string
-    closingTxid: string
+    closingTxid?: string
 }
 
 export type Config = {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -65,6 +65,7 @@ export type ClosedChannelPaymentDetails = {
     shortChannelId: string
     state: ChannelState
     fundingTxid: string
+    closingTxid: string
 }
 
 export type Config = {


### PR DESCRIPTION
`closed_channel_to_transaction` was expanded to 2 fields which could depend on a chainservice lookup:
- `closed_at`
- `closing_txid`

I've refactored it to make it more readable, extracting the lookup methods to separate functions.

This also includes a new optional field `closing_txid` in `Channel`, which is by default empty and is looked up (and persisted) once, just as `closed_at`.

Fixes #484