### PR TITLE
Hard code the published release version number into the example package

### DIFF
--- a/libs/sdk-react-native/DEVELOPING.md
+++ b/libs/sdk-react-native/DEVELOPING.md
@@ -22,7 +22,7 @@ yarn global add tslint typescript
 ```
 
 On first usage you will need to run:
-```
+```bash
 make init
 ```
 
@@ -36,8 +36,7 @@ make react-native-codegen
 ## Building the bindings
 
 Then to build and copy the Kotlin and Swift bindings into the React Native plugin:
-
-```
+```bash
 make all
 ```
 
@@ -68,3 +67,24 @@ To use the locally built bindings instead of integrating them remotely:
 Reinstall the dependencies in the example project and run it.
 It will now use the locally built bindings.
 
+## Testing with the example app
+
+To test locally built bindings in the example app, the npm dependencies need to be updated to use the local package.
+In `example/package.json` replace the current version with `file:../`:
+```json
+    "@breeztech/react-native-breez-sdk": "file:../",
+```
+
+Run the npm/yarn install to download dependences for both the react-native-breez-sdk package and the example app:
+```bash
+yarn bootstrap
+```
+
+Finally in `example/` start either the iOS or Android app:
+```bash
+yarn android
+```
+or for iOS:
+```bash
+yarn ios
+```

--- a/libs/sdk-react-native/PUBLISHING.md
+++ b/libs/sdk-react-native/PUBLISHING.md
@@ -29,7 +29,11 @@ make all
  >* ios/libs/libbreez_sdk_core.a
 
 ### Publish
-When publishing, make sure the version number in `package.json` is updated. Then login to npm:
+When publishing, make sure the following are updated:
+- Update the version number in `package.json`.
+- Set the published version of `@breeztech/react-native-breez-sdk` in `example/package.json`. 
+
+Then login to npm:
 ```
 npm login --@scope=@breeztech
 ```

--- a/libs/sdk-react-native/README.md
+++ b/libs/sdk-react-native/README.md
@@ -10,13 +10,13 @@ The Breez SDK provides the following services:
 
 ## Installation
 
-```console
-$ npm install @breeztech/react-native-breez-sdk
+```bash
+npm install @breeztech/react-native-breez-sdk
 ```
 or
 
-```console
-$ yarn add @breeztech/react-native-breez-sdk
+```bash
+yarn add @breeztech/react-native-breez-sdk
 ```
 
 ### Important fix for React Native versions below 0.71.0
@@ -31,7 +31,7 @@ If your project uses a React Native version less < 0.71.0, and you want to build
 
 To fix this you need to disambiguate which file to use by adding the following snippet to your app's `android/app/build.gradle`:
 
-``` gradle
+```gradle
 android {
     // ...
     packagingOptions {
@@ -55,8 +55,10 @@ Please contact [support@breez.technology](mailto:support@breez.technology?subjec
 ```ts
 import React, { useEffect } from "react"
 import { 
+    BreezEvent,
     defaultConfig,
-    EnvironmentType,    
+    EnvironmentType,   
+    NodeConfigVariant, 
     sendPayment,
     connect 
 } from "@breeztech/react-native-breez-sdk";
@@ -65,6 +67,10 @@ import BuildConfig from "react-native-build-config"
 const App = () => (
     ...
 
+    const onEvent = (breezEvent: BreezEvent) => {
+        console.log(`${JSON.stringify(breezEvent)}`)
+    }
+
     const payInvoice = async (bolt11: string, sats?: number) => {
         // Pay invoice
         const payment = await sendPayment(bolt11, sats)
@@ -72,10 +78,9 @@ const App = () => (
 
     useEffect(() => {
         const asyncFn = async () => {
-            
-            // create the specific node configuration
+            // Create the specific node configuration
             const nodeConfig = {
-                type: "greenlight",
+                type: NodeConfigVariant.GREENLIGHT,
                 config: {
                     partnerCredentials: {
                         deviceKey: null,
@@ -88,7 +93,7 @@ const App = () => (
             const config = await defaultConfig(EnvironmentType.PRODUCTION, BuildConfig.BREEZ_API_KEY, nodeConfig)            
 
              // Connect to the Breez SDK make it ready to use
-            await connect(config, seed)            
+            await connect(config, seed, onEvent)            
         }
 
         asyncFn()
@@ -103,14 +108,14 @@ export default App
 ## Example
 
 In the `example` folder of the [Breez SDK repository](https://github.com/breez/breez-sdk/tree/main/libs/sdk-react-native/example) you will find a basic application for using Breez SDK. Change directory into the folder and install the dependencies:
-```console
-$ yarn
+```bash
+yarn
 ```
 Then to run on android:
-```console
-$ yarn android
+```bash
+yarn android
 ```
 or for iOS:
-```console
-$ yarn pods && yarn ios
+```bash
+yarn pods && yarn ios
 ```

--- a/libs/sdk-react-native/example/App.js
+++ b/libs/sdk-react-native/example/App.js
@@ -23,6 +23,7 @@ import {
     lspInfo,
     listFiatCurrencies,
     mnemonicToSeed,
+    NodeConfigVariant,
     nodeInfo,
     openChannelFee,
     receivePayment,
@@ -81,7 +82,7 @@ const App = () => {
                 addLine("mnemonicToSeed", obfuscateString(JSON.stringify(seed)))
 
                 const nodeConfig = {
-                    type: "greenlight",
+                    type: NodeConfigVariant.GREENLIGHT,
                     config: {}
                 }
 

--- a/libs/sdk-react-native/example/README.md
+++ b/libs/sdk-react-native/example/README.md
@@ -7,19 +7,22 @@ or replace `INSERT_YOUR_BREEZ_API_KEY` in the following files:
 * `android/app/gradle.properties`
 * `ios/Secrets.xconfig`
 
-## Build and Run
+## Build
+
+Run the npm/yarn install to download dependences:
+```bash
+yarn
+```
+or
+```bash
+npm i
+```
+
+## Run
 
 ### Android
 
 ```bash
-# In directory sdk-react-native
-make android
-yarn
-
-# In the example directory
-cd example
-rm -rf node_modules
-yarn
 yarn android
 ```
 
@@ -35,14 +38,6 @@ yarn android
 ### iOS
 
 ```bash
-# In directory sdk-react-native
-make ios
-yarn
-
-# In the example directory
-cd example
-rm -rf node_modules
-yarn
 yarn pods
 yarn ios
 ```

--- a/libs/sdk-react-native/example/package.json
+++ b/libs/sdk-react-native/example/package.json
@@ -13,7 +13,7 @@
     "rebuild": "rm -rf node_modules && yarn && yarn pods"
   },
   "dependencies": {
-    "@breeztech/react-native-breez-sdk": "file:../",
+    "@breeztech/react-native-breez-sdk": "0.2.5",
     "@dreson4/react-native-quick-bip39": "^0.0.5",
     "react": "18.1.0",
     "react-native": "0.70.6",


### PR DESCRIPTION
This PR sets the version of the `@breeztech/react-native-breez-sdk` dependency in the example app to the latest released version. This is to avoid inconsistencies between the released cocoapods/maven bindings and the generated react native code in the repository when running the example app. To test locally built bindings the `DEVELOPING.md` guide has to be followed.

Fixes #485 