### PR TITLE
RN example metro config fix

### DIFF
--- a/libs/sdk-react-native/.gitignore
+++ b/libs/sdk-react-native/.gitignore
@@ -44,6 +44,8 @@ android.iml
 
 # Cocoapods
 #
+breez_sdk.podspec.*
+BreezSDK.podspec
 example/ios/Pods
 
 # node.js

--- a/libs/sdk-react-native/DEVELOPING.md
+++ b/libs/sdk-react-native/DEVELOPING.md
@@ -58,7 +58,7 @@ This will generate the following artifacts:
 To use the locally built bindings instead of integrating them remotely:
 
 - For iOS:
-	- Remove `breez_sdk.podspec`
+	- Rename `breez_sdk.podspec` to `breez_sdk.podspec.prod`
 	- Rename `BreezSDK.podspec.dev` to `BreezSDK.podspec`
 - For Android:
 	- Remove the following line from the dependencies section in `android/build.gradle`:

--- a/libs/sdk-react-native/example/metro.config.js
+++ b/libs/sdk-react-native/example/metro.config.js
@@ -1,39 +1,22 @@
-const path = require('path');
-const blacklist = require('metro-config/src/defaults/exclusionList');
-const escape = require('escape-string-regexp');
-const pak = require('../package.json');
-
-const root = path.resolve(__dirname, '..');
-
-const modules = Object.keys({
-  ...pak.peerDependencies,
-});
+/**
+ * Metro configuration for React Native
+ * https://github.com/facebook/react-native
+ *
+ * @format
+ */
+const { getDefaultConfig } = require("metro-config")
+const { resolver: defaultResolver } = getDefaultConfig.getDefaultValues()
 
 module.exports = {
-  projectRoot: __dirname,
-  watchFolders: [root],
-
-  // We need to make sure that only one version is loaded for peerDependencies
-  // So we blacklist them at the root, and alias them to the versions in example's node_modules
-  resolver: {
-    blacklistRE: blacklist(
-      modules.map(
-        m => new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`),
-      ),
-    ),
-
-    extraNodeModules: modules.reduce((acc, name) => {
-      acc[name] = path.join(__dirname, 'node_modules', name);
-      return acc;
-    }, {}),
-  },
-
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: true,
-      },
-    }),
-  },
-};
+    resolver: {
+        ...defaultResolver,
+    },
+    transformer: {
+        getTransformOptions: async () => ({
+            transform: {
+                experimentalImportSupport: false,
+                inlineRequires: true
+            }
+        })
+    }
+}

--- a/libs/sdk-react-native/example/yarn.lock
+++ b/libs/sdk-react-native/example/yarn.lock
@@ -915,7 +915,7 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@breeztech/react-native-breez-sdk@file:..":
-  version "0.2.3"
+  version "0.2.5"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
Simplifies the example app metro config to not be dependent on the local sdk-react-native package