### PR TITLE
Make CI callable from remote repo

### DIFF
--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -8,6 +8,10 @@ on:
         type: string
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -30,6 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with: 
         ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository || github.repository }}
 
     - name: Install rust toolchain
       run: |

--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -16,9 +16,15 @@ on:
         description: 'commit/tag/branch reference'
         required: true
         type: string
+      use-dummy-binaries:
+        description: 'If true, creates dummy binaries rather than real binaries'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
+    if: ${{ !inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
     name: build ${{ matrix.target }}
     strategy:
@@ -81,6 +87,61 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     name: build jniLibs
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-aarch64-linux-android
+          path: arm64-v8a
+      
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-armv7-linux-androideabi
+          path: armeabi-v7a
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-i686-linux-android
+          path: x86
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdk-bindings-x86_64-linux-android
+          path: x86_64
+      
+      - name: Archive jniLibs
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdk-bindings-android-jniLibs
+          path: ./*
+
+  build-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: ubuntu-latest
+    name: build android dummies
+    strategy:
+      matrix:
+        target: [
+          aarch64-linux-android,
+          armv7-linux-androideabi,
+          i686-linux-android,
+          x86_64-linux-android,
+        ]
+    steps:
+      - name: Build Android ${{ matrix.target }} dummy
+        run: |
+          touch libbreez_sdk_bindings.so
+          touch libc++_shared.so.so
+
+      - name: Upload dummy Android ${{ matrix.target }} artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdk-bindings-${{ matrix.target }}
+          path: ./*
+
+  jnilibs-dummy:
+    needs: build-dummies
+    runs-on: ubuntu-latest
+    name: build jniLibs dummy
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -8,6 +8,10 @@ on:
         type: string
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -28,6 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with: 
         ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository || github.repository }}
 
     - name: Install rust toolchain
       run: |

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -16,9 +16,15 @@ on:
         description: 'commit/tag/branch reference'
         required: true
         type: string
+      use-dummy-binaries:
+        description: 'If true, creates dummy binaries rather than real binaries'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
+    if: ${{ !inputs.use-dummy-binaries }}
     runs-on: macOS-latest
     name: build ${{ matrix.target }}
     strategy:
@@ -91,3 +97,26 @@ jobs:
         path: |
           darwin-universal/libbreez_sdk_bindings.dylib
           darwin-universal/libbreez_sdk_bindings.a
+
+  build-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: ubuntu-latest
+    name: build darwin dummies
+    strategy:
+      matrix:
+        target: [
+          aarch64-apple-darwin,
+          x86_64-apple-darwin,
+          darwin-universal
+        ]
+    steps:
+      - name: Build dummy darwin ${{ matrix.target }}
+        run: |
+          touch libbreez_sdk_bindings.dylib
+          touch libbreez_sdk_bindings.a
+
+      - name: Upload dummy darwin ${{ matrix.target }} artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdk-bindings-${{ matrix.target }}
+          path: ./*

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -16,9 +16,15 @@ on:
         description: 'commit/tag/branch reference'
         required: true
         type: string
+      use-dummy-binaries:
+        description: 'If true, creates dummy binaries rather than real binaries'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
+    if: ${{ !inputs.use-dummy-binaries }}
     runs-on: macOS-latest
     name: build ${{ matrix.target }}
     strategy:
@@ -65,3 +71,25 @@ jobs:
       with:
         name: sdk-bindings-${{ matrix.target }}
         path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a
+
+  build-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: ubuntu-latest
+    name: build ios dummies
+    strategy:
+      matrix:
+        target: [
+          aarch64-apple-ios,
+          x86_64-apple-ios,
+          aarch64-apple-ios-sim,
+        ]
+    steps:
+      - name: Build dummy ios ${{ matrix.target }}
+        run: |
+          touch libbreez_sdk_bindings.a
+
+      - name: Upload dummy ios ${{ matrix.target }} artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdk-bindings-${{ matrix.target }}
+          path: ./*

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -8,6 +8,10 @@ on:
         type: string
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -29,6 +33,7 @@ jobs:
       uses: actions/checkout@v3
       with: 
         ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository || github.repository }}
 
     - name: Install rust toolchain
       run: |

--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -8,6 +8,10 @@ on:
         type: string
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -28,6 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with: 
         ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository || github.repository }}
 
     - name: Install rust toolchain
       run: |

--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -16,9 +16,15 @@ on:
         description: 'commit/tag/branch reference'
         required: true
         type: string
+      use-dummy-binaries:
+        description: 'If true, creates dummy binaries rather than real binaries'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
+    if: ${{ !inputs.use-dummy-binaries }}
     runs-on: ubuntu-20.04
     name: build ${{ matrix.target }}
     strategy:
@@ -74,3 +80,24 @@ jobs:
       with:
         name: sdk-bindings-${{ matrix.target }}
         path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.so
+
+  build-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: ubuntu-latest
+    name: build linux dummies
+    strategy:
+      matrix:
+        target: [
+          aarch64-unknown-linux-gnu,
+          x86_64-unknown-linux-gnu,
+        ]
+    steps:
+      - name: Build dummy linux ${{ matrix.target }}
+        run: |
+          touch libbreez_sdk_bindings.so
+
+      - name: Upload dummy linux ${{ matrix.target }} artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdk-bindings-${{ matrix.target }}
+          path: ./*

--- a/.github/workflows/build-bindings-windows.yml
+++ b/.github/workflows/build-bindings-windows.yml
@@ -8,6 +8,10 @@ on:
         type: string
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -28,6 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with: 
         ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository || github.repository }}
 
     - name: Install rust toolchain
       run: |

--- a/.github/workflows/build-bindings-windows.yml
+++ b/.github/workflows/build-bindings-windows.yml
@@ -16,9 +16,15 @@ on:
         description: 'commit/tag/branch reference'
         required: true
         type: string
+      use-dummy-binaries:
+        description: 'If true, creates dummy binaries rather than real binaries'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
+    if: ${{ !inputs.use-dummy-binaries }}
     runs-on: windows-latest
     name: build ${{ matrix.target }}
     strategy:
@@ -59,3 +65,24 @@ jobs:
       with:
         name: sdk-bindings-${{ matrix.target }}
         path: libs/target/${{ matrix.target }}/release/breez_sdk_bindings.dll
+
+  build-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: ubuntu-latest
+    name: build windows dummies
+    strategy:
+      matrix:
+        target: [
+          x86_64-pc-windows-msvc,
+          i686-pc-windows-msvc,
+        ]
+    steps:
+      - name: Build dummy windows ${{ matrix.target }}
+        run: |
+          touch breez_sdk_bindings.dll
+
+      - name: Upload dummy windows ${{ matrix.target }} artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdk-bindings-${{ matrix.target }}
+          path: ./*

--- a/.github/workflows/build-language-bindings.yml
+++ b/.github/workflows/build-language-bindings.yml
@@ -28,6 +28,10 @@ on:
         default: false
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -60,6 +64,7 @@ jobs:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
   
       - name: Install rust

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -34,6 +34,11 @@ on:
         description: 'version for the react native package (MAJOR.MINOR.BUILD)'
         required: false
         type: string
+      use-dummy-binaries:
+        description: 'boolean indicating whether to use dummies for the sdk binaries. Default = false.'
+        required: false
+        type: boolean
+        default: false
       publish:
         description: 'boolean indicating whether packages should be published. true to publish. false to build only. Default = false.'
         required: false
@@ -102,6 +107,7 @@ jobs:
       kotlin-mpp-package-version: ${{ inputs.kotlin-mpp-package-version }}
       flutter-package-version: ${{ inputs.flutter-package-version }}
       react-native-package-version: ${{ inputs.react-native-package-version }}
+      use-dummy-binaries: ${{ inputs.use-dummy-binaries }}
       publish: ${{ inputs.publish }}
     steps:
       - run: echo "set pre-setup output variables"
@@ -140,6 +146,7 @@ jobs:
       flutter-package-version: ${{ needs.pre-setup.outputs.flutter-package-version || '0.0.2' }}
       react-native-package-version: ${{ needs.pre-setup.outputs.react-native-package-version || '0.0.2' }}
       publish: ${{ needs.pre-setup.outputs.publish }}
+      use-dummy-binaries: ${{ needs.pre-setup.outputs.use-dummy-binaries }}
     steps:
       - run: echo "set setup output variables"
 
@@ -150,6 +157,7 @@ jobs:
     with:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-darwin:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-darwin == 'true' }}
@@ -157,6 +165,7 @@ jobs:
     with:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-linux:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-linux == 'true' }}
@@ -164,6 +173,7 @@ jobs:
     with:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-android:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-android == 'true' }}
@@ -171,6 +181,7 @@ jobs:
     with:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-ios:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-ios == 'true' }}
@@ -178,6 +189,7 @@ jobs:
     with:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
 
   build-language-bindings:
     needs: setup

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -217,6 +217,7 @@ jobs:
       ref: ${{ needs.setup.outputs.csharp-ref }}
       package-version: ${{ needs.setup.outputs.csharp-package-version }}
       publish: ${{ needs.setup.outputs.publish == 'true' }}
+      skip-tests: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -39,6 +39,49 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+      csharp-package-version:
+        description: 'version for the C# nuget package (MAJOR.MINOR.BUILD)'
+        required: false
+        type: string
+      csharp-ref:
+        description: 'optional commit/tag/branch reference for the C# project. Defaults to ref.'
+        required: false
+        type: string
+      golang-package-version:
+        description: 'version for the golang package (MAJOR.MINOR.BUILD) (no v prefix)'
+        required: false
+        type: string
+      maven-package-version:
+        description: 'version for the android package (MAJOR.MINOR.BUILD)'
+        required: false
+        type: string
+      kotlin-mpp-package-version:
+        description: 'version for the kotlin multiplatform package (MAJOR.MINOR.BUILD)'
+        required: false
+        type: string
+      flutter-package-version:
+        description: 'version for the flutter package (MAJOR.MINOR.BUILD) (no v prefix)'
+        required: false
+        type: string
+      react-native-package-version:
+        description: 'version for the react native package (MAJOR.MINOR.BUILD)'
+        required: false
+        type: string
+      use-dummy-binaries:
+        description: 'boolean indicating whether to use dummies for the sdk binaries. Default = false.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   pre-setup:
@@ -50,6 +93,7 @@ jobs:
       # changes that you won't want to commit to main yet.
       # You can set these values manually, to test how the CI behaves with 
       # certain inputs.
+      repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
       csharp-package-version: ${{ inputs.csharp-package-version }}
       csharp-ref: ${{ inputs.csharp-ref || inputs.ref || github.sha }}
@@ -72,6 +116,7 @@ jobs:
       # checks in this file have the format `boolean == 'true'`. So feel free
       # to set these variables here to `true` or `false` 
       # (e.g. bindings-windows: true) if you want to test something.
+      repository: ${{ needs.pre-setup.outputs.repository }}
       bindings-windows: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version }}
       bindings-darwin: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version }}
       bindings-linux: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version }}
@@ -103,36 +148,42 @@ jobs:
     if: ${{ needs.setup.outputs.bindings-windows == 'true' }}
     uses: ./.github/workflows/build-bindings-windows.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
   build-bindings-darwin:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-darwin == 'true' }}
     uses: ./.github/workflows/build-bindings-darwin.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
   build-bindings-linux:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-linux == 'true' }}
     uses: ./.github/workflows/build-bindings-linux.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
   build-bindings-android:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-android == 'true' }}
     uses: ./.github/workflows/build-bindings-android.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
   build-bindings-ios:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-ios == 'true' }}
     uses: ./.github/workflows/build-bindings-ios.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
 
   build-language-bindings:
     needs: setup
     uses: ./.github/workflows/build-language-bindings.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       kotlin: ${{ needs.setup.outputs.kotlin == 'true'}}
       csharp: ${{ needs.setup.outputs.csharp == 'true'}}
@@ -150,6 +201,7 @@ jobs:
     if: ${{ needs.setup.outputs.csharp == 'true' }}
     uses: ./.github/workflows/publish-csharp.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.csharp-ref }}
       package-version: ${{ needs.setup.outputs.csharp-package-version }}
       publish: ${{ needs.setup.outputs.publish == 'true' }}
@@ -181,6 +233,7 @@ jobs:
     if: ${{ needs.setup.outputs.maven == 'true' }}
     uses: ./.github/workflows/publish-android.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       package-version: ${{ needs.setup.outputs.maven-package-version }}
       publish: ${{ needs.setup.outputs.publish == 'true' }}
@@ -197,6 +250,7 @@ jobs:
     if: ${{ needs.setup.outputs.kotlin-mpp == 'true' }}
     uses: ./.github/workflows/publish-kotlin-mpp.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       package-version: ${{ needs.setup.outputs.kotlin-mpp-package-version }}
       publish: ${{ needs.setup.outputs.publish == 'true' }}
@@ -211,6 +265,7 @@ jobs:
     if: ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       package-version: ${{ needs.setup.outputs.flutter-package-version }}
       publish: ${{ needs.setup.outputs.publish == 'true' }}
@@ -225,6 +280,7 @@ jobs:
     if: ${{ needs.setup.outputs.react-native == 'true' }}
     uses: ./.github/workflows/publish-react-native.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       package-version: ${{ needs.setup.outputs.react-native-package-version }}
       publish: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -2,6 +2,10 @@ name: Publish Android Bindings
 on:
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -30,6 +34,7 @@ jobs:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/publish-csharp.yml
+++ b/.github/workflows/publish-csharp.yml
@@ -2,6 +2,10 @@ name: Publish C# Bindings
 on:
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -27,6 +31,7 @@ jobs:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
  
       - uses: actions/download-artifact@v3
@@ -103,6 +108,7 @@ jobs:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
       
       - uses: actions/download-artifact@v3

--- a/.github/workflows/publish-csharp.yml
+++ b/.github/workflows/publish-csharp.yml
@@ -14,6 +14,11 @@ on:
         description: 'version for the nuget package (MAJOR.MINOR.BUILD)'
         required: true
         type: string
+      skip-tests:
+        description: 'value indicating whether to skip the tests'
+        required: false
+        default: false
+        type: boolean
       publish:
         description: 'value indicating whether to publish to nuget.'
         required: true
@@ -106,22 +111,26 @@ jobs:
         ]
     steps:
       - name: Checkout breez-sdk repo
+        if: ${{ !inputs.skip-tests }}
         uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
       
       - uses: actions/download-artifact@v3
+        if: ${{ !inputs.skip-tests }}
         with:
           name: Breez.Sdk.${{ inputs.package-version || '0.0.1' }}.nupkg
           path: libs/sdk-bindings/bindings-csharp/src/bin/Release
 
       - name: Setup dotnet
+        if: ${{ !inputs.skip-tests }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
       
       - name: test package
+        if: ${{ !inputs.skip-tests }}
         working-directory: libs/sdk-bindings/bindings-csharp/test
         run: dotnet run
       

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -2,6 +2,10 @@ name: Publish Flutter Package
 on:   
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -35,6 +39,7 @@ jobs:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
           path: breez-sdk
 

--- a/.github/workflows/publish-kotlin-mpp.yml
+++ b/.github/workflows/publish-kotlin-mpp.yml
@@ -2,6 +2,10 @@ name: Publish Kotlin multiplatform Bindings
 on:
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -30,6 +34,7 @@ jobs:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
 
       - uses: actions/setup-java@v3

--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -2,6 +2,10 @@ name: Publish React Native Plugin
 on:
   workflow_call:
     inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
       ref:
         description: 'commit/tag/branch reference'
         required: true
@@ -27,6 +31,7 @@ jobs:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup node


### PR DESCRIPTION
In order to compile the packages for different languages to use in breez-sdk-docs,it's useful to be able to compile the packages from there. However, when checking out the repository, by default it uses the repository of the _caller_ repository. This PR makes it possible to build the sdk packages from a remote repository by making it possible to explicitly set the repository name (but not publish them).

Also this adds an option to the CI to create dummy binaries rather than real binaries. Building binaries can take a lot of time. If you only want to see the package structure for example, or you only want a package with proper language bindings, you can use dummy binaries to speed up the CI process. Like in breez-sdk-docs, we don't really need the runtime binaries, we just need the package structure with language bindings.

Goal is to support https://github.com/breez/breez-sdk-docs/pull/81