### PR TITLE
ci: fix workflow_call inputs

### DIFF
--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -89,14 +89,14 @@ jobs:
       # certain inputs.
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
-      csharp-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'csharp') && inputs.package-version) || '' }}
+      csharp-package-version: ${{ inputs.csharp-package-version || (contains(fromJSON(inputs.packages-to-publish), 'csharp') && inputs.package-version) || '' }}
       csharp-ref: ${{ inputs.csharp-ref || inputs.ref || github.sha }}
-      golang-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'golang') && inputs.package-version) || '' }}
-      maven-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'maven') && inputs.package-version) || ''}}
-      kotlin-mpp-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'kotlin-mpp') && inputs.package-version) || '' }}
-      flutter-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'flutter') && inputs.package-version) || '' }}
-      react-native-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'react-native') && inputs.package-version) || '' }}
-      python-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'python') && inputs.package-version) || '' }}
+      golang-package-version: ${{ inputs.golang-package-version || (contains(fromJSON(inputs.packages-to-publish), 'golang') && inputs.package-version) || '' }}
+      maven-package-version: ${{ inputs.maven-package-version || (contains(fromJSON(inputs.packages-to-publish), 'maven') && inputs.package-version) || ''}}
+      kotlin-mpp-package-version: ${{ inputs.kotlin-mpp-package-version || (contains(fromJSON(inputs.packages-to-publish), 'kotlin-mpp') && inputs.package-version) || '' }}
+      flutter-package-version: ${{ inputs.flutter-package-version || (contains(fromJSON(inputs.packages-to-publish), 'flutter') && inputs.package-version) || '' }}
+      react-native-package-version: ${{ inputs.react-native-package-version || (contains(fromJSON(inputs.packages-to-publish), 'react-native') && inputs.package-version) || '' }}
+      python-package-version: ${{ inputs.python-package-version || (contains(fromJSON(inputs.packages-to-publish), 'python') && inputs.package-version) || '' }}
       use-dummy-binaries: ${{ inputs.use-dummy-binaries }}
       publish: ${{ inputs.publish }}
     steps:


### PR DESCRIPTION
https://github.com/breez/breez-sdk/pull/569 Inadvertently broke the workflow_call CI: https://github.com/breez/breez-sdk-docs/actions/runs/6816197496/job/18536990174

This PR re-adds support for workflow_call. The workflow_call parameters are not bounded by input limits, but the json parsing doesn't work on those inputs.