### PR TITLE
Persist payment attempts before starting

### DIFF
--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use bitcoin::util::bip32;
+use std::time::SystemTimeError;
 use thiserror::Error;
 
 use crate::{
@@ -672,6 +673,14 @@ impl From<SdkError> for SendPaymentError {
             _ => Self::Generic {
                 err: value.to_string(),
             },
+        }
+    }
+}
+
+impl From<SystemTimeError> for SendPaymentError {
+    fn from(err: SystemTimeError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
         }
     }
 }


### PR DESCRIPTION
Partially addresses #570.

The proposed solution isn't applicable to keysend payments as there isn't a payment hash available before requesting the payment to the specified node id.

I am looking for feedback and ideas for addressing the keysend part. Addressing the keysend part in a later PR is also an option.