### PR TITLE
Fix breez-sdk-flutter files on name changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.8'
+          flutter-version: '3.13.9'
           channel: 'stable'
 
       - name: Flutter bridge codegen

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Set package version
         working-directory: flutter
         run: |
-          flutter pub global activate pubspec_version
-          pubver set ${{ inputs.package-version }}
+          sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
+          rm pubspec.yaml.bak
 
       - name: Archive flutter release
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.8'
+          flutter-version: '3.13.9'
           channel: 'stable'                      
 
       - name: Copy package files        

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -38,11 +38,6 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           path: breez-sdk
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: sdk-bindings-android-jniLibs
-          path: flutter/android/src/main/jniLibs
-
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.13.8'
@@ -52,13 +47,21 @@ jobs:
         working-directory: flutter
         run: |
           rm -f ../breez-sdk/libs/sdk-flutter/ios/breez_sdk.podspec.dev
-          mv ../breez-sdk/libs/sdk-flutter/ios/breez_sdk.podspec.production ../breez-sdk/libs/sdk-flutter/ios/breez_sdk.podspec
+          rm -r ios
+          rm -r android
+          rm -r lib
           cp -r ../breez-sdk/libs/sdk-flutter/ios .
+          mv ios/breez_sdk.podspec.production ios/breez_sdk.podspec
           cp -r ../breez-sdk/libs/sdk-flutter/android .
           cp -r ../breez-sdk/libs/sdk-flutter/lib .
           cp ../breez-sdk/libs/sdk-flutter/pubspec.yaml .
-          cp ../breez-sdk/libs/sdk-flutter/pubspec.lock .          
-      
+          cp ../breez-sdk/libs/sdk-flutter/pubspec.lock .  
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-android-jniLibs
+          path: flutter/android/src/main/jniLibs
+
       - name: Set package version
         working-directory: flutter
         run: |


### PR DESCRIPTION
Fixes https://github.com/breez/breez-sdk/issues/575

- makes sure the lib, android and ios folders are cleared before copying in the new files to avoid added files on file name changes
- updates the flutter package version with sed, rather than pubver, because pubver doesn't support null safety (build failed)
- bumps the flutter version to 3.13.9