### PR TITLE
Extend payment type filter to include `ClosedChannels` type

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -148,7 +148,7 @@ dictionary Payment {
 };
 
 dictionary ListPaymentsRequest {
-    sequence<PaymentTypeFilter> filters;
+    sequence<PaymentTypeFilter>? filters = null;
     i64? from_timestamp = null;
     i64? to_timestamp = null;
     boolean? include_failures = null;

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -121,6 +121,7 @@ dictionary CheckMessageResponse {
 enum PaymentTypeFilter {
     "Sent",
     "Received",
+    "ClosedChannels",
     "All",
 };
 
@@ -148,7 +149,7 @@ dictionary Payment {
 };
 
 dictionary ListPaymentsRequest {
-    PaymentTypeFilter filter;
+    sequence<PaymentTypeFilter> filters;
     i64? from_timestamp = null;
     i64? to_timestamp = null;
     boolean? include_failures = null;

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -122,7 +122,6 @@ enum PaymentTypeFilter {
     "Sent",
     "Received",
     "ClosedChannels",
-    "All",
 };
 
 enum PaymentStatus {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2032,7 +2032,7 @@ pub(crate) mod tests {
 
         let all = breez_services
             .list_payments(ListPaymentsRequest {
-                filters: vec![],
+                filters: None,
                 from_timestamp: None,
                 to_timestamp: None,
                 include_failures: None,
@@ -2048,7 +2048,7 @@ pub(crate) mod tests {
 
         let received = breez_services
             .list_payments(ListPaymentsRequest {
-                filters: vec![PaymentTypeFilter::Received],
+                filters: Some(vec![PaymentTypeFilter::Received]),
                 from_timestamp: None,
                 to_timestamp: None,
                 include_failures: None,
@@ -2060,7 +2060,10 @@ pub(crate) mod tests {
 
         let sent = breez_services
             .list_payments(ListPaymentsRequest {
-                filters: vec![PaymentTypeFilter::Sent, PaymentTypeFilter::ClosedChannels],
+                filters: Some(vec![
+                    PaymentTypeFilter::Sent,
+                    PaymentTypeFilter::ClosedChannels,
+                ]),
                 from_timestamp: None,
                 to_timestamp: None,
                 include_failures: None,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2032,7 +2032,7 @@ pub(crate) mod tests {
 
         let all = breez_services
             .list_payments(ListPaymentsRequest {
-                filters: vec![PaymentTypeFilter::All],
+                filters: vec![],
                 from_timestamp: None,
                 to_timestamp: None,
                 include_failures: None,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2032,7 +2032,7 @@ pub(crate) mod tests {
 
         let all = breez_services
             .list_payments(ListPaymentsRequest {
-                filter: PaymentTypeFilter::All,
+                filters: vec![PaymentTypeFilter::All],
                 from_timestamp: None,
                 to_timestamp: None,
                 include_failures: None,
@@ -2048,7 +2048,7 @@ pub(crate) mod tests {
 
         let received = breez_services
             .list_payments(ListPaymentsRequest {
-                filter: PaymentTypeFilter::Received,
+                filters: vec![PaymentTypeFilter::Received],
                 from_timestamp: None,
                 to_timestamp: None,
                 include_failures: None,
@@ -2060,7 +2060,7 @@ pub(crate) mod tests {
 
         let sent = breez_services
             .list_payments(ListPaymentsRequest {
-                filter: PaymentTypeFilter::Sent,
+                filters: vec![PaymentTypeFilter::Sent, PaymentTypeFilter::ClosedChannels],
                 from_timestamp: None,
                 to_timestamp: None,
                 include_failures: None,

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -745,7 +745,6 @@ impl Wire2Api<PaymentTypeFilter> for i32 {
             0 => PaymentTypeFilter::Sent,
             1 => PaymentTypeFilter::Received,
             2 => PaymentTypeFilter::ClosedChannels,
-            3 => PaymentTypeFilter::All,
             _ => unreachable!("Invalid variant for PaymentTypeFilter: {}", self),
         }
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -744,7 +744,8 @@ impl Wire2Api<PaymentTypeFilter> for i32 {
         match self {
             0 => PaymentTypeFilter::Sent,
             1 => PaymentTypeFilter::Received,
-            2 => PaymentTypeFilter::All,
+            2 => PaymentTypeFilter::ClosedChannels,
+            3 => PaymentTypeFilter::All,
             _ => unreachable!("Invalid variant for PaymentTypeFilter: {}", self),
         }
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -38,7 +38,7 @@ pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
 pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 60 minutes
 
 /// Different types of supported payments
-#[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize, Hash)]
 pub enum PaymentType {
     Sent,
     Received,
@@ -576,9 +576,11 @@ impl From<Network> for bitcoin::network::constants::Network {
 }
 
 /// Different types of supported filters which can be applied when retrieving the transaction list
+#[derive(PartialEq)]
 pub enum PaymentTypeFilter {
     Sent,
     Received,
+    ClosedChannels,
     All,
 }
 
@@ -656,7 +658,7 @@ pub struct Payment {
 
 /// Represents a list payments request.
 pub struct ListPaymentsRequest {
-    pub filter: PaymentTypeFilter,
+    pub filters: Vec<PaymentTypeFilter>,
     pub from_timestamp: Option<i64>,
     pub to_timestamp: Option<i64>,
     pub include_failures: Option<bool>,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -581,7 +581,6 @@ pub enum PaymentTypeFilter {
     Sent,
     Received,
     ClosedChannels,
-    All,
 }
 
 /// Different types of supported feerates

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -657,7 +657,7 @@ pub struct Payment {
 
 /// Represents a list payments request.
 pub struct ListPaymentsRequest {
-    pub filters: Vec<PaymentTypeFilter>,
+    pub filters: Option<Vec<PaymentTypeFilter>>,
     pub from_timestamp: Option<i64>,
     pub to_timestamp: Option<i64>,
     pub include_failures: Option<bool>,

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Row;
 use rusqlite::{params, OptionalExtension};
+use std::collections::HashSet;
 
 use std::str::FromStr;
 
@@ -133,7 +134,7 @@ impl SqliteStorage {
     /// or [Self::get_completed_payment_by_hash]
     pub fn list_payments(&self, req: ListPaymentsRequest) -> SdkResult<Vec<Payment>> {
         let where_clause = filter_to_where_clause(
-            req.filter,
+            req.filters,
             req.from_timestamp,
             req.to_timestamp,
             req.include_failures,
@@ -262,7 +263,7 @@ impl SqliteStorage {
 }
 
 fn filter_to_where_clause(
-    type_filter: PaymentTypeFilter,
+    type_filters: Vec<PaymentTypeFilter>,
     from_timestamp: Option<i64>,
     to_timestamp: Option<i64>,
     include_failures: Option<bool>,
@@ -280,18 +281,31 @@ fn filter_to_where_clause(
         where_clause.push(format!("status != {}", PaymentStatus::Failed as i64));
     };
 
-    match type_filter {
-        PaymentTypeFilter::Sent => {
-            where_clause.push(format!(
-                "payment_type in ('{}','{}') ",
-                PaymentType::Sent,
-                PaymentType::ClosedChannel
-            ));
+    if !type_filters.contains(&PaymentTypeFilter::All) {
+        let mut type_filter_clause: HashSet<PaymentType> = HashSet::new();
+        for type_filter in type_filters {
+            match type_filter {
+                PaymentTypeFilter::Sent => {
+                    type_filter_clause.insert(PaymentType::Sent);
+                }
+                PaymentTypeFilter::Received => {
+                    type_filter_clause.insert(PaymentType::Received);
+                }
+                PaymentTypeFilter::ClosedChannels => {
+                    type_filter_clause.insert(PaymentType::ClosedChannel);
+                }
+                _ => {}
+            }
         }
-        PaymentTypeFilter::Received => {
-            where_clause.push(format!("payment_type = '{}' ", PaymentType::Received));
-        }
-        PaymentTypeFilter::All => (),
+
+        where_clause.push(format!(
+            "payment_type in ({})",
+            type_filter_clause
+                .iter()
+                .map(|t| format!("'{}'", t))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
 
     let mut where_clause_str = String::new();
@@ -460,7 +474,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // retrieve all
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::All,
+        filters: vec![PaymentTypeFilter::All],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -472,7 +486,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     //test only sent
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::Sent,
+        filters: vec![PaymentTypeFilter::Sent, PaymentTypeFilter::ClosedChannels],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -490,7 +504,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     //test only received
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::Received,
+        filters: vec![PaymentTypeFilter::Received],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -505,7 +519,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     storage.insert_or_update_payments(&txs)?;
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::All,
+        filters: vec![PaymentTypeFilter::All],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -517,7 +531,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     storage.insert_open_channel_payment_info("123", 150)?;
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::All,
+        filters: vec![PaymentTypeFilter::All],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -528,7 +542,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // test all with failures
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::All,
+        filters: vec![PaymentTypeFilter::All],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: Some(true),
@@ -539,7 +553,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // test sent with failures
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::Sent,
+        filters: vec![PaymentTypeFilter::Sent, PaymentTypeFilter::ClosedChannels],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: Some(true),
@@ -550,7 +564,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // test limit
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::All,
+        filters: vec![PaymentTypeFilter::All],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: Some(false),
@@ -561,7 +575,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // test offset
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filter: PaymentTypeFilter::All,
+        filters: vec![PaymentTypeFilter::All],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: Some(false),

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -281,7 +281,7 @@ fn filter_to_where_clause(
         where_clause.push(format!("status != {}", PaymentStatus::Failed as i64));
     };
 
-    if !type_filters.contains(&PaymentTypeFilter::All) {
+    if !type_filters.is_empty() {
         let mut type_filter_clause: HashSet<PaymentType> = HashSet::new();
         for type_filter in type_filters {
             match type_filter {
@@ -294,7 +294,6 @@ fn filter_to_where_clause(
                 PaymentTypeFilter::ClosedChannels => {
                     type_filter_clause.insert(PaymentType::ClosedChannel);
                 }
-                _ => {}
             }
         }
 
@@ -474,7 +473,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // retrieve all
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: vec![PaymentTypeFilter::All],
+        filters: vec![],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -519,7 +518,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     storage.insert_or_update_payments(&txs)?;
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: vec![PaymentTypeFilter::All],
+        filters: vec![],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -531,7 +530,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     storage.insert_open_channel_payment_info("123", 150)?;
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: vec![PaymentTypeFilter::All],
+        filters: vec![],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: None,
@@ -542,7 +541,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // test all with failures
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: vec![PaymentTypeFilter::All],
+        filters: vec![],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: Some(true),
@@ -564,7 +563,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // test limit
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: vec![PaymentTypeFilter::All],
+        filters: vec![],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: Some(false),
@@ -575,7 +574,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
 
     // test offset
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: vec![PaymentTypeFilter::All],
+        filters: vec![],
         from_timestamp: None,
         to_timestamp: None,
         include_failures: Some(false),

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -72,8 +72,13 @@ typedef struct wire_StaticBackupRequest {
   struct wire_uint_8_list *working_dir;
 } wire_StaticBackupRequest;
 
+typedef struct wire_list_payment_type_filter {
+  int32_t *ptr;
+  int32_t len;
+} wire_list_payment_type_filter;
+
 typedef struct wire_ListPaymentsRequest {
-  int32_t filter;
+  struct wire_list_payment_type_filter *filters;
   int64_t *from_timestamp;
   int64_t *to_timestamp;
   bool *include_failures;
@@ -338,6 +343,8 @@ uint32_t *new_box_autoadd_u32_0(uint32_t value);
 
 uint64_t *new_box_autoadd_u64_0(uint64_t value);
 
+struct wire_list_payment_type_filter *new_list_payment_type_filter_0(int32_t len);
+
 struct wire_uint_8_list *new_uint_8_list_0(int32_t len);
 
 union NodeConfigKind *inflate_NodeConfig_Greenlight(void);
@@ -416,6 +423,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_sweep_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_u32_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_u64_0);
+    dummy_var ^= ((int64_t) (void*) new_list_payment_type_filter_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
     dummy_var ^= ((int64_t) (void*) inflate_NodeConfig_Greenlight);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturn);

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1097,7 +1097,6 @@ enum PaymentTypeFilter {
   Sent,
   Received,
   ClosedChannels,
-  All,
 }
 
 /// Denominator in an exchange rate

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -571,7 +571,7 @@ class InvoicePaidDetails {
 
 /// Represents a list payments request.
 class ListPaymentsRequest {
-  final List<PaymentTypeFilter> filters;
+  final List<PaymentTypeFilter>? filters;
   final int? fromTimestamp;
   final int? toTimestamp;
   final bool? includeFailures;
@@ -579,7 +579,7 @@ class ListPaymentsRequest {
   final int? limit;
 
   const ListPaymentsRequest({
-    required this.filters,
+    this.filters,
     this.fromTimestamp,
     this.toTimestamp,
     this.includeFailures,
@@ -3569,6 +3569,12 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_list_payment_type_filter> api2wire_opt_list_payment_type_filter(
+      List<PaymentTypeFilter>? raw) {
+    return raw == null ? ffi.nullptr : api2wire_list_payment_type_filter(raw);
+  }
+
+  @protected
   ffi.Pointer<wire_uint_8_list> api2wire_opt_uint_8_list(Uint8List? raw) {
     return raw == null ? ffi.nullptr : api2wire_uint_8_list(raw);
   }
@@ -3733,7 +3739,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   void _api_fill_to_wire_list_payments_request(ListPaymentsRequest apiObj, wire_ListPaymentsRequest wireObj) {
-    wireObj.filters = api2wire_list_payment_type_filter(apiObj.filters);
+    wireObj.filters = api2wire_opt_list_payment_type_filter(apiObj.filters);
     wireObj.from_timestamp = api2wire_opt_box_autoadd_i64(apiObj.fromTimestamp);
     wireObj.to_timestamp = api2wire_opt_box_autoadd_i64(apiObj.toTimestamp);
     wireObj.include_failures = api2wire_opt_box_autoadd_bool(apiObj.includeFailures);

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -571,7 +571,7 @@ class InvoicePaidDetails {
 
 /// Represents a list payments request.
 class ListPaymentsRequest {
-  final PaymentTypeFilter filter;
+  final List<PaymentTypeFilter> filters;
   final int? fromTimestamp;
   final int? toTimestamp;
   final bool? includeFailures;
@@ -579,7 +579,7 @@ class ListPaymentsRequest {
   final int? limit;
 
   const ListPaymentsRequest({
-    required this.filter,
+    required this.filters,
     this.fromTimestamp,
     this.toTimestamp,
     this.includeFailures,
@@ -1096,6 +1096,7 @@ enum PaymentType {
 enum PaymentTypeFilter {
   Sent,
   Received,
+  ClosedChannels,
   All,
 }
 
@@ -3524,6 +3525,15 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_list_payment_type_filter> api2wire_list_payment_type_filter(List<PaymentTypeFilter> raw) {
+    final ans = inner.new_list_payment_type_filter_0(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      ans.ref.ptr[i] = api2wire_payment_type_filter(raw[i]);
+    }
+    return ans;
+  }
+
+  @protected
   ffi.Pointer<wire_uint_8_list> api2wire_opt_String(String? raw) {
     return raw == null ? ffi.nullptr : api2wire_String(raw);
   }
@@ -3724,7 +3734,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   void _api_fill_to_wire_list_payments_request(ListPaymentsRequest apiObj, wire_ListPaymentsRequest wireObj) {
-    wireObj.filter = api2wire_payment_type_filter(apiObj.filter);
+    wireObj.filters = api2wire_list_payment_type_filter(apiObj.filters);
     wireObj.from_timestamp = api2wire_opt_box_autoadd_i64(apiObj.fromTimestamp);
     wireObj.to_timestamp = api2wire_opt_box_autoadd_i64(apiObj.toTimestamp);
     wireObj.include_failures = api2wire_opt_box_autoadd_bool(apiObj.includeFailures);
@@ -4854,6 +4864,20 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_u64_0 =
       _new_box_autoadd_u64_0Ptr.asFunction<ffi.Pointer<ffi.Uint64> Function(int)>();
 
+  ffi.Pointer<wire_list_payment_type_filter> new_list_payment_type_filter_0(
+    int len,
+  ) {
+    return _new_list_payment_type_filter_0(
+      len,
+    );
+  }
+
+  late final _new_list_payment_type_filter_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_payment_type_filter> Function(ffi.Int32)>>(
+          'new_list_payment_type_filter_0');
+  late final _new_list_payment_type_filter_0 = _new_list_payment_type_filter_0Ptr
+      .asFunction<ffi.Pointer<wire_list_payment_type_filter> Function(int)>();
+
   ffi.Pointer<wire_uint_8_list> new_uint_8_list_0(
     int len,
   ) {
@@ -4967,9 +4991,15 @@ class wire_StaticBackupRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> working_dir;
 }
 
-class wire_ListPaymentsRequest extends ffi.Struct {
+class wire_list_payment_type_filter extends ffi.Struct {
+  external ffi.Pointer<ffi.Int32> ptr;
+
   @ffi.Int32()
-  external int filter;
+  external int len;
+}
+
+class wire_ListPaymentsRequest extends ffi.Struct {
+  external ffi.Pointer<wire_list_payment_type_filter> filters;
 
   external ffi.Pointer<ffi.Int64> from_timestamp;
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -726,14 +726,19 @@ fun asLnInvoiceList(arr: ReadableArray): List<LnInvoice> {
 fun asListPaymentsRequest(listPaymentsRequest: ReadableMap): ListPaymentsRequest? {
     if (!validateMandatoryFields(
             listPaymentsRequest,
-            arrayOf(
-                "filters",
-            ),
+            arrayOf(),
         )
     ) {
         return null
     }
-    val filters = listPaymentsRequest.getArray("filters")?.let { asPaymentTypeFilterList(it) }!!
+    val filters =
+        if (hasNonNullKey(listPaymentsRequest, "filters")) {
+            listPaymentsRequest.getArray("filters")?.let {
+                asPaymentTypeFilterList(it)
+            }
+        } else {
+            null
+        }
     val fromTimestamp =
         if (hasNonNullKey(
                 listPaymentsRequest,
@@ -769,7 +774,7 @@ fun asListPaymentsRequest(listPaymentsRequest: ReadableMap): ListPaymentsRequest
 
 fun readableMapOf(listPaymentsRequest: ListPaymentsRequest): ReadableMap {
     return readableMapOf(
-        "filters" to readableArrayOf(listPaymentsRequest.filters),
+        "filters" to listPaymentsRequest.filters?.let { readableArrayOf(it) },
         "fromTimestamp" to listPaymentsRequest.fromTimestamp,
         "toTimestamp" to listPaymentsRequest.toTimestamp,
         "includeFailures" to listPaymentsRequest.includeFailures,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -727,13 +727,13 @@ fun asListPaymentsRequest(listPaymentsRequest: ReadableMap): ListPaymentsRequest
     if (!validateMandatoryFields(
             listPaymentsRequest,
             arrayOf(
-                "filter",
+                "filters",
             ),
         )
     ) {
         return null
     }
-    val filter = listPaymentsRequest.getString("filter")?.let { asPaymentTypeFilter(it) }!!
+    val filters = listPaymentsRequest.getArray("filters")?.let { asPaymentTypeFilterList(it) }!!
     val fromTimestamp =
         if (hasNonNullKey(
                 listPaymentsRequest,
@@ -758,7 +758,7 @@ fun asListPaymentsRequest(listPaymentsRequest: ReadableMap): ListPaymentsRequest
     val offset = if (hasNonNullKey(listPaymentsRequest, "offset")) listPaymentsRequest.getInt("offset").toUInt() else null
     val limit = if (hasNonNullKey(listPaymentsRequest, "limit")) listPaymentsRequest.getInt("limit").toUInt() else null
     return ListPaymentsRequest(
-        filter,
+        filters,
         fromTimestamp,
         toTimestamp,
         includeFailures,
@@ -769,7 +769,7 @@ fun asListPaymentsRequest(listPaymentsRequest: ReadableMap): ListPaymentsRequest
 
 fun readableMapOf(listPaymentsRequest: ListPaymentsRequest): ReadableMap {
     return readableMapOf(
-        "filter" to listPaymentsRequest.filter.name.lowercase(),
+        "filters" to readableArrayOf(listPaymentsRequest.filters),
         "fromTimestamp" to listPaymentsRequest.fromTimestamp,
         "toTimestamp" to listPaymentsRequest.toTimestamp,
         "includeFailures" to listPaymentsRequest.includeFailures,
@@ -3370,6 +3370,7 @@ fun pushToArray(
         is LspInformation -> array.pushMap(readableMapOf(value))
         is OpeningFeeParams -> array.pushMap(readableMapOf(value))
         is Payment -> array.pushMap(readableMapOf(value))
+        is PaymentTypeFilter -> array.pushMap(readableMapOf(value))
         is Rate -> array.pushMap(readableMapOf(value))
         is ReverseSwapInfo -> array.pushMap(readableMapOf(value))
         is RouteHint -> array.pushMap(readableMapOf(value))

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -657,8 +657,10 @@ class BreezSDKMapper {
     }
 
     static func asListPaymentsRequest(listPaymentsRequest: [String: Any?]) throws -> ListPaymentsRequest {
-        guard let filtersTmp = listPaymentsRequest["filters"] as? [String] else { throw SdkError.Generic(message: "Missing mandatory field filters for type ListPaymentsRequest") }
-        let filters = filtersTmp
+        var filters: [PaymentTypeFilter]?
+        if let filtersTmp = listPaymentsRequest["filters"] as? [String] {
+            filters = filtersTmp
+        }
 
         let fromTimestamp = listPaymentsRequest["fromTimestamp"] as? Int64
         let toTimestamp = listPaymentsRequest["toTimestamp"] as? Int64
@@ -678,7 +680,7 @@ class BreezSDKMapper {
 
     static func dictionaryOf(listPaymentsRequest: ListPaymentsRequest) -> [String: Any?] {
         return [
-            "filters": arrayOf(paymentTypeFilterList: listPaymentsRequest.filters),
+            "filters": listPaymentsRequest.filters == nil ? nil : arrayOf(paymentTypeFilterList: listPaymentsRequest.filters!),
             "fromTimestamp": listPaymentsRequest.fromTimestamp == nil ? nil : listPaymentsRequest.fromTimestamp,
             "toTimestamp": listPaymentsRequest.toTimestamp == nil ? nil : listPaymentsRequest.toTimestamp,
             "includeFailures": listPaymentsRequest.includeFailures == nil ? nil : listPaymentsRequest.includeFailures,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -3222,9 +3222,6 @@ class BreezSDKMapper {
         case "closedChannels":
             return PaymentTypeFilter.closedChannels
 
-        case "all":
-            return PaymentTypeFilter.all
-
         default: throw SdkError.Generic(message: "Invalid variant \(paymentTypeFilter) for enum PaymentTypeFilter")
         }
     }
@@ -3239,9 +3236,6 @@ class BreezSDKMapper {
 
         case .closedChannels:
             return "closedChannels"
-
-        case .all:
-            return "all"
         }
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -657,8 +657,8 @@ class BreezSDKMapper {
     }
 
     static func asListPaymentsRequest(listPaymentsRequest: [String: Any?]) throws -> ListPaymentsRequest {
-        guard let filterTmp = listPaymentsRequest["filter"] as? String else { throw SdkError.Generic(message: "Missing mandatory field filter for type ListPaymentsRequest") }
-        let filter = try asPaymentTypeFilter(paymentTypeFilter: filterTmp)
+        guard let filtersTmp = listPaymentsRequest["filters"] as? [String] else { throw SdkError.Generic(message: "Missing mandatory field filters for type ListPaymentsRequest") }
+        let filters = filtersTmp
 
         let fromTimestamp = listPaymentsRequest["fromTimestamp"] as? Int64
         let toTimestamp = listPaymentsRequest["toTimestamp"] as? Int64
@@ -667,7 +667,7 @@ class BreezSDKMapper {
         let limit = listPaymentsRequest["limit"] as? UInt32
 
         return ListPaymentsRequest(
-            filter: filter,
+            filters: filters,
             fromTimestamp: fromTimestamp,
             toTimestamp: toTimestamp,
             includeFailures: includeFailures,
@@ -678,7 +678,7 @@ class BreezSDKMapper {
 
     static func dictionaryOf(listPaymentsRequest: ListPaymentsRequest) -> [String: Any?] {
         return [
-            "filter": valueOf(paymentTypeFilter: listPaymentsRequest.filter),
+            "filters": arrayOf(paymentTypeFilterList: listPaymentsRequest.filters),
             "fromTimestamp": listPaymentsRequest.fromTimestamp == nil ? nil : listPaymentsRequest.fromTimestamp,
             "toTimestamp": listPaymentsRequest.toTimestamp == nil ? nil : listPaymentsRequest.toTimestamp,
             "includeFailures": listPaymentsRequest.includeFailures == nil ? nil : listPaymentsRequest.includeFailures,
@@ -3219,6 +3219,9 @@ class BreezSDKMapper {
         case "received":
             return PaymentTypeFilter.received
 
+        case "closedChannels":
+            return PaymentTypeFilter.closedChannels
+
         case "all":
             return PaymentTypeFilter.all
 
@@ -3233,6 +3236,9 @@ class BreezSDKMapper {
 
         case .received:
             return "received"
+
+        case .closedChannels:
+            return "closedChannels"
 
         case .all:
             return "all"

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -635,8 +635,7 @@ export enum PaymentType {
 export enum PaymentTypeFilter {
     SENT = "sent",
     RECEIVED = "received",
-    CLOSED_CHANNELS = "closedChannels",
-    ALL = "all"
+    CLOSED_CHANNELS = "closedChannels"
 }
 
 export enum ReverseSwapStatus {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -125,7 +125,7 @@ export type LnInvoice = {
 }
 
 export type ListPaymentsRequest = {
-    filter: PaymentTypeFilter
+    filters: PaymentTypeFilter[]
     fromTimestamp?: number
     toTimestamp?: number
     includeFailures?: boolean
@@ -635,6 +635,7 @@ export enum PaymentType {
 export enum PaymentTypeFilter {
     SENT = "sent",
     RECEIVED = "received",
+    CLOSED_CHANNELS = "closedChannels",
     ALL = "all"
 }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -125,7 +125,7 @@ export type LnInvoice = {
 }
 
 export type ListPaymentsRequest = {
-    filters: PaymentTypeFilter[]
+    filters?: PaymentTypeFilter[]
     fromTimestamp?: number
     toTimestamp?: number
     includeFailures?: boolean

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -216,7 +216,7 @@ pub(crate) async fn handle_command(
         } => {
             let payments = sdk()?
                 .list_payments(ListPaymentsRequest {
-                    filters: vec![],
+                    filters: None,
                     from_timestamp,
                     to_timestamp,
                     include_failures: Some(include_failures),

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -216,7 +216,7 @@ pub(crate) async fn handle_command(
         } => {
             let payments = sdk()?
                 .list_payments(ListPaymentsRequest {
-                    filter: PaymentTypeFilter::All,
+                    filters: vec![PaymentTypeFilter::All],
                     from_timestamp,
                     to_timestamp,
                     include_failures: Some(include_failures),

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -6,9 +6,9 @@ use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
     parse, BreezEvent, BreezServices, BuyBitcoinRequest, CheckMessageRequest, EventListener,
     GreenlightCredentials, ListPaymentsRequest, LnUrlPayRequest, LnUrlWithdrawRequest,
-    PaymentTypeFilter, ReceiveOnchainRequest, ReceivePaymentRequest, RefundRequest,
-    ReverseSwapFeesRequest, SendOnchainRequest, SendPaymentRequest, SendSpontaneousPaymentRequest,
-    SignMessageRequest, StaticBackupRequest, SweepRequest,
+    ReceiveOnchainRequest, ReceivePaymentRequest, RefundRequest, ReverseSwapFeesRequest,
+    SendOnchainRequest, SendPaymentRequest, SendSpontaneousPaymentRequest, SignMessageRequest,
+    StaticBackupRequest, SweepRequest,
 };
 use breez_sdk_core::{Config, GreenlightNodeConfig, NodeConfig};
 use once_cell::sync::OnceCell;
@@ -216,7 +216,7 @@ pub(crate) async fn handle_command(
         } => {
             let payments = sdk()?
                 .list_payments(ListPaymentsRequest {
-                    filters: vec![PaymentTypeFilter::All],
+                    filters: vec![],
                     from_timestamp,
                     to_timestamp,
                     include_failures: Some(include_failures),


### PR DESCRIPTION
Removes payment type `ClosedChannels` from being part of the payment type filter `Sent` to allow for specific type filtering in the payments list.