### PR TITLE
Remove command "stop" from `disconnect` and NodeAPI trait

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -236,7 +236,6 @@ impl BreezServices {
                 err: format!("Shutdown failed: {e}"),
             })?;
         *started = false;
-        self.node_api.stop().await;
         Ok(())
     }
 

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1323,10 +1323,6 @@ impl NodeAPI for Greenlight {
         debug!("send_custom_message returned status {:?}", resp.status);
         Ok(())
     }
-
-    async fn stop(&self) {
-        _ = self.execute_command(NodeCommand::Stop.to_string()).await;
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -79,7 +79,6 @@ pub trait NodeAPI: Send + Sync {
         amount_msat: u64,
     ) -> NodeResult<PaymentResponse>;
     async fn start(&self) -> NodeResult<String>;
-    async fn stop(&self);
 
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain
     /// Large channels first.

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -430,8 +430,6 @@ impl NodeAPI for MockNodeAPI {
             tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok),
         ))
     }
-
-    async fn stop(&self) {}
 }
 
 impl MockNodeAPI {


### PR DESCRIPTION
As discussed in https://github.com/breez/breez-sdk/pull/612#discussion_r1395572300 , removing the call to `NodeAPI::stop()` from `disconnect` to avoid unpredictable behavior when using the same seed on multiple clients.

Since it's not meant to be called in any service method because of the above, I also removed it from the trait.

`stop` can still be called as a dev command.