### PR TITLE
Include payment information in `InvoicePaid`-event

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -331,6 +331,7 @@ dictionary LogEntry {
 dictionary InvoicePaidDetails {
     string payment_hash;
     string bolt11;
+    Payment? payment;
 };
 
 dictionary PaymentFailedData {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -106,6 +106,7 @@ pub struct PaymentFailedData {
 pub struct InvoicePaidDetails {
     pub payment_hash: String,
     pub bolt11: String,
+    pub payment: Option<Payment>,
 }
 
 pub trait LogStream: Send + Sync {
@@ -1134,7 +1135,7 @@ impl BreezServices {
                                                   if payment.is_some() {
                                                       let res = cloned
                                                           .persister
-                                                          .insert_or_update_payments(&vec![payment.unwrap()]);
+                                                          .insert_or_update_payments(&vec![payment.clone().unwrap()]);
                                                       debug!("paid invoice was added to payments list {:?}", res);
                                                   }
                                                   if let Err(e) = cloned.do_sync(true).await {
@@ -1144,6 +1145,7 @@ impl BreezServices {
                                                       details: InvoicePaidDetails {
                                                           payment_hash: hex::encode(p.payment_hash),
                                                           bolt11: p.bolt11,
+                                                          payment,
                                                       },
                                                   }).await;
                                               }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1117,6 +1117,7 @@ impl support::IntoDart for InvoicePaidDetails {
         vec![
             self.payment_hash.into_into_dart().into_dart(),
             self.bolt11.into_into_dart().into_dart(),
+            self.payment.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -910,6 +910,7 @@ mod tests {
                 details: crate::InvoicePaidDetails {
                     payment_hash: hex::encode(swap_info.payment_hash.clone()),
                     bolt11: "".to_string(),
+                    payment: None,
                 },
             })
             .await?;

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -583,10 +583,12 @@ sealed class InputType with _$InputType {
 class InvoicePaidDetails {
   final String paymentHash;
   final String bolt11;
+  final Payment? payment;
 
   const InvoicePaidDetails({
     required this.paymentHash,
     required this.bolt11,
+    this.payment,
   });
 }
 
@@ -2802,10 +2804,11 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   InvoicePaidDetails _wire2api_invoice_paid_details(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return InvoicePaidDetails(
       paymentHash: _wire2api_String(arr[0]),
       bolt11: _wire2api_String(arr[1]),
+      payment: _wire2api_opt_box_autoadd_payment(arr[2]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -633,9 +633,11 @@ fun asInvoicePaidDetails(invoicePaidDetails: ReadableMap): InvoicePaidDetails? {
     }
     val paymentHash = invoicePaidDetails.getString("paymentHash")!!
     val bolt11 = invoicePaidDetails.getString("bolt11")!!
+    val payment = if (hasNonNullKey(invoicePaidDetails, "payment")) invoicePaidDetails.getMap("payment")?.let { asPayment(it) } else null
     return InvoicePaidDetails(
         paymentHash,
         bolt11,
+        payment,
     )
 }
 
@@ -643,6 +645,7 @@ fun readableMapOf(invoicePaidDetails: InvoicePaidDetails): ReadableMap {
     return readableMapOf(
         "paymentHash" to invoicePaidDetails.paymentHash,
         "bolt11" to invoicePaidDetails.bolt11,
+        "payment" to invoicePaidDetails.payment?.let { readableMapOf(it) },
     )
 }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -565,10 +565,15 @@ class BreezSDKMapper {
     static func asInvoicePaidDetails(invoicePaidDetails: [String: Any?]) throws -> InvoicePaidDetails {
         guard let paymentHash = invoicePaidDetails["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type InvoicePaidDetails") }
         guard let bolt11 = invoicePaidDetails["bolt11"] as? String else { throw SdkError.Generic(message: "Missing mandatory field bolt11 for type InvoicePaidDetails") }
+        var payment: Payment?
+        if let paymentTmp = invoicePaidDetails["payment"] as? [String: Any?] {
+            payment = try asPayment(payment: paymentTmp)
+        }
 
         return InvoicePaidDetails(
             paymentHash: paymentHash,
-            bolt11: bolt11
+            bolt11: bolt11,
+            payment: payment
         )
     }
 
@@ -576,6 +581,7 @@ class BreezSDKMapper {
         return [
             "paymentHash": invoicePaidDetails.paymentHash,
             "bolt11": invoicePaidDetails.bolt11,
+            "payment": invoicePaidDetails.payment == nil ? nil : dictionaryOf(payment: invoicePaidDetails.payment!),
         ]
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -109,6 +109,7 @@ export type GreenlightNodeConfig = {
 export type InvoicePaidDetails = {
     paymentHash: string
     bolt11: string
+    payment?: Payment
 }
 
 export type LnInvoice = {


### PR DESCRIPTION
Allows using the Breez `EventListener` in rust without the need of a circular reference to the sdk to be able to get basic payment information. It also aligns more with the other Payment events. 

The specific use case for this is to report analytics such as duration of payment, fees and more.