### PR TITLE
default cltv_expiry for invoices 144 blocks

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1792,7 +1792,7 @@ impl Receiver for PaymentReceiver {
                 request.preimage,
                 request.use_description_hash,
                 Some(expiry),
-                request.cltv,
+                Some(request.cltv.unwrap_or(144)),
             )
             .await?;
         info!("Invoice created {}", invoice);


### PR DESCRIPTION
Currently the default cltv expiry of the node is used for invoices. If the default cltv expiry is too low, however, this increases force close risk with a signer that is not always online. Increase the default final cltv expiry to 144 blocks, so there's enough leeway for a client to come back online after a period of time and settle pending htlcs.

Fixes https://github.com/breez/breez-sdk/issues/523