### PR TITLE
rename PaymentTypeFilter ClosedChannels enum to ClosedChannel

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -188,7 +188,7 @@ dictionary CheckMessageResponse {
 enum PaymentTypeFilter {
     "Sent",
     "Received",
-    "ClosedChannels",
+    "ClosedChannel",
 };
 
 enum PaymentStatus {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2088,7 +2088,7 @@ pub(crate) mod tests {
             .list_payments(ListPaymentsRequest {
                 filters: Some(vec![
                     PaymentTypeFilter::Sent,
-                    PaymentTypeFilter::ClosedChannels,
+                    PaymentTypeFilter::ClosedChannel,
                 ]),
                 ..Default::default()
             })

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -783,7 +783,7 @@ impl Wire2Api<PaymentTypeFilter> for i32 {
         match self {
             0 => PaymentTypeFilter::Sent,
             1 => PaymentTypeFilter::Received,
-            2 => PaymentTypeFilter::ClosedChannels,
+            2 => PaymentTypeFilter::ClosedChannel,
             _ => unreachable!("Invalid variant for PaymentTypeFilter: {}", self),
         }
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -528,7 +528,7 @@ impl From<Network> for bitcoin::network::constants::Network {
 pub enum PaymentTypeFilter {
     Sent,
     Received,
-    ClosedChannels,
+    ClosedChannel,
 }
 
 /// Different types of supported feerates

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -291,7 +291,7 @@ fn filter_to_where_clause(
                     PaymentTypeFilter::Received => {
                         type_filter_clause.insert(PaymentType::Received);
                     }
-                    PaymentTypeFilter::ClosedChannels => {
+                    PaymentTypeFilter::ClosedChannel => {
                         type_filter_clause.insert(PaymentType::ClosedChannel);
                     }
                 }
@@ -481,7 +481,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
         filters: Some(vec![
             PaymentTypeFilter::Sent,
-            PaymentTypeFilter::ClosedChannels,
+            PaymentTypeFilter::ClosedChannel,
         ]),
         ..Default::default()
     })?;
@@ -525,7 +525,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {
         filters: Some(vec![
             PaymentTypeFilter::Sent,
-            PaymentTypeFilter::ClosedChannels,
+            PaymentTypeFilter::ClosedChannel,
         ]),
         include_failures: Some(true),
         ..Default::default()

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1106,7 +1106,7 @@ enum PaymentType {
 enum PaymentTypeFilter {
   Sent,
   Received,
-  ClosedChannels,
+  ClosedChannel,
 }
 
 class PrepareRefundRequest {

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -3598,8 +3598,8 @@ class BreezSDKMapper {
         case "received":
             return PaymentTypeFilter.received
 
-        case "closedChannels":
-            return PaymentTypeFilter.closedChannels
+        case "closedChannel":
+            return PaymentTypeFilter.closedChannel
 
         default: throw SdkError.Generic(message: "Invalid variant \(paymentTypeFilter) for enum PaymentTypeFilter")
         }
@@ -3613,8 +3613,8 @@ class BreezSDKMapper {
         case .received:
             return "received"
 
-        case .closedChannels:
-            return "closedChannels"
+        case .closedChannel:
+            return "closedChannel"
         }
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -656,7 +656,7 @@ export enum PaymentType {
 export enum PaymentTypeFilter {
     SENT = "sent",
     RECEIVED = "received",
-    CLOSED_CHANNELS = "closedChannels"
+    CLOSED_CHANNEL = "closedChannel"
 }
 
 export enum ReverseSwapStatus {


### PR DESCRIPTION
In order to be able to more easily compare `PaymentTypeFilter` and `PaymentType` I think we can rename `PaymentTypeFilter`'s enum from `ClosedChannels`=> `ClosedChannel`. 

cc: @danielgranhao 


