### PR TITLE
Log full list of payments on trace instead of debug

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1397,7 +1397,7 @@ async fn pull_transactions(
         .list_pays(cln::ListpaysRequest::default())
         .await?
         .into_inner();
-    debug!("list payments: {:?}", payments);
+    trace!("list payments (unfiltered): {:?}", payments);
     // construct the payment transactions (pending and complete)
     let outbound_transactions: NodeResult<Vec<Payment>> = payments
         .pays


### PR DESCRIPTION
This reduces the typical log size for a pulse test from 40-50MB to ~1MB.

Related: #639