### PR TITLE
throw on error in C# tests

### DIFF
--- a/libs/sdk-bindings/bindings-csharp/test/Program.cs
+++ b/libs/sdk-bindings/bindings-csharp/test/Program.cs
@@ -13,6 +13,7 @@ try
 catch (Exception e)
 {
  Console.WriteLine(e.Message);
+ throw;
 }
 
 class SDKListener : EventListener

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.cs
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.cs
@@ -13,6 +13,7 @@ try
 catch (Exception e)
 {
  Console.WriteLine(e.Message);
+ throw;
 }
 
 class SDKListener : EventListener


### PR DESCRIPTION
C# CI tests are always happy, because they don't throw. I noticed this because the tests succeeded when I replaced the sdk binaries with dummy binaries.