### PR TITLE
Add Default trait, util constructor for Request args

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -356,11 +356,8 @@ impl BreezServices {
             .receive_payment(ReceivePaymentRequest {
                 amount_msat: req.amount_msat,
                 description: req.description.unwrap_or_default(),
-                preimage: None,
-                opening_fee_params: None,
                 use_description_hash: Some(false),
-                expiry: None,
-                cltv: None,
+                ..Default::default()
             })
             .await
             .map_err(|_| anyhow!("Failed to receive payment"))?
@@ -2050,14 +2047,7 @@ pub(crate) mod tests {
         assert_eq!(fetched_state, dummy_node_state);
 
         let all = breez_services
-            .list_payments(ListPaymentsRequest {
-                filters: None,
-                from_timestamp: None,
-                to_timestamp: None,
-                include_failures: None,
-                offset: None,
-                limit: None,
-            })
+            .list_payments(ListPaymentsRequest::default())
             .await?;
         let mut cloned = all.clone();
 
@@ -2068,11 +2058,7 @@ pub(crate) mod tests {
         let received = breez_services
             .list_payments(ListPaymentsRequest {
                 filters: Some(vec![PaymentTypeFilter::Received]),
-                from_timestamp: None,
-                to_timestamp: None,
-                include_failures: None,
-                offset: None,
-                limit: None,
+                ..Default::default()
             })
             .await?;
         assert_eq!(received, vec![cloned[1].clone(), cloned[0].clone()]);
@@ -2083,11 +2069,7 @@ pub(crate) mod tests {
                     PaymentTypeFilter::Sent,
                     PaymentTypeFilter::ClosedChannels,
                 ]),
-                from_timestamp: None,
-                to_timestamp: None,
-                include_failures: None,
-                offset: None,
-                limit: None,
+                ..Default::default()
             })
             .await?;
         assert_eq!(sent, vec![cloned[2].clone()]);
@@ -2131,11 +2113,8 @@ pub(crate) mod tests {
             .receive_payment(ReceivePaymentRequest {
                 amount_msat: 3_000_000,
                 description: "should populate lsp hints".to_string(),
-                preimage: None,
-                opening_fee_params: None,
                 use_description_hash: Some(false),
-                expiry: None,
-                cltv: None,
+                ..Default::default()
             })
             .await?
             .ln_invoice;
@@ -2189,10 +2168,9 @@ pub(crate) mod tests {
         let breez_services = breez_services().await?;
         breez_services.sync().await?;
         let moonpay_url = breez_services
-            .buy_bitcoin(BuyBitcoinRequest {
-                provider: BuyBitcoinProvider::Moonpay,
-                opening_fee_params: None,
-            })
+            .buy_bitcoin(BuyBitcoinRequest::from_provider(
+                BuyBitcoinProvider::Moonpay,
+            ))
             .await?
             .url;
         let parsed = Url::parse(&moonpay_url)?;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2168,9 +2168,10 @@ pub(crate) mod tests {
         let breez_services = breez_services().await?;
         breez_services.sync().await?;
         let moonpay_url = breez_services
-            .buy_bitcoin(BuyBitcoinRequest::from_provider(
-                BuyBitcoinProvider::Moonpay,
-            ))
+            .buy_bitcoin(BuyBitcoinRequest {
+                provider: BuyBitcoinProvider::Moonpay,
+                opening_fee_params: None,
+            })
             .await?
             .url;
         let parsed = Url::parse(&moonpay_url)?;

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -751,16 +751,6 @@ pub struct ReceivePaymentRequest {
     pub cltv: Option<u32>,
 }
 
-impl ReceivePaymentRequest {
-    pub fn from_amount_and_description(amount_msat: u64, description: String) -> Self {
-        ReceivePaymentRequest {
-            amount_msat,
-            description,
-            ..Default::default()
-        }
-    }
-}
-
 /// Represents a receive payment response.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceivePaymentResponse {
@@ -776,15 +766,6 @@ pub struct SendPaymentRequest {
     pub bolt11: String,
     /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
     pub amount_msat: Option<u64>,
-}
-
-impl SendPaymentRequest {
-    pub fn from_bolt11(bolt11: String) -> Self {
-        SendPaymentRequest {
-            bolt11,
-            amount_msat: None,
-        }
-    }
 }
 
 /// Represents a send spontaneous payment request.
@@ -817,15 +798,6 @@ pub struct OpenChannelFeeRequest {
     pub expiry: Option<u32>,
 }
 
-impl OpenChannelFeeRequest {
-    pub fn from_amount(amount_msat: u64) -> Self {
-        OpenChannelFeeRequest {
-            amount_msat,
-            expiry: None,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenChannelFeeResponse {
     pub fee_msat: u64,
@@ -841,15 +813,6 @@ pub struct ReceiveOnchainRequest {
 pub struct BuyBitcoinRequest {
     pub provider: BuyBitcoinProvider,
     pub opening_fee_params: Option<OpeningFeeParams>,
-}
-
-impl BuyBitcoinRequest {
-    pub fn from_provider(provider: BuyBitcoinProvider) -> Self {
-        BuyBitcoinRequest {
-            provider,
-            opening_fee_params: None,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -657,6 +657,7 @@ pub struct Payment {
 }
 
 /// Represents a list payments request.
+#[derive(Default)]
 pub struct ListPaymentsRequest {
     pub filters: Option<Vec<PaymentTypeFilter>>,
     pub from_timestamp: Option<i64>,
@@ -724,13 +725,13 @@ pub struct ClosedChannelPaymentDetails {
     pub closing_txid: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ReverseSwapFeesRequest {
     pub send_amount_sat: Option<u64>,
 }
 
 /// Represents a receive payment request.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ReceivePaymentRequest {
     /// The amount in satoshis for this payment request
     pub amount_msat: u64,
@@ -750,6 +751,16 @@ pub struct ReceivePaymentRequest {
     pub cltv: Option<u32>,
 }
 
+impl ReceivePaymentRequest {
+    pub fn from_amount_and_description(amount_msat: u64, description: String) -> Self {
+        ReceivePaymentRequest {
+            amount_msat,
+            description,
+            ..Default::default()
+        }
+    }
+}
+
 /// Represents a receive payment response.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceivePaymentResponse {
@@ -763,8 +774,17 @@ pub struct ReceivePaymentResponse {
 pub struct SendPaymentRequest {
     /// The bolt11 invoice
     pub bolt11: String,
-    /// The amount to pay in millisatoshis
+    /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
     pub amount_msat: Option<u64>,
+}
+
+impl SendPaymentRequest {
+    pub fn from_bolt11(bolt11: String) -> Self {
+        SendPaymentRequest {
+            bolt11,
+            amount_msat: None,
+        }
+    }
 }
 
 /// Represents a send spontaneous payment request.
@@ -797,13 +817,22 @@ pub struct OpenChannelFeeRequest {
     pub expiry: Option<u32>,
 }
 
+impl OpenChannelFeeRequest {
+    pub fn from_amount(amount_msat: u64) -> Self {
+        OpenChannelFeeRequest {
+            amount_msat,
+            expiry: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenChannelFeeResponse {
     pub fee_msat: u64,
     pub used_fee_params: Option<OpeningFeeParams>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ReceiveOnchainRequest {
     pub opening_fee_params: Option<OpeningFeeParams>,
 }
@@ -812,6 +841,15 @@ pub struct ReceiveOnchainRequest {
 pub struct BuyBitcoinRequest {
     pub provider: BuyBitcoinProvider,
     pub opening_fee_params: Option<OpeningFeeParams>,
+}
+
+impl BuyBitcoinRequest {
+    pub fn from_provider(provider: BuyBitcoinProvider) -> Self {
+        BuyBitcoinRequest {
+            provider,
+            opening_fee_params: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -474,14 +474,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // retrieve all
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: None,
-        from_timestamp: None,
-        to_timestamp: None,
-        include_failures: None,
-        offset: None,
-        limit: None,
-    })?;
+    let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
 
@@ -491,11 +484,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
             PaymentTypeFilter::Sent,
             PaymentTypeFilter::ClosedChannels,
         ]),
-        from_timestamp: None,
-        to_timestamp: None,
-        include_failures: None,
-        offset: None,
-        limit: None,
+        ..Default::default()
     })?;
     assert_eq!(retrieve_txs.len(), 1);
     assert_eq!(retrieve_txs[0], txs[0]);
@@ -509,11 +498,7 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
     //test only received
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
         filters: Some(vec![PaymentTypeFilter::Received]),
-        from_timestamp: None,
-        to_timestamp: None,
-        include_failures: None,
-        offset: None,
-        limit: None,
+        ..Default::default()
     })?;
     assert_eq!(retrieve_txs.len(), 1);
     assert_eq!(retrieve_txs[0], txs[1]);
@@ -522,36 +507,18 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(max_ts, 2000);
 
     storage.insert_or_update_payments(&txs)?;
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: None,
-        from_timestamp: None,
-        to_timestamp: None,
-        include_failures: None,
-        offset: None,
-        limit: None,
-    })?;
+    let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
     assert_eq!(retrieve_txs.len(), 2);
     assert_eq!(retrieve_txs, txs);
 
     storage.insert_open_channel_payment_info("123", 150)?;
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: None,
-        from_timestamp: None,
-        to_timestamp: None,
-        include_failures: None,
-        offset: None,
-        limit: None,
-    })?;
+    let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
     assert_eq!(retrieve_txs[0].fee_msat, 50);
 
     // test all with failures
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: None,
-        from_timestamp: None,
-        to_timestamp: None,
         include_failures: Some(true),
-        offset: None,
-        limit: None,
+        ..Default::default()
     })?;
     assert_eq!(retrieve_txs.len(), 3);
 
@@ -561,33 +528,25 @@ fn test_ln_transactions() -> Result<(), Box<dyn std::error::Error>> {
             PaymentTypeFilter::Sent,
             PaymentTypeFilter::ClosedChannels,
         ]),
-        from_timestamp: None,
-        to_timestamp: None,
         include_failures: Some(true),
-        offset: None,
-        limit: None,
+        ..Default::default()
     })?;
     assert_eq!(retrieve_txs.len(), 2);
 
     // test limit
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: None,
-        from_timestamp: None,
-        to_timestamp: None,
         include_failures: Some(false),
-        offset: None,
         limit: Some(1),
+        ..Default::default()
     })?;
     assert_eq!(retrieve_txs.len(), 1);
 
     // test offset
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: None,
-        from_timestamp: None,
-        to_timestamp: None,
         include_failures: Some(false),
         offset: Some(1),
         limit: Some(1),
+        ..Default::default()
     })?;
     assert_eq!(retrieve_txs.len(), 1);
     assert_eq!(retrieve_txs[0].id, payment_hash_with_lnurl_withdraw);

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -132,11 +132,10 @@ pub(crate) async fn handle_command(
                 .receive_payment(ReceivePaymentRequest {
                     amount_msat,
                     description,
-                    preimage: None,
-                    opening_fee_params: None,
                     use_description_hash,
                     expiry,
                     cltv,
+                    ..Default::default()
                 })
                 .await?;
             let mut result = serde_json::to_string(&recv_payment_response)?;
@@ -150,9 +149,7 @@ pub(crate) async fn handle_command(
             sat_per_vbyte,
         } => {
             let pair_info = sdk()?
-                .fetch_reverse_swap_fees(ReverseSwapFeesRequest {
-                    send_amount_sat: None,
-                })
+                .fetch_reverse_swap_fees(ReverseSwapFeesRequest::default())
                 .await
                 .map_err(|e| anyhow!("Failed to fetch reverse swap fee infos: {e}"))?;
 
@@ -297,9 +294,7 @@ pub(crate) async fn handle_command(
         }
         Commands::ReceiveOnchain {} => serde_json::to_string_pretty(
             &sdk()?
-                .receive_onchain(ReceiveOnchainRequest {
-                    opening_fee_params: None,
-                })
+                .receive_onchain(ReceiveOnchainRequest::default())
                 .await?,
         )
         .map_err(|e| e.into()),
@@ -437,10 +432,7 @@ pub(crate) async fn handle_command(
         }
         Commands::BuyBitcoin { provider } => {
             let res = sdk()?
-                .buy_bitcoin(BuyBitcoinRequest {
-                    provider: provider.clone(),
-                    opening_fee_params: None,
-                })
+                .buy_bitcoin(BuyBitcoinRequest::from_provider(provider.clone()))
                 .await?;
             Ok(format!("Here your {:?} url: {}", provider, res.url))
         }

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -432,7 +432,10 @@ pub(crate) async fn handle_command(
         }
         Commands::BuyBitcoin { provider } => {
             let res = sdk()?
-                .buy_bitcoin(BuyBitcoinRequest::from_provider(provider.clone()))
+                .buy_bitcoin(BuyBitcoinRequest {
+                    provider: provider.clone(),
+                    opening_fee_params: None,
+                })
                 .await?;
             Ok(format!("Here your {:?} url: {}", provider, res.url))
         }


### PR DESCRIPTION
This PR simplifies the construction of user-facing Request structs:
- derives `Default` where possible
- adds `from_...` constructors for structs where only a few fields are always needed, but the rest are optional

Request structs where all fields are always needed, or where only 1 field is optional, were left out because the ergonomics wouldn't be improved by such a change.