### PR TITLE
one command for code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: fmt clippy
+all: fmt clippy codegen
 
 fmt:
 	cd libs && cargo fmt -- --check
@@ -9,3 +9,11 @@ clippy:
 	cd libs && cargo clippy -- -D warnings -A clippy::uninlined-format-args
 	cd libs && cargo clippy --tests -- -D warnings -A clippy::uninlined-format-args
 	cd tools/sdk-cli && cargo clippy -- -D warnings
+
+codegen: flutter-codegen react-native-codegen
+
+flutter-codegen:
+	make -C ./libs/sdk-flutter flutter_rust_bridge
+
+react-native-codegen:
+	make -C ./libs/sdk-react-native react-native-codegen

--- a/libs/sdk-flutter/makefile
+++ b/libs/sdk-flutter/makefile
@@ -6,7 +6,6 @@ OS_NAME=$(shell uname | tr '[:upper:]' '[:lower:]')
 init:
 	cargo install cargo-ndk
 	cargo install cargo-expand
-	cargo install flutter_rust_bridge_codegen --version 1.80.1
 	flutter pub get
 
 ## all: Compile iOS, Android
@@ -16,6 +15,7 @@ all: ios android
 dev: ios-dev android
 
 flutter_rust_bridge:
+	cargo install flutter_rust_bridge_codegen --version 1.80.1
 	flutter_rust_bridge_codegen --dart-format-line-length 110 -r ../sdk-core/src/binding.rs -d lib/bridge_generated.dart -c ios/Classes/bridge_generated.h
 
 ios: $(SOURCES) flutter_rust_bridge


### PR DESCRIPTION
Add the code generation to the root makefile.
Now the sanity check before checking in your code will be running one command in the root folder:
```
make -j$(nproc)
```

That does `fmt`, `clippy`, flutter and react native generation. All in parallel.