### PR TITLE
use req for sweepRequest

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -619,7 +619,7 @@ enum BuyBitcoinProvider {
 
 dictionary PrepareSweepRequest {
     string to_address;
-    u64 sats_per_vbyte;
+    u64 sat_per_vbyte;
 };
 
 dictionary PrepareSweepResponse {
@@ -629,7 +629,7 @@ dictionary PrepareSweepResponse {
 
 dictionary SweepRequest {
     string to_address;
-    u32 fee_rate_sats_per_vbyte;
+    u32 sat_per_vbyte;
 };
 
 dictionary SweepResponse {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -517,7 +517,7 @@ impl BreezServices {
         self.start_node().await?;
         let txid = self
             .node_api
-            .sweep(req.to_address, req.fee_rate_sats_per_vbyte)
+            .sweep(req.to_address, req.sat_per_vbyte)
             .await?;
         self.sync().await?;
         Ok(SweepResponse { txid })

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -760,7 +760,7 @@ impl Wire2Api<PrepareSweepRequest> for wire_PrepareSweepRequest {
     fn wire2api(self) -> PrepareSweepRequest {
         PrepareSweepRequest {
             to_address: self.to_address.wire2api(),
-            sats_per_vbyte: self.sats_per_vbyte.wire2api(),
+            sat_per_vbyte: self.sat_per_vbyte.wire2api(),
         }
     }
 }
@@ -844,7 +844,7 @@ impl Wire2Api<SweepRequest> for wire_SweepRequest {
     fn wire2api(self) -> SweepRequest {
         SweepRequest {
             to_address: self.to_address.wire2api(),
-            fee_rate_sats_per_vbyte: self.fee_rate_sats_per_vbyte.wire2api(),
+            sat_per_vbyte: self.sat_per_vbyte.wire2api(),
         }
     }
 }
@@ -998,7 +998,7 @@ pub struct wire_PrepareRefundRequest {
 #[derive(Clone)]
 pub struct wire_PrepareSweepRequest {
     to_address: *mut wire_uint_8_list,
-    sats_per_vbyte: u64,
+    sat_per_vbyte: u64,
 }
 
 #[repr(C)]
@@ -1072,7 +1072,7 @@ pub struct wire_StaticBackupRequest {
 #[derive(Clone)]
 pub struct wire_SweepRequest {
     to_address: *mut wire_uint_8_list,
-    fee_rate_sats_per_vbyte: u32,
+    sat_per_vbyte: u32,
 }
 
 #[repr(C)]
@@ -1380,7 +1380,7 @@ impl NewWithNullPtr for wire_PrepareSweepRequest {
     fn new_with_null_ptr() -> Self {
         Self {
             to_address: core::ptr::null_mut(),
-            sats_per_vbyte: Default::default(),
+            sat_per_vbyte: Default::default(),
         }
     }
 }
@@ -1534,7 +1534,7 @@ impl NewWithNullPtr for wire_SweepRequest {
     fn new_with_null_ptr() -> Self {
         Self {
             to_address: core::ptr::null_mut(),
-            fee_rate_sats_per_vbyte: Default::default(),
+            sat_per_vbyte: Default::default(),
         }
     }
 }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -874,12 +874,12 @@ impl NodeAPI for Greenlight {
         Ok(hex::encode(node_info.id))
     }
 
-    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> NodeResult<Vec<u8>> {
+    async fn sweep(&self, to_address: String, sat_per_vbyte: u32) -> NodeResult<Vec<u8>> {
         let mut client = self.get_node_client().await?;
 
         let request = cln::WithdrawRequest {
             feerate: Some(cln::Feerate {
-                style: Some(cln::feerate::Style::Perkw(fee_rate_sats_per_vbyte * 250)),
+                style: Some(cln::feerate::Style::Perkw(sat_per_vbyte * 250)),
             }),
             satoshi: Some(cln::AmountOrAll {
                 value: Some(cln::amount_or_all::Value::All(true)),
@@ -932,7 +932,7 @@ impl NodeAPI for Greenlight {
         let witness_input_size: u64 = 110;
         let tx_weight = tx.strippedsize() as u64 * WITNESS_SCALE_FACTOR as u64
             + witness_input_size * txins.len() as u64;
-        let fee: u64 = tx_weight * req.sats_per_vbyte / WITNESS_SCALE_FACTOR as u64;
+        let fee: u64 = tx_weight * req.sat_per_vbyte / WITNESS_SCALE_FACTOR as u64;
         if fee >= amount {
             return Err(NodeError::Generic(anyhow!(
                 "Insufficient funds to pay fees"

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -810,7 +810,7 @@ pub struct BuyBitcoinResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SweepRequest {
     pub to_address: String,
-    pub fee_rate_sats_per_vbyte: u32,
+    pub sat_per_vbyte: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1234,7 +1234,7 @@ pub enum BuyBitcoinProvider {
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
 pub struct PrepareSweepRequest {
     pub to_address: String,
-    pub sats_per_vbyte: u64,
+    pub sat_per_vbyte: u64,
 }
 
 /// We need to prepare a sweep transaction to know what a fee it will be charged in satoshis

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -90,7 +90,7 @@ pub trait NodeAPI: Send + Sync {
         max_hops: u32,
         last_hop: Option<&RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>>;
-    async fn sweep(&self, to_address: String, fee_rate_sats_per_vbyte: u32) -> NodeResult<Vec<u8>>;
+    async fn sweep(&self, to_address: String, sat_per_vbyte: u32) -> NodeResult<Vec<u8>>;
     async fn prepare_sweep(&self, req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse>;
     async fn start_signer(&self, shutdown: mpsc::Receiver<()>);
     async fn list_peers(&self) -> NodeResult<Vec<Peer>>;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -336,11 +336,7 @@ impl NodeAPI for MockNodeAPI {
         Ok("".to_string())
     }
 
-    async fn sweep(
-        &self,
-        _to_address: String,
-        _fee_rate_sats_per_vbyte: u32,
-    ) -> NodeResult<Vec<u8>> {
+    async fn sweep(&self, _to_address: String, _sat_per_vbyte: u32) -> NodeResult<Vec<u8>> {
         Ok(rand_vec_u8(32))
     }
 

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -170,12 +170,12 @@ typedef struct wire_BuyBitcoinRequest {
 
 typedef struct wire_SweepRequest {
   struct wire_uint_8_list *to_address;
-  uint32_t fee_rate_sats_per_vbyte;
+  uint32_t sat_per_vbyte;
 } wire_SweepRequest;
 
 typedef struct wire_PrepareSweepRequest {
   struct wire_uint_8_list *to_address;
-  uint64_t sats_per_vbyte;
+  uint64_t sat_per_vbyte;
 } wire_PrepareSweepRequest;
 
 typedef struct wire_PrepareRefundRequest {

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -383,15 +383,9 @@ class BreezSDK {
   Future<RecommendedFees> recommendedFees() async => await _lnToolkit.recommendedFees();
 
   Future<PrepareSweepResponse> prepareSweep({
-    required String address,
-    required int satsPerVbyte,
+    required PrepareSweepRequest req,
   }) async =>
-      _lnToolkit.prepareSweep(
-        req: PrepareSweepRequest(
-          toAddress: address,
-          satsPerVbyte: satsPerVbyte,
-        ),
-      );
+      _lnToolkit.prepareSweep(req: req);
 
   /* CLI API's */
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1193,11 +1193,11 @@ class PrepareRefundResponse {
 /// satoshis per vbyte which will be converted to absolute satoshis.
 class PrepareSweepRequest {
   final String toAddress;
-  final int satsPerVbyte;
+  final int satPerVbyte;
 
   const PrepareSweepRequest({
     required this.toAddress,
-    required this.satsPerVbyte,
+    required this.satPerVbyte,
   });
 }
 
@@ -1639,11 +1639,11 @@ enum SwapStatus {
 
 class SweepRequest {
   final String toAddress;
-  final int feeRateSatsPerVbyte;
+  final int satPerVbyte;
 
   const SweepRequest({
     required this.toAddress,
-    required this.feeRateSatsPerVbyte,
+    required this.satPerVbyte,
   });
 }
 
@@ -4093,7 +4093,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_prepare_sweep_request(PrepareSweepRequest apiObj, wire_PrepareSweepRequest wireObj) {
     wireObj.to_address = api2wire_String(apiObj.toAddress);
-    wireObj.sats_per_vbyte = api2wire_u64(apiObj.satsPerVbyte);
+    wireObj.sat_per_vbyte = api2wire_u64(apiObj.satPerVbyte);
   }
 
   void _api_fill_to_wire_receive_onchain_request(
@@ -4151,7 +4151,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_sweep_request(SweepRequest apiObj, wire_SweepRequest wireObj) {
     wireObj.to_address = api2wire_String(apiObj.toAddress);
-    wireObj.fee_rate_sats_per_vbyte = api2wire_u32(apiObj.feeRateSatsPerVbyte);
+    wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
   }
 }
 
@@ -5507,14 +5507,14 @@ final class wire_SweepRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> to_address;
 
   @ffi.Uint32()
-  external int fee_rate_sats_per_vbyte;
+  external int sat_per_vbyte;
 }
 
 final class wire_PrepareSweepRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> to_address;
 
   @ffi.Uint64()
-  external int sats_per_vbyte;
+  external int sat_per_vbyte;
 }
 
 final class wire_PrepareRefundRequest extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1979,24 +1979,24 @@ fun asPrepareSweepRequest(prepareSweepRequest: ReadableMap): PrepareSweepRequest
             prepareSweepRequest,
             arrayOf(
                 "toAddress",
-                "satsPerVbyte",
+                "satPerVbyte",
             ),
         )
     ) {
         return null
     }
     val toAddress = prepareSweepRequest.getString("toAddress")!!
-    val satsPerVbyte = prepareSweepRequest.getDouble("satsPerVbyte").toULong()
+    val satPerVbyte = prepareSweepRequest.getDouble("satPerVbyte").toULong()
     return PrepareSweepRequest(
         toAddress,
-        satsPerVbyte,
+        satPerVbyte,
     )
 }
 
 fun readableMapOf(prepareSweepRequest: PrepareSweepRequest): ReadableMap {
     return readableMapOf(
         "toAddress" to prepareSweepRequest.toAddress,
-        "satsPerVbyte" to prepareSweepRequest.satsPerVbyte,
+        "satPerVbyte" to prepareSweepRequest.satPerVbyte,
     )
 }
 
@@ -3077,24 +3077,24 @@ fun asSweepRequest(sweepRequest: ReadableMap): SweepRequest? {
             sweepRequest,
             arrayOf(
                 "toAddress",
-                "feeRateSatsPerVbyte",
+                "satPerVbyte",
             ),
         )
     ) {
         return null
     }
     val toAddress = sweepRequest.getString("toAddress")!!
-    val feeRateSatsPerVbyte = sweepRequest.getInt("feeRateSatsPerVbyte").toUInt()
+    val satPerVbyte = sweepRequest.getInt("satPerVbyte").toUInt()
     return SweepRequest(
         toAddress,
-        feeRateSatsPerVbyte,
+        satPerVbyte,
     )
 }
 
 fun readableMapOf(sweepRequest: SweepRequest): ReadableMap {
     return readableMapOf(
         "toAddress" to sweepRequest.toAddress,
-        "feeRateSatsPerVbyte" to sweepRequest.feeRateSatsPerVbyte,
+        "satPerVbyte" to sweepRequest.satPerVbyte,
     )
 }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1,7 +1,7 @@
 import BreezSDK
 import Foundation
 
-class BreezSDKMapper {
+enum BreezSDKMapper {
     static func asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: [String: Any?]) throws -> AesSuccessActionDataDecrypted {
         guard let description = aesSuccessActionDataDecrypted["description"] as? String else { throw SdkError.Generic(message: "Missing mandatory field description for type AesSuccessActionDataDecrypted") }
         guard let plaintext = aesSuccessActionDataDecrypted["plaintext"] as? String else { throw SdkError.Generic(message: "Missing mandatory field plaintext for type AesSuccessActionDataDecrypted") }
@@ -1775,18 +1775,18 @@ class BreezSDKMapper {
 
     static func asPrepareSweepRequest(prepareSweepRequest: [String: Any?]) throws -> PrepareSweepRequest {
         guard let toAddress = prepareSweepRequest["toAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field toAddress for type PrepareSweepRequest") }
-        guard let satsPerVbyte = prepareSweepRequest["satsPerVbyte"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field satsPerVbyte for type PrepareSweepRequest") }
+        guard let satPerVbyte = prepareSweepRequest["satPerVbyte"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field satPerVbyte for type PrepareSweepRequest") }
 
         return PrepareSweepRequest(
             toAddress: toAddress,
-            satsPerVbyte: satsPerVbyte
+            satPerVbyte: satPerVbyte
         )
     }
 
     static func dictionaryOf(prepareSweepRequest: PrepareSweepRequest) -> [String: Any?] {
         return [
             "toAddress": prepareSweepRequest.toAddress,
-            "satsPerVbyte": prepareSweepRequest.satsPerVbyte,
+            "satPerVbyte": prepareSweepRequest.satPerVbyte,
         ]
     }
 
@@ -2708,18 +2708,18 @@ class BreezSDKMapper {
 
     static func asSweepRequest(sweepRequest: [String: Any?]) throws -> SweepRequest {
         guard let toAddress = sweepRequest["toAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field toAddress for type SweepRequest") }
-        guard let feeRateSatsPerVbyte = sweepRequest["feeRateSatsPerVbyte"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field feeRateSatsPerVbyte for type SweepRequest") }
+        guard let satPerVbyte = sweepRequest["satPerVbyte"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field satPerVbyte for type SweepRequest") }
 
         return SweepRequest(
             toAddress: toAddress,
-            feeRateSatsPerVbyte: feeRateSatsPerVbyte
+            satPerVbyte: satPerVbyte
         )
     }
 
     static func dictionaryOf(sweepRequest: SweepRequest) -> [String: Any?] {
         return [
             "toAddress": sweepRequest.toAddress,
-            "feeRateSatsPerVbyte": sweepRequest.feeRateSatsPerVbyte,
+            "satPerVbyte": sweepRequest.satPerVbyte,
         ]
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -316,7 +316,7 @@ export type PrepareRefundResponse = {
 
 export type PrepareSweepRequest = {
     toAddress: string
-    satsPerVbyte: number
+    satPerVbyte: number
 }
 
 export type PrepareSweepResponse = {
@@ -471,7 +471,7 @@ export type SwapInfo = {
 
 export type SweepRequest = {
     toAddress: string
-    feeRateSatsPerVbyte: number
+    satPerVbyte: number
 }
 
 export type SweepResponse = {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -232,24 +232,24 @@ pub(crate) async fn handle_command(
         }
         Commands::Sweep {
             to_address,
-            fee_rate_sats_per_vbyte,
+            sat_per_vbyte,
         } => {
             sdk()?
                 .sweep(SweepRequest {
                     to_address,
-                    fee_rate_sats_per_vbyte,
+                    sat_per_vbyte,
                 })
                 .await?;
             Ok("Onchain funds were swept successfully".to_string())
         }
         Commands::PrepareSweep {
             to_address,
-            sats_per_vbyte,
+            sat_per_vbyte,
         } => {
             sdk()?
                 .sweep(SweepRequest {
                     to_address,
-                    fee_rate_sats_per_vbyte: sats_per_vbyte,
+                    sat_per_vbyte,
                 })
                 .await?;
             Ok("Onchain funds were swept succesfully".to_string())

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -157,7 +157,7 @@ pub(crate) enum Commands {
         to_address: String,
 
         /// The fee rate for the sweep transaction
-        fee_rate_sats_per_vbyte: u32,
+        sat_per_vbyte: u32,
     },
 
     /// Calculate the fee (in sats) for a potential transaction
@@ -166,7 +166,7 @@ pub(crate) enum Commands {
         to_address: String,
 
         /// The fee rate for the transaction in vbyte/sats
-        sats_per_vbyte: u32,
+        sat_per_vbyte: u32,
     },
 
     /// List available LSPs


### PR DESCRIPTION
This pr adds the following changes.

- [039247c](https://github.com/breez/breez-sdk/pull/603/commits/039247c4db3ad239a14dd67cb1e70d609c58033d) Which requires `PrepareSweepRequest` as parameter.
- [ba6493b](https://github.com/breez/breez-sdk/pull/603/commits/ba6493bd6b772df156ec13ab932a1cbbbf4f31c9) Changes name of param to `sats_per_vbyte` for consistency for both `Sweep` and `Refund` request and prepare . 

Not sure if `sats_per_vbyte` is the preferred name, but I think we should use the same name for consistency.