### PR TITLE
Build python wheels for 3.11 and 3.12

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3

--- a/libs/sdk-bindings/bindings-python/README.md
+++ b/libs/sdk-bindings/bindings-python/README.md
@@ -24,6 +24,8 @@ It will create wheels for the following Python versions and Platforms and upload
 | **Python 3.8**  | ✅               | ✅                 | ✅            | ✅             |
 | **Python 3.9**  | ✅               | ✅                 | ✅            | ✅             |
 | **Python 3.10** | ✅               | ✅                 | ✅            | ✅             |
+| **Python 3.11** | ✅               | ✅                 | ✅            | ✅             |
+| **Python 3.12** | ✅               | ✅                 | ✅            | ✅             |
 
 ## Building Manually
 


### PR DESCRIPTION
Treats #606.

Configures the CI to also build wheels for Python 3.11 and 3.12.

After merging, I'd say we re-run the CI for `0.2.9` and use the `0.2.9.post1` [post-release tag](https://peps.python.org/pep-0440/#post-releases) for the Python package. That way we don't have to create a whole new SDK release just for uploading the new wheels while also unblocking #606.