### PR TITLE
Validate selected LSP

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -917,15 +917,18 @@ impl BreezServices {
         Ok(())
     }
 
-    /// Connects to the selected LSP peer. If none is selected, this selects the first one from [`list_lsps`] and persists the selection.
+    /// Connects to the selected LSP peer.
+    /// This validates if the selected LSP is still in [`list_lsps`].
+    /// If not or no LSP is selected, it selects the first LSP in [`list_lsps`].
     async fn connect_lsp_peer(&self, node_pubkey: String) -> SdkResult<()> {
-        // Sets the LSP id, if not already set
-        if self.persister.get_lsp_id()?.is_none() {
-            if let Some(lsp) = self.lsp_api.list_lsps(node_pubkey).await?.first().cloned() {
-                self.persister.set_lsp_id(lsp.id)?;
-            }
-        }
-        if let Ok(lsp_info) = self.lsp_info().await {
+        let lsps = self.lsp_api.list_lsps(node_pubkey).await?;
+        let lsp = self
+            .persister
+            .get_lsp_id()?
+            .and_then(|lsp_id| lsps.clone().into_iter().find(|lsp| lsp.id == lsp_id))
+            .or_else(|| lsps.first().cloned());
+        if let Some(lsp_info) = lsp {
+            self.persister.set_lsp_id(lsp_info.id)?;
             let node_id = lsp_info.pubkey;
             let address = lsp_info.host;
             let lsp_connected = self


### PR DESCRIPTION
1. Validate that the selected LSP is still in list_lsps, else select the first LSP in the list. 
2. Only add a route hint if optional short_channel_id is set. This ensures only a route hint is added for channel opening, or if there is an existing channel open with the selected LSP. Route hints are not added for previously used LSPs.

Fixes #634