### PR TITLE
Validate bolt11 network

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -28,6 +28,7 @@ enum LnUrlPayError {
     "Generic",
     "InvalidAmount",
     "InvalidInvoice",
+    "InvalidNetwork",
     "InvalidUri",
     "InvoiceExpired",
     "PaymentFailed",
@@ -81,6 +82,7 @@ enum SendPaymentError {
     "InvalidAmount",
     "InvalidInvoice",
     "InvoiceExpired",
+    "InvalidNetwork",
     "PaymentFailed",
     "PaymentTimeout",
     "RouteNotFound",
@@ -134,6 +136,7 @@ dictionary RouteHint {
 
 dictionary LNInvoice {
     string bolt11;
+    Network network;
     string payee_pubkey;
     string payment_hash;
     string? description;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -242,10 +242,12 @@ impl BreezServices {
         req: SendPaymentRequest,
     ) -> Result<SendPaymentResponse, SendPaymentError> {
         self.start_node().await?;
-        validate_network(req.bolt11.as_str(), self.config.network)?;
         let parsed_invoice = parse_invoice(req.bolt11.as_str())?;
         let invoice_amount_msat = parsed_invoice.amount_msat.unwrap_or_default();
         let provided_amount_msat = req.amount_msat.unwrap_or_default();
+
+        // Valid the invoice network against the config network
+        validate_network(parsed_invoice.clone(), self.config.network)?;
 
         // Ensure amount is provided for zero invoice
         if provided_amount_msat == 0 && invoice_amount_msat == 0 {

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1133,6 +1133,7 @@ impl support::IntoDart for LNInvoice {
     fn into_dart(self) -> support::DartAbi {
         vec![
             self.bolt11.into_into_dart().into_dart(),
+            self.network.into_into_dart().into_dart(),
             self.payee_pubkey.into_into_dart().into_dart(),
             self.payment_hash.into_into_dart().into_dart(),
             self.description.into_dart(),

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -67,6 +67,9 @@ pub enum LnUrlPayError {
     #[error("Invalid invoice: {err}")]
     InvalidInvoice { err: String },
 
+    #[error("Invalid network: {err}")]
+    InvalidNetwork { err: String },
+
     #[error("Invalid uri: {err}")]
     InvalidUri { err: String },
 
@@ -105,15 +108,26 @@ impl From<bitcoin::hashes::hex::Error> for LnUrlPayError {
     }
 }
 
+impl From<InvoiceError> for LnUrlPayError {
+    fn from(value: InvoiceError) -> Self {
+        match value {
+            InvoiceError::InvalidNetwork(err) => Self::InvalidNetwork {
+                err: err.to_string(),
+            },
+            _ => Self::InvalidInvoice {
+                err: value.to_string(),
+            },
+        }
+    }
+}
+
 impl From<LnUrlError> for LnUrlPayError {
     fn from(value: LnUrlError) -> Self {
         match value {
             LnUrlError::InvalidUri(err) => Self::InvalidUri {
                 err: err.to_string(),
             },
-            LnUrlError::InvalidInvoice(err) => Self::InvalidInvoice {
-                err: err.to_string(),
-            },
+            LnUrlError::InvalidInvoice(err) => err.into(),
             LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity {
                 err: err.to_string(),
             },
@@ -149,6 +163,7 @@ impl From<SendPaymentError> for LnUrlPayError {
             SendPaymentError::AlreadyPaid => Self::AlreadyPaid,
             SendPaymentError::InvalidAmount { err } => Self::InvalidAmount { err },
             SendPaymentError::InvalidInvoice { err } => Self::InvalidInvoice { err },
+            SendPaymentError::InvalidNetwork { err } => Self::InvalidNetwork { err },
             SendPaymentError::InvoiceExpired { err } => Self::InvoiceExpired { err },
             SendPaymentError::PaymentFailed { err } => Self::PaymentFailed { err },
             SendPaymentError::PaymentTimeout { err } => Self::PaymentTimeout { err },
@@ -571,6 +586,9 @@ pub enum SendPaymentError {
     #[error("Invalid invoice: {err}")]
     InvalidInvoice { err: String },
 
+    #[error("Invalid network: {err}")]
+    InvalidNetwork { err: String },
+
     #[error("Invoice expired: {err}")]
     InvoiceExpired { err: String },
 
@@ -599,17 +617,14 @@ impl From<anyhow::Error> for SendPaymentError {
 }
 
 impl From<InvoiceError> for SendPaymentError {
-    fn from(err: InvoiceError) -> Self {
-        Self::InvalidInvoice {
-            err: err.to_string(),
-        }
-    }
-}
-
-impl From<InvoiceError> for LnUrlPayError {
-    fn from(err: InvoiceError) -> Self {
-        Self::InvalidInvoice {
-            err: err.to_string(),
+    fn from(value: InvoiceError) -> Self {
+        match value {
+            InvoiceError::InvalidNetwork(err) => Self::InvalidNetwork {
+                err: err.to_string(),
+            },
+            _ => Self::InvalidInvoice {
+                err: value.to_string(),
+            },
         }
     }
 }

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -9,12 +9,17 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::{SystemTimeError, UNIX_EPOCH};
 
+use crate::Network;
+
 pub type InvoiceResult<T, E = InvoiceError> = Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum InvoiceError {
     #[error("Generic: {0}")]
     Generic(#[from] anyhow::Error),
+
+    #[error("Invalid network: {0}")]
+    InvalidNetwork(anyhow::Error),
 
     #[error("Validation: {0}")]
     Validation(anyhow::Error),
@@ -60,6 +65,7 @@ impl From<SystemTimeError> for InvoiceError {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct LNInvoice {
     pub bolt11: String,
+    pub network: Network,
     pub payee_pubkey: String,
     pub payment_hash: String,
     pub description: Option<String>,
@@ -189,6 +195,25 @@ pub fn add_lsp_routing_hints(
     Ok(invoice_builder.build_raw()?)
 }
 
+// Validate that the BOLT11 payment request matches the network
+pub fn validate_network(bolt11: &str, network: Network) -> InvoiceResult<()> {
+    if bolt11.trim().is_empty() {
+        return Err(InvoiceError::Validation(anyhow!(
+            "bolt11 is an empty string"
+        )));
+    }
+    let re = Regex::new(r"(?i)^lightning:")?;
+    let bolt11 = re.replace_all(bolt11, "");
+    let signed = bolt11.parse::<SignedRawInvoice>()?;
+    let invoice = Invoice::from_signed(signed)?;
+    match invoice.network() == network.into() {
+        true => Ok(()),
+        false => Err(InvoiceError::InvalidNetwork(anyhow!(
+            "Invoice network does not match config"
+        ))),
+    }
+}
+
 /// Parse a BOLT11 payment request and return a structure contains the parsed fields.
 pub fn parse_invoice(bolt11: &str) -> InvoiceResult<LNInvoice> {
     if bolt11.trim().is_empty() {
@@ -200,7 +225,6 @@ pub fn parse_invoice(bolt11: &str) -> InvoiceResult<LNInvoice> {
     let bolt11 = re.replace_all(bolt11, "");
     let signed = bolt11.parse::<SignedRawInvoice>()?;
     let invoice = Invoice::from_signed(signed)?;
-
     let since_the_epoch = invoice.timestamp().duration_since(UNIX_EPOCH)?;
 
     // make sure signature is valid
@@ -221,6 +245,7 @@ pub fn parse_invoice(bolt11: &str) -> InvoiceResult<LNInvoice> {
     // return the parsed invoice
     let ln_invoice = LNInvoice {
         bolt11: bolt11.to_string(),
+        network: invoice.network().into(),
         payee_pubkey,
         expiry: invoice.expiry_time().as_secs(),
         amount_msat: invoice.amount_milli_satoshis(),
@@ -270,5 +295,50 @@ mod tests {
 
         let encoded = add_lsp_routing_hints(payreq, Some(route_hint), 100).unwrap();
         print!("{encoded:?}");
+    }
+
+    #[test]
+    fn test_parse_invoice_network() {
+        let payreq = String::from("lnbc110n1p38q3gtpp5ypz09jrd8p993snjwnm68cph4ftwp22le34xd4r8ftspwshxhmnsdqqxqyjw5qcqpxsp5htlg8ydpywvsa7h3u4hdn77ehs4z4e844em0apjyvmqfkzqhhd2q9qgsqqqyssqszpxzxt9uuqzymr7zxcdccj5g69s8q7zzjs7sgxn9ejhnvdh6gqjcy22mss2yexunagm5r2gqczh8k24cwrqml3njskm548aruhpwssq9nvrvz");
+        assert!(validate_network(&payreq, Network::Bitcoin).is_ok());
+
+        let res = parse_invoice(&payreq).unwrap();
+
+        let private_key_vec =
+            hex::decode("3e171115f50b2c355836dc026a6d54d525cf0d796eb50b3460a205d25c9d38fd")
+                .unwrap();
+        let mut private_key: [u8; 32] = Default::default();
+        private_key.copy_from_slice(&private_key_vec[0..32]);
+        let hint_hop = RouteHintHop {
+            src_node_id: res.payee_pubkey,
+            short_channel_id: 1234,
+            fees_base_msat: 1000,
+            fees_proportional_millionths: 100,
+            cltv_expiry_delta: 2000,
+            htlc_minimum_msat: Some(3000),
+            htlc_maximum_msat: Some(4000),
+        };
+        let route_hint = RouteHint {
+            hops: vec![hint_hop],
+        };
+
+        let encoded = add_lsp_routing_hints(payreq, Some(route_hint), 100).unwrap();
+        print!("{encoded:?}");
+    }
+
+    #[test]
+    fn test_parse_invoice_invalid_bitcoin_network() {
+        let payreq = String::from("lnbc110n1p38q3gtpp5ypz09jrd8p993snjwnm68cph4ftwp22le34xd4r8ftspwshxhmnsdqqxqyjw5qcqpxsp5htlg8ydpywvsa7h3u4hdn77ehs4z4e844em0apjyvmqfkzqhhd2q9qgsqqqyssqszpxzxt9uuqzymr7zxcdccj5g69s8q7zzjs7sgxn9ejhnvdh6gqjcy22mss2yexunagm5r2gqczh8k24cwrqml3njskm548aruhpwssq9nvrvz");
+
+        assert!(validate_network(&payreq, Network::Testnet).is_err());
+        assert!(parse_invoice(&payreq).is_ok());
+    }
+
+    #[test]
+    fn test_parse_invoice_invalid_testnet_network() {
+        let payreq = String::from("lntb15u1pj53l9tpp5p7kjsjcv3eqa39upytmj6k7ac8rqvdffyqr4um98pq5n4ppwxvnsdpzxysy2umswfjhxum0yppk76twypgxzmnwvyxqrrsscqp79qy9qsqsp53xw4x5ezpzvnheff9mrt0ju72u5a5dnxyh4rq6gtweufv9650d4qwqj3ds5xfg4pxc9h7a2g43fmntr4tt322jzujsycvuvury50u994kzr8539qf658hrp07hyz634qpvkeh378wnvf7lddp2x7yfgyk9cp7f7937");
+
+        assert!(validate_network(&payreq, Network::Bitcoin).is_err());
+        assert!(parse_invoice(&payreq).is_ok());
     }
 }

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -107,8 +107,9 @@ fn validate_invoice(
     data: &LnUrlPayRequestData,
     network: Network,
 ) -> LnUrlResult<()> {
-    validate_network(bolt11, network)?;
     let invoice = parse_invoice(bolt11)?;
+    // Valid the invoice network against the config network
+    validate_network(invoice.clone(), network)?;
 
     match invoice.description_hash {
         None => {

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -1,8 +1,8 @@
-use crate::invoice::parse_invoice;
+use crate::invoice::{parse_invoice, validate_network};
 use crate::lnurl::maybe_replace_host_with_mockito_test_host;
 use crate::lnurl::pay::model::{CallbackResponse, SuccessAction, ValidatedCallbackResponse};
-use crate::LnUrlErrorData;
 use crate::{ensure_sdk, input_parser::*};
+use crate::{LnUrlErrorData, Network};
 use anyhow::anyhow;
 use bitcoin::hashes::{sha256, Hash};
 use std::str::FromStr;
@@ -20,6 +20,7 @@ pub(crate) async fn validate_lnurl_pay(
     user_amount_msat: u64,
     comment: Option<String>,
     req_data: LnUrlPayRequestData,
+    network: Network,
 ) -> LnUrlResult<ValidatedCallbackResponse> {
     validate_user_input(
         user_amount_msat,
@@ -46,7 +47,7 @@ pub(crate) async fn validate_lnurl_pay(
             }
         }
 
-        validate_invoice(user_amount_msat, &callback_resp.pr, &req_data)?;
+        validate_invoice(user_amount_msat, &callback_resp.pr, &req_data, network)?;
         Ok(ValidatedCallbackResponse::EndpointSuccess {
             data: callback_resp,
         })
@@ -104,7 +105,9 @@ fn validate_invoice(
     user_amount_msat: u64,
     bolt11: &str,
     data: &LnUrlPayRequestData,
+    network: Network,
 ) -> LnUrlResult<()> {
+    validate_network(bolt11, network)?;
     let invoice = parse_invoice(bolt11)?;
 
     match invoice.description_hash {
@@ -668,10 +671,63 @@ mod tests {
         let inv = rand_invoice_with_description_hash(temp_desc.clone())?;
         let payreq: String = rand_invoice_with_description_hash(temp_desc)?.to_string();
 
-        assert!(validate_invoice(inv.amount_milli_satoshis().unwrap(), &payreq, &req).is_ok());
-        assert!(
-            validate_invoice(inv.amount_milli_satoshis().unwrap() + 1000, &payreq, &req).is_err()
-        );
+        assert!(validate_invoice(
+            inv.amount_milli_satoshis().unwrap(),
+            &payreq,
+            &req,
+            Network::Bitcoin
+        )
+        .is_ok());
+        assert!(validate_invoice(
+            inv.amount_milli_satoshis().unwrap() + 1000,
+            &payreq,
+            &req,
+            Network::Bitcoin,
+        )
+        .is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lnurl_pay_validate_invoice_network() -> Result<()> {
+        let req = get_test_pay_req_data(0, 50_000, 0);
+        let temp_desc = req.metadata_str.clone();
+        let inv = rand_invoice_with_description_hash(temp_desc.clone())?;
+        let payreq: String = rand_invoice_with_description_hash(temp_desc)?.to_string();
+
+        assert!(validate_invoice(
+            inv.amount_milli_satoshis().unwrap(),
+            &payreq,
+            &req,
+            Network::Bitcoin,
+        )
+        .is_ok());
+        assert!(validate_invoice(
+            inv.amount_milli_satoshis().unwrap() + 1000,
+            &payreq,
+            &req,
+            Network::Bitcoin,
+        )
+        .is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lnurl_pay_validate_invoice_wrong_network() -> Result<()> {
+        let req = get_test_pay_req_data(0, 25_000, 0);
+        let temp_desc = req.metadata_str.clone();
+        let inv = rand_invoice_with_description_hash(temp_desc.clone())?;
+        let payreq: String = rand_invoice_with_description_hash(temp_desc)?.to_string();
+
+        assert!(validate_invoice(
+            inv.amount_milli_satoshis().unwrap(),
+            &payreq,
+            &req,
+            Network::Testnet,
+        )
+        .is_err());
 
         Ok(())
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -506,7 +506,7 @@ pub struct GreenlightCredentials {
 }
 
 /// The different supported bitcoin networks
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Display, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Network {
     /// Mainnet
     Bitcoin,

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -485,7 +485,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
             description: Some("desc".to_string()),
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
-                    payment_hash: hex::encode(payment_hash_with_swap_info.clone()),
+                    payment_hash: hex::encode(payment_hash_with_swap_info),
                     label: "label".to_string(),
                     destination_pubkey: "pubkey".to_string(),
                     payment_preimage: "payment_preimage".to_string(),

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -618,6 +618,7 @@ class ListPaymentsRequest {
 /// Wrapper for a BOLT11 LN invoice
 class LNInvoice {
   final String bolt11;
+  final Network network;
   final String payeePubkey;
   final String paymentHash;
   final String? description;
@@ -631,6 +632,7 @@ class LNInvoice {
 
   const LNInvoice({
     required this.bolt11,
+    required this.network,
     required this.payeePubkey,
     required this.paymentHash,
     this.description,
@@ -2862,19 +2864,20 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LNInvoice _wire2api_ln_invoice(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
+    if (arr.length != 12) throw Exception('unexpected arr length: expect 12 but see ${arr.length}');
     return LNInvoice(
       bolt11: _wire2api_String(arr[0]),
-      payeePubkey: _wire2api_String(arr[1]),
-      paymentHash: _wire2api_String(arr[2]),
-      description: _wire2api_opt_String(arr[3]),
-      descriptionHash: _wire2api_opt_String(arr[4]),
-      amountMsat: _wire2api_opt_box_autoadd_u64(arr[5]),
-      timestamp: _wire2api_u64(arr[6]),
-      expiry: _wire2api_u64(arr[7]),
-      routingHints: _wire2api_list_route_hint(arr[8]),
-      paymentSecret: _wire2api_uint_8_list(arr[9]),
-      minFinalCltvExpiryDelta: _wire2api_u64(arr[10]),
+      network: _wire2api_network(arr[1]),
+      payeePubkey: _wire2api_String(arr[2]),
+      paymentHash: _wire2api_String(arr[3]),
+      description: _wire2api_opt_String(arr[4]),
+      descriptionHash: _wire2api_opt_String(arr[5]),
+      amountMsat: _wire2api_opt_box_autoadd_u64(arr[6]),
+      timestamp: _wire2api_u64(arr[7]),
+      expiry: _wire2api_u64(arr[8]),
+      routingHints: _wire2api_list_route_hint(arr[9]),
+      paymentSecret: _wire2api_uint_8_list(arr[10]),
+      minFinalCltvExpiryDelta: _wire2api_u64(arr[11]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -665,6 +665,7 @@ fun asLnInvoice(lnInvoice: ReadableMap): LnInvoice? {
             lnInvoice,
             arrayOf(
                 "bolt11",
+                "network",
                 "payeePubkey",
                 "paymentHash",
                 "timestamp",
@@ -678,6 +679,7 @@ fun asLnInvoice(lnInvoice: ReadableMap): LnInvoice? {
         return null
     }
     val bolt11 = lnInvoice.getString("bolt11")!!
+    val network = lnInvoice.getString("network")?.let { asNetwork(it) }!!
     val payeePubkey = lnInvoice.getString("payeePubkey")!!
     val paymentHash = lnInvoice.getString("paymentHash")!!
     val description = if (hasNonNullKey(lnInvoice, "description")) lnInvoice.getString("description") else null
@@ -690,6 +692,7 @@ fun asLnInvoice(lnInvoice: ReadableMap): LnInvoice? {
     val minFinalCltvExpiryDelta = lnInvoice.getDouble("minFinalCltvExpiryDelta").toULong()
     return LnInvoice(
         bolt11,
+        network,
         payeePubkey,
         paymentHash,
         description,
@@ -706,6 +709,7 @@ fun asLnInvoice(lnInvoice: ReadableMap): LnInvoice? {
 fun readableMapOf(lnInvoice: LnInvoice): ReadableMap {
     return readableMapOf(
         "bolt11" to lnInvoice.bolt11,
+        "network" to lnInvoice.network.name.lowercase(),
         "payeePubkey" to lnInvoice.payeePubkey,
         "paymentHash" to lnInvoice.paymentHash,
         "description" to lnInvoice.description,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -35,6 +35,19 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         throw SdkException.Generic("BreezServices not initialized")
     }
 
+    @Throws(SdkException::class)
+    private fun ensureWorkingDir(workingDir: String) {
+        try {
+            val workingDirFile = File(workingDir)
+
+            if (!workingDirFile.exists() && !workingDirFile.mkdirs()) {
+                throw SdkException.Generic("Mandatory field workingDir must contain a writable directory")
+            }
+        } catch (e: SecurityException) {
+            throw SdkException.Generic("Mandatory field workingDir must contain a writable directory")
+        }
+    }
+
     @ReactMethod
     fun addListener(eventName: String) {}
 
@@ -100,10 +113,6 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                 val res = defaultConfig(envTypeTmp, apiKey, nodeConfigTmp)
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
 
-                if (!workingDir.exists()) {
-                    workingDir.mkdirs()
-                }
-
                 res.workingDir = workingDir.absolutePath
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -159,6 +168,8 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             val configTmp = asConfig(config) ?: run { throw SdkException.Generic("Missing mandatory field config of type Config") }
             val emitter = reactApplicationContext.getJSModule(RCTDeviceEventEmitter::class.java)
 
+            ensureWorkingDir(configTmp.workingDir)
+
             breezServices = connect(configTmp, asUByteList(seed), BreezSDKListener(emitter))
             promise.resolve(readableMapOf("status" to "ok"))
         } catch (e: Exception) {
@@ -172,6 +183,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         executor.execute {
             try {
                 getBreezServices().disconnect()
+                breezServices = null
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
                 promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1,7 +1,7 @@
 import BreezSDK
 import Foundation
 
-class BreezSDKMapper {
+enum BreezSDKMapper {
     static func asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: [String: Any?]) throws -> AesSuccessActionDataDecrypted {
         guard let description = aesSuccessActionDataDecrypted["description"] as? String else { throw SdkError.Generic(message: "Missing mandatory field description for type AesSuccessActionDataDecrypted") }
         guard let plaintext = aesSuccessActionDataDecrypted["plaintext"] as? String else { throw SdkError.Generic(message: "Missing mandatory field plaintext for type AesSuccessActionDataDecrypted") }
@@ -604,6 +604,9 @@ class BreezSDKMapper {
 
     static func asLnInvoice(lnInvoice: [String: Any?]) throws -> LnInvoice {
         guard let bolt11 = lnInvoice["bolt11"] as? String else { throw SdkError.Generic(message: "Missing mandatory field bolt11 for type LnInvoice") }
+        guard let networkTmp = lnInvoice["network"] as? String else { throw SdkError.Generic(message: "Missing mandatory field network for type LnInvoice") }
+        let network = try asNetwork(network: networkTmp)
+
         guard let payeePubkey = lnInvoice["payeePubkey"] as? String else { throw SdkError.Generic(message: "Missing mandatory field payeePubkey for type LnInvoice") }
         guard let paymentHash = lnInvoice["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type LnInvoice") }
         let description = lnInvoice["description"] as? String
@@ -619,6 +622,7 @@ class BreezSDKMapper {
 
         return LnInvoice(
             bolt11: bolt11,
+            network: network,
             payeePubkey: payeePubkey,
             paymentHash: paymentHash,
             description: description,
@@ -635,6 +639,7 @@ class BreezSDKMapper {
     static func dictionaryOf(lnInvoice: LnInvoice) -> [String: Any?] {
         return [
             "bolt11": lnInvoice.bolt11,
+            "network": valueOf(network: lnInvoice.network),
             "payeePubkey": lnInvoice.payeePubkey,
             "paymentHash": lnInvoice.paymentHash,
             "description": lnInvoice.description == nil ? nil : lnInvoice.description,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -114,6 +114,7 @@ export type InvoicePaidDetails = {
 
 export type LnInvoice = {
     bolt11: string
+    network: Network
     payeePubkey: string
     paymentHash: string
     description?: string


### PR DESCRIPTION
This PR adds the invoice network to the LNInvoice response of `parse_input` and `parse_invoice`. It also validates the bolt11 invoice network against the config network when calling `send_payment` or `lnurl_pay`.

- [x] Validate send_payment
- [x] Validate lnurl_pay

Fixes #462