### PR TITLE
Fix Golang bindings build

### DIFF
--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -48,14 +48,14 @@ csharp-linux: $(SOURCES)
 	cp ../target/$(TARGET)/release/libbreez_sdk_bindings.so ffi/csharp
 
 golang-darwin: darwin-universal
-	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go
+	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.1.5+v0.23.0
 	uniffi-bindgen-go src/breez_sdk.udl -o ffi/golang -c ./uniffi.toml
 	cp ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ffi/golang
 	cp -r ffi/golang/breez/breez_sdk tests/bindings/golang/
 
 TARGET ?= aarch64-unknown-linux-gnu
 golang-linux: $(SOURCES)
-	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go
+	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.1.5+v0.23.0
 	cargo build --release --target $(TARGET)
 	uniffi-bindgen-go src/breez_sdk.udl -o ffi/golang -c ./uniffi.toml
 	cp ../target/$(TARGET)/release/libbreez_sdk_bindings.so ffi/golang


### PR DESCRIPTION
Set the uniffi-bindgen-go tag to prevent upgrade to uniffi 0.25.0

https://github.com/breez/breez-sdk/actions/runs/6877122930/job/18704131597?pr=586
```
   Compiling uniffi-bindgen-go v0.1.2+v.0.25.0 (/Users/runner/.cargo/git/checkouts/uniffi-bindgen-go-10b6486a739c08f4/91eacef/bindgen)
    Finished release [optimized] target(s) in 1m 57s
   Replacing /Users/runner/.cargo/bin/uniffi-bindgen-go
    Replaced package `uniffi-bindgen-go v0.1.2+v.0.23.0 (https://github.com/NordSecurity/uniffi-bindgen-go#62347acd)` with `uniffi-bindgen-go v0.1.2+v.0.25.0 (https://github.com/NordSecurity/uniffi-bindgen-go#91eacefc)` (executable `uniffi-bindgen-go`)
cp: ffi/golang/breez/breez_sdk: No such file or directory
Error: Process completed with exit code 1.
```