### PR TITLE
Schedule signer if `GL::connect()` has seed and creds

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -142,7 +142,11 @@ impl Greenlight {
                 match encryptd_creds {
                     Some(c) => {
                         persister.set_gl_credentials(c)?;
-                        Greenlight::new(config, seed, creds, persister).await
+                        let gl_node = Greenlight::new(config, seed, creds, persister).await?;
+                        // Make small API call to ensure the signer can be scheduled. This will fail if there are any network issues.
+                        // The other two scenarios (recover, register) already include a network call.
+                        gl_node.start().await?;
+                        Ok(gl_node)
                     }
                     None => {
                         return Err(anyhow!("Failed to encrypt credentials"));


### PR DESCRIPTION
Include a GL API call on `Greenlight::connect`, for the case when we already know the seed node credentials.

This ensures network connectivity is there and starts a signer, so our `sdk.connect()` returns only with a running signer.