### PR TITLE
Add lightweight connectivity check on connect()

### DIFF
--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -1,11 +1,13 @@
+use crate::connectivity::NeedsConnectivity;
 use crate::input_parser::get_parse_and_log_response;
+
 use anyhow::{anyhow, Result};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::{OutPoint, Txid};
 use serde::{Deserialize, Serialize};
 
 #[tonic::async_trait]
-pub trait ChainService: Send + Sync {
+pub trait ChainService: NeedsConnectivity + Send + Sync {
     async fn recommended_fees(&self) -> Result<RecommendedFees>;
     /// Gets up to 50 onchain and up to 25 mempool transactions associated with this address.
     ///
@@ -251,6 +253,13 @@ impl ChainService for MempoolSpace {
         }
     }
 }
+
+impl NeedsConnectivity for MempoolSpace {
+    fn get_endpoint_url(&self) -> String {
+        self.base_url.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::chain::{MempoolSpace, OnchainTx};

--- a/libs/sdk-core/src/connectivity.rs
+++ b/libs/sdk-core/src/connectivity.rs
@@ -1,0 +1,31 @@
+use std::net::TcpStream;
+use std::str::FromStr;
+
+use reqwest::Url;
+
+use crate::error::{SdkError, SdkResult};
+
+#[tonic::async_trait]
+pub trait NeedsConnectivity {
+    fn get_endpoint_url(&self) -> String;
+
+    /// Lightweight connectivity check.
+    /// Performs a DNS lookup and tries to open a TCP connection to the endpoint.
+    async fn check_connectivity(&self) -> SdkResult<()> {
+        let base_url = self.get_endpoint_url();
+        let url = Url::from_str(&base_url).map_err(|_| SdkError::ServiceConnectivity {
+            err: format!("Invalid URL: {base_url}"),
+        })?;
+        let addrs = url
+            .socket_addrs(|| None)
+            .map_err(|e| SdkError::ServiceConnectivity {
+                err: format!("Cannot resolve {base_url} URL because {e}"),
+            })?;
+
+        TcpStream::connect(&*addrs)
+            .map(|_| ())
+            .map_err(|e| SdkError::ServiceConnectivity {
+                err: format!("Cannot connect to {base_url} because {e}"),
+            })
+    }
+}

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -163,6 +163,7 @@ mod backup;
 pub mod binding;
 mod breez_services;
 mod chain;
+mod connectivity;
 mod crypt;
 pub mod error;
 mod fiat;

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
 use crate::breez_services::BreezServer;
+use crate::connectivity::NeedsConnectivity;
 use crate::error::SdkResult;
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{self, GetReverseRoutingNodeRequest, PaymentInformation, RegisterPaymentReply};
@@ -376,7 +377,7 @@ impl ReverseSwapperRoutingAPI for BreezServer {
 
 /// Trait covering reverse swap functionality on the external service
 #[tonic::async_trait]
-pub(crate) trait ReverseSwapServiceAPI: Send + Sync {
+pub(crate) trait ReverseSwapServiceAPI: NeedsConnectivity + Send + Sync {
     /// Lookup the most recent reverse swap pair info using the Boltz API. The fees are only valid
     /// for a set amount of time.
     async fn fetch_reverse_swap_fees(&self) -> ReverseSwapResult<ReverseSwapPairInfo>;
@@ -461,6 +462,12 @@ impl Config {
             exemptfee_msat: 20000,
             node_config,
         }
+    }
+}
+
+impl NeedsConnectivity for Config {
+    fn get_endpoint_url(&self) -> String {
+        self.breezserver.clone()
     }
 }
 

--- a/libs/sdk-core/src/moonpay.rs
+++ b/libs/sdk-core/src/moonpay.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use reqwest::Url;
 
 use crate::breez_services::BreezServer;
+use crate::connectivity::NeedsConnectivity;
 use crate::grpc::SignUrlRequest;
 use crate::SwapInfo;
 
@@ -43,6 +44,12 @@ async fn create_moonpay_url(wallet_address: &str, max_amount: &str) -> Result<Ur
         ],
     )?;
     Ok(url)
+}
+
+impl NeedsConnectivity for MoonPayConfig {
+    fn get_endpoint_url(&self) -> String {
+        self.base_url.clone()
+    }
 }
 
 #[tonic::async_trait]

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,6 +1,6 @@
 use crate::{
-    invoice::InvoiceError, persist::error::PersistError, CustomMessage, PaymentResponse, Peer,
-    PrepareSweepRequest, PrepareSweepResponse, SyncResponse,
+    connectivity::NeedsConnectivity, invoice::InvoiceError, persist::error::PersistError,
+    CustomMessage, PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse, SyncResponse,
 };
 use anyhow::Result;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
@@ -50,7 +50,7 @@ pub enum NodeError {
 
 /// Trait covering functions affecting the LN node
 #[tonic::async_trait]
-pub trait NodeAPI: Send + Sync {
+pub trait NodeAPI: NeedsConnectivity + Send + Sync {
     async fn create_invoice(
         &self,
         amount_msat: u64,

--- a/libs/sdk-core/src/swap_out/boltzswap.rs
+++ b/libs/sdk-core/src/swap_out/boltzswap.rs
@@ -1,16 +1,15 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
-use serde_json::to_string_pretty;
-
 use anyhow::{anyhow, Result};
 use bitcoin::Txid;
-use serde_json::json;
-
 use const_format::concatcp;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::{Body, Client};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serde_json::to_string_pretty;
 
+use crate::connectivity::NeedsConnectivity;
 use crate::input_parser::get_parse_and_log_response;
 use crate::models::ReverseSwapPairInfo;
 use crate::swap_out::reverseswap::CreateReverseSwapResponse;
@@ -245,6 +244,12 @@ impl ReverseSwapServiceAPI for BoltzApi {
                     ))
                 })
             })
+    }
+}
+
+impl NeedsConnectivity for BoltzApi {
+    fn get_endpoint_url(&self) -> String {
+        GET_PAIRS_ENDPOINT.to_string()
     }
 }
 

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -62,7 +62,7 @@ enum TxStatus {
 /// It uses internally an implementation of [ReverseSwapServiceAPI] that represents Boltz reverse swapper service.
 pub(crate) struct BTCSendSwap {
     config: Config,
-    pub(crate) reverse_swapper_api: Arc<dyn ReverseSwapperRoutingAPI>,
+    reverse_swapper_api: Arc<dyn ReverseSwapperRoutingAPI>,
     pub(crate) reverse_swap_service_api: Arc<dyn ReverseSwapServiceAPI>,
     persister: Arc<crate::persist::db::SqliteStorage>,
     chain_service: Arc<dyn ChainService>,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -28,6 +28,7 @@ use tonic::Streaming;
 use crate::backup::{BackupState, BackupTransport};
 use crate::breez_services::Receiver;
 use crate::chain::{ChainService, OnchainTx, Outspend, RecommendedFees, TxStatus};
+use crate::connectivity::NeedsConnectivity;
 use crate::error::{ReceivePaymentError, SdkError, SdkResult};
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentReply};
@@ -215,6 +216,12 @@ impl ChainService for MockChainService {
         let mut array = [0; 32];
         rand::thread_rng().fill(&mut array);
         Ok(hex::encode(array))
+    }
+}
+
+impl NeedsConnectivity for MockChainService {
+    fn get_endpoint_url(&self) -> String {
+        "localhost".into()
     }
 }
 
@@ -416,6 +423,12 @@ impl NodeAPI for MockNodeAPI {
         Ok(Box::pin(
             tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok),
         ))
+    }
+}
+
+impl NeedsConnectivity for MockNodeAPI {
+    fn get_endpoint_url(&self) -> String {
+        "localhost".into()
     }
 }
 


### PR DESCRIPTION
This PR updates `connect()` to include an active, lightweight connectivity check for the various services used.

Before, `connect()` would only create services, to be used when necessary in later calls. A connectivity issue would have only been seen later on, when a sub-service would be used.

An exception was the Greenlight service, which made an active connection during `connect` for `register` and `recover`. In those cases, any connectivity issues to the scheduler would have thrown an error in our `connect`. However, if the node was already registered and credentials already known, no connection to the Greenlight Scheduler was made during our `connect`. With this PR, the Greenlight connectivity is checked regardless of the node init method.