### PR TITLE
Report payment failures

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -596,6 +596,26 @@ dictionary LnUrlAuthRequestData {
     string url;
 };
 
+dictionary ReportPaymentFailureDetails {
+    string payment_hash;
+    string? comment;
+};
+
+[Enum]
+interface ReportIssueRequest {
+    PaymentFailure(ReportPaymentFailureDetails data);
+};
+
+enum HealthCheckStatus {
+    "Operational",
+    "Maintenance",
+    "ServiceDisruption",
+};
+
+dictionary ServiceHealthCheckResponse {
+    HealthCheckStatus status;
+};
+
 dictionary MetadataItem {
     string key;
     string value;
@@ -718,6 +738,9 @@ interface BlockingBreezServices {
    LnUrlCallbackStatus lnurl_auth(LnUrlAuthRequestData req_data);
 
    [Throws=SdkError]
+   void report_issue(ReportIssueRequest req);
+
+   [Throws=SdkError]
    NodeCredentials? node_credentials();
 
    [Throws=SdkError]
@@ -800,6 +823,9 @@ interface BlockingBreezServices {
 
    [Throws=SendOnchainError]
    SendOnchainResponse send_onchain(SendOnchainRequest req);
+
+   [Throws=SdkError]
+   ServiceHealthCheckResponse service_health_check();
 
    [Throws=SdkError]
    string execute_dev_command(string command);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -5,22 +5,24 @@ use breez_sdk_core::{
     BackupStatus, BitcoinAddressData, BreezEvent, BreezServices, BuyBitcoinProvider,
     BuyBitcoinRequest, BuyBitcoinResponse, ChannelState, CheckMessageRequest, CheckMessageResponse,
     ClosedChannelPaymentDetails, Config, CurrencyInfo, EnvironmentType, EventListener,
-    FeeratePreset, FiatCurrency, GreenlightCredentials, GreenlightNodeConfig, InputType,
-    InvoicePaidDetails, LNInvoice, ListPaymentsRequest, LnPaymentDetails, LnUrlAuthRequestData,
-    LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayErrorData, LnUrlPayRequest, LnUrlPayRequestData,
-    LnUrlPayResult, LnUrlPaySuccessData, LnUrlWithdrawRequest, LnUrlWithdrawRequestData,
-    LnUrlWithdrawResult, LnUrlWithdrawSuccessData, LocaleOverrides, LocalizedName, LogEntry,
-    LogStream, LspInformation, MaxReverseSwapAmountResponse, MessageSuccessActionData,
-    MetadataItem, Network, NodeConfig, NodeCredentials, NodeState, OpenChannelFeeRequest,
-    OpenChannelFeeResponse, OpeningFeeParams, OpeningFeeParamsMenu, Payment, PaymentDetails,
-    PaymentFailedData, PaymentStatus, PaymentType, PaymentTypeFilter, PrepareRefundRequest,
-    PrepareRefundResponse, PrepareSweepRequest, PrepareSweepResponse, Rate, ReceiveOnchainRequest,
-    ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees, RefundRequest, RefundResponse,
+    FeeratePreset, FiatCurrency, GreenlightCredentials, GreenlightNodeConfig, HealthCheckStatus,
+    InputType, InvoicePaidDetails, LNInvoice, ListPaymentsRequest, LnPaymentDetails,
+    LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayErrorData, LnUrlPayRequest,
+    LnUrlPayRequestData, LnUrlPayResult, LnUrlPaySuccessData, LnUrlWithdrawRequest,
+    LnUrlWithdrawRequestData, LnUrlWithdrawResult, LnUrlWithdrawSuccessData, LocaleOverrides,
+    LocalizedName, LogEntry, LogStream, LspInformation, MaxReverseSwapAmountResponse,
+    MessageSuccessActionData, MetadataItem, Network, NodeConfig, NodeCredentials, NodeState,
+    OpenChannelFeeRequest, OpenChannelFeeResponse, OpeningFeeParams, OpeningFeeParamsMenu, Payment,
+    PaymentDetails, PaymentFailedData, PaymentStatus, PaymentType, PaymentTypeFilter,
+    PrepareRefundRequest, PrepareRefundResponse, PrepareSweepRequest, PrepareSweepResponse, Rate,
+    ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees,
+    RefundRequest, RefundResponse, ReportIssueRequest, ReportPaymentFailureDetails,
     ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint,
     RouteHintHop, SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
-    SendSpontaneousPaymentRequest, SignMessageRequest, SignMessageResponse, StaticBackupRequest,
-    StaticBackupResponse, SuccessActionProcessed, SwapInfo, SwapStatus, SweepRequest,
-    SweepResponse, Symbol, UnspentTransactionOutput, UrlSuccessActionData,
+    SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SignMessageRequest,
+    SignMessageResponse, StaticBackupRequest, StaticBackupResponse, SuccessActionProcessed,
+    SwapInfo, SwapStatus, SweepRequest, SweepResponse, Symbol, UnspentTransactionOutput,
+    UrlSuccessActionData,
 };
 use log::{Level, LevelFilter, Metadata, Record};
 use once_cell::sync::{Lazy, OnceCell};
@@ -183,6 +185,14 @@ impl BlockingBreezServices {
         req_data: LnUrlAuthRequestData,
     ) -> Result<LnUrlCallbackStatus, LnUrlAuthError> {
         rt().block_on(self.breez_services.lnurl_auth(req_data))
+    }
+
+    pub fn service_health_check(&self) -> SdkResult<ServiceHealthCheckResponse> {
+        rt().block_on(self.breez_services.service_health_check())
+    }
+
+    pub fn report_issue(&self, req: ReportIssueRequest) -> SdkResult<()> {
+        rt().block_on(self.breez_services.report_issue(req))
     }
 
     pub fn sweep(&self, req: SweepRequest) -> SdkResult<SweepResponse> {

--- a/libs/sdk-core/build.rs
+++ b/libs/sdk-core/build.rs
@@ -1,4 +1,19 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("src/grpc/proto/breez.proto")?;
+    set_git_revision_hash();
     Ok(())
+}
+
+fn set_git_revision_hash() {
+    use std::process::Command;
+
+    let args = &["rev-parse", "--short=10", "HEAD"];
+    let Ok(output) = Command::new("git").args(args).output() else {
+        return;
+    };
+    let rev = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if rev.is_empty() {
+        return;
+    }
+    println!("cargo:rustc-env=SDK_GIT_HASH={}", rev);
 }

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -38,10 +38,10 @@ use crate::{
     NodeCredentials, OpenChannelFeeRequest, OpenChannelFeeResponse, PrepareRefundRequest,
     PrepareRefundResponse, PrepareSweepRequest, PrepareSweepResponse, ReceiveOnchainRequest,
     ReceivePaymentRequest, ReceivePaymentResponse, RefundRequest, RefundResponse,
-    ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo, SendOnchainRequest,
-    SendOnchainResponse, SendPaymentRequest, SendPaymentResponse, SendSpontaneousPaymentRequest,
-    SignMessageRequest, SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
-    SweepRequest, SweepResponse,
+    ReportIssueRequest, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
+    SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
+    SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SignMessageRequest,
+    SignMessageResponse, StaticBackupRequest, StaticBackupResponse, SweepRequest, SweepResponse,
 };
 
 /*
@@ -303,6 +303,20 @@ pub fn lnurl_withdraw(req: LnUrlWithdrawRequest) -> Result<LnUrlWithdrawResult> 
 pub fn lnurl_auth(req_data: LnUrlAuthRequestData) -> Result<LnUrlCallbackStatus> {
     block_on(async { get_breez_services().await?.lnurl_auth(req_data).await })
         .map_err(anyhow::Error::new::<LnUrlAuthError>)
+}
+
+/*  Support API's */
+
+/// See [BreezServices::service_health_check]
+pub fn service_health_check() -> Result<ServiceHealthCheckResponse> {
+    block_on(async { get_breez_services().await?.service_health_check().await })
+        .map_err(anyhow::Error::new::<SdkError>)
+}
+
+/// See [BreezServices::report_issue]
+pub fn report_issue(req: ReportIssueRequest) -> Result<()> {
+    block_on(async { get_breez_services().await?.report_issue(req).await })
+        .map_err(anyhow::Error::new::<SdkError>)
 }
 
 /*  Fiat Currency API's */

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -35,6 +35,7 @@ use crate::grpc::fund_manager_client::FundManagerClient;
 use crate::grpc::information_client::InformationClient;
 use crate::grpc::payment_notifier_client::PaymentNotifierClient;
 use crate::grpc::signer_client::SignerClient;
+use crate::grpc::support_client::SupportClient;
 use crate::grpc::swapper_client::SwapperClient;
 use crate::grpc::PaymentInformation;
 use crate::invoice::{
@@ -157,6 +158,7 @@ pub struct BreezServices {
     lsp_api: Arc<dyn LspAPI>,
     fiat_api: Arc<dyn FiatAPI>,
     moonpay_api: Arc<dyn MoonPayApi>,
+    support_api: Arc<dyn SupportAPI>,
     chain_service: Arc<dyn ChainService>,
     persister: Arc<SqliteStorage>,
     payment_receiver: Arc<PaymentReceiver>,
@@ -185,6 +187,9 @@ impl BreezServices {
         seed: Vec<u8>,
         event_listener: Box<dyn EventListener>,
     ) -> SdkResult<Arc<BreezServices>> {
+        let sdk_version = option_env!("CARGO_PKG_VERSION").unwrap_or_default();
+        let sdk_git_hash = option_env!("SDK_GIT_HASH").unwrap_or_default();
+        info!("SDK v{sdk_version} ({sdk_git_hash})");
         let start = Instant::now();
         let services = BreezServicesBuilder::new(config)
             .seed(seed)
@@ -462,6 +467,39 @@ impl BreezServices {
         req: ReceivePaymentRequest,
     ) -> Result<ReceivePaymentResponse, ReceivePaymentError> {
         self.payment_receiver.receive_payment(req).await
+    }
+
+    /// Fetches the service health check from the support API.
+    pub async fn service_health_check(&self) -> SdkResult<ServiceHealthCheckResponse> {
+        self.support_api.service_health_check().await
+    }
+
+    /// Report an issue.
+    ///
+    /// Calling `report_issue` with a [ReportIssueRequest] enum param sends an issue report using the Support API.
+    /// - [ReportIssueRequest::PaymentFailure] sends a payment failure report to the Support API
+    /// using the provided `payment_hash` to lookup the failed payment and the current [NodeState].
+    pub async fn report_issue(&self, req: ReportIssueRequest) -> SdkResult<()> {
+        match self.persister.get_node_state()? {
+            Some(node_state) => match req {
+                ReportIssueRequest::PaymentFailure { data } => {
+                    let payment = self
+                        .persister
+                        .get_payment_by_hash(&data.payment_hash)?
+                        .ok_or(SdkError::Generic {
+                            err: "Payment not found".into(),
+                        })?;
+                    let lsp_id = self.persister.get_lsp_id()?;
+
+                    self.support_api
+                        .report_payment_failure(node_state, payment, lsp_id, data.comment)
+                        .await
+                }
+            },
+            None => Err(SdkError::Generic {
+                err: "Node state not found".into(),
+            }),
+        }
     }
 
     /// Retrieve the decrypted credentials from the node.
@@ -1494,6 +1532,7 @@ struct BreezServicesBuilder {
     lsp_api: Option<Arc<dyn LspAPI>>,
     fiat_api: Option<Arc<dyn FiatAPI>>,
     persister: Option<Arc<SqliteStorage>>,
+    support_api: Option<Arc<dyn SupportAPI>>,
     swapper_api: Option<Arc<dyn SwapperAPI>>,
     /// Reverse swap functionality on the Breez Server
     reverse_swapper_api: Option<Arc<dyn ReverseSwapperRoutingAPI>>,
@@ -1512,6 +1551,7 @@ impl BreezServicesBuilder {
             lsp_api: None,
             fiat_api: None,
             persister: None,
+            support_api: None,
             swapper_api: None,
             reverse_swapper_api: None,
             reverse_swap_service_api: None,
@@ -1542,6 +1582,11 @@ impl BreezServicesBuilder {
 
     pub fn persister(&mut self, persister: Arc<SqliteStorage>) -> &mut Self {
         self.persister = Some(persister);
+        self
+    }
+
+    pub fn support_api(&mut self, support_api: Arc<dyn SupportAPI>) -> &mut Self {
+        self.support_api = Some(support_api.clone());
         self
     }
 
@@ -1700,6 +1745,10 @@ impl BreezServicesBuilder {
                 .fiat_api
                 .clone()
                 .unwrap_or_else(|| breez_server.clone()),
+            support_api: self
+                .support_api
+                .clone()
+                .unwrap_or_else(|| breez_server.clone()),
             moonpay_api: self
                 .moonpay_api
                 .clone()
@@ -1733,11 +1782,8 @@ impl BreezServer {
         }
     }
 
-    pub(crate) async fn get_channel_opener_client(
-        &self,
-    ) -> SdkResult<ChannelOpenerClient<InterceptedService<Channel, ApiKeyInterceptor>>> {
-        let s = self.server_url.clone();
-        let channel = Channel::from_shared(s)
+    async fn channel(&self) -> SdkResult<Channel> {
+        Channel::from_shared(self.server_url.clone())
             .map_err(|e| SdkError::ServiceConnectivity {
                 err: format!("(Breez: {}) {e}", self.server_url.clone()),
             })?
@@ -1748,22 +1794,32 @@ impl BreezServer {
                     "(Breez: {}) Failed to connect: {e}",
                     self.server_url.clone()
                 ),
-            })?;
+            })
+    }
 
-        let api_key_metadata: Option<MetadataValue<Ascii>> = match &self.api_key {
-            Some(key) => Some(format!("Bearer {key}").parse().map_err(
+    fn api_key_metadata(&self) -> SdkResult<Option<MetadataValue<Ascii>>> {
+        match &self.api_key {
+            Some(key) => Ok(Some(format!("Bearer {key}").parse().map_err(
                 |e: InvalidMetadataValue| SdkError::ServiceConnectivity {
                     err: format!(
                         "(Breez: {}) Failed parse API key: {e}",
                         self.server_url.clone()
                     ),
                 },
-            )?),
-            _ => None,
-        };
-        let client =
-            ChannelOpenerClient::with_interceptor(channel, ApiKeyInterceptor { api_key_metadata });
-        Ok(client)
+            )?)),
+            _ => Ok(None),
+        }
+    }
+
+    pub(crate) async fn get_channel_opener_client(
+        &self,
+    ) -> SdkResult<ChannelOpenerClient<InterceptedService<Channel, ApiKeyInterceptor>>> {
+        let channel = self.channel().await?;
+        let api_key_metadata = self.api_key_metadata()?;
+        Ok(ChannelOpenerClient::with_interceptor(
+            channel,
+            ApiKeyInterceptor { api_key_metadata },
+        ))
     }
 
     pub(crate) async fn get_subscription_client(
@@ -1794,6 +1850,17 @@ impl BreezServer {
             err: format!("(Breez: {}) {e}", self.server_url.clone()),
         })?;
         Ok(SignerClient::new(Endpoint::new(url)?.connect().await?))
+    }
+
+    pub(crate) async fn get_support_client(
+        &self,
+    ) -> SdkResult<SupportClient<InterceptedService<Channel, ApiKeyInterceptor>>> {
+        let channel = self.channel().await?;
+        let api_key_metadata = self.api_key_metadata()?;
+        Ok(SupportClient::with_interceptor(
+            channel,
+            ApiKeyInterceptor { api_key_metadata },
+        ))
     }
 
     pub(crate) async fn get_swapper_client(&self) -> SdkResult<SwapperClient<Channel>> {

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -170,6 +170,16 @@ pub extern "C" fn wire_lnurl_auth(port_: i64, req_data: *mut wire_LnUrlAuthReque
 }
 
 #[no_mangle]
+pub extern "C" fn wire_service_health_check(port_: i64) {
+    wire_service_health_check_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_report_issue(port_: i64, req: *mut wire_ReportIssueRequest) {
+    wire_report_issue_impl(port_, req)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_fetch_fiat_rates(port_: i64) {
     wire_fetch_fiat_rates_impl(port_)
 }
@@ -349,6 +359,17 @@ pub extern "C" fn new_box_autoadd_receive_payment_request_0() -> *mut wire_Recei
 #[no_mangle]
 pub extern "C" fn new_box_autoadd_refund_request_0() -> *mut wire_RefundRequest {
     support::new_leak_box_ptr(wire_RefundRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn new_box_autoadd_report_issue_request_0() -> *mut wire_ReportIssueRequest {
+    support::new_leak_box_ptr(wire_ReportIssueRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn new_box_autoadd_report_payment_failure_details_0(
+) -> *mut wire_ReportPaymentFailureDetails {
+    support::new_leak_box_ptr(wire_ReportPaymentFailureDetails::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -537,6 +558,18 @@ impl Wire2Api<RefundRequest> for *mut wire_RefundRequest {
     fn wire2api(self) -> RefundRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<RefundRequest>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<ReportIssueRequest> for *mut wire_ReportIssueRequest {
+    fn wire2api(self) -> ReportIssueRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<ReportIssueRequest>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<ReportPaymentFailureDetails> for *mut wire_ReportPaymentFailureDetails {
+    fn wire2api(self) -> ReportPaymentFailureDetails {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<ReportPaymentFailureDetails>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<ReverseSwapFeesRequest> for *mut wire_ReverseSwapFeesRequest {
@@ -798,6 +831,28 @@ impl Wire2Api<RefundRequest> for wire_RefundRequest {
         }
     }
 }
+impl Wire2Api<ReportIssueRequest> for wire_ReportIssueRequest {
+    fn wire2api(self) -> ReportIssueRequest {
+        match self.tag {
+            0 => unsafe {
+                let ans = support::box_from_leak_ptr(self.kind);
+                let ans = support::box_from_leak_ptr(ans.PaymentFailure);
+                ReportIssueRequest::PaymentFailure {
+                    data: ans.data.wire2api(),
+                }
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+impl Wire2Api<ReportPaymentFailureDetails> for wire_ReportPaymentFailureDetails {
+    fn wire2api(self) -> ReportPaymentFailureDetails {
+        ReportPaymentFailureDetails {
+            payment_hash: self.payment_hash.wire2api(),
+            comment: self.comment.wire2api(),
+        }
+    }
+}
 impl Wire2Api<ReverseSwapFeesRequest> for wire_ReverseSwapFeesRequest {
     fn wire2api(self) -> ReverseSwapFeesRequest {
         ReverseSwapFeesRequest {
@@ -1034,6 +1089,13 @@ pub struct wire_RefundRequest {
 
 #[repr(C)]
 #[derive(Clone)]
+pub struct wire_ReportPaymentFailureDetails {
+    payment_hash: *mut wire_uint_8_list,
+    comment: *mut wire_uint_8_list,
+}
+
+#[repr(C)]
+#[derive(Clone)]
 pub struct wire_ReverseSwapFeesRequest {
     send_amount_sat: *mut u64,
 }
@@ -1103,6 +1165,24 @@ pub union NodeConfigKind {
 #[derive(Clone)]
 pub struct wire_NodeConfig_Greenlight {
     config: *mut wire_GreenlightNodeConfig,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_ReportIssueRequest {
+    tag: i32,
+    kind: *mut ReportIssueRequestKind,
+}
+
+#[repr(C)]
+pub union ReportIssueRequestKind {
+    PaymentFailure: *mut wire_ReportIssueRequest_PaymentFailure,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_ReportIssueRequest_PaymentFailure {
+    data: *mut wire_ReportPaymentFailureDetails,
 }
 
 // Section: impl NewWithNullPtr
@@ -1441,6 +1521,45 @@ impl NewWithNullPtr for wire_RefundRequest {
 }
 
 impl Default for wire_RefundRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl Default for wire_ReportIssueRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_ReportIssueRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            tag: -1,
+            kind: core::ptr::null_mut(),
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn inflate_ReportIssueRequest_PaymentFailure() -> *mut ReportIssueRequestKind {
+    support::new_leak_box_ptr(ReportIssueRequestKind {
+        PaymentFailure: support::new_leak_box_ptr(wire_ReportIssueRequest_PaymentFailure {
+            data: core::ptr::null_mut(),
+        }),
+    })
+}
+
+impl NewWithNullPtr for wire_ReportPaymentFailureDetails {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            payment_hash: core::ptr::null_mut(),
+            comment: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_ReportPaymentFailureDetails {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/libs/sdk-core/src/grpc/proto/breez.proto
+++ b/libs/sdk-core/src/grpc/proto/breez.proto
@@ -97,6 +97,11 @@ service Signer {
   rpc SignUrl(SignUrlRequest) returns (SignUrlResponse) {}
 }
 
+service Support {
+  rpc ReportPaymentFailure(ReportPaymentFailureRequest) returns (ReportPaymentFailureReply) {}
+  rpc BreezStatus(BreezStatusRequest) returns (BreezStatusReply) {}
+}
+
 message SignUrlRequest {
   string baseUrl = 1 [ json_name = "base_url" ];
   string queryString = 2 [ json_name = "query_string" ];
@@ -399,6 +404,33 @@ message BreezAppVersionsReply { repeated string version = 1; }
 message GetReverseRoutingNodeRequest {}
 message GetReverseRoutingNodeReply { bytes node_id = 1; }
 
+message ReportPaymentFailureRequest {
+  // The sdk build version
+  string sdk_version = 1;
+  // The sdk build git hash
+  string sdk_git_hash = 2;
+  // The node pubkey reporting the failure
+  string node_id = 3;
+  // The currently used lsp id
+  string lsp_id = 4;
+  // The ISO 8601 timestamp 
+  string timestamp = 5;
+  // The optional comment/error response text
+  string comment = 6;
+  // The JSON encoded report payload
+  string report = 7;
+}
+message ReportPaymentFailureReply {}
+
+message BreezStatusRequest {}
+message BreezStatusReply {
+  enum BreezStatus {
+    OPERATIONAL = 0;
+    MAINTENANCE = 1;
+    SERVICE_DISRUPTION = 2;
+  }
+  BreezStatus status = 1;
+}
 
 /////////////////////////////////////////////
 // From lspd.proto

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -181,6 +181,7 @@ mod models;
 mod moonpay;
 mod node_api;
 mod persist;
+mod support;
 mod swap_in;
 mod swap_out;
 #[cfg(test)]

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -774,6 +774,48 @@ pub struct SendPaymentResponse {
     pub payment: Payment,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReportPaymentFailureDetails {
+    /// The payment hash of the payment failure
+    pub payment_hash: String,
+    /// The comment or error text
+    pub comment: Option<String>,
+}
+
+/// Represents a report issue request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ReportIssueRequest {
+    PaymentFailure { data: ReportPaymentFailureDetails },
+}
+
+/// Indicates the different service health check statuses.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum HealthCheckStatus {
+    Operational,
+    Maintenance,
+    ServiceDisruption,
+}
+
+/// Represents a service health check response.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ServiceHealthCheckResponse {
+    pub status: HealthCheckStatus,
+}
+
+/// Trait covering support-related functionality
+#[tonic::async_trait]
+pub trait SupportAPI: Send + Sync {
+    async fn service_health_check(&self) -> SdkResult<ServiceHealthCheckResponse>;
+
+    async fn report_payment_failure(
+        &self,
+        node_state: NodeState,
+        payment: Payment,
+        lsp_id: Option<String>,
+        comment: Option<String>,
+    ) -> SdkResult<()>;
+}
+
 #[derive(Clone)]
 pub struct StaticBackupRequest {
     pub working_dir: String,

--- a/libs/sdk-core/src/support.rs
+++ b/libs/sdk-core/src/support.rs
@@ -1,0 +1,80 @@
+use std::time::SystemTime;
+
+use crate::error::SdkResult;
+use crate::grpc::{BreezStatusRequest, ReportPaymentFailureRequest};
+use crate::{breez_services::BreezServer, error::SdkError};
+use crate::{HealthCheckStatus, NodeState, Payment, ServiceHealthCheckResponse, SupportAPI};
+use anyhow::anyhow;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tonic::Request;
+
+#[derive(Serialize, Deserialize)]
+struct PaymentFailureReport {
+    pub node_state: NodeState,
+    pub payment: Payment,
+}
+
+impl TryFrom<i32> for HealthCheckStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(HealthCheckStatus::Operational),
+            1 => Ok(HealthCheckStatus::Maintenance),
+            2 => Ok(HealthCheckStatus::ServiceDisruption),
+            _ => Err(anyhow!("illegal value")),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl SupportAPI for BreezServer {
+    async fn service_health_check(&self) -> SdkResult<ServiceHealthCheckResponse> {
+        let mut client = self.get_support_client().await?;
+
+        let request = Request::new(BreezStatusRequest {});
+        let response =
+            client
+                .breez_status(request)
+                .await
+                .map_err(|e| SdkError::ServiceConnectivity {
+                    err: format!("(Breez) Fetch status failed: {e}"),
+                })?;
+        let status = response.into_inner().status.try_into()?;
+        Ok(ServiceHealthCheckResponse { status })
+    }
+
+    async fn report_payment_failure(
+        &self,
+        node_state: NodeState,
+        payment: Payment,
+        lsp_id: Option<String>,
+        comment: Option<String>,
+    ) -> SdkResult<()> {
+        let mut client = self.get_support_client().await?;
+        let timestamp: DateTime<Utc> = SystemTime::now().into();
+        let report = PaymentFailureReport {
+            node_state: node_state.clone(),
+            payment,
+        };
+
+        let request = Request::new(ReportPaymentFailureRequest {
+            sdk_version: option_env!("CARGO_PKG_VERSION")
+                .unwrap_or_default()
+                .to_string(),
+            sdk_git_hash: option_env!("SDK_GIT_HASH").unwrap_or_default().to_string(),
+            node_id: node_state.id,
+            lsp_id: lsp_id.unwrap_or_default(),
+            timestamp: timestamp.to_rfc3339(),
+            comment: comment.unwrap_or_default(),
+            report: serde_json::to_string(&report)?,
+        });
+        _ = client.report_payment_failure(request).await.map_err(|e| {
+            SdkError::ServiceConnectivity {
+                err: format!("(Breez) Report payment failure failed: {e}"),
+            }
+        })?;
+        Ok(())
+    }
+}

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -152,6 +152,24 @@ typedef struct wire_LnUrlAuthRequestData {
   struct wire_uint_8_list *url;
 } wire_LnUrlAuthRequestData;
 
+typedef struct wire_ReportPaymentFailureDetails {
+  struct wire_uint_8_list *payment_hash;
+  struct wire_uint_8_list *comment;
+} wire_ReportPaymentFailureDetails;
+
+typedef struct wire_ReportIssueRequest_PaymentFailure {
+  struct wire_ReportPaymentFailureDetails *data;
+} wire_ReportIssueRequest_PaymentFailure;
+
+typedef union ReportIssueRequestKind {
+  struct wire_ReportIssueRequest_PaymentFailure *PaymentFailure;
+} ReportIssueRequestKind;
+
+typedef struct wire_ReportIssueRequest {
+  int32_t tag;
+  union ReportIssueRequestKind *kind;
+} wire_ReportIssueRequest;
+
 typedef struct wire_SendOnchainRequest {
   uint64_t amount_sat;
   struct wire_uint_8_list *onchain_recipient_address;
@@ -278,6 +296,10 @@ void wire_lnurl_withdraw(int64_t port_, struct wire_LnUrlWithdrawRequest *req);
 
 void wire_lnurl_auth(int64_t port_, struct wire_LnUrlAuthRequestData *req_data);
 
+void wire_service_health_check(int64_t port_);
+
+void wire_report_issue(int64_t port_, struct wire_ReportIssueRequest *req);
+
 void wire_fetch_fiat_rates(int64_t port_);
 
 void wire_list_fiat_currencies(int64_t port_);
@@ -350,6 +372,10 @@ struct wire_ReceivePaymentRequest *new_box_autoadd_receive_payment_request_0(voi
 
 struct wire_RefundRequest *new_box_autoadd_refund_request_0(void);
 
+struct wire_ReportIssueRequest *new_box_autoadd_report_issue_request_0(void);
+
+struct wire_ReportPaymentFailureDetails *new_box_autoadd_report_payment_failure_details_0(void);
+
 struct wire_ReverseSwapFeesRequest *new_box_autoadd_reverse_swap_fees_request_0(void);
 
 struct wire_SendOnchainRequest *new_box_autoadd_send_onchain_request_0(void);
@@ -373,6 +399,8 @@ struct wire_list_payment_type_filter *new_list_payment_type_filter_0(int32_t len
 struct wire_uint_8_list *new_uint_8_list_0(int32_t len);
 
 union NodeConfigKind *inflate_NodeConfig_Greenlight(void);
+
+union ReportIssueRequestKind *inflate_ReportIssueRequest_PaymentFailure(void);
 
 void free_WireSyncReturn(WireSyncReturn ptr);
 
@@ -410,6 +438,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_lnurl_pay);
     dummy_var ^= ((int64_t) (void*) wire_lnurl_withdraw);
     dummy_var ^= ((int64_t) (void*) wire_lnurl_auth);
+    dummy_var ^= ((int64_t) (void*) wire_service_health_check);
+    dummy_var ^= ((int64_t) (void*) wire_report_issue);
     dummy_var ^= ((int64_t) (void*) wire_fetch_fiat_rates);
     dummy_var ^= ((int64_t) (void*) wire_list_fiat_currencies);
     dummy_var ^= ((int64_t) (void*) wire_max_reverse_swap_amount);
@@ -446,6 +476,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_receive_onchain_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_receive_payment_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_refund_request_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_report_issue_request_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_report_payment_failure_details_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_reverse_swap_fees_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_onchain_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_payment_request_0);
@@ -458,6 +490,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_list_payment_type_filter_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
     dummy_var ^= ((int64_t) (void*) inflate_NodeConfig_Greenlight);
+    dummy_var ^= ((int64_t) (void*) inflate_ReportIssueRequest_PaymentFailure);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturn);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     dummy_var ^= ((int64_t) (void*) get_dart_object);

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -387,6 +387,20 @@ class BreezSDK {
   }) async =>
       _lnToolkit.prepareSweep(req: req);
 
+  /* Support API's */
+
+  /// Send an issue report using the Support API.
+  /// - `ReportIssueRequest.paymentFailure` sends a payment failure report to the Support API
+  ///   using the provided `paymentHash` to lookup the failed `Payment` and the current `NodeState`.
+  Future<void> reportIssue({
+    required ReportIssueRequest req,
+  }) async {
+    return await _lnToolkit.reportIssue(req: req);
+  }
+
+  /// Fetches the service health check from the support API.
+  Future<ServiceHealthCheckResponse> serviceHealthCheck() async => await _lnToolkit.serviceHealthCheck();
+
   /* CLI API's */
 
   /// Execute a command directly on the NodeAPI interface.

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -176,6 +176,16 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kLnurlAuthConstMeta;
 
+  /// See [BreezServices::service_health_check]
+  Future<ServiceHealthCheckResponse> serviceHealthCheck({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kServiceHealthCheckConstMeta;
+
+  /// See [BreezServices::report_issue]
+  Future<void> reportIssue({required ReportIssueRequest req, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kReportIssueConstMeta;
+
   /// See [BreezServices::fetch_fiat_rates]
   Future<List<Rate>> fetchFiatRates({dynamic hint});
 
@@ -523,6 +533,13 @@ class GreenlightNodeConfig {
     this.partnerCredentials,
     this.inviteCode,
   });
+}
+
+/// Indicates the different service health check statuses.
+enum HealthCheckStatus {
+  Operational,
+  Maintenance,
+  ServiceDisruption,
 }
 
 @freezed
@@ -1332,6 +1349,26 @@ class RefundResponse {
   });
 }
 
+@freezed
+sealed class ReportIssueRequest with _$ReportIssueRequest {
+  const factory ReportIssueRequest.paymentFailure({
+    required ReportPaymentFailureDetails data,
+  }) = ReportIssueRequest_PaymentFailure;
+}
+
+class ReportPaymentFailureDetails {
+  /// The payment hash of the payment failure
+  final String paymentHash;
+
+  /// The comment or error text
+  final String? comment;
+
+  const ReportPaymentFailureDetails({
+    required this.paymentHash,
+    this.comment,
+  });
+}
+
 class ReverseSwapFeesRequest {
   final int? sendAmountSat;
 
@@ -1522,6 +1559,15 @@ class SendSpontaneousPaymentRequest {
   const SendSpontaneousPaymentRequest({
     required this.nodeId,
     required this.amountMsat,
+  });
+}
+
+/// Represents a service health check response.
+class ServiceHealthCheckResponse {
+  final HealthCheckStatus status;
+
+  const ServiceHealthCheckResponse({
+    required this.status,
   });
 }
 
@@ -2225,6 +2271,37 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["reqData"],
       );
 
+  Future<ServiceHealthCheckResponse> serviceHealthCheck({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_service_health_check(port_),
+      parseSuccessData: _wire2api_service_health_check_response,
+      constMeta: kServiceHealthCheckConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kServiceHealthCheckConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "service_health_check",
+        argNames: [],
+      );
+
+  Future<void> reportIssue({required ReportIssueRequest req, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_report_issue_request(req);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_report_issue(port_, arg0),
+      parseSuccessData: _wire2api_unit,
+      constMeta: kReportIssueConstMeta,
+      argValues: [req],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kReportIssueConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "report_issue",
+        argNames: ["req"],
+      );
+
   Future<List<Rate>> fetchFiatRates({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_fetch_fiat_rates(port_),
@@ -2786,6 +2863,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       partnerCredentials: _wire2api_opt_box_autoadd_greenlight_credentials(arr[0]),
       inviteCode: _wire2api_opt_String(arr[1]),
     );
+  }
+
+  HealthCheckStatus _wire2api_health_check_status(dynamic raw) {
+    return HealthCheckStatus.values[raw as int];
   }
 
   int _wire2api_i32(dynamic raw) {
@@ -3424,6 +3505,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     );
   }
 
+  ServiceHealthCheckResponse _wire2api_service_health_check_response(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return ServiceHealthCheckResponse(
+      status: _wire2api_health_check_status(arr[0]),
+    );
+  }
+
   SignMessageResponse _wire2api_sign_message_response(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
@@ -3758,6 +3847,21 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_ReportIssueRequest> api2wire_box_autoadd_report_issue_request(ReportIssueRequest raw) {
+    final ptr = inner.new_box_autoadd_report_issue_request_0();
+    _api_fill_to_wire_report_issue_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<wire_ReportPaymentFailureDetails> api2wire_box_autoadd_report_payment_failure_details(
+      ReportPaymentFailureDetails raw) {
+    final ptr = inner.new_box_autoadd_report_payment_failure_details_0();
+    _api_fill_to_wire_report_payment_failure_details(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_ReverseSwapFeesRequest> api2wire_box_autoadd_reverse_swap_fees_request(
       ReverseSwapFeesRequest raw) {
     final ptr = inner.new_box_autoadd_reverse_swap_fees_request_0();
@@ -3977,6 +4081,16 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_refund_request(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_report_issue_request(
+      ReportIssueRequest apiObj, ffi.Pointer<wire_ReportIssueRequest> wireObj) {
+    _api_fill_to_wire_report_issue_request(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_box_autoadd_report_payment_failure_details(
+      ReportPaymentFailureDetails apiObj, ffi.Pointer<wire_ReportPaymentFailureDetails> wireObj) {
+    _api_fill_to_wire_report_payment_failure_details(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_reverse_swap_fees_request(
       ReverseSwapFeesRequest apiObj, ffi.Pointer<wire_ReverseSwapFeesRequest> wireObj) {
     _api_fill_to_wire_reverse_swap_fees_request(apiObj, wireObj.ref);
@@ -4165,6 +4279,22 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.swap_address = api2wire_String(apiObj.swapAddress);
     wireObj.to_address = api2wire_String(apiObj.toAddress);
     wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
+  }
+
+  void _api_fill_to_wire_report_issue_request(ReportIssueRequest apiObj, wire_ReportIssueRequest wireObj) {
+    if (apiObj is ReportIssueRequest_PaymentFailure) {
+      var pre_data = api2wire_box_autoadd_report_payment_failure_details(apiObj.data);
+      wireObj.tag = 0;
+      wireObj.kind = inner.inflate_ReportIssueRequest_PaymentFailure();
+      wireObj.kind.ref.PaymentFailure.ref.data = pre_data;
+      return;
+    }
+  }
+
+  void _api_fill_to_wire_report_payment_failure_details(
+      ReportPaymentFailureDetails apiObj, wire_ReportPaymentFailureDetails wireObj) {
+    wireObj.payment_hash = api2wire_String(apiObj.paymentHash);
+    wireObj.comment = api2wire_opt_String(apiObj.comment);
   }
 
   void _api_fill_to_wire_reverse_swap_fees_request(
@@ -4750,6 +4880,34 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_lnurl_auth =
       _wire_lnurl_authPtr.asFunction<void Function(int, ffi.Pointer<wire_LnUrlAuthRequestData>)>();
 
+  void wire_service_health_check(
+    int port_,
+  ) {
+    return _wire_service_health_check(
+      port_,
+    );
+  }
+
+  late final _wire_service_health_checkPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_service_health_check');
+  late final _wire_service_health_check = _wire_service_health_checkPtr.asFunction<void Function(int)>();
+
+  void wire_report_issue(
+    int port_,
+    ffi.Pointer<wire_ReportIssueRequest> req,
+  ) {
+    return _wire_report_issue(
+      port_,
+      req,
+    );
+  }
+
+  late final _wire_report_issuePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ReportIssueRequest>)>>(
+          'wire_report_issue');
+  late final _wire_report_issue =
+      _wire_report_issuePtr.asFunction<void Function(int, ffi.Pointer<wire_ReportIssueRequest>)>();
+
   void wire_fetch_fiat_rates(
     int port_,
   ) {
@@ -5187,6 +5345,27 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_refund_request_0 =
       _new_box_autoadd_refund_request_0Ptr.asFunction<ffi.Pointer<wire_RefundRequest> Function()>();
 
+  ffi.Pointer<wire_ReportIssueRequest> new_box_autoadd_report_issue_request_0() {
+    return _new_box_autoadd_report_issue_request_0();
+  }
+
+  late final _new_box_autoadd_report_issue_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ReportIssueRequest> Function()>>(
+          'new_box_autoadd_report_issue_request_0');
+  late final _new_box_autoadd_report_issue_request_0 = _new_box_autoadd_report_issue_request_0Ptr
+      .asFunction<ffi.Pointer<wire_ReportIssueRequest> Function()>();
+
+  ffi.Pointer<wire_ReportPaymentFailureDetails> new_box_autoadd_report_payment_failure_details_0() {
+    return _new_box_autoadd_report_payment_failure_details_0();
+  }
+
+  late final _new_box_autoadd_report_payment_failure_details_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ReportPaymentFailureDetails> Function()>>(
+          'new_box_autoadd_report_payment_failure_details_0');
+  late final _new_box_autoadd_report_payment_failure_details_0 =
+      _new_box_autoadd_report_payment_failure_details_0Ptr
+          .asFunction<ffi.Pointer<wire_ReportPaymentFailureDetails> Function()>();
+
   ffi.Pointer<wire_ReverseSwapFeesRequest> new_box_autoadd_reverse_swap_fees_request_0() {
     return _new_box_autoadd_reverse_swap_fees_request_0();
   }
@@ -5319,6 +5498,16 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Pointer<NodeConfigKind> Function()>>('inflate_NodeConfig_Greenlight');
   late final _inflate_NodeConfig_Greenlight =
       _inflate_NodeConfig_GreenlightPtr.asFunction<ffi.Pointer<NodeConfigKind> Function()>();
+
+  ffi.Pointer<ReportIssueRequestKind> inflate_ReportIssueRequest_PaymentFailure() {
+    return _inflate_ReportIssueRequest_PaymentFailure();
+  }
+
+  late final _inflate_ReportIssueRequest_PaymentFailurePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ReportIssueRequestKind> Function()>>(
+          'inflate_ReportIssueRequest_PaymentFailure');
+  late final _inflate_ReportIssueRequest_PaymentFailure = _inflate_ReportIssueRequest_PaymentFailurePtr
+      .asFunction<ffi.Pointer<ReportIssueRequestKind> Function()>();
 
   void free_WireSyncReturn(
     WireSyncReturn ptr,
@@ -5539,6 +5728,27 @@ final class wire_LnUrlAuthRequestData extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> domain;
 
   external ffi.Pointer<wire_uint_8_list> url;
+}
+
+final class wire_ReportPaymentFailureDetails extends ffi.Struct {
+  external ffi.Pointer<wire_uint_8_list> payment_hash;
+
+  external ffi.Pointer<wire_uint_8_list> comment;
+}
+
+final class wire_ReportIssueRequest_PaymentFailure extends ffi.Struct {
+  external ffi.Pointer<wire_ReportPaymentFailureDetails> data;
+}
+
+final class ReportIssueRequestKind extends ffi.Union {
+  external ffi.Pointer<wire_ReportIssueRequest_PaymentFailure> PaymentFailure;
+}
+
+final class wire_ReportIssueRequest extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external ffi.Pointer<ReportIssueRequestKind> kind;
 }
 
 final class wire_SendOnchainRequest extends ffi.Struct {

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -4661,6 +4661,211 @@ abstract class PaymentDetails_ClosedChannel implements PaymentDetails {
 }
 
 /// @nodoc
+mixin _$ReportIssueRequest {
+  ReportPaymentFailureDetails get data => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ReportPaymentFailureDetails data) paymentFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ReportPaymentFailureDetails data)? paymentFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ReportPaymentFailureDetails data)? paymentFailure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReportIssueRequest_PaymentFailure value) paymentFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReportIssueRequest_PaymentFailure value)? paymentFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReportIssueRequest_PaymentFailure value)? paymentFailure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReportIssueRequestCopyWith<ReportIssueRequest> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReportIssueRequestCopyWith<$Res> {
+  factory $ReportIssueRequestCopyWith(ReportIssueRequest value, $Res Function(ReportIssueRequest) then) =
+      _$ReportIssueRequestCopyWithImpl<$Res, ReportIssueRequest>;
+  @useResult
+  $Res call({ReportPaymentFailureDetails data});
+}
+
+/// @nodoc
+class _$ReportIssueRequestCopyWithImpl<$Res, $Val extends ReportIssueRequest>
+    implements $ReportIssueRequestCopyWith<$Res> {
+  _$ReportIssueRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+  }) {
+    return _then(_value.copyWith(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as ReportPaymentFailureDetails,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ReportIssueRequest_PaymentFailureImplCopyWith<$Res>
+    implements $ReportIssueRequestCopyWith<$Res> {
+  factory _$$ReportIssueRequest_PaymentFailureImplCopyWith(_$ReportIssueRequest_PaymentFailureImpl value,
+          $Res Function(_$ReportIssueRequest_PaymentFailureImpl) then) =
+      __$$ReportIssueRequest_PaymentFailureImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({ReportPaymentFailureDetails data});
+}
+
+/// @nodoc
+class __$$ReportIssueRequest_PaymentFailureImplCopyWithImpl<$Res>
+    extends _$ReportIssueRequestCopyWithImpl<$Res, _$ReportIssueRequest_PaymentFailureImpl>
+    implements _$$ReportIssueRequest_PaymentFailureImplCopyWith<$Res> {
+  __$$ReportIssueRequest_PaymentFailureImplCopyWithImpl(_$ReportIssueRequest_PaymentFailureImpl _value,
+      $Res Function(_$ReportIssueRequest_PaymentFailureImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+  }) {
+    return _then(_$ReportIssueRequest_PaymentFailureImpl(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as ReportPaymentFailureDetails,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReportIssueRequest_PaymentFailureImpl implements ReportIssueRequest_PaymentFailure {
+  const _$ReportIssueRequest_PaymentFailureImpl({required this.data});
+
+  @override
+  final ReportPaymentFailureDetails data;
+
+  @override
+  String toString() {
+    return 'ReportIssueRequest.paymentFailure(data: $data)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReportIssueRequest_PaymentFailureImpl &&
+            (identical(other.data, data) || other.data == data));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, data);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReportIssueRequest_PaymentFailureImplCopyWith<_$ReportIssueRequest_PaymentFailureImpl> get copyWith =>
+      __$$ReportIssueRequest_PaymentFailureImplCopyWithImpl<_$ReportIssueRequest_PaymentFailureImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ReportPaymentFailureDetails data) paymentFailure,
+  }) {
+    return paymentFailure(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ReportPaymentFailureDetails data)? paymentFailure,
+  }) {
+    return paymentFailure?.call(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ReportPaymentFailureDetails data)? paymentFailure,
+    required TResult orElse(),
+  }) {
+    if (paymentFailure != null) {
+      return paymentFailure(data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReportIssueRequest_PaymentFailure value) paymentFailure,
+  }) {
+    return paymentFailure(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReportIssueRequest_PaymentFailure value)? paymentFailure,
+  }) {
+    return paymentFailure?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReportIssueRequest_PaymentFailure value)? paymentFailure,
+    required TResult orElse(),
+  }) {
+    if (paymentFailure != null) {
+      return paymentFailure(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ReportIssueRequest_PaymentFailure implements ReportIssueRequest {
+  const factory ReportIssueRequest_PaymentFailure({required final ReportPaymentFailureDetails data}) =
+      _$ReportIssueRequest_PaymentFailureImpl;
+
+  @override
+  ReportPaymentFailureDetails get data;
+  @override
+  @JsonKey(ignore: true)
+  _$$ReportIssueRequest_PaymentFailureImplCopyWith<_$ReportIssueRequest_PaymentFailureImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$SuccessActionProcessed {
   Object get data => throw _privateConstructorUsedError;
   @optionalTypeArgs

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -2392,6 +2392,42 @@ fun asRefundResponseList(arr: ReadableArray): List<RefundResponse> {
     return list
 }
 
+fun asReportPaymentFailureDetails(reportPaymentFailureDetails: ReadableMap): ReportPaymentFailureDetails? {
+    if (!validateMandatoryFields(
+            reportPaymentFailureDetails,
+            arrayOf(
+                "paymentHash",
+            ),
+        )
+    ) {
+        return null
+    }
+    val paymentHash = reportPaymentFailureDetails.getString("paymentHash")!!
+    val comment = if (hasNonNullKey(reportPaymentFailureDetails, "comment")) reportPaymentFailureDetails.getString("comment") else null
+    return ReportPaymentFailureDetails(
+        paymentHash,
+        comment,
+    )
+}
+
+fun readableMapOf(reportPaymentFailureDetails: ReportPaymentFailureDetails): ReadableMap {
+    return readableMapOf(
+        "paymentHash" to reportPaymentFailureDetails.paymentHash,
+        "comment" to reportPaymentFailureDetails.comment,
+    )
+}
+
+fun asReportPaymentFailureDetailsList(arr: ReadableArray): List<ReportPaymentFailureDetails> {
+    val list = ArrayList<ReportPaymentFailureDetails>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asReportPaymentFailureDetails(value)!!)
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+        }
+    }
+    return list
+}
+
 fun asReverseSwapFeesRequest(reverseSwapFeesRequest: ReadableMap): ReverseSwapFeesRequest? {
     if (!validateMandatoryFields(
             reverseSwapFeesRequest,
@@ -2814,6 +2850,39 @@ fun asSendSpontaneousPaymentRequestList(arr: ReadableArray): List<SendSpontaneou
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendSpontaneousPaymentRequest(value)!!)
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+        }
+    }
+    return list
+}
+
+fun asServiceHealthCheckResponse(serviceHealthCheckResponse: ReadableMap): ServiceHealthCheckResponse? {
+    if (!validateMandatoryFields(
+            serviceHealthCheckResponse,
+            arrayOf(
+                "status",
+            ),
+        )
+    ) {
+        return null
+    }
+    val status = serviceHealthCheckResponse.getString("status")?.let { asHealthCheckStatus(it) }!!
+    return ServiceHealthCheckResponse(
+        status,
+    )
+}
+
+fun readableMapOf(serviceHealthCheckResponse: ServiceHealthCheckResponse): ReadableMap {
+    return readableMapOf(
+        "status" to serviceHealthCheckResponse.status.name.lowercase(),
+    )
+}
+
+fun asServiceHealthCheckResponseList(arr: ReadableArray): List<ServiceHealthCheckResponse> {
+    val list = ArrayList<ServiceHealthCheckResponse>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asServiceHealthCheckResponse(value)!!)
             else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }
@@ -3409,6 +3478,21 @@ fun asFeeratePresetList(arr: ReadableArray): List<FeeratePreset> {
     return list
 }
 
+fun asHealthCheckStatus(type: String): HealthCheckStatus {
+    return HealthCheckStatus.valueOf(type.uppercase())
+}
+
+fun asHealthCheckStatusList(arr: ReadableArray): List<HealthCheckStatus> {
+    val list = ArrayList<HealthCheckStatus>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is String -> list.add(asHealthCheckStatus(value)!!)
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+        }
+    }
+    return list
+}
+
 fun asInputType(inputType: ReadableMap): InputType? {
     val type = inputType.getString("type")
 
@@ -3763,6 +3847,37 @@ fun asPaymentTypeFilterList(arr: ReadableArray): List<PaymentTypeFilter> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asPaymentTypeFilter(value)!!)
+            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+        }
+    }
+    return list
+}
+
+fun asReportIssueRequest(reportIssueRequest: ReadableMap): ReportIssueRequest? {
+    val type = reportIssueRequest.getString("type")
+
+    if (type == "paymentFailure") {
+        return ReportIssueRequest.PaymentFailure(reportIssueRequest.getMap("data")?.let { asReportPaymentFailureDetails(it) }!!)
+    }
+    return null
+}
+
+fun readableMapOf(reportIssueRequest: ReportIssueRequest): ReadableMap? {
+    val map = Arguments.createMap()
+    when (reportIssueRequest) {
+        is ReportIssueRequest.PaymentFailure -> {
+            pushToMap(map, "type", "paymentFailure")
+            pushToMap(map, "data", readableMapOf(reportIssueRequest.data))
+        }
+    }
+    return map
+}
+
+fun asReportIssueRequestList(arr: ReadableArray): List<ReportIssueRequest> {
+    val list = ArrayList<ReportIssueRequest>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asReportIssueRequest(value)!!)
             else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
         }
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -303,6 +303,22 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
+    fun reportIssue(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
+        executor.execute {
+            try {
+                val reqTmp = asReportIssueRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type ReportIssueRequest") }
+                getBreezServices().reportIssue(reqTmp)
+                promise.resolve(readableMapOf("status" to "ok"))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun nodeCredentials(promise: Promise) {
         executor.execute {
             try {
@@ -707,6 +723,18 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
                         throw SdkException.Generic("Missing mandatory field req of type SendOnchainRequest")
                     }
                 val res = getBreezServices().sendOnchain(sendOnchainRequest)
+                promise.resolve(readableMapOf(res))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
+    fun serviceHealthCheck(promise: Promise) {
+        executor.execute {
+            try {
+                val res = getBreezServices().serviceHealthCheck()
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
                 promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2119,6 +2119,40 @@ enum BreezSDKMapper {
         return refundResponseList.map { v -> [String: Any?] in dictionaryOf(refundResponse: v) }
     }
 
+    static func asReportPaymentFailureDetails(reportPaymentFailureDetails: [String: Any?]) throws -> ReportPaymentFailureDetails {
+        guard let paymentHash = reportPaymentFailureDetails["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type ReportPaymentFailureDetails") }
+        let comment = reportPaymentFailureDetails["comment"] as? String
+
+        return ReportPaymentFailureDetails(
+            paymentHash: paymentHash,
+            comment: comment
+        )
+    }
+
+    static func dictionaryOf(reportPaymentFailureDetails: ReportPaymentFailureDetails) -> [String: Any?] {
+        return [
+            "paymentHash": reportPaymentFailureDetails.paymentHash,
+            "comment": reportPaymentFailureDetails.comment == nil ? nil : reportPaymentFailureDetails.comment,
+        ]
+    }
+
+    static func asReportPaymentFailureDetailsList(arr: [Any]) throws -> [ReportPaymentFailureDetails] {
+        var list = [ReportPaymentFailureDetails]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var reportPaymentFailureDetails = try asReportPaymentFailureDetails(reportPaymentFailureDetails: val)
+                list.append(reportPaymentFailureDetails)
+            } else {
+                throw SdkError.Generic(message: "Unexpected type ReportPaymentFailureDetails")
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(reportPaymentFailureDetailsList: [ReportPaymentFailureDetails]) -> [Any] {
+        return reportPaymentFailureDetailsList.map { v -> [String: Any?] in dictionaryOf(reportPaymentFailureDetails: v) }
+    }
+
     static func asReverseSwapFeesRequest(reverseSwapFeesRequest: [String: Any?]) throws -> ReverseSwapFeesRequest {
         let sendAmountSat = reverseSwapFeesRequest["sendAmountSat"] as? UInt64
 
@@ -2493,6 +2527,37 @@ enum BreezSDKMapper {
 
     static func arrayOf(sendSpontaneousPaymentRequestList: [SendSpontaneousPaymentRequest]) -> [Any] {
         return sendSpontaneousPaymentRequestList.map { v -> [String: Any?] in dictionaryOf(sendSpontaneousPaymentRequest: v) }
+    }
+
+    static func asServiceHealthCheckResponse(serviceHealthCheckResponse: [String: Any?]) throws -> ServiceHealthCheckResponse {
+        guard let statusTmp = serviceHealthCheckResponse["status"] as? String else { throw SdkError.Generic(message: "Missing mandatory field status for type ServiceHealthCheckResponse") }
+        let status = try asHealthCheckStatus(healthCheckStatus: statusTmp)
+
+        return ServiceHealthCheckResponse(
+            status: status)
+    }
+
+    static func dictionaryOf(serviceHealthCheckResponse: ServiceHealthCheckResponse) -> [String: Any?] {
+        return [
+            "status": valueOf(healthCheckStatus: serviceHealthCheckResponse.status),
+        ]
+    }
+
+    static func asServiceHealthCheckResponseList(arr: [Any]) throws -> [ServiceHealthCheckResponse] {
+        var list = [ServiceHealthCheckResponse]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var serviceHealthCheckResponse = try asServiceHealthCheckResponse(serviceHealthCheckResponse: val)
+                list.append(serviceHealthCheckResponse)
+            } else {
+                throw SdkError.Generic(message: "Unexpected type ServiceHealthCheckResponse")
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(serviceHealthCheckResponseList: [ServiceHealthCheckResponse]) -> [Any] {
+        return serviceHealthCheckResponseList.map { v -> [String: Any?] in dictionaryOf(serviceHealthCheckResponse: v) }
     }
 
     static func asSignMessageRequest(signMessageRequest: [String: Any?]) throws -> SignMessageRequest {
@@ -3179,6 +3244,51 @@ enum BreezSDKMapper {
         return list
     }
 
+    static func asHealthCheckStatus(healthCheckStatus: String) throws -> HealthCheckStatus {
+        switch healthCheckStatus {
+        case "operational":
+            return HealthCheckStatus.operational
+
+        case "maintenance":
+            return HealthCheckStatus.maintenance
+
+        case "serviceDisruption":
+            return HealthCheckStatus.serviceDisruption
+
+        default: throw SdkError.Generic(message: "Invalid variant \(healthCheckStatus) for enum HealthCheckStatus")
+        }
+    }
+
+    static func valueOf(healthCheckStatus: HealthCheckStatus) -> String {
+        switch healthCheckStatus {
+        case .operational:
+            return "operational"
+
+        case .maintenance:
+            return "maintenance"
+
+        case .serviceDisruption:
+            return "serviceDisruption"
+        }
+    }
+
+    static func arrayOf(healthCheckStatusList: [HealthCheckStatus]) -> [String] {
+        return healthCheckStatusList.map { v -> String in valueOf(healthCheckStatus: v) }
+    }
+
+    static func asHealthCheckStatusList(arr: [Any]) throws -> [HealthCheckStatus] {
+        var list = [HealthCheckStatus]()
+        for value in arr {
+            if let val = value as? String {
+                var healthCheckStatus = try asHealthCheckStatus(healthCheckStatus: val)
+                list.append(healthCheckStatus)
+            } else {
+                throw SdkError.Generic(message: "Unexpected type HealthCheckStatus")
+            }
+        }
+        return list
+    }
+
     static func asInputType(inputType: [String: Any?]) throws -> InputType {
         let type = inputType["type"] as! String
         if type == "bitcoinAddress" {
@@ -3805,6 +3915,47 @@ enum BreezSDKMapper {
                 list.append(paymentTypeFilter)
             } else {
                 throw SdkError.Generic(message: "Unexpected type PaymentTypeFilter")
+            }
+        }
+        return list
+    }
+
+    static func asReportIssueRequest(reportIssueRequest: [String: Any?]) throws -> ReportIssueRequest {
+        let type = reportIssueRequest["type"] as! String
+        if type == "paymentFailure" {
+            guard let dataTmp = reportIssueRequest["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type ReportIssueRequest") }
+            let _data = try asReportPaymentFailureDetails(reportPaymentFailureDetails: dataTmp)
+
+            return ReportIssueRequest.paymentFailure(data: _data)
+        }
+
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum ReportIssueRequest")
+    }
+
+    static func dictionaryOf(reportIssueRequest: ReportIssueRequest) -> [String: Any?] {
+        switch reportIssueRequest {
+        case let .paymentFailure(
+            data
+        ):
+            return [
+                "type": "paymentFailure",
+                "data": dictionaryOf(reportPaymentFailureDetails: data),
+            ]
+        }
+    }
+
+    static func arrayOf(reportIssueRequestList: [ReportIssueRequest]) -> [Any] {
+        return reportIssueRequestList.map { v -> [String: Any?] in dictionaryOf(reportIssueRequest: v) }
+    }
+
+    static func asReportIssueRequestList(arr: [Any]) throws -> [ReportIssueRequest] {
+        var list = [ReportIssueRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var reportIssueRequest = try asReportIssueRequest(reportIssueRequest: val)
+                list.append(reportIssueRequest)
+            } else {
+                throw SdkError.Generic(message: "Unexpected type ReportIssueRequest")
             }
         }
         return list

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -89,6 +89,12 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    reportIssue: (NSDictionary*)req
+    resolve: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     nodeCredentials: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )
@@ -239,6 +245,11 @@ RCT_EXTERN_METHOD(
 RCT_EXTERN_METHOD(
     sendOnchain: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
+    serviceHealthCheck: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )
 

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -210,6 +210,17 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
+    @objc(reportIssue:resolve:reject:)
+    func reportIssue(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            let reqTmp = try BreezSDKMapper.asReportIssueRequest(reportIssueRequest: req)
+            try getBreezServices().reportIssue(req: reqTmp)
+            resolve(["status": "ok"])
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(nodeCredentials:reject:)
     func nodeCredentials(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
@@ -515,6 +526,16 @@ class RNBreezSDK: RCTEventEmitter {
             let sendOnchainRequest = try BreezSDKMapper.asSendOnchainRequest(sendOnchainRequest: req)
             var res = try getBreezServices().sendOnchain(req: sendOnchainRequest)
             resolve(BreezSDKMapper.dictionaryOf(sendOnchainResponse: res))
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
+    @objc(serviceHealthCheck:reject:)
+    func serviceHealthCheck(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            var res = try getBreezServices().serviceHealthCheck()
+            resolve(BreezSDKMapper.dictionaryOf(serviceHealthCheckResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -368,6 +368,11 @@ export type RefundResponse = {
     refundTxId: string
 }
 
+export type ReportPaymentFailureDetails = {
+    paymentHash: string
+    comment?: string
+}
+
 export type ReverseSwapFeesRequest = {
     sendAmountSat?: number
 }
@@ -428,6 +433,10 @@ export type SendPaymentResponse = {
 export type SendSpontaneousPaymentRequest = {
     nodeId: string
     amountMsat: number
+}
+
+export type ServiceHealthCheckResponse = {
+    status: HealthCheckStatus
 }
 
 export type SignMessageRequest = {
@@ -553,6 +562,12 @@ export enum FeeratePreset {
     REGULAR = "regular",
     ECONOMY = "economy",
     PRIORITY = "priority"
+}
+
+export enum HealthCheckStatus {
+    OPERATIONAL = "operational",
+    MAINTENANCE = "maintenance",
+    SERVICE_DISRUPTION = "serviceDisruption"
 }
 
 export enum InputTypeVariant {
@@ -690,6 +705,15 @@ export enum PaymentTypeFilter {
     CLOSED_CHANNEL = "closedChannel"
 }
 
+export enum ReportIssueRequestVariant {
+    PAYMENT_FAILURE = "paymentFailure"
+}
+
+export type ReportIssueRequest = {
+    type: ReportIssueRequestVariant.PAYMENT_FAILURE,
+    data: ReportPaymentFailureDetails
+}
+
 export enum ReverseSwapStatus {
     INITIAL = "initial",
     IN_PROGRESS = "inProgress",
@@ -797,6 +821,10 @@ export const withdrawLnurl = async (request: LnUrlWithdrawRequest): Promise<LnUr
 export const lnurlAuth = async (reqData: LnUrlAuthRequestData): Promise<LnUrlCallbackStatus> => {
     const response = await BreezSDK.lnurlAuth(reqData)
     return response
+}
+
+export const reportIssue = async (req: ReportIssueRequest): Promise<void> => {
+    await BreezSDK.reportIssue(req)
 }
 
 export const nodeCredentials = async (): Promise<NodeCredentials | null> => {
@@ -932,6 +960,11 @@ export const maxReverseSwapAmount = async (): Promise<MaxReverseSwapAmountRespon
 
 export const sendOnchain = async (req: SendOnchainRequest): Promise<SendOnchainResponse> => {
     const response = await BreezSDK.sendOnchain(req)
+    return response
+}
+
+export const serviceHealthCheck = async (): Promise<ServiceHealthCheckResponse> => {
+    const response = await BreezSDK.serviceHealthCheck()
     return response
 }
 

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -230,6 +230,15 @@ pub(crate) enum Commands {
         sat_per_vbyte: u32,
     },
 
+    /// Fetches the service health check
+    ServiceHealthCheck {},
+
+    /// Send a payment failure report
+    ReportPaymentFailure {
+        payment_hash: String,
+        comment: Option<String>,
+    },
+
     /// Execute a low level node command (used for debugging)
     ExecuteDevCommand {
         command: String,


### PR DESCRIPTION
This PR adds an issue reporting interface to initially support reporting payment failures to the Support API.

I have implemented a generic reporting interface to allow it to extended later by adding extra variants on the req enum param. Perhaps with the option to support reporting other issues around service availability, lsp or swap failures.

Depends on breez/server#35
Fixes #618