### PR TITLE
Fix publish Python matrix for Linux wheels

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3


### PR DESCRIPTION
Dummy me only added Python 3.11 and 3.12 for the macOS wheels but not for the Linux wheels in #608. This should fix it.