### PR TITLE
Fix RN workingDir and disconnect handling

### DIFF
--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -35,6 +35,19 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         throw SdkException.Generic("BreezServices not initialized")
     }
 
+    @Throws(SdkException::class)
+    private fun ensureWorkingDir(workingDir: String) {
+        try {
+            val workingDirFile = File(workingDir)
+
+            if (!workingDirFile.exists() && !workingDirFile.mkdirs()) {
+                throw SdkException.Generic("Mandatory field workingDir must contain a writable directory")
+            }
+        } catch (e: SecurityException) {
+            throw SdkException.Generic("Mandatory field workingDir must contain a writable directory")
+        }
+    }
+
     @ReactMethod
     fun addListener(eventName: String) {}
 
@@ -100,10 +113,6 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 val res = defaultConfig(envTypeTmp, apiKey, nodeConfigTmp)
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
 
-                if (!workingDir.exists()) {
-                    workingDir.mkdirs()
-                }
-
                 res.workingDir = workingDir.absolutePath
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -159,6 +168,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             val configTmp = asConfig(config) ?: run { throw SdkException.Generic("Missing mandatory field config of type Config") }
             val emitter = reactApplicationContext.getJSModule(RCTDeviceEventEmitter::class.java)
 
+            ensureWorkingDir(configTmp.workingDir)
+
             breezServices = connect(configTmp, asUByteList(seed), BreezSDKListener(emitter))
             promise.resolve(readableMapOf("status" to "ok"))
         } catch (e: Exception) {
@@ -172,6 +183,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         executor.execute {
             try {
                 getBreezServices().disconnect()
+                breezServices = null
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
                 promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)

--- a/libs/sdk-react-native/example/ios/Podfile.lock
+++ b/libs/sdk-react-native/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - BreezSDK (0.2.3):
+  - BreezSDK (0.2.7):
     - React-Core
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
@@ -552,7 +552,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  BreezSDK: 29da4e607a0db869f3a8f530630fd0b3067a09de
+  BreezSDK: 8a21e8626fad0fe52f3f0b864a43689a53afc6df
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 48289402952f4f7a4e235de70a9a590aa0b79ef4

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1,7 +1,7 @@
 import BreezSDK
 import Foundation
 
-class BreezSDKMapper {
+enum BreezSDKMapper {
     static func asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: [String: Any?]) throws -> AesSuccessActionDataDecrypted {
         guard let description = aesSuccessActionDataDecrypted["description"] as? String else { throw SdkError.Generic(message: "Missing mandatory field description for type AesSuccessActionDataDecrypted") }
         guard let plaintext = aesSuccessActionDataDecrypted["plaintext"] as? String else { throw SdkError.Generic(message: "Missing mandatory field plaintext for type AesSuccessActionDataDecrypted") }


### PR DESCRIPTION
Generated code for breez/breez-sdk-rn-generator#14

> This PR enables different nodes to be run through RN (one at a time) by allowing the workingDir to be set as a subdirectory of the application directory and resetting the breezServices instance when disconnect is called.