### PR TITLE
msat receive_payment and lnurl_withdraw

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -313,7 +313,7 @@ dictionary ReverseSwapFeesRequest {
 };
 
 dictionary ReceivePaymentRequest {
-    u64 amount_sats;
+    u64 amount_msat;
     string description;
     sequence<u8>? preimage = null;
     OpeningFeeParams? opening_fee_params = null;
@@ -478,6 +478,12 @@ interface LnUrlCallbackStatus {
     ErrorStatus(LnUrlErrorData data);
 };
 
+dictionary LnUrlWithdrawRequest {
+    LnUrlWithdrawRequestData data;
+    u64 amount_msat;
+    string? description = null;
+};
+
 [Enum]
 interface LnUrlWithdrawResult {
     Ok(LnUrlWithdrawSuccessData data);
@@ -545,13 +551,13 @@ interface BlockingBreezServices {
    Payment send_spontaneous_payment(string node_id, u64 amount_sats);
 
    [Throws=SdkError]
-   ReceivePaymentResponse receive_payment(ReceivePaymentRequest req_data);
+   ReceivePaymentResponse receive_payment(ReceivePaymentRequest request);
 
    [Throws=SdkError]
    LnUrlPayResult pay_lnurl(LnUrlPayRequestData req_data, u64 amount_sats, string? comment);
 
    [Throws=SdkError]
-   LnUrlWithdrawResult withdraw_lnurl(LnUrlWithdrawRequestData req_data, u64 amount_sats, string? description);
+   LnUrlWithdrawResult withdraw_lnurl(LnUrlWithdrawRequest request);
 
    [Throws=SdkError]
    LnUrlCallbackStatus lnurl_auth(LnUrlAuthRequestData req_data);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -12,7 +12,7 @@ use breez_sdk_core::{
     ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType, EventListener,
     FeeratePreset, FiatCurrency, GreenlightCredentials, GreenlightNodeConfig, InputType,
     InvoicePaidDetails, LNInvoice, ListPaymentsRequest, LnPaymentDetails, LnUrlAuthRequestData,
-    LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult,
+    LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayRequestData, LnUrlPayResult, LnUrlWithdrawRequest,
     LnUrlWithdrawRequestData, LnUrlWithdrawResult, LnUrlWithdrawSuccessData, LocaleOverrides,
     LocalizedName, LogEntry, LogStream, LspInformation, MessageSuccessActionData, MetadataItem,
     Network, NodeConfig, NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse,
@@ -129,9 +129,9 @@ impl BlockingBreezServices {
 
     pub fn receive_payment(
         &self,
-        req_data: ReceivePaymentRequest,
+        request: ReceivePaymentRequest,
     ) -> SdkResult<ReceivePaymentResponse> {
-        rt().block_on(self.breez_services.receive_payment(req_data))
+        rt().block_on(self.breez_services.receive_payment(request))
     }
 
     pub fn node_info(&self) -> SdkResult<NodeState> {
@@ -179,17 +179,9 @@ impl BlockingBreezServices {
         .map_err(|e| e.into())
     }
 
-    pub fn withdraw_lnurl(
-        &self,
-        req_data: LnUrlWithdrawRequestData,
-        amount_sats: u64,
-        description: Option<String>,
-    ) -> SdkResult<LnUrlWithdrawResult> {
-        rt().block_on(
-            self.breez_services
-                .lnurl_withdraw(req_data, amount_sats, description),
-        )
-        .map_err(|e| e.into())
+    pub fn withdraw_lnurl(&self, request: LnUrlWithdrawRequest) -> SdkResult<LnUrlWithdrawResult> {
+        rt().block_on(self.breez_services.lnurl_withdraw(request))
+            .map_err(|e| e.into())
     }
 
     pub fn lnurl_auth(&self, req_data: LnUrlAuthRequestData) -> SdkResult<LnUrlCallbackStatus> {

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -23,20 +23,18 @@ use crate::breez_services::{self, BreezEvent, BreezServices, EventListener};
 use crate::chain::RecommendedFees;
 use crate::error::SdkError;
 use crate::fiat::{FiatCurrency, Rate};
-use crate::input_parser::{
-    self, InputType, LnUrlAuthRequestData, LnUrlPayRequestData, LnUrlWithdrawRequestData,
-};
+use crate::input_parser::{self, InputType, LnUrlAuthRequestData, LnUrlPayRequestData};
 use crate::invoice::{self, LNInvoice};
 use crate::lnurl::pay::model::LnUrlPayResult;
 use crate::lsp::LspInformation;
 use crate::models::{Config, LogEntry, NodeState, Payment, SwapInfo};
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
-    EnvironmentType, ListPaymentsRequest, LnUrlCallbackStatus, LnUrlWithdrawResult, NodeConfig,
-    OpenChannelFeeRequest, OpenChannelFeeResponse, ReceiveOnchainRequest, ReceivePaymentRequest,
-    ReceivePaymentResponse, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
-    SignMessageRequest, SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
-    SweepRequest, SweepResponse,
+    EnvironmentType, ListPaymentsRequest, LnUrlCallbackStatus, LnUrlWithdrawRequest,
+    LnUrlWithdrawResult, NodeConfig, OpenChannelFeeRequest, OpenChannelFeeResponse,
+    ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse, ReverseSwapFeesRequest,
+    ReverseSwapInfo, ReverseSwapPairInfo, SignMessageRequest, SignMessageResponse,
+    StaticBackupRequest, StaticBackupResponse, SweepRequest, SweepResponse,
 };
 
 /*
@@ -249,8 +247,8 @@ pub fn send_spontaneous_payment(node_id: String, amount_sats: u64) -> Result<Pay
 }
 
 /// See [BreezServices::receive_payment]
-pub fn receive_payment(req_data: ReceivePaymentRequest) -> Result<ReceivePaymentResponse> {
-    block_on(async { get_breez_services().await?.receive_payment(req_data).await })
+pub fn receive_payment(request: ReceivePaymentRequest) -> Result<ReceivePaymentResponse> {
+    block_on(async { get_breez_services().await?.receive_payment(request).await })
         .map_err(anyhow::Error::new)
 }
 
@@ -271,17 +269,8 @@ pub fn lnurl_pay(
 }
 
 /// See [BreezServices::lnurl_withdraw]
-pub fn lnurl_withdraw(
-    req_data: LnUrlWithdrawRequestData,
-    amount_sats: u64,
-    description: Option<String>,
-) -> Result<LnUrlWithdrawResult> {
-    block_on(async {
-        get_breez_services()
-            .await?
-            .lnurl_withdraw(req_data, amount_sats, description)
-            .await
-    })
+pub fn lnurl_withdraw(request: LnUrlWithdrawRequest) -> Result<LnUrlWithdrawResult> {
+    block_on(async { get_breez_services().await?.lnurl_withdraw(request).await })
 }
 
 /// See [BreezServices::lnurl_auth]

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -145,8 +145,8 @@ pub extern "C" fn wire_send_spontaneous_payment(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_receive_payment(port_: i64, req_data: *mut wire_ReceivePaymentRequest) {
-    wire_receive_payment_impl(port_, req_data)
+pub extern "C" fn wire_receive_payment(port_: i64, request: *mut wire_ReceivePaymentRequest) {
+    wire_receive_payment_impl(port_, request)
 }
 
 #[no_mangle]
@@ -160,13 +160,8 @@ pub extern "C" fn wire_lnurl_pay(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_lnurl_withdraw(
-    port_: i64,
-    req_data: *mut wire_LnUrlWithdrawRequestData,
-    amount_sats: u64,
-    description: *mut wire_uint_8_list,
-) {
-    wire_lnurl_withdraw_impl(port_, req_data, amount_sats, description)
+pub extern "C" fn wire_lnurl_withdraw(port_: i64, request: *mut wire_LnUrlWithdrawRequest) {
+    wire_lnurl_withdraw_impl(port_, request)
 }
 
 #[no_mangle]
@@ -314,9 +309,8 @@ pub extern "C" fn new_box_autoadd_ln_url_pay_request_data_0() -> *mut wire_LnUrl
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_ln_url_withdraw_request_data_0(
-) -> *mut wire_LnUrlWithdrawRequestData {
-    support::new_leak_box_ptr(wire_LnUrlWithdrawRequestData::new_with_null_ptr())
+pub extern "C" fn new_box_autoadd_ln_url_withdraw_request_0() -> *mut wire_LnUrlWithdrawRequest {
+    support::new_leak_box_ptr(wire_LnUrlWithdrawRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -453,10 +447,10 @@ impl Wire2Api<LnUrlPayRequestData> for *mut wire_LnUrlPayRequestData {
         Wire2Api::<LnUrlPayRequestData>::wire2api(*wrap).into()
     }
 }
-impl Wire2Api<LnUrlWithdrawRequestData> for *mut wire_LnUrlWithdrawRequestData {
-    fn wire2api(self) -> LnUrlWithdrawRequestData {
+impl Wire2Api<LnUrlWithdrawRequest> for *mut wire_LnUrlWithdrawRequest {
+    fn wire2api(self) -> LnUrlWithdrawRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
-        Wire2Api::<LnUrlWithdrawRequestData>::wire2api(*wrap).into()
+        Wire2Api::<LnUrlWithdrawRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<NodeConfig> for *mut wire_NodeConfig {
@@ -610,6 +604,15 @@ impl Wire2Api<LnUrlPayRequestData> for wire_LnUrlPayRequestData {
         }
     }
 }
+impl Wire2Api<LnUrlWithdrawRequest> for wire_LnUrlWithdrawRequest {
+    fn wire2api(self) -> LnUrlWithdrawRequest {
+        LnUrlWithdrawRequest {
+            data: self.data.wire2api(),
+            amount_msat: self.amount_msat.wire2api(),
+            description: self.description.wire2api(),
+        }
+    }
+}
 impl Wire2Api<LnUrlWithdrawRequestData> for wire_LnUrlWithdrawRequestData {
     fn wire2api(self) -> LnUrlWithdrawRequestData {
         LnUrlWithdrawRequestData {
@@ -667,7 +670,7 @@ impl Wire2Api<ReceiveOnchainRequest> for wire_ReceiveOnchainRequest {
 impl Wire2Api<ReceivePaymentRequest> for wire_ReceivePaymentRequest {
     fn wire2api(self) -> ReceivePaymentRequest {
         ReceivePaymentRequest {
-            amount_sats: self.amount_sats.wire2api(),
+            amount_msat: self.amount_msat.wire2api(),
             description: self.description.wire2api(),
             preimage: self.preimage.wire2api(),
             opening_fee_params: self.opening_fee_params.wire2api(),
@@ -795,6 +798,14 @@ pub struct wire_LnUrlPayRequestData {
 
 #[repr(C)]
 #[derive(Clone)]
+pub struct wire_LnUrlWithdrawRequest {
+    data: wire_LnUrlWithdrawRequestData,
+    amount_msat: u64,
+    description: *mut wire_uint_8_list,
+}
+
+#[repr(C)]
+#[derive(Clone)]
 pub struct wire_LnUrlWithdrawRequestData {
     callback: *mut wire_uint_8_list,
     k1: *mut wire_uint_8_list,
@@ -830,7 +841,7 @@ pub struct wire_ReceiveOnchainRequest {
 #[repr(C)]
 #[derive(Clone)]
 pub struct wire_ReceivePaymentRequest {
-    amount_sats: u64,
+    amount_msat: u64,
     description: *mut wire_uint_8_list,
     preimage: *mut wire_uint_8_list,
     opening_fee_params: *mut wire_OpeningFeeParams,
@@ -1041,6 +1052,22 @@ impl Default for wire_LnUrlPayRequestData {
     }
 }
 
+impl NewWithNullPtr for wire_LnUrlWithdrawRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            data: Default::default(),
+            amount_msat: Default::default(),
+            description: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_LnUrlWithdrawRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_LnUrlWithdrawRequestData {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -1134,7 +1161,7 @@ impl Default for wire_ReceiveOnchainRequest {
 impl NewWithNullPtr for wire_ReceivePaymentRequest {
     fn new_with_null_ptr() -> Self {
         Self {
-            amount_sats: Default::default(),
+            amount_msat: Default::default(),
             description: core::ptr::null_mut(),
             preimage: core::ptr::null_mut(),
             opening_fee_params: core::ptr::null_mut(),

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -62,6 +62,7 @@ use crate::models::GreenlightNodeConfig;
 use crate::models::ListPaymentsRequest;
 use crate::models::LnPaymentDetails;
 use crate::models::LnUrlCallbackStatus;
+use crate::models::LnUrlWithdrawRequest;
 use crate::models::LnUrlWithdrawResult;
 use crate::models::LnUrlWithdrawSuccessData;
 use crate::models::LogEntry;
@@ -432,7 +433,7 @@ fn wire_send_spontaneous_payment_impl(
 }
 fn wire_receive_payment_impl(
     port_: MessagePort,
-    req_data: impl Wire2Api<ReceivePaymentRequest> + UnwindSafe,
+    request: impl Wire2Api<ReceivePaymentRequest> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -441,8 +442,8 @@ fn wire_receive_payment_impl(
             mode: FfiCallMode::Normal,
         },
         move || {
-            let api_req_data = req_data.wire2api();
-            move |task_callback| receive_payment(api_req_data)
+            let api_request = request.wire2api();
+            move |task_callback| receive_payment(api_request)
         },
     )
 }
@@ -468,9 +469,7 @@ fn wire_lnurl_pay_impl(
 }
 fn wire_lnurl_withdraw_impl(
     port_: MessagePort,
-    req_data: impl Wire2Api<LnUrlWithdrawRequestData> + UnwindSafe,
-    amount_sats: impl Wire2Api<u64> + UnwindSafe,
-    description: impl Wire2Api<Option<String>> + UnwindSafe,
+    request: impl Wire2Api<LnUrlWithdrawRequest> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -479,10 +478,8 @@ fn wire_lnurl_withdraw_impl(
             mode: FfiCallMode::Normal,
         },
         move || {
-            let api_req_data = req_data.wire2api();
-            let api_amount_sats = amount_sats.wire2api();
-            let api_description = description.wire2api();
-            move |task_callback| lnurl_withdraw(api_req_data, api_amount_sats, api_description)
+            let api_request = request.wire2api();
+            move |task_callback| lnurl_withdraw(api_request)
         },
     )
 }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -322,7 +322,7 @@ impl Greenlight {
 impl NodeAPI for Greenlight {
     async fn create_invoice(
         &self,
-        amount_sats: u64,
+        amount_msat: u64,
         description: String,
         preimage: Option<Vec<u8>>,
         use_description_hash: Option<bool>,
@@ -333,9 +333,7 @@ impl NodeAPI for Greenlight {
         let request = InvoiceRequest {
             amount_msat: Some(AmountOrAny {
                 value: Some(gl_client::pb::cln::amount_or_any::Value::Amount(
-                    gl_client::pb::cln::Amount {
-                        msat: amount_sats * 1000,
-                    },
+                    gl_client::pb::cln::Amount { msat: amount_msat },
                 )),
             }),
             label: format!(

--- a/libs/sdk-core/src/swap.rs
+++ b/libs/sdk-core/src/swap.rs
@@ -397,7 +397,7 @@ impl BTCReceiveSwap {
             let invoice = self
                 .payment_receiver
                 .receive_payment(ReceivePaymentRequest {
-                    amount_sats: swap_info.confirmed_sats,
+                    amount_msat: swap_info.confirmed_sats * 1000,
                     description: String::from("Bitcoin Transfer"),
                     preimage: Some(swap_info.preimage),
                     opening_fee_params: swap_info.channel_opening_fees,

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -91,7 +91,7 @@ typedef struct wire_OpeningFeeParams {
 } wire_OpeningFeeParams;
 
 typedef struct wire_ReceivePaymentRequest {
-  uint64_t amount_sats;
+  uint64_t amount_msat;
   struct wire_uint_8_list *description;
   struct wire_uint_8_list *preimage;
   struct wire_OpeningFeeParams *opening_fee_params;
@@ -117,6 +117,12 @@ typedef struct wire_LnUrlWithdrawRequestData {
   uint64_t min_withdrawable;
   uint64_t max_withdrawable;
 } wire_LnUrlWithdrawRequestData;
+
+typedef struct wire_LnUrlWithdrawRequest {
+  struct wire_LnUrlWithdrawRequestData data;
+  uint64_t amount_msat;
+  struct wire_uint_8_list *description;
+} wire_LnUrlWithdrawRequest;
 
 typedef struct wire_LnUrlAuthRequestData {
   struct wire_uint_8_list *k1;
@@ -217,17 +223,14 @@ void wire_send_spontaneous_payment(int64_t port_,
                                    struct wire_uint_8_list *node_id,
                                    uint64_t amount_sats);
 
-void wire_receive_payment(int64_t port_, struct wire_ReceivePaymentRequest *req_data);
+void wire_receive_payment(int64_t port_, struct wire_ReceivePaymentRequest *request);
 
 void wire_lnurl_pay(int64_t port_,
                     uint64_t user_amount_sat,
                     struct wire_uint_8_list *comment,
                     struct wire_LnUrlPayRequestData *req_data);
 
-void wire_lnurl_withdraw(int64_t port_,
-                         struct wire_LnUrlWithdrawRequestData *req_data,
-                         uint64_t amount_sats,
-                         struct wire_uint_8_list *description);
+void wire_lnurl_withdraw(int64_t port_, struct wire_LnUrlWithdrawRequest *request);
 
 void wire_lnurl_auth(int64_t port_, struct wire_LnUrlAuthRequestData *req_data);
 
@@ -286,7 +289,7 @@ struct wire_LnUrlAuthRequestData *new_box_autoadd_ln_url_auth_request_data_0(voi
 
 struct wire_LnUrlPayRequestData *new_box_autoadd_ln_url_pay_request_data_0(void);
 
-struct wire_LnUrlWithdrawRequestData *new_box_autoadd_ln_url_withdraw_request_data_0(void);
+struct wire_LnUrlWithdrawRequest *new_box_autoadd_ln_url_withdraw_request_0(void);
 
 struct wire_NodeConfig *new_box_autoadd_node_config_0(void);
 
@@ -372,7 +375,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_list_payments_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_auth_request_data_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_pay_request_data_0);
-    dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_withdraw_request_data_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_withdraw_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_node_config_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_open_channel_fee_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_opening_fee_params_0);

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -246,12 +246,11 @@ class BreezSDK {
   ///
   /// # Arguments
   ///
-  /// * `amountSats` - The amount to receive in satoshis
-  /// * `description` - The bolt11 payment request description
+  /// * `request` - Request parameters for receiving a payment
   Future<ReceivePaymentResponse> receivePayment({
-    required ReceivePaymentRequest reqData,
+    required ReceivePaymentRequest request,
   }) async {
-    return await _lnToolkit.receivePayment(reqData: reqData);
+    return await _lnToolkit.receivePayment(request: request);
   }
 
   /* LNURL API's */
@@ -273,19 +272,11 @@ class BreezSDK {
   /// Second step of LNURL-withdraw. The first step is `parse()`, which also validates the LNURL destination
   /// and generates the `LnUrlWithdrawRequestData` payload needed here.
   ///
-  /// This call will validate the given `amount_sats` against the parameters
-  /// of the LNURL endpoint (`req_data`). If they match the endpoint requirements, the LNURL withdraw
+  /// This call will validate the given amount in the `request` against the parameters
+  /// of the LNURL endpoint data in the `request`. If they match the endpoint requirements, the LNURL withdraw
   /// request is made. A successful result here means the endpoint started the payment.
-  Future<LnUrlWithdrawResult> lnurlWithdraw({
-    required LnUrlWithdrawRequestData reqData,
-    required int amountSats,
-    String? description,
-  }) async {
-    return await _lnToolkit.lnurlWithdraw(
-      reqData: reqData,
-      amountSats: amountSats,
-      description: description,
-    );
+  Future<LnUrlWithdrawResult> lnurlWithdraw({required LnUrlWithdrawRequest request}) async {
+    return await _lnToolkit.lnurlWithdraw(request: request);
   }
 
   /// Third and last step of LNURL-auth. The first step is `parse()`, which also validates the LNURL destination

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -147,7 +147,7 @@ abstract class BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kSendSpontaneousPaymentConstMeta;
 
   /// See [BreezServices::receive_payment]
-  Future<ReceivePaymentResponse> receivePayment({required ReceivePaymentRequest reqData, dynamic hint});
+  Future<ReceivePaymentResponse> receivePayment({required ReceivePaymentRequest request, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kReceivePaymentConstMeta;
 
@@ -158,11 +158,7 @@ abstract class BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kLnurlPayConstMeta;
 
   /// See [BreezServices::lnurl_withdraw]
-  Future<LnUrlWithdrawResult> lnurlWithdraw(
-      {required LnUrlWithdrawRequestData reqData,
-      required int amountSats,
-      String? description,
-      dynamic hint});
+  Future<LnUrlWithdrawResult> lnurlWithdraw({required LnUrlWithdrawRequest request, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kLnurlWithdrawConstMeta;
 
@@ -762,6 +758,27 @@ class LnUrlPayResult with _$LnUrlPayResult {
   }) = LnUrlPayResult_EndpointError;
 }
 
+class LnUrlWithdrawRequest {
+  /// Request data containing information on how to call the lnurl withdraw
+  /// endpoint. Typically retrieved by calling `parse()` on a lnurl withdraw
+  /// input.
+  final LnUrlWithdrawRequestData data;
+
+  /// The amount to withdraw from the lnurl withdraw endpoint. Must be between
+  /// `min_withdrawable` and `max_withdrawable`.
+  final int amountMsat;
+
+  /// Optional description that will be put in the payment request for the
+  /// lnurl withdraw endpoint.
+  final String? description;
+
+  const LnUrlWithdrawRequest({
+    required this.data,
+    required this.amountMsat,
+    this.description,
+  });
+}
+
 /// Wrapped in a [LnUrlWithdraw], this is the result of [parse] when given a LNURL-withdraw endpoint.
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
@@ -1092,7 +1109,7 @@ class ReceiveOnchainRequest {
 /// Represents a receive payment request.
 class ReceivePaymentRequest {
   /// The amount in satoshis for this payment request
-  final int amountSats;
+  final int amountMsat;
 
   /// The description for this payment request.
   final String description;
@@ -1115,7 +1132,7 @@ class ReceivePaymentRequest {
   final int? cltv;
 
   const ReceivePaymentRequest({
-    required this.amountSats,
+    required this.amountMsat,
     required this.description,
     this.preimage,
     this.openingFeeParams,
@@ -1895,20 +1912,20 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["nodeId", "amountSats"],
       );
 
-  Future<ReceivePaymentResponse> receivePayment({required ReceivePaymentRequest reqData, dynamic hint}) {
-    var arg0 = _platform.api2wire_box_autoadd_receive_payment_request(reqData);
+  Future<ReceivePaymentResponse> receivePayment({required ReceivePaymentRequest request, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_receive_payment_request(request);
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_receive_payment(port_, arg0),
       parseSuccessData: _wire2api_receive_payment_response,
       constMeta: kReceivePaymentConstMeta,
-      argValues: [reqData],
+      argValues: [request],
       hint: hint,
     ));
   }
 
   FlutterRustBridgeTaskConstMeta get kReceivePaymentConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "receive_payment",
-        argNames: ["reqData"],
+        argNames: ["request"],
       );
 
   Future<LnUrlPayResult> lnurlPay(
@@ -1930,26 +1947,20 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["userAmountSat", "comment", "reqData"],
       );
 
-  Future<LnUrlWithdrawResult> lnurlWithdraw(
-      {required LnUrlWithdrawRequestData reqData,
-      required int amountSats,
-      String? description,
-      dynamic hint}) {
-    var arg0 = _platform.api2wire_box_autoadd_ln_url_withdraw_request_data(reqData);
-    var arg1 = _platform.api2wire_u64(amountSats);
-    var arg2 = _platform.api2wire_opt_String(description);
+  Future<LnUrlWithdrawResult> lnurlWithdraw({required LnUrlWithdrawRequest request, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_ln_url_withdraw_request(request);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_lnurl_withdraw(port_, arg0, arg1, arg2),
+      callFfi: (port_) => _platform.inner.wire_lnurl_withdraw(port_, arg0),
       parseSuccessData: _wire2api_ln_url_withdraw_result,
       constMeta: kLnurlWithdrawConstMeta,
-      argValues: [reqData, amountSats, description],
+      argValues: [request],
       hint: hint,
     ));
   }
 
   FlutterRustBridgeTaskConstMeta get kLnurlWithdrawConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "lnurl_withdraw",
-        argNames: ["reqData", "amountSats", "description"],
+        argNames: ["request"],
       );
 
   Future<LnUrlCallbackStatus> lnurlAuth({required LnUrlAuthRequestData reqData, dynamic hint}) {
@@ -3295,10 +3306,10 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
-  ffi.Pointer<wire_LnUrlWithdrawRequestData> api2wire_box_autoadd_ln_url_withdraw_request_data(
-      LnUrlWithdrawRequestData raw) {
-    final ptr = inner.new_box_autoadd_ln_url_withdraw_request_data_0();
-    _api_fill_to_wire_ln_url_withdraw_request_data(raw, ptr.ref);
+  ffi.Pointer<wire_LnUrlWithdrawRequest> api2wire_box_autoadd_ln_url_withdraw_request(
+      LnUrlWithdrawRequest raw) {
+    final ptr = inner.new_box_autoadd_ln_url_withdraw_request_0();
+    _api_fill_to_wire_ln_url_withdraw_request(raw, ptr.ref);
     return ptr;
   }
 
@@ -3479,9 +3490,9 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_ln_url_pay_request_data(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_ln_url_withdraw_request_data(
-      LnUrlWithdrawRequestData apiObj, ffi.Pointer<wire_LnUrlWithdrawRequestData> wireObj) {
-    _api_fill_to_wire_ln_url_withdraw_request_data(apiObj, wireObj.ref);
+  void _api_fill_to_wire_box_autoadd_ln_url_withdraw_request(
+      LnUrlWithdrawRequest apiObj, ffi.Pointer<wire_LnUrlWithdrawRequest> wireObj) {
+    _api_fill_to_wire_ln_url_withdraw_request(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_node_config(NodeConfig apiObj, ffi.Pointer<wire_NodeConfig> wireObj) {
@@ -3592,6 +3603,13 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.ln_address = api2wire_opt_String(apiObj.lnAddress);
   }
 
+  void _api_fill_to_wire_ln_url_withdraw_request(
+      LnUrlWithdrawRequest apiObj, wire_LnUrlWithdrawRequest wireObj) {
+    _api_fill_to_wire_ln_url_withdraw_request_data(apiObj.data, wireObj.data);
+    wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
+    wireObj.description = api2wire_opt_String(apiObj.description);
+  }
+
   void _api_fill_to_wire_ln_url_withdraw_request_data(
       LnUrlWithdrawRequestData apiObj, wire_LnUrlWithdrawRequestData wireObj) {
     wireObj.callback = api2wire_String(apiObj.callback);
@@ -3643,7 +3661,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_receive_payment_request(
       ReceivePaymentRequest apiObj, wire_ReceivePaymentRequest wireObj) {
-    wireObj.amount_sats = api2wire_u64(apiObj.amountSats);
+    wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
     wireObj.description = api2wire_String(apiObj.description);
     wireObj.preimage = api2wire_opt_uint_8_list(apiObj.preimage);
     wireObj.opening_fee_params = api2wire_opt_box_autoadd_opening_fee_params(apiObj.openingFeeParams);
@@ -4132,11 +4150,11 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
 
   void wire_receive_payment(
     int port_,
-    ffi.Pointer<wire_ReceivePaymentRequest> req_data,
+    ffi.Pointer<wire_ReceivePaymentRequest> request,
   ) {
     return _wire_receive_payment(
       port_,
-      req_data,
+      request,
     );
   }
 
@@ -4169,24 +4187,19 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
 
   void wire_lnurl_withdraw(
     int port_,
-    ffi.Pointer<wire_LnUrlWithdrawRequestData> req_data,
-    int amount_sats,
-    ffi.Pointer<wire_uint_8_list> description,
+    ffi.Pointer<wire_LnUrlWithdrawRequest> request,
   ) {
     return _wire_lnurl_withdraw(
       port_,
-      req_data,
-      amount_sats,
-      description,
+      request,
     );
   }
 
-  late final _wire_lnurl_withdrawPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_LnUrlWithdrawRequestData>, ffi.Uint64,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_lnurl_withdraw');
-  late final _wire_lnurl_withdraw = _wire_lnurl_withdrawPtr.asFunction<
-      void Function(int, ffi.Pointer<wire_LnUrlWithdrawRequestData>, int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_lnurl_withdrawPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_LnUrlWithdrawRequest>)>>(
+          'wire_lnurl_withdraw');
+  late final _wire_lnurl_withdraw =
+      _wire_lnurl_withdrawPtr.asFunction<void Function(int, ffi.Pointer<wire_LnUrlWithdrawRequest>)>();
 
   void wire_lnurl_auth(
     int port_,
@@ -4520,16 +4533,15 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_ln_url_pay_request_data_0 = _new_box_autoadd_ln_url_pay_request_data_0Ptr
       .asFunction<ffi.Pointer<wire_LnUrlPayRequestData> Function()>();
 
-  ffi.Pointer<wire_LnUrlWithdrawRequestData> new_box_autoadd_ln_url_withdraw_request_data_0() {
-    return _new_box_autoadd_ln_url_withdraw_request_data_0();
+  ffi.Pointer<wire_LnUrlWithdrawRequest> new_box_autoadd_ln_url_withdraw_request_0() {
+    return _new_box_autoadd_ln_url_withdraw_request_0();
   }
 
-  late final _new_box_autoadd_ln_url_withdraw_request_data_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_LnUrlWithdrawRequestData> Function()>>(
-          'new_box_autoadd_ln_url_withdraw_request_data_0');
-  late final _new_box_autoadd_ln_url_withdraw_request_data_0 =
-      _new_box_autoadd_ln_url_withdraw_request_data_0Ptr
-          .asFunction<ffi.Pointer<wire_LnUrlWithdrawRequestData> Function()>();
+  late final _new_box_autoadd_ln_url_withdraw_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_LnUrlWithdrawRequest> Function()>>(
+          'new_box_autoadd_ln_url_withdraw_request_0');
+  late final _new_box_autoadd_ln_url_withdraw_request_0 = _new_box_autoadd_ln_url_withdraw_request_0Ptr
+      .asFunction<ffi.Pointer<wire_LnUrlWithdrawRequest> Function()>();
 
   ffi.Pointer<wire_NodeConfig> new_box_autoadd_node_config_0() {
     return _new_box_autoadd_node_config_0();
@@ -4794,7 +4806,7 @@ class wire_OpeningFeeParams extends ffi.Struct {
 
 class wire_ReceivePaymentRequest extends ffi.Struct {
   @ffi.Uint64()
-  external int amount_sats;
+  external int amount_msat;
 
   external ffi.Pointer<wire_uint_8_list> description;
 
@@ -4840,6 +4852,15 @@ class wire_LnUrlWithdrawRequestData extends ffi.Struct {
 
   @ffi.Uint64()
   external int max_withdrawable;
+}
+
+class wire_LnUrlWithdrawRequest extends ffi.Struct {
+  external wire_LnUrlWithdrawRequestData data;
+
+  @ffi.Uint64()
+  external int amount_msat;
+
+  external ffi.Pointer<wire_uint_8_list> description;
 }
 
 class wire_LnUrlAuthRequestData extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -956,6 +956,46 @@ fun asLnUrlPayRequestDataList(arr: ReadableArray): List<LnUrlPayRequestData> {
     return list
 }
 
+fun asLnUrlWithdrawRequest(data: ReadableMap): LnUrlWithdrawRequest? {
+    if (!validateMandatoryFields(
+            data,
+            arrayOf(
+                "data",
+                "amountMsat",
+            ),
+        )
+    ) {
+        return null
+    }
+    val data = data.getMap("data")?.let { asLnUrlWithdrawRequestData(it) }!!
+    val amountMsat = data.getDouble("amountMsat").toULong()
+    val description = if (hasNonNullKey(data, "description")) data.getString("description") else null
+    return LnUrlWithdrawRequest(
+        data,
+        amountMsat,
+        description,
+    )
+}
+
+fun readableMapOf(lnUrlWithdrawRequest: LnUrlWithdrawRequest): ReadableMap {
+    return readableMapOf(
+        "data" to readableMapOf(lnUrlWithdrawRequest.data),
+        "amountMsat" to lnUrlWithdrawRequest.amountMsat,
+        "description" to lnUrlWithdrawRequest.description,
+    )
+}
+
+fun asLnUrlWithdrawRequestList(arr: ReadableArray): List<LnUrlWithdrawRequest> {
+    val list = ArrayList<LnUrlWithdrawRequest>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asLnUrlWithdrawRequest(value)!!)
+            else -> throw IllegalArgumentException("Unsupported type ${value::class.java.name}")
+        }
+    }
+    return list
+}
+
 fun asLnUrlWithdrawRequestData(data: ReadableMap): LnUrlWithdrawRequestData? {
     if (!validateMandatoryFields(
             data,
@@ -1713,14 +1753,14 @@ fun asReceivePaymentRequest(data: ReadableMap): ReceivePaymentRequest? {
     if (!validateMandatoryFields(
             data,
             arrayOf(
-                "amountSats",
+                "amountMsat",
                 "description",
             ),
         )
     ) {
         return null
     }
-    val amountSats = data.getDouble("amountSats").toULong()
+    val amountMsat = data.getDouble("amountMsat").toULong()
     val description = data.getString("description")!!
     val preimage = if (hasNonNullKey(data, "preimage")) data.getArray("preimage")?.let { asUByteList(it) } else null
     val openingFeeParams =
@@ -1735,7 +1775,7 @@ fun asReceivePaymentRequest(data: ReadableMap): ReceivePaymentRequest? {
     val expiry = if (hasNonNullKey(data, "expiry")) data.getInt("expiry").toUInt() else null
     val cltv = if (hasNonNullKey(data, "cltv")) data.getInt("cltv").toUInt() else null
     return ReceivePaymentRequest(
-        amountSats,
+        amountMsat,
         description,
         preimage,
         openingFeeParams,
@@ -1747,7 +1787,7 @@ fun asReceivePaymentRequest(data: ReadableMap): ReceivePaymentRequest? {
 
 fun readableMapOf(receivePaymentRequest: ReceivePaymentRequest): ReadableMap {
     return readableMapOf(
-        "amountSats" to receivePaymentRequest.amountSats,
+        "amountMsat" to receivePaymentRequest.amountMsat,
         "description" to receivePaymentRequest.description,
         "preimage" to receivePaymentRequest.preimage?.let { readableArrayOf(it) },
         "openingFeeParams" to receivePaymentRequest.openingFeeParams?.let { readableMapOf(it) },

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -215,14 +215,14 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
 
     @ReactMethod
     fun receivePayment(
-        reqData: ReadableMap,
+        request: ReadableMap,
         promise: Promise,
     ) {
         executor.execute {
             try {
                 val receivePaymentRequest =
-                    asReceivePaymentRequest(reqData) ?: run {
-                        throw SdkException.Generic("Missing mandatory field reqData of type ReceivePaymentRequest")
+                    asReceivePaymentRequest(request) ?: run {
+                        throw SdkException.Generic("Missing mandatory field request of type ReceivePaymentRequest")
                     }
                 val res = getBreezServices().receivePayment(receivePaymentRequest)
                 promise.resolve(readableMapOf(res))
@@ -256,19 +256,16 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
 
     @ReactMethod
     fun withdrawLnurl(
-        reqData: ReadableMap,
-        amountSats: Double,
-        description: String,
+        request: ReadableMap,
         promise: Promise,
     ) {
         executor.execute {
             try {
-                val lnUrlWithdrawRequestData =
-                    asLnUrlWithdrawRequestData(reqData) ?: run {
-                        throw SdkException.Generic("Missing mandatory field reqData of type LnUrlWithdrawRequestData")
+                val lnUrlWithdrawRequest =
+                    asLnUrlWithdrawRequest(request) ?: run {
+                        throw SdkException.Generic("Missing mandatory field request of type LnUrlWithdrawRequest")
                     }
-                val descriptionTmp = description.takeUnless { it.isEmpty() }
-                val res = getBreezServices().withdrawLnurl(lnUrlWithdrawRequestData, amountSats.toULong(), descriptionTmp)
+                val res = getBreezServices().withdrawLnurl(lnUrlWithdrawRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: SdkException) {
                 promise.reject(e.javaClass.simpleName, e.message, e)

--- a/libs/sdk-react-native/example/App.js
+++ b/libs/sdk-react-native/example/App.js
@@ -133,7 +133,7 @@ const App = () => {
                 addLine("openChannelFee", JSON.stringify(openChannelFeeResult))
 
                 const receivePaymentResult = await receivePayment({
-                    amountSats: 100000,
+                    amountMsat: 100000000,
                     description: "Hello world",
                     expiry: 3600,
                     cltv: 144,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -885,6 +885,45 @@ class BreezSDKMapper {
         return lnUrlPayRequestDataList.map { v -> [String: Any?] in dictionaryOf(lnUrlPayRequestData: v) }
     }
 
+    static func asLnUrlWithdrawRequest(data: [String: Any?]) throws -> LnUrlWithdrawRequest {
+        guard let dataTmp = data["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlWithdrawRequest") }
+        let data = try asLnUrlWithdrawRequestData(data: dataTmp)
+
+        guard let amountMsat = data["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type LnUrlWithdrawRequest") }
+        let description = data["description"] as? String
+
+        return LnUrlWithdrawRequest(
+            data: data,
+            amountMsat: amountMsat,
+            description: description
+        )
+    }
+
+    static func dictionaryOf(lnUrlWithdrawRequest: LnUrlWithdrawRequest) -> [String: Any?] {
+        return [
+            "data": dictionaryOf(lnUrlWithdrawRequestData: lnUrlWithdrawRequest.data),
+            "amountMsat": lnUrlWithdrawRequest.amountMsat,
+            "description": lnUrlWithdrawRequest.description == nil ? nil : lnUrlWithdrawRequest.description,
+        ]
+    }
+
+    static func asLnUrlWithdrawRequestList(arr: [Any]) throws -> [LnUrlWithdrawRequest] {
+        var list = [LnUrlWithdrawRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var lnUrlWithdrawRequest = try asLnUrlWithdrawRequest(data: val)
+                list.append(lnUrlWithdrawRequest)
+            } else {
+                throw SdkError.Generic(message: "Invalid element type LnUrlWithdrawRequest")
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(lnUrlWithdrawRequestList: [LnUrlWithdrawRequest]) -> [Any] {
+        return lnUrlWithdrawRequestList.map { v -> [String: Any?] in dictionaryOf(lnUrlWithdrawRequest: v) }
+    }
+
     static func asLnUrlWithdrawRequestData(data: [String: Any?]) throws -> LnUrlWithdrawRequestData {
         guard let callback = data["callback"] as? String else { throw SdkError.Generic(message: "Missing mandatory field callback for type LnUrlWithdrawRequestData") }
         guard let k1 = data["k1"] as? String else { throw SdkError.Generic(message: "Missing mandatory field k1 for type LnUrlWithdrawRequestData") }
@@ -1573,7 +1612,7 @@ class BreezSDKMapper {
     }
 
     static func asReceivePaymentRequest(data: [String: Any?]) throws -> ReceivePaymentRequest {
-        guard let amountSats = data["amountSats"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountSats for type ReceivePaymentRequest") }
+        guard let amountMsat = data["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type ReceivePaymentRequest") }
         guard let description = data["description"] as? String else { throw SdkError.Generic(message: "Missing mandatory field description for type ReceivePaymentRequest") }
         let preimage = data["preimage"] as? [UInt8]
         var openingFeeParams: OpeningFeeParams?
@@ -1586,7 +1625,7 @@ class BreezSDKMapper {
         let cltv = data["cltv"] as? UInt32
 
         return ReceivePaymentRequest(
-            amountSats: amountSats,
+            amountMsat: amountMsat,
             description: description,
             preimage: preimage,
             openingFeeParams: openingFeeParams,
@@ -1598,7 +1637,7 @@ class BreezSDKMapper {
 
     static func dictionaryOf(receivePaymentRequest: ReceivePaymentRequest) -> [String: Any?] {
         return [
-            "amountSats": receivePaymentRequest.amountSats,
+            "amountMsat": receivePaymentRequest.amountMsat,
             "description": receivePaymentRequest.description,
             "preimage": receivePaymentRequest.preimage == nil ? nil : receivePaymentRequest.preimage,
             "openingFeeParams": receivePaymentRequest.openingFeeParams == nil ? nil : dictionaryOf(openingFeeParams: receivePaymentRequest.openingFeeParams!),

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -67,7 +67,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    receivePayment: (NSDictionary*)reqData
+    receivePayment: (NSDictionary*)request
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )
@@ -81,9 +81,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    withdrawLnurl: (NSDictionary*)reqData
-    amountSats: (NSUInteger*)amountSats
-    description: (NSString*)description
+    withdrawLnurl: (NSDictionary*)request
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -152,10 +152,10 @@ class RNBreezSDK: RCTEventEmitter {
     }
 
     @objc(receivePayment:resolve:reject:)
-    func receivePayment(_ reqData: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func receivePayment(_ request: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            let receivePaymentRequest = try BreezSDKMapper.asReceivePaymentRequest(data: reqData)
-            var res = try getBreezServices().receivePayment(reqData: receivePaymentRequest)
+            let receivePaymentRequest = try BreezSDKMapper.asReceivePaymentRequest(data: request)
+            var res = try getBreezServices().receivePayment(request: receivePaymentRequest)
             resolve(BreezSDKMapper.dictionaryOf(receivePaymentResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
@@ -174,12 +174,11 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
-    @objc(withdrawLnurl:amountSats:description:resolve:reject:)
-    func withdrawLnurl(_ reqData: [String: Any], amountSats: UInt64, description: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(withdrawLnurl:resolve:reject:)
+    func withdrawLnurl(_ request: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            let lnUrlWithdrawRequestData = try BreezSDKMapper.asLnUrlWithdrawRequestData(data: reqData)
-            let descriptionTmp = description.isEmpty ? nil : description
-            var res = try getBreezServices().withdrawLnurl(reqData: lnUrlWithdrawRequestData, amountSats: amountSats, description: descriptionTmp)
+            let lnUrlWithdrawRequest = try BreezSDKMapper.asLnUrlWithdrawRequest(data: request)
+            var res = try getBreezServices().withdrawLnurl(request: lnUrlWithdrawRequest)
             resolve(BreezSDKMapper.dictionaryOf(lnUrlWithdrawResult: res))
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -167,6 +167,12 @@ export type LnUrlPayRequestData = {
     lnAddress?: string
 }
 
+export type LnUrlWithdrawRequest = {
+    data: LnUrlWithdrawRequestData
+    amountMsat: number
+    description?: string
+}
+
 export type LnUrlWithdrawRequestData = {
     callback: string
     k1: string
@@ -284,7 +290,7 @@ export type ReceiveOnchainRequest = {
 }
 
 export type ReceivePaymentRequest = {
-    amountSats: number
+    amountMsat: number
     description: string
     preimage?: number[]
     openingFeeParams?: OpeningFeeParams
@@ -680,8 +686,8 @@ export const sendSpontaneousPayment = async (nodeId: string, amountSats: number)
     return response
 }
 
-export const receivePayment = async (reqData: ReceivePaymentRequest): Promise<ReceivePaymentResponse> => {
-    const response = await BreezSDK.receivePayment(reqData)
+export const receivePayment = async (request: ReceivePaymentRequest): Promise<ReceivePaymentResponse> => {
+    const response = await BreezSDK.receivePayment(request)
     return response
 }
 
@@ -690,8 +696,8 @@ export const payLnurl = async (reqData: LnUrlPayRequestData, amountSats: number,
     return response
 }
 
-export const withdrawLnurl = async (reqData: LnUrlWithdrawRequestData, amountSats: number, description: string = ""): Promise<LnUrlWithdrawResult> => {
-    const response = await BreezSDK.withdrawLnurl(reqData, amountSats, description)
+export const withdrawLnurl = async (request: LnUrlWithdrawRequest): Promise<LnUrlWithdrawResult> => {
+    const response = await BreezSDK.withdrawLnurl(request)
     return response
 }
 

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -53,7 +53,7 @@ pub(crate) enum Commands {
 
     /// Generate a bolt11 invoice
     ReceivePayment {
-        amount: u64,
+        amount_msat: u64,
         description: String,
         #[clap(name = "use_description_hash", short = 's', long = "desc_hash")]
         use_description_hash: Option<bool>,


### PR DESCRIPTION
Convert the interfaces for `receive_payment` and `lnurl_withdraw` to use msat parameters.
Note this is BREAKING CHANGE.

lnurl_withdraw now also takes a request struct.

The interface for the cli now also takes msat in receive_payment, that may be confusing for regular cli users.

Uncertainties:
- I'm unsure about the flutter code changes. I ran the flutter_rust_bridge and updated breez_sdk.dart manually. 

