### PR TITLE
Validate RN optional field values

### DIFF
--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -34,7 +34,7 @@ fun asAesSuccessActionDataDecryptedList(arr: ReadableArray): List<AesSuccessActi
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asAesSuccessActionDataDecrypted(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -67,7 +67,7 @@ fun asBackupFailedDataList(arr: ReadableArray): List<BackupFailedData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBackupFailedData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -103,7 +103,7 @@ fun asBackupStatusList(arr: ReadableArray): List<BackupStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBackupStatus(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -149,7 +149,7 @@ fun asBitcoinAddressDataList(arr: ReadableArray): List<BitcoinAddressData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBitcoinAddressData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -192,7 +192,7 @@ fun asBuyBitcoinRequestList(arr: ReadableArray): List<BuyBitcoinRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBuyBitcoinRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -235,7 +235,7 @@ fun asBuyBitcoinResponseList(arr: ReadableArray): List<BuyBitcoinResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBuyBitcoinResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -276,7 +276,7 @@ fun asCheckMessageRequestList(arr: ReadableArray): List<CheckMessageRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -309,7 +309,7 @@ fun asCheckMessageResponseList(arr: ReadableArray): List<CheckMessageResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -362,7 +362,7 @@ fun asClosedChannelPaymentDetailsList(arr: ReadableArray): List<ClosedChannelPay
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asClosedChannelPaymentDetails(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -429,7 +429,7 @@ fun asConfigList(arr: ReadableArray): List<Config> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asConfig(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -495,7 +495,7 @@ fun asCurrencyInfoList(arr: ReadableArray): List<CurrencyInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asCurrencyInfo(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -532,7 +532,7 @@ fun asFiatCurrencyList(arr: ReadableArray): List<FiatCurrency> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asFiatCurrency(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -569,7 +569,7 @@ fun asGreenlightCredentialsList(arr: ReadableArray): List<GreenlightCredentials>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asGreenlightCredentials(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -614,7 +614,7 @@ fun asGreenlightNodeConfigList(arr: ReadableArray): List<GreenlightNodeConfig> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asGreenlightNodeConfig(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -654,7 +654,7 @@ fun asInvoicePaidDetailsList(arr: ReadableArray): List<InvoicePaidDetails> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asInvoicePaidDetails(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -728,7 +728,7 @@ fun asLnInvoiceList(arr: ReadableArray): List<LnInvoice> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnInvoice(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -799,7 +799,7 @@ fun asListPaymentsRequestList(arr: ReadableArray): List<ListPaymentsRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asListPaymentsRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -883,7 +883,7 @@ fun asLnPaymentDetailsList(arr: ReadableArray): List<LnPaymentDetails> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnPaymentDetails(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -927,7 +927,7 @@ fun asLnUrlAuthRequestDataList(arr: ReadableArray): List<LnUrlAuthRequestData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlAuthRequestData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -960,7 +960,7 @@ fun asLnUrlErrorDataList(arr: ReadableArray): List<LnUrlErrorData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlErrorData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -997,7 +997,7 @@ fun asLnUrlPayErrorDataList(arr: ReadableArray): List<LnUrlPayErrorData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayErrorData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1037,7 +1037,7 @@ fun asLnUrlPayRequestList(arr: ReadableArray): List<LnUrlPayRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1093,7 +1093,7 @@ fun asLnUrlPayRequestDataList(arr: ReadableArray): List<LnUrlPayRequestData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequestData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1136,7 +1136,7 @@ fun asLnUrlPaySuccessDataList(arr: ReadableArray): List<LnUrlPaySuccessData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPaySuccessData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1176,7 +1176,7 @@ fun asLnUrlWithdrawRequestList(arr: ReadableArray): List<LnUrlWithdrawRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1225,7 +1225,7 @@ fun asLnUrlWithdrawRequestDataList(arr: ReadableArray): List<LnUrlWithdrawReques
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequestData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1258,7 +1258,7 @@ fun asLnUrlWithdrawSuccessDataList(arr: ReadableArray): List<LnUrlWithdrawSucces
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawSuccessData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1298,7 +1298,7 @@ fun asLocaleOverridesList(arr: ReadableArray): List<LocaleOverrides> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLocaleOverrides(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1335,7 +1335,7 @@ fun asLocalizedNameList(arr: ReadableArray): List<LocalizedName> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLocalizedName(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1372,7 +1372,7 @@ fun asLogEntryList(arr: ReadableArray): List<LogEntry> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLogEntry(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1453,7 +1453,7 @@ fun asLspInformationList(arr: ReadableArray): List<LspInformation> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLspInformation(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1486,7 +1486,7 @@ fun asMaxReverseSwapAmountResponseList(arr: ReadableArray): List<MaxReverseSwapA
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asMaxReverseSwapAmountResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1519,7 +1519,7 @@ fun asMessageSuccessActionDataList(arr: ReadableArray): List<MessageSuccessActio
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asMessageSuccessActionData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1556,7 +1556,7 @@ fun asMetadataItemList(arr: ReadableArray): List<MetadataItem> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asMetadataItem(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1629,7 +1629,7 @@ fun asNodeStateList(arr: ReadableArray): List<NodeState> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asNodeState(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1665,7 +1665,7 @@ fun asOpenChannelFeeRequestList(arr: ReadableArray): List<OpenChannelFeeRequest>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpenChannelFeeRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1708,7 +1708,7 @@ fun asOpenChannelFeeResponseList(arr: ReadableArray): List<OpenChannelFeeRespons
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpenChannelFeeResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1761,7 +1761,7 @@ fun asOpeningFeeParamsList(arr: ReadableArray): List<OpeningFeeParams> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpeningFeeParams(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1794,7 +1794,7 @@ fun asOpeningFeeParamsMenuList(arr: ReadableArray): List<OpeningFeeParamsMenu> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asOpeningFeeParamsMenu(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1854,7 +1854,7 @@ fun asPaymentList(arr: ReadableArray): List<Payment> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPayment(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1894,7 +1894,7 @@ fun asPaymentFailedDataList(arr: ReadableArray): List<PaymentFailedData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPaymentFailedData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1935,7 +1935,7 @@ fun asPrepareRefundRequestList(arr: ReadableArray): List<PrepareRefundRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -1972,7 +1972,7 @@ fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2009,7 +2009,7 @@ fun asPrepareSweepRequestList(arr: ReadableArray): List<PrepareSweepRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSweepRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2046,7 +2046,7 @@ fun asPrepareSweepResponseList(arr: ReadableArray): List<PrepareSweepResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSweepResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2083,7 +2083,7 @@ fun asRateList(arr: ReadableArray): List<Rate> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRate(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2125,7 +2125,7 @@ fun asReceiveOnchainRequestList(arr: ReadableArray): List<ReceiveOnchainRequest>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReceiveOnchainRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2204,7 +2204,7 @@ fun asReceivePaymentRequestList(arr: ReadableArray): List<ReceivePaymentRequest>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2263,7 +2263,7 @@ fun asReceivePaymentResponseList(arr: ReadableArray): List<ReceivePaymentRespons
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2312,7 +2312,7 @@ fun asRecommendedFeesList(arr: ReadableArray): List<RecommendedFees> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRecommendedFees(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2353,7 +2353,7 @@ fun asRefundRequestList(arr: ReadableArray): List<RefundRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRefundRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2386,7 +2386,7 @@ fun asRefundResponseList(arr: ReadableArray): List<RefundResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRefundResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2422,7 +2422,7 @@ fun asReportPaymentFailureDetailsList(arr: ReadableArray): List<ReportPaymentFai
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReportPaymentFailureDetails(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2462,7 +2462,7 @@ fun asReverseSwapFeesRequestList(arr: ReadableArray): List<ReverseSwapFeesReques
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReverseSwapFeesRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2513,7 +2513,7 @@ fun asReverseSwapInfoList(arr: ReadableArray): List<ReverseSwapInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReverseSwapInfo(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2578,7 +2578,7 @@ fun asReverseSwapPairInfoList(arr: ReadableArray): List<ReverseSwapPairInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReverseSwapPairInfo(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2611,7 +2611,7 @@ fun asRouteHintList(arr: ReadableArray): List<RouteHint> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRouteHint(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2666,7 +2666,7 @@ fun asRouteHintHopList(arr: ReadableArray): List<RouteHintHop> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRouteHintHop(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2711,7 +2711,7 @@ fun asSendOnchainRequestList(arr: ReadableArray): List<SendOnchainRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendOnchainRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2744,7 +2744,7 @@ fun asSendOnchainResponseList(arr: ReadableArray): List<SendOnchainResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendOnchainResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2780,7 +2780,7 @@ fun asSendPaymentRequestList(arr: ReadableArray): List<SendPaymentRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2813,7 +2813,7 @@ fun asSendPaymentResponseList(arr: ReadableArray): List<SendPaymentResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2850,7 +2850,7 @@ fun asSendSpontaneousPaymentRequestList(arr: ReadableArray): List<SendSpontaneou
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSendSpontaneousPaymentRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2883,7 +2883,7 @@ fun asServiceHealthCheckResponseList(arr: ReadableArray): List<ServiceHealthChec
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asServiceHealthCheckResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2916,7 +2916,7 @@ fun asSignMessageRequestList(arr: ReadableArray): List<SignMessageRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2949,7 +2949,7 @@ fun asSignMessageResponseList(arr: ReadableArray): List<SignMessageResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -2982,7 +2982,7 @@ fun asStaticBackupRequestList(arr: ReadableArray): List<StaticBackupRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asStaticBackupRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3022,7 +3022,7 @@ fun asStaticBackupResponseList(arr: ReadableArray): List<StaticBackupResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asStaticBackupResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3139,7 +3139,7 @@ fun asSwapInfoList(arr: ReadableArray): List<SwapInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSwapInfo(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3176,7 +3176,7 @@ fun asSweepRequestList(arr: ReadableArray): List<SweepRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSweepRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3209,7 +3209,7 @@ fun asSweepResponseList(arr: ReadableArray): List<SweepResponse> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSweepResponse(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3249,7 +3249,7 @@ fun asSymbolList(arr: ReadableArray): List<Symbol> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSymbol(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3298,7 +3298,7 @@ fun asUnspentTransactionOutputList(arr: ReadableArray): List<UnspentTransactionO
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asUnspentTransactionOutput(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3335,7 +3335,7 @@ fun asUrlSuccessActionDataList(arr: ReadableArray): List<UrlSuccessActionData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asUrlSuccessActionData(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3375,7 +3375,7 @@ fun asAesSuccessActionDataResultList(arr: ReadableArray): List<AesSuccessActionD
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asAesSuccessActionDataResult(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3452,7 +3452,7 @@ fun asBreezEventList(arr: ReadableArray): List<BreezEvent> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asBreezEvent(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3467,7 +3467,7 @@ fun asBuyBitcoinProviderList(arr: ReadableArray): List<BuyBitcoinProvider> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asBuyBitcoinProvider(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3482,7 +3482,7 @@ fun asChannelStateList(arr: ReadableArray): List<ChannelState> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asChannelState(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3497,7 +3497,7 @@ fun asEnvironmentTypeList(arr: ReadableArray): List<EnvironmentType> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asEnvironmentType(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3512,7 +3512,7 @@ fun asFeeratePresetList(arr: ReadableArray): List<FeeratePreset> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asFeeratePreset(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3527,7 +3527,7 @@ fun asHealthCheckStatusList(arr: ReadableArray): List<HealthCheckStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asHealthCheckStatus(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3607,7 +3607,7 @@ fun asInputTypeList(arr: ReadableArray): List<InputType> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asInputType(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3644,7 +3644,7 @@ fun asLnUrlCallbackStatusList(arr: ReadableArray): List<LnUrlCallbackStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlCallbackStatus(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3689,7 +3689,7 @@ fun asLnUrlPayResultList(arr: ReadableArray): List<LnUrlPayResult> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayResult(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3727,7 +3727,7 @@ fun asLnUrlWithdrawResultList(arr: ReadableArray): List<LnUrlWithdrawResult> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawResult(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3742,7 +3742,7 @@ fun asNetworkList(arr: ReadableArray): List<Network> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asNetwork(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3773,7 +3773,7 @@ fun asNodeConfigList(arr: ReadableArray): List<NodeConfig> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asNodeConfig(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3804,7 +3804,7 @@ fun asNodeCredentialsList(arr: ReadableArray): List<NodeCredentials> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asNodeCredentials(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3842,7 +3842,7 @@ fun asPaymentDetailsList(arr: ReadableArray): List<PaymentDetails> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPaymentDetails(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3857,7 +3857,7 @@ fun asPaymentStatusList(arr: ReadableArray): List<PaymentStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asPaymentStatus(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3872,7 +3872,7 @@ fun asPaymentTypeList(arr: ReadableArray): List<PaymentType> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asPaymentType(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3887,7 +3887,7 @@ fun asPaymentTypeFilterList(arr: ReadableArray): List<PaymentTypeFilter> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asPaymentTypeFilter(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3918,7 +3918,7 @@ fun asReportIssueRequestList(arr: ReadableArray): List<ReportIssueRequest> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asReportIssueRequest(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3933,7 +3933,7 @@ fun asReverseSwapStatusList(arr: ReadableArray): List<ReverseSwapStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asReverseSwapStatus(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3978,7 +3978,7 @@ fun asSuccessActionProcessedList(arr: ReadableArray): List<SuccessActionProcesse
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSuccessActionProcessed(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -3993,7 +3993,7 @@ fun asSwapStatusList(arr: ReadableArray): List<SwapStatus> {
     for (value in arr.toArrayList()) {
         when (value) {
             is String -> list.add(asSwapStatus(value)!!)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -4048,7 +4048,7 @@ fun pushToArray(
         is UnspentTransactionOutput -> array.pushMap(readableMapOf(value))
         is Array<*> -> array.pushArray(readableArrayOf(value.asIterable()))
         is List<*> -> array.pushArray(readableArrayOf(value))
-        else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+        else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
     }
 }
 
@@ -4095,7 +4095,7 @@ fun asUByteList(arr: ReadableArray): List<UByte> {
             is Double -> list.add(value.toInt().toUByte())
             is Int -> list.add(value.toUByte())
             is UByte -> list.add(value)
-            else -> throw SdkException.Generic("Unexpected type ${value::class.java.name}")
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
     return list
@@ -4107,4 +4107,19 @@ fun asStringList(arr: ReadableArray): List<String> {
         list.add(value.toString())
     }
     return list
+}
+
+fun errMissingMandatoryField(
+    fieldName: String,
+    typeName: String,
+): String {
+    return "Missing mandatory field $fieldName for type $typeName"
+}
+
+fun errUnexpectedType(typeName: String): String {
+    return "Unexpected type $typeName"
+}
+
+fun errUnexpectedValue(fieldName: String): String {
+    return "Unexpected value for optional field $fieldName"
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -109,7 +109,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         executor.execute {
             try {
                 val envTypeTmp = asEnvironmentType(envType)
-                val nodeConfigTmp = asNodeConfig(nodeConfig) ?: run { throw SdkException.Generic("Missing mandatory field nodeConfig of type NodeConfig") }
+                val nodeConfigTmp = asNodeConfig(nodeConfig) ?: run { throw SdkException.Generic(errMissingMandatoryField("nodeConfig", "NodeConfig")) }
                 val res = defaultConfig(envTypeTmp, apiKey, nodeConfigTmp)
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
 
@@ -130,7 +130,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val staticBackupRequest =
                     asStaticBackupRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type StaticBackupRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "StaticBackupRequest"))
                     }
                 val res = staticBackup(staticBackupRequest)
                 promise.resolve(readableMapOf(res))
@@ -165,7 +165,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         }
 
         try {
-            val configTmp = asConfig(config) ?: run { throw SdkException.Generic("Missing mandatory field config of type Config") }
+            val configTmp = asConfig(config) ?: run { throw SdkException.Generic(errMissingMandatoryField("config", "Config")) }
             val emitter = reactApplicationContext.getJSModule(RCTDeviceEventEmitter::class.java)
 
             ensureWorkingDir(configTmp.workingDir)
@@ -200,7 +200,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val sendPaymentRequest =
                     asSendPaymentRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type SendPaymentRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "SendPaymentRequest"))
                     }
                 val res = getBreezServices().sendPayment(sendPaymentRequest)
                 promise.resolve(readableMapOf(res))
@@ -219,7 +219,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val sendSpontaneousPaymentRequest =
                     asSendSpontaneousPaymentRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type SendSpontaneousPaymentRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "SendSpontaneousPaymentRequest"))
                     }
                 val res = getBreezServices().sendSpontaneousPayment(sendSpontaneousPaymentRequest)
                 promise.resolve(readableMapOf(res))
@@ -238,7 +238,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val receivePaymentRequest =
                     asReceivePaymentRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type ReceivePaymentRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "ReceivePaymentRequest"))
                     }
                 val res = getBreezServices().receivePayment(receivePaymentRequest)
                 promise.resolve(readableMapOf(res))
@@ -255,7 +255,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val lnUrlPayRequest = asLnUrlPayRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type LnUrlPayRequest") }
+                val lnUrlPayRequest = asLnUrlPayRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "LnUrlPayRequest")) }
                 val res = getBreezServices().payLnurl(lnUrlPayRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -273,7 +273,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val lnUrlWithdrawRequest =
                     asLnUrlWithdrawRequest(request) ?: run {
-                        throw SdkException.Generic("Missing mandatory field request of type LnUrlWithdrawRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("request", "LnUrlWithdrawRequest"))
                     }
                 val res = getBreezServices().withdrawLnurl(lnUrlWithdrawRequest)
                 promise.resolve(readableMapOf(res))
@@ -292,7 +292,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val lnUrlAuthRequestData =
                     asLnUrlAuthRequestData(reqData) ?: run {
-                        throw SdkException.Generic("Missing mandatory field reqData of type LnUrlAuthRequestData")
+                        throw SdkException.Generic(errMissingMandatoryField("reqData", "LnUrlAuthRequestData"))
                     }
                 val res = getBreezServices().lnurlAuth(lnUrlAuthRequestData)
                 promise.resolve(readableMapOf(res))
@@ -309,7 +309,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val reqTmp = asReportIssueRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type ReportIssueRequest") }
+                val reqTmp = asReportIssueRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ReportIssueRequest")) }
                 getBreezServices().reportIssue(reqTmp)
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
@@ -351,7 +351,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val signMessageRequest =
                     asSignMessageRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type SignMessageRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "SignMessageRequest"))
                     }
                 val res = getBreezServices().signMessage(signMessageRequest)
                 promise.resolve(readableMapOf(res))
@@ -370,7 +370,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val checkMessageRequest =
                     asCheckMessageRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type CheckMessageRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "CheckMessageRequest"))
                     }
                 val res = getBreezServices().checkMessage(checkMessageRequest)
                 promise.resolve(readableMapOf(res))
@@ -428,7 +428,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val listPaymentsRequest =
                     asListPaymentsRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type ListPaymentsRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "ListPaymentsRequest"))
                     }
                 val res = getBreezServices().listPayments(listPaymentsRequest)
                 promise.resolve(readableArrayOf(res))
@@ -445,7 +445,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val sweepRequest = asSweepRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type SweepRequest") }
+                val sweepRequest = asSweepRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "SweepRequest")) }
                 val res = getBreezServices().sweep(sweepRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -529,7 +529,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val openChannelFeeRequest =
                     asOpenChannelFeeRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type OpenChannelFeeRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "OpenChannelFeeRequest"))
                     }
                 val res = getBreezServices().openChannelFee(openChannelFeeRequest)
                 promise.resolve(readableMapOf(res))
@@ -599,7 +599,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val receiveOnchainRequest =
                     asReceiveOnchainRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type ReceiveOnchainRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "ReceiveOnchainRequest"))
                     }
                 val res = getBreezServices().receiveOnchain(receiveOnchainRequest)
                 promise.resolve(readableMapOf(res))
@@ -642,7 +642,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val prepareRefundRequest =
                     asPrepareRefundRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type PrepareRefundRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "PrepareRefundRequest"))
                     }
                 val res = getBreezServices().prepareRefund(prepareRefundRequest)
                 promise.resolve(readableMapOf(res))
@@ -659,7 +659,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val refundRequest = asRefundRequest(req) ?: run { throw SdkException.Generic("Missing mandatory field req of type RefundRequest") }
+                val refundRequest = asRefundRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "RefundRequest")) }
                 val res = getBreezServices().refund(refundRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -677,7 +677,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val reverseSwapFeesRequest =
                     asReverseSwapFeesRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type ReverseSwapFeesRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "ReverseSwapFeesRequest"))
                     }
                 val res = getBreezServices().fetchReverseSwapFees(reverseSwapFeesRequest)
                 promise.resolve(readableMapOf(res))
@@ -720,7 +720,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val sendOnchainRequest =
                     asSendOnchainRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type SendOnchainRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "SendOnchainRequest"))
                     }
                 val res = getBreezServices().sendOnchain(sendOnchainRequest)
                 promise.resolve(readableMapOf(res))
@@ -788,10 +788,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val buyBitcoinRequest =
-                    asBuyBitcoinRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type BuyBitcoinRequest")
-                    }
+                val buyBitcoinRequest = asBuyBitcoinRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "BuyBitcoinRequest")) }
                 val res = getBreezServices().buyBitcoin(buyBitcoinRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -809,7 +806,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
             try {
                 val prepareSweepRequest =
                     asPrepareSweepRequest(req) ?: run {
-                        throw SdkException.Generic("Missing mandatory field req of type PrepareSweepRequest")
+                        throw SdkException.Generic(errMissingMandatoryField("req", "PrepareSweepRequest"))
                     }
                 val res = getBreezServices().prepareSweep(prepareSweepRequest)
                 promise.resolve(readableMapOf(res))

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -3,8 +3,12 @@ import Foundation
 
 enum BreezSDKMapper {
     static func asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: [String: Any?]) throws -> AesSuccessActionDataDecrypted {
-        guard let description = aesSuccessActionDataDecrypted["description"] as? String else { throw SdkError.Generic(message: "Missing mandatory field description for type AesSuccessActionDataDecrypted") }
-        guard let plaintext = aesSuccessActionDataDecrypted["plaintext"] as? String else { throw SdkError.Generic(message: "Missing mandatory field plaintext for type AesSuccessActionDataDecrypted") }
+        guard let description = aesSuccessActionDataDecrypted["description"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "AesSuccessActionDataDecrypted"))
+        }
+        guard let plaintext = aesSuccessActionDataDecrypted["plaintext"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "plaintext", typeName: "AesSuccessActionDataDecrypted"))
+        }
 
         return AesSuccessActionDataDecrypted(
             description: description,
@@ -26,7 +30,7 @@ enum BreezSDKMapper {
                 var aesSuccessActionDataDecrypted = try asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: val)
                 list.append(aesSuccessActionDataDecrypted)
             } else {
-                throw SdkError.Generic(message: "Unexpected type AesSuccessActionDataDecrypted")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionDataDecrypted"))
             }
         }
         return list
@@ -37,7 +41,9 @@ enum BreezSDKMapper {
     }
 
     static func asBackupFailedData(backupFailedData: [String: Any?]) throws -> BackupFailedData {
-        guard let error = backupFailedData["error"] as? String else { throw SdkError.Generic(message: "Missing mandatory field error for type BackupFailedData") }
+        guard let error = backupFailedData["error"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "error", typeName: "BackupFailedData"))
+        }
 
         return BackupFailedData(
             error: error)
@@ -56,7 +62,7 @@ enum BreezSDKMapper {
                 var backupFailedData = try asBackupFailedData(backupFailedData: val)
                 list.append(backupFailedData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type BackupFailedData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "BackupFailedData"))
             }
         }
         return list
@@ -67,8 +73,16 @@ enum BreezSDKMapper {
     }
 
     static func asBackupStatus(backupStatus: [String: Any?]) throws -> BackupStatus {
-        guard let backedUp = backupStatus["backedUp"] as? Bool else { throw SdkError.Generic(message: "Missing mandatory field backedUp for type BackupStatus") }
-        let lastBackupTime = backupStatus["lastBackupTime"] as? UInt64
+        guard let backedUp = backupStatus["backedUp"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "backedUp", typeName: "BackupStatus"))
+        }
+        var lastBackupTime: UInt64?
+        if hasNonNilKey(data: backupStatus, key: "lastBackupTime") {
+            guard let lastBackupTimeTmp = backupStatus["lastBackupTime"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lastBackupTime"))
+            }
+            lastBackupTime = lastBackupTimeTmp
+        }
 
         return BackupStatus(
             backedUp: backedUp,
@@ -90,7 +104,7 @@ enum BreezSDKMapper {
                 var backupStatus = try asBackupStatus(backupStatus: val)
                 list.append(backupStatus)
             } else {
-                throw SdkError.Generic(message: "Unexpected type BackupStatus")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "BackupStatus"))
             }
         }
         return list
@@ -101,13 +115,35 @@ enum BreezSDKMapper {
     }
 
     static func asBitcoinAddressData(bitcoinAddressData: [String: Any?]) throws -> BitcoinAddressData {
-        guard let address = bitcoinAddressData["address"] as? String else { throw SdkError.Generic(message: "Missing mandatory field address for type BitcoinAddressData") }
-        guard let networkTmp = bitcoinAddressData["network"] as? String else { throw SdkError.Generic(message: "Missing mandatory field network for type BitcoinAddressData") }
+        guard let address = bitcoinAddressData["address"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "BitcoinAddressData"))
+        }
+        guard let networkTmp = bitcoinAddressData["network"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "BitcoinAddressData"))
+        }
         let network = try asNetwork(network: networkTmp)
 
-        let amountSat = bitcoinAddressData["amountSat"] as? UInt64
-        let label = bitcoinAddressData["label"] as? String
-        let message = bitcoinAddressData["message"] as? String
+        var amountSat: UInt64?
+        if hasNonNilKey(data: bitcoinAddressData, key: "amountSat") {
+            guard let amountSatTmp = bitcoinAddressData["amountSat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "amountSat"))
+            }
+            amountSat = amountSatTmp
+        }
+        var label: String?
+        if hasNonNilKey(data: bitcoinAddressData, key: "label") {
+            guard let labelTmp = bitcoinAddressData["label"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "label"))
+            }
+            label = labelTmp
+        }
+        var message: String?
+        if hasNonNilKey(data: bitcoinAddressData, key: "message") {
+            guard let messageTmp = bitcoinAddressData["message"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "message"))
+            }
+            message = messageTmp
+        }
 
         return BitcoinAddressData(
             address: address,
@@ -135,7 +171,7 @@ enum BreezSDKMapper {
                 var bitcoinAddressData = try asBitcoinAddressData(bitcoinAddressData: val)
                 list.append(bitcoinAddressData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type BitcoinAddressData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "BitcoinAddressData"))
             }
         }
         return list
@@ -146,7 +182,9 @@ enum BreezSDKMapper {
     }
 
     static func asBuyBitcoinRequest(buyBitcoinRequest: [String: Any?]) throws -> BuyBitcoinRequest {
-        guard let providerTmp = buyBitcoinRequest["provider"] as? String else { throw SdkError.Generic(message: "Missing mandatory field provider for type BuyBitcoinRequest") }
+        guard let providerTmp = buyBitcoinRequest["provider"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "provider", typeName: "BuyBitcoinRequest"))
+        }
         let provider = try asBuyBitcoinProvider(buyBitcoinProvider: providerTmp)
 
         var openingFeeParams: OpeningFeeParams?
@@ -174,7 +212,7 @@ enum BreezSDKMapper {
                 var buyBitcoinRequest = try asBuyBitcoinRequest(buyBitcoinRequest: val)
                 list.append(buyBitcoinRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type BuyBitcoinRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "BuyBitcoinRequest"))
             }
         }
         return list
@@ -185,7 +223,9 @@ enum BreezSDKMapper {
     }
 
     static func asBuyBitcoinResponse(buyBitcoinResponse: [String: Any?]) throws -> BuyBitcoinResponse {
-        guard let url = buyBitcoinResponse["url"] as? String else { throw SdkError.Generic(message: "Missing mandatory field url for type BuyBitcoinResponse") }
+        guard let url = buyBitcoinResponse["url"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "BuyBitcoinResponse"))
+        }
         var openingFeeParams: OpeningFeeParams?
         if let openingFeeParamsTmp = buyBitcoinResponse["openingFeeParams"] as? [String: Any?] {
             openingFeeParams = try asOpeningFeeParams(openingFeeParams: openingFeeParamsTmp)
@@ -211,7 +251,7 @@ enum BreezSDKMapper {
                 var buyBitcoinResponse = try asBuyBitcoinResponse(buyBitcoinResponse: val)
                 list.append(buyBitcoinResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type BuyBitcoinResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "BuyBitcoinResponse"))
             }
         }
         return list
@@ -222,9 +262,15 @@ enum BreezSDKMapper {
     }
 
     static func asCheckMessageRequest(checkMessageRequest: [String: Any?]) throws -> CheckMessageRequest {
-        guard let message = checkMessageRequest["message"] as? String else { throw SdkError.Generic(message: "Missing mandatory field message for type CheckMessageRequest") }
-        guard let pubkey = checkMessageRequest["pubkey"] as? String else { throw SdkError.Generic(message: "Missing mandatory field pubkey for type CheckMessageRequest") }
-        guard let signature = checkMessageRequest["signature"] as? String else { throw SdkError.Generic(message: "Missing mandatory field signature for type CheckMessageRequest") }
+        guard let message = checkMessageRequest["message"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "CheckMessageRequest"))
+        }
+        guard let pubkey = checkMessageRequest["pubkey"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pubkey", typeName: "CheckMessageRequest"))
+        }
+        guard let signature = checkMessageRequest["signature"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "signature", typeName: "CheckMessageRequest"))
+        }
 
         return CheckMessageRequest(
             message: message,
@@ -248,7 +294,7 @@ enum BreezSDKMapper {
                 var checkMessageRequest = try asCheckMessageRequest(checkMessageRequest: val)
                 list.append(checkMessageRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type CheckMessageRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "CheckMessageRequest"))
             }
         }
         return list
@@ -259,7 +305,9 @@ enum BreezSDKMapper {
     }
 
     static func asCheckMessageResponse(checkMessageResponse: [String: Any?]) throws -> CheckMessageResponse {
-        guard let isValid = checkMessageResponse["isValid"] as? Bool else { throw SdkError.Generic(message: "Missing mandatory field isValid for type CheckMessageResponse") }
+        guard let isValid = checkMessageResponse["isValid"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "isValid", typeName: "CheckMessageResponse"))
+        }
 
         return CheckMessageResponse(
             isValid: isValid)
@@ -278,7 +326,7 @@ enum BreezSDKMapper {
                 var checkMessageResponse = try asCheckMessageResponse(checkMessageResponse: val)
                 list.append(checkMessageResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type CheckMessageResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "CheckMessageResponse"))
             }
         }
         return list
@@ -289,12 +337,24 @@ enum BreezSDKMapper {
     }
 
     static func asClosedChannelPaymentDetails(closedChannelPaymentDetails: [String: Any?]) throws -> ClosedChannelPaymentDetails {
-        guard let shortChannelId = closedChannelPaymentDetails["shortChannelId"] as? String else { throw SdkError.Generic(message: "Missing mandatory field shortChannelId for type ClosedChannelPaymentDetails") }
-        guard let stateTmp = closedChannelPaymentDetails["state"] as? String else { throw SdkError.Generic(message: "Missing mandatory field state for type ClosedChannelPaymentDetails") }
+        guard let shortChannelId = closedChannelPaymentDetails["shortChannelId"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "shortChannelId", typeName: "ClosedChannelPaymentDetails"))
+        }
+        guard let stateTmp = closedChannelPaymentDetails["state"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "state", typeName: "ClosedChannelPaymentDetails"))
+        }
         let state = try asChannelState(channelState: stateTmp)
 
-        guard let fundingTxid = closedChannelPaymentDetails["fundingTxid"] as? String else { throw SdkError.Generic(message: "Missing mandatory field fundingTxid for type ClosedChannelPaymentDetails") }
-        let closingTxid = closedChannelPaymentDetails["closingTxid"] as? String
+        guard let fundingTxid = closedChannelPaymentDetails["fundingTxid"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fundingTxid", typeName: "ClosedChannelPaymentDetails"))
+        }
+        var closingTxid: String?
+        if hasNonNilKey(data: closedChannelPaymentDetails, key: "closingTxid") {
+            guard let closingTxidTmp = closedChannelPaymentDetails["closingTxid"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "closingTxid"))
+            }
+            closingTxid = closingTxidTmp
+        }
 
         return ClosedChannelPaymentDetails(
             shortChannelId: shortChannelId,
@@ -320,7 +380,7 @@ enum BreezSDKMapper {
                 var closedChannelPaymentDetails = try asClosedChannelPaymentDetails(closedChannelPaymentDetails: val)
                 list.append(closedChannelPaymentDetails)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ClosedChannelPaymentDetails")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ClosedChannelPaymentDetails"))
             }
         }
         return list
@@ -331,18 +391,46 @@ enum BreezSDKMapper {
     }
 
     static func asConfig(config: [String: Any?]) throws -> Config {
-        guard let breezserver = config["breezserver"] as? String else { throw SdkError.Generic(message: "Missing mandatory field breezserver for type Config") }
-        guard let mempoolspaceUrl = config["mempoolspaceUrl"] as? String else { throw SdkError.Generic(message: "Missing mandatory field mempoolspaceUrl for type Config") }
-        guard let workingDir = config["workingDir"] as? String else { throw SdkError.Generic(message: "Missing mandatory field workingDir for type Config") }
-        guard let networkTmp = config["network"] as? String else { throw SdkError.Generic(message: "Missing mandatory field network for type Config") }
+        guard let breezserver = config["breezserver"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "breezserver", typeName: "Config"))
+        }
+        guard let mempoolspaceUrl = config["mempoolspaceUrl"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "mempoolspaceUrl", typeName: "Config"))
+        }
+        guard let workingDir = config["workingDir"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "workingDir", typeName: "Config"))
+        }
+        guard let networkTmp = config["network"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "Config"))
+        }
         let network = try asNetwork(network: networkTmp)
 
-        guard let paymentTimeoutSec = config["paymentTimeoutSec"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field paymentTimeoutSec for type Config") }
-        let defaultLspId = config["defaultLspId"] as? String
-        let apiKey = config["apiKey"] as? String
-        guard let maxfeePercent = config["maxfeePercent"] as? Double else { throw SdkError.Generic(message: "Missing mandatory field maxfeePercent for type Config") }
-        guard let exemptfeeMsat = config["exemptfeeMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field exemptfeeMsat for type Config") }
-        guard let nodeConfigTmp = config["nodeConfig"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field nodeConfig for type Config") }
+        guard let paymentTimeoutSec = config["paymentTimeoutSec"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTimeoutSec", typeName: "Config"))
+        }
+        var defaultLspId: String?
+        if hasNonNilKey(data: config, key: "defaultLspId") {
+            guard let defaultLspIdTmp = config["defaultLspId"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "defaultLspId"))
+            }
+            defaultLspId = defaultLspIdTmp
+        }
+        var apiKey: String?
+        if hasNonNilKey(data: config, key: "apiKey") {
+            guard let apiKeyTmp = config["apiKey"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "apiKey"))
+            }
+            apiKey = apiKeyTmp
+        }
+        guard let maxfeePercent = config["maxfeePercent"] as? Double else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxfeePercent", typeName: "Config"))
+        }
+        guard let exemptfeeMsat = config["exemptfeeMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "exemptfeeMsat", typeName: "Config"))
+        }
+        guard let nodeConfigTmp = config["nodeConfig"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "nodeConfig", typeName: "Config"))
+        }
         let nodeConfig = try asNodeConfig(nodeConfig: nodeConfigTmp)
 
         return Config(
@@ -381,7 +469,7 @@ enum BreezSDKMapper {
                 var config = try asConfig(config: val)
                 list.append(config)
             } else {
-                throw SdkError.Generic(message: "Unexpected type Config")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "Config"))
             }
         }
         return list
@@ -392,9 +480,19 @@ enum BreezSDKMapper {
     }
 
     static func asCurrencyInfo(currencyInfo: [String: Any?]) throws -> CurrencyInfo {
-        guard let name = currencyInfo["name"] as? String else { throw SdkError.Generic(message: "Missing mandatory field name for type CurrencyInfo") }
-        guard let fractionSize = currencyInfo["fractionSize"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field fractionSize for type CurrencyInfo") }
-        let spacing = currencyInfo["spacing"] as? UInt32
+        guard let name = currencyInfo["name"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "CurrencyInfo"))
+        }
+        guard let fractionSize = currencyInfo["fractionSize"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fractionSize", typeName: "CurrencyInfo"))
+        }
+        var spacing: UInt32?
+        if hasNonNilKey(data: currencyInfo, key: "spacing") {
+            guard let spacingTmp = currencyInfo["spacing"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "spacing"))
+            }
+            spacing = spacingTmp
+        }
         var symbol: Symbol?
         if let symbolTmp = currencyInfo["symbol"] as? [String: Any?] {
             symbol = try asSymbol(symbol: symbolTmp)
@@ -445,7 +543,7 @@ enum BreezSDKMapper {
                 var currencyInfo = try asCurrencyInfo(currencyInfo: val)
                 list.append(currencyInfo)
             } else {
-                throw SdkError.Generic(message: "Unexpected type CurrencyInfo")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "CurrencyInfo"))
             }
         }
         return list
@@ -456,8 +554,12 @@ enum BreezSDKMapper {
     }
 
     static func asFiatCurrency(fiatCurrency: [String: Any?]) throws -> FiatCurrency {
-        guard let id = fiatCurrency["id"] as? String else { throw SdkError.Generic(message: "Missing mandatory field id for type FiatCurrency") }
-        guard let infoTmp = fiatCurrency["info"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field info for type FiatCurrency") }
+        guard let id = fiatCurrency["id"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "FiatCurrency"))
+        }
+        guard let infoTmp = fiatCurrency["info"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "info", typeName: "FiatCurrency"))
+        }
         let info = try asCurrencyInfo(currencyInfo: infoTmp)
 
         return FiatCurrency(
@@ -480,7 +582,7 @@ enum BreezSDKMapper {
                 var fiatCurrency = try asFiatCurrency(fiatCurrency: val)
                 list.append(fiatCurrency)
             } else {
-                throw SdkError.Generic(message: "Unexpected type FiatCurrency")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "FiatCurrency"))
             }
         }
         return list
@@ -491,8 +593,12 @@ enum BreezSDKMapper {
     }
 
     static func asGreenlightCredentials(greenlightCredentials: [String: Any?]) throws -> GreenlightCredentials {
-        guard let deviceKey = greenlightCredentials["deviceKey"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field deviceKey for type GreenlightCredentials") }
-        guard let deviceCert = greenlightCredentials["deviceCert"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field deviceCert for type GreenlightCredentials") }
+        guard let deviceKey = greenlightCredentials["deviceKey"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "deviceKey", typeName: "GreenlightCredentials"))
+        }
+        guard let deviceCert = greenlightCredentials["deviceCert"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "deviceCert", typeName: "GreenlightCredentials"))
+        }
 
         return GreenlightCredentials(
             deviceKey: deviceKey,
@@ -514,7 +620,7 @@ enum BreezSDKMapper {
                 var greenlightCredentials = try asGreenlightCredentials(greenlightCredentials: val)
                 list.append(greenlightCredentials)
             } else {
-                throw SdkError.Generic(message: "Unexpected type GreenlightCredentials")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "GreenlightCredentials"))
             }
         }
         return list
@@ -530,7 +636,13 @@ enum BreezSDKMapper {
             partnerCredentials = try asGreenlightCredentials(greenlightCredentials: partnerCredentialsTmp)
         }
 
-        let inviteCode = greenlightNodeConfig["inviteCode"] as? String
+        var inviteCode: String?
+        if hasNonNilKey(data: greenlightNodeConfig, key: "inviteCode") {
+            guard let inviteCodeTmp = greenlightNodeConfig["inviteCode"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "inviteCode"))
+            }
+            inviteCode = inviteCodeTmp
+        }
 
         return GreenlightNodeConfig(
             partnerCredentials: partnerCredentials,
@@ -552,7 +664,7 @@ enum BreezSDKMapper {
                 var greenlightNodeConfig = try asGreenlightNodeConfig(greenlightNodeConfig: val)
                 list.append(greenlightNodeConfig)
             } else {
-                throw SdkError.Generic(message: "Unexpected type GreenlightNodeConfig")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "GreenlightNodeConfig"))
             }
         }
         return list
@@ -563,8 +675,12 @@ enum BreezSDKMapper {
     }
 
     static func asInvoicePaidDetails(invoicePaidDetails: [String: Any?]) throws -> InvoicePaidDetails {
-        guard let paymentHash = invoicePaidDetails["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type InvoicePaidDetails") }
-        guard let bolt11 = invoicePaidDetails["bolt11"] as? String else { throw SdkError.Generic(message: "Missing mandatory field bolt11 for type InvoicePaidDetails") }
+        guard let paymentHash = invoicePaidDetails["paymentHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "InvoicePaidDetails"))
+        }
+        guard let bolt11 = invoicePaidDetails["bolt11"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "InvoicePaidDetails"))
+        }
         var payment: Payment?
         if let paymentTmp = invoicePaidDetails["payment"] as? [String: Any?] {
             payment = try asPayment(payment: paymentTmp)
@@ -592,7 +708,7 @@ enum BreezSDKMapper {
                 var invoicePaidDetails = try asInvoicePaidDetails(invoicePaidDetails: val)
                 list.append(invoicePaidDetails)
             } else {
-                throw SdkError.Generic(message: "Unexpected type InvoicePaidDetails")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "InvoicePaidDetails"))
             }
         }
         return list
@@ -603,22 +719,58 @@ enum BreezSDKMapper {
     }
 
     static func asLnInvoice(lnInvoice: [String: Any?]) throws -> LnInvoice {
-        guard let bolt11 = lnInvoice["bolt11"] as? String else { throw SdkError.Generic(message: "Missing mandatory field bolt11 for type LnInvoice") }
-        guard let networkTmp = lnInvoice["network"] as? String else { throw SdkError.Generic(message: "Missing mandatory field network for type LnInvoice") }
+        guard let bolt11 = lnInvoice["bolt11"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "LnInvoice"))
+        }
+        guard let networkTmp = lnInvoice["network"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "LnInvoice"))
+        }
         let network = try asNetwork(network: networkTmp)
 
-        guard let payeePubkey = lnInvoice["payeePubkey"] as? String else { throw SdkError.Generic(message: "Missing mandatory field payeePubkey for type LnInvoice") }
-        guard let paymentHash = lnInvoice["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type LnInvoice") }
-        let description = lnInvoice["description"] as? String
-        let descriptionHash = lnInvoice["descriptionHash"] as? String
-        let amountMsat = lnInvoice["amountMsat"] as? UInt64
-        guard let timestamp = lnInvoice["timestamp"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field timestamp for type LnInvoice") }
-        guard let expiry = lnInvoice["expiry"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field expiry for type LnInvoice") }
-        guard let routingHintsTmp = lnInvoice["routingHints"] as? [[String: Any?]] else { throw SdkError.Generic(message: "Missing mandatory field routingHints for type LnInvoice") }
+        guard let payeePubkey = lnInvoice["payeePubkey"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payeePubkey", typeName: "LnInvoice"))
+        }
+        guard let paymentHash = lnInvoice["paymentHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnInvoice"))
+        }
+        var description: String?
+        if hasNonNilKey(data: lnInvoice, key: "description") {
+            guard let descriptionTmp = lnInvoice["description"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "description"))
+            }
+            description = descriptionTmp
+        }
+        var descriptionHash: String?
+        if hasNonNilKey(data: lnInvoice, key: "descriptionHash") {
+            guard let descriptionHashTmp = lnInvoice["descriptionHash"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "descriptionHash"))
+            }
+            descriptionHash = descriptionHashTmp
+        }
+        var amountMsat: UInt64?
+        if hasNonNilKey(data: lnInvoice, key: "amountMsat") {
+            guard let amountMsatTmp = lnInvoice["amountMsat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "amountMsat"))
+            }
+            amountMsat = amountMsatTmp
+        }
+        guard let timestamp = lnInvoice["timestamp"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "LnInvoice"))
+        }
+        guard let expiry = lnInvoice["expiry"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "expiry", typeName: "LnInvoice"))
+        }
+        guard let routingHintsTmp = lnInvoice["routingHints"] as? [[String: Any?]] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "routingHints", typeName: "LnInvoice"))
+        }
         let routingHints = try asRouteHintList(arr: routingHintsTmp)
 
-        guard let paymentSecret = lnInvoice["paymentSecret"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field paymentSecret for type LnInvoice") }
-        guard let minFinalCltvExpiryDelta = lnInvoice["minFinalCltvExpiryDelta"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field minFinalCltvExpiryDelta for type LnInvoice") }
+        guard let paymentSecret = lnInvoice["paymentSecret"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentSecret", typeName: "LnInvoice"))
+        }
+        guard let minFinalCltvExpiryDelta = lnInvoice["minFinalCltvExpiryDelta"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minFinalCltvExpiryDelta", typeName: "LnInvoice"))
+        }
 
         return LnInvoice(
             bolt11: bolt11,
@@ -660,7 +812,7 @@ enum BreezSDKMapper {
                 var lnInvoice = try asLnInvoice(lnInvoice: val)
                 list.append(lnInvoice)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnInvoice")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnInvoice"))
             }
         }
         return list
@@ -676,11 +828,41 @@ enum BreezSDKMapper {
             filters = try asPaymentTypeFilterList(arr: filtersTmp)
         }
 
-        let fromTimestamp = listPaymentsRequest["fromTimestamp"] as? Int64
-        let toTimestamp = listPaymentsRequest["toTimestamp"] as? Int64
-        let includeFailures = listPaymentsRequest["includeFailures"] as? Bool
-        let offset = listPaymentsRequest["offset"] as? UInt32
-        let limit = listPaymentsRequest["limit"] as? UInt32
+        var fromTimestamp: Int64?
+        if hasNonNilKey(data: listPaymentsRequest, key: "fromTimestamp") {
+            guard let fromTimestampTmp = listPaymentsRequest["fromTimestamp"] as? Int64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "fromTimestamp"))
+            }
+            fromTimestamp = fromTimestampTmp
+        }
+        var toTimestamp: Int64?
+        if hasNonNilKey(data: listPaymentsRequest, key: "toTimestamp") {
+            guard let toTimestampTmp = listPaymentsRequest["toTimestamp"] as? Int64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "toTimestamp"))
+            }
+            toTimestamp = toTimestampTmp
+        }
+        var includeFailures: Bool?
+        if hasNonNilKey(data: listPaymentsRequest, key: "includeFailures") {
+            guard let includeFailuresTmp = listPaymentsRequest["includeFailures"] as? Bool else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "includeFailures"))
+            }
+            includeFailures = includeFailuresTmp
+        }
+        var offset: UInt32?
+        if hasNonNilKey(data: listPaymentsRequest, key: "offset") {
+            guard let offsetTmp = listPaymentsRequest["offset"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "offset"))
+            }
+            offset = offsetTmp
+        }
+        var limit: UInt32?
+        if hasNonNilKey(data: listPaymentsRequest, key: "limit") {
+            guard let limitTmp = listPaymentsRequest["limit"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "limit"))
+            }
+            limit = limitTmp
+        }
 
         return ListPaymentsRequest(
             filters: filters,
@@ -710,7 +892,7 @@ enum BreezSDKMapper {
                 var listPaymentsRequest = try asListPaymentsRequest(listPaymentsRequest: val)
                 list.append(listPaymentsRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ListPaymentsRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ListPaymentsRequest"))
             }
         }
         return list
@@ -721,20 +903,50 @@ enum BreezSDKMapper {
     }
 
     static func asLnPaymentDetails(lnPaymentDetails: [String: Any?]) throws -> LnPaymentDetails {
-        guard let paymentHash = lnPaymentDetails["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type LnPaymentDetails") }
-        guard let label = lnPaymentDetails["label"] as? String else { throw SdkError.Generic(message: "Missing mandatory field label for type LnPaymentDetails") }
-        guard let destinationPubkey = lnPaymentDetails["destinationPubkey"] as? String else { throw SdkError.Generic(message: "Missing mandatory field destinationPubkey for type LnPaymentDetails") }
-        guard let paymentPreimage = lnPaymentDetails["paymentPreimage"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentPreimage for type LnPaymentDetails") }
-        guard let keysend = lnPaymentDetails["keysend"] as? Bool else { throw SdkError.Generic(message: "Missing mandatory field keysend for type LnPaymentDetails") }
-        guard let bolt11 = lnPaymentDetails["bolt11"] as? String else { throw SdkError.Generic(message: "Missing mandatory field bolt11 for type LnPaymentDetails") }
+        guard let paymentHash = lnPaymentDetails["paymentHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnPaymentDetails"))
+        }
+        guard let label = lnPaymentDetails["label"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "label", typeName: "LnPaymentDetails"))
+        }
+        guard let destinationPubkey = lnPaymentDetails["destinationPubkey"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destinationPubkey", typeName: "LnPaymentDetails"))
+        }
+        guard let paymentPreimage = lnPaymentDetails["paymentPreimage"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentPreimage", typeName: "LnPaymentDetails"))
+        }
+        guard let keysend = lnPaymentDetails["keysend"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "keysend", typeName: "LnPaymentDetails"))
+        }
+        guard let bolt11 = lnPaymentDetails["bolt11"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "LnPaymentDetails"))
+        }
         var lnurlSuccessAction: SuccessActionProcessed?
         if let lnurlSuccessActionTmp = lnPaymentDetails["lnurlSuccessAction"] as? [String: Any?] {
             lnurlSuccessAction = try asSuccessActionProcessed(successActionProcessed: lnurlSuccessActionTmp)
         }
 
-        let lnurlMetadata = lnPaymentDetails["lnurlMetadata"] as? String
-        let lnAddress = lnPaymentDetails["lnAddress"] as? String
-        let lnurlWithdrawEndpoint = lnPaymentDetails["lnurlWithdrawEndpoint"] as? String
+        var lnurlMetadata: String?
+        if hasNonNilKey(data: lnPaymentDetails, key: "lnurlMetadata") {
+            guard let lnurlMetadataTmp = lnPaymentDetails["lnurlMetadata"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlMetadata"))
+            }
+            lnurlMetadata = lnurlMetadataTmp
+        }
+        var lnAddress: String?
+        if hasNonNilKey(data: lnPaymentDetails, key: "lnAddress") {
+            guard let lnAddressTmp = lnPaymentDetails["lnAddress"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnAddress"))
+            }
+            lnAddress = lnAddressTmp
+        }
+        var lnurlWithdrawEndpoint: String?
+        if hasNonNilKey(data: lnPaymentDetails, key: "lnurlWithdrawEndpoint") {
+            guard let lnurlWithdrawEndpointTmp = lnPaymentDetails["lnurlWithdrawEndpoint"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlWithdrawEndpoint"))
+            }
+            lnurlWithdrawEndpoint = lnurlWithdrawEndpointTmp
+        }
         var swapInfo: SwapInfo?
         if let swapInfoTmp = lnPaymentDetails["swapInfo"] as? [String: Any?] {
             swapInfo = try asSwapInfo(swapInfo: swapInfoTmp)
@@ -778,7 +990,7 @@ enum BreezSDKMapper {
                 var lnPaymentDetails = try asLnPaymentDetails(lnPaymentDetails: val)
                 list.append(lnPaymentDetails)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnPaymentDetails")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnPaymentDetails"))
             }
         }
         return list
@@ -789,10 +1001,22 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlAuthRequestData(lnUrlAuthRequestData: [String: Any?]) throws -> LnUrlAuthRequestData {
-        guard let k1 = lnUrlAuthRequestData["k1"] as? String else { throw SdkError.Generic(message: "Missing mandatory field k1 for type LnUrlAuthRequestData") }
-        guard let domain = lnUrlAuthRequestData["domain"] as? String else { throw SdkError.Generic(message: "Missing mandatory field domain for type LnUrlAuthRequestData") }
-        guard let url = lnUrlAuthRequestData["url"] as? String else { throw SdkError.Generic(message: "Missing mandatory field url for type LnUrlAuthRequestData") }
-        let action = lnUrlAuthRequestData["action"] as? String
+        guard let k1 = lnUrlAuthRequestData["k1"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "k1", typeName: "LnUrlAuthRequestData"))
+        }
+        guard let domain = lnUrlAuthRequestData["domain"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "domain", typeName: "LnUrlAuthRequestData"))
+        }
+        guard let url = lnUrlAuthRequestData["url"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "LnUrlAuthRequestData"))
+        }
+        var action: String?
+        if hasNonNilKey(data: lnUrlAuthRequestData, key: "action") {
+            guard let actionTmp = lnUrlAuthRequestData["action"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "action"))
+            }
+            action = actionTmp
+        }
 
         return LnUrlAuthRequestData(
             k1: k1,
@@ -818,7 +1042,7 @@ enum BreezSDKMapper {
                 var lnUrlAuthRequestData = try asLnUrlAuthRequestData(lnUrlAuthRequestData: val)
                 list.append(lnUrlAuthRequestData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlAuthRequestData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlAuthRequestData"))
             }
         }
         return list
@@ -829,7 +1053,9 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlErrorData(lnUrlErrorData: [String: Any?]) throws -> LnUrlErrorData {
-        guard let reason = lnUrlErrorData["reason"] as? String else { throw SdkError.Generic(message: "Missing mandatory field reason for type LnUrlErrorData") }
+        guard let reason = lnUrlErrorData["reason"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "LnUrlErrorData"))
+        }
 
         return LnUrlErrorData(
             reason: reason)
@@ -848,7 +1074,7 @@ enum BreezSDKMapper {
                 var lnUrlErrorData = try asLnUrlErrorData(lnUrlErrorData: val)
                 list.append(lnUrlErrorData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlErrorData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlErrorData"))
             }
         }
         return list
@@ -859,8 +1085,12 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlPayErrorData(lnUrlPayErrorData: [String: Any?]) throws -> LnUrlPayErrorData {
-        guard let paymentHash = lnUrlPayErrorData["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type LnUrlPayErrorData") }
-        guard let reason = lnUrlPayErrorData["reason"] as? String else { throw SdkError.Generic(message: "Missing mandatory field reason for type LnUrlPayErrorData") }
+        guard let paymentHash = lnUrlPayErrorData["paymentHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnUrlPayErrorData"))
+        }
+        guard let reason = lnUrlPayErrorData["reason"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "LnUrlPayErrorData"))
+        }
 
         return LnUrlPayErrorData(
             paymentHash: paymentHash,
@@ -882,7 +1112,7 @@ enum BreezSDKMapper {
                 var lnUrlPayErrorData = try asLnUrlPayErrorData(lnUrlPayErrorData: val)
                 list.append(lnUrlPayErrorData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlPayErrorData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayErrorData"))
             }
         }
         return list
@@ -893,11 +1123,21 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlPayRequest(lnUrlPayRequest: [String: Any?]) throws -> LnUrlPayRequest {
-        guard let dataTmp = lnUrlPayRequest["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlPayRequest") }
+        guard let dataTmp = lnUrlPayRequest["data"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayRequest"))
+        }
         let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
 
-        guard let amountMsat = lnUrlPayRequest["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type LnUrlPayRequest") }
-        let comment = lnUrlPayRequest["comment"] as? String
+        guard let amountMsat = lnUrlPayRequest["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "LnUrlPayRequest"))
+        }
+        var comment: String?
+        if hasNonNilKey(data: lnUrlPayRequest, key: "comment") {
+            guard let commentTmp = lnUrlPayRequest["comment"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "comment"))
+            }
+            comment = commentTmp
+        }
 
         return LnUrlPayRequest(
             data: data,
@@ -921,7 +1161,7 @@ enum BreezSDKMapper {
                 var lnUrlPayRequest = try asLnUrlPayRequest(lnUrlPayRequest: val)
                 list.append(lnUrlPayRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlPayRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayRequest"))
             }
         }
         return list
@@ -932,13 +1172,31 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlPayRequestData(lnUrlPayRequestData: [String: Any?]) throws -> LnUrlPayRequestData {
-        guard let callback = lnUrlPayRequestData["callback"] as? String else { throw SdkError.Generic(message: "Missing mandatory field callback for type LnUrlPayRequestData") }
-        guard let minSendable = lnUrlPayRequestData["minSendable"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field minSendable for type LnUrlPayRequestData") }
-        guard let maxSendable = lnUrlPayRequestData["maxSendable"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field maxSendable for type LnUrlPayRequestData") }
-        guard let metadataStr = lnUrlPayRequestData["metadataStr"] as? String else { throw SdkError.Generic(message: "Missing mandatory field metadataStr for type LnUrlPayRequestData") }
-        guard let commentAllowed = lnUrlPayRequestData["commentAllowed"] as? UInt16 else { throw SdkError.Generic(message: "Missing mandatory field commentAllowed for type LnUrlPayRequestData") }
-        guard let domain = lnUrlPayRequestData["domain"] as? String else { throw SdkError.Generic(message: "Missing mandatory field domain for type LnUrlPayRequestData") }
-        let lnAddress = lnUrlPayRequestData["lnAddress"] as? String
+        guard let callback = lnUrlPayRequestData["callback"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "callback", typeName: "LnUrlPayRequestData"))
+        }
+        guard let minSendable = lnUrlPayRequestData["minSendable"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minSendable", typeName: "LnUrlPayRequestData"))
+        }
+        guard let maxSendable = lnUrlPayRequestData["maxSendable"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxSendable", typeName: "LnUrlPayRequestData"))
+        }
+        guard let metadataStr = lnUrlPayRequestData["metadataStr"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "metadataStr", typeName: "LnUrlPayRequestData"))
+        }
+        guard let commentAllowed = lnUrlPayRequestData["commentAllowed"] as? UInt16 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "commentAllowed", typeName: "LnUrlPayRequestData"))
+        }
+        guard let domain = lnUrlPayRequestData["domain"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "domain", typeName: "LnUrlPayRequestData"))
+        }
+        var lnAddress: String?
+        if hasNonNilKey(data: lnUrlPayRequestData, key: "lnAddress") {
+            guard let lnAddressTmp = lnUrlPayRequestData["lnAddress"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnAddress"))
+            }
+            lnAddress = lnAddressTmp
+        }
 
         return LnUrlPayRequestData(
             callback: callback,
@@ -970,7 +1228,7 @@ enum BreezSDKMapper {
                 var lnUrlPayRequestData = try asLnUrlPayRequestData(lnUrlPayRequestData: val)
                 list.append(lnUrlPayRequestData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlPayRequestData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayRequestData"))
             }
         }
         return list
@@ -986,7 +1244,9 @@ enum BreezSDKMapper {
             successAction = try asSuccessActionProcessed(successActionProcessed: successActionTmp)
         }
 
-        guard let paymentHash = lnUrlPaySuccessData["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type LnUrlPaySuccessData") }
+        guard let paymentHash = lnUrlPaySuccessData["paymentHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnUrlPaySuccessData"))
+        }
 
         return LnUrlPaySuccessData(
             successAction: successAction,
@@ -1008,7 +1268,7 @@ enum BreezSDKMapper {
                 var lnUrlPaySuccessData = try asLnUrlPaySuccessData(lnUrlPaySuccessData: val)
                 list.append(lnUrlPaySuccessData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlPaySuccessData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPaySuccessData"))
             }
         }
         return list
@@ -1019,11 +1279,21 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlWithdrawRequest(lnUrlWithdrawRequest: [String: Any?]) throws -> LnUrlWithdrawRequest {
-        guard let dataTmp = lnUrlWithdrawRequest["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlWithdrawRequest") }
+        guard let dataTmp = lnUrlWithdrawRequest["data"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawRequest"))
+        }
         let data = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: dataTmp)
 
-        guard let amountMsat = lnUrlWithdrawRequest["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type LnUrlWithdrawRequest") }
-        let description = lnUrlWithdrawRequest["description"] as? String
+        guard let amountMsat = lnUrlWithdrawRequest["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "LnUrlWithdrawRequest"))
+        }
+        var description: String?
+        if hasNonNilKey(data: lnUrlWithdrawRequest, key: "description") {
+            guard let descriptionTmp = lnUrlWithdrawRequest["description"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "description"))
+            }
+            description = descriptionTmp
+        }
 
         return LnUrlWithdrawRequest(
             data: data,
@@ -1047,7 +1317,7 @@ enum BreezSDKMapper {
                 var lnUrlWithdrawRequest = try asLnUrlWithdrawRequest(lnUrlWithdrawRequest: val)
                 list.append(lnUrlWithdrawRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawRequest"))
             }
         }
         return list
@@ -1058,11 +1328,21 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: [String: Any?]) throws -> LnUrlWithdrawRequestData {
-        guard let callback = lnUrlWithdrawRequestData["callback"] as? String else { throw SdkError.Generic(message: "Missing mandatory field callback for type LnUrlWithdrawRequestData") }
-        guard let k1 = lnUrlWithdrawRequestData["k1"] as? String else { throw SdkError.Generic(message: "Missing mandatory field k1 for type LnUrlWithdrawRequestData") }
-        guard let defaultDescription = lnUrlWithdrawRequestData["defaultDescription"] as? String else { throw SdkError.Generic(message: "Missing mandatory field defaultDescription for type LnUrlWithdrawRequestData") }
-        guard let minWithdrawable = lnUrlWithdrawRequestData["minWithdrawable"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field minWithdrawable for type LnUrlWithdrawRequestData") }
-        guard let maxWithdrawable = lnUrlWithdrawRequestData["maxWithdrawable"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field maxWithdrawable for type LnUrlWithdrawRequestData") }
+        guard let callback = lnUrlWithdrawRequestData["callback"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "callback", typeName: "LnUrlWithdrawRequestData"))
+        }
+        guard let k1 = lnUrlWithdrawRequestData["k1"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "k1", typeName: "LnUrlWithdrawRequestData"))
+        }
+        guard let defaultDescription = lnUrlWithdrawRequestData["defaultDescription"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "defaultDescription", typeName: "LnUrlWithdrawRequestData"))
+        }
+        guard let minWithdrawable = lnUrlWithdrawRequestData["minWithdrawable"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minWithdrawable", typeName: "LnUrlWithdrawRequestData"))
+        }
+        guard let maxWithdrawable = lnUrlWithdrawRequestData["maxWithdrawable"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxWithdrawable", typeName: "LnUrlWithdrawRequestData"))
+        }
 
         return LnUrlWithdrawRequestData(
             callback: callback,
@@ -1090,7 +1370,7 @@ enum BreezSDKMapper {
                 var lnUrlWithdrawRequestData = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: val)
                 list.append(lnUrlWithdrawRequestData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawRequestData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawRequestData"))
             }
         }
         return list
@@ -1101,7 +1381,9 @@ enum BreezSDKMapper {
     }
 
     static func asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: [String: Any?]) throws -> LnUrlWithdrawSuccessData {
-        guard let invoiceTmp = lnUrlWithdrawSuccessData["invoice"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field invoice for type LnUrlWithdrawSuccessData") }
+        guard let invoiceTmp = lnUrlWithdrawSuccessData["invoice"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "LnUrlWithdrawSuccessData"))
+        }
         let invoice = try asLnInvoice(lnInvoice: invoiceTmp)
 
         return LnUrlWithdrawSuccessData(
@@ -1121,7 +1403,7 @@ enum BreezSDKMapper {
                 var lnUrlWithdrawSuccessData = try asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: val)
                 list.append(lnUrlWithdrawSuccessData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawSuccessData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawSuccessData"))
             }
         }
         return list
@@ -1132,9 +1414,19 @@ enum BreezSDKMapper {
     }
 
     static func asLocaleOverrides(localeOverrides: [String: Any?]) throws -> LocaleOverrides {
-        guard let locale = localeOverrides["locale"] as? String else { throw SdkError.Generic(message: "Missing mandatory field locale for type LocaleOverrides") }
-        let spacing = localeOverrides["spacing"] as? UInt32
-        guard let symbolTmp = localeOverrides["symbol"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field symbol for type LocaleOverrides") }
+        guard let locale = localeOverrides["locale"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "locale", typeName: "LocaleOverrides"))
+        }
+        var spacing: UInt32?
+        if hasNonNilKey(data: localeOverrides, key: "spacing") {
+            guard let spacingTmp = localeOverrides["spacing"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "spacing"))
+            }
+            spacing = spacingTmp
+        }
+        guard let symbolTmp = localeOverrides["symbol"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "symbol", typeName: "LocaleOverrides"))
+        }
         let symbol = try asSymbol(symbol: symbolTmp)
 
         return LocaleOverrides(
@@ -1159,7 +1451,7 @@ enum BreezSDKMapper {
                 var localeOverrides = try asLocaleOverrides(localeOverrides: val)
                 list.append(localeOverrides)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LocaleOverrides")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LocaleOverrides"))
             }
         }
         return list
@@ -1170,8 +1462,12 @@ enum BreezSDKMapper {
     }
 
     static func asLocalizedName(localizedName: [String: Any?]) throws -> LocalizedName {
-        guard let locale = localizedName["locale"] as? String else { throw SdkError.Generic(message: "Missing mandatory field locale for type LocalizedName") }
-        guard let name = localizedName["name"] as? String else { throw SdkError.Generic(message: "Missing mandatory field name for type LocalizedName") }
+        guard let locale = localizedName["locale"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "locale", typeName: "LocalizedName"))
+        }
+        guard let name = localizedName["name"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "LocalizedName"))
+        }
 
         return LocalizedName(
             locale: locale,
@@ -1193,7 +1489,7 @@ enum BreezSDKMapper {
                 var localizedName = try asLocalizedName(localizedName: val)
                 list.append(localizedName)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LocalizedName")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LocalizedName"))
             }
         }
         return list
@@ -1204,8 +1500,12 @@ enum BreezSDKMapper {
     }
 
     static func asLogEntry(logEntry: [String: Any?]) throws -> LogEntry {
-        guard let line = logEntry["line"] as? String else { throw SdkError.Generic(message: "Missing mandatory field line for type LogEntry") }
-        guard let level = logEntry["level"] as? String else { throw SdkError.Generic(message: "Missing mandatory field level for type LogEntry") }
+        guard let line = logEntry["line"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "line", typeName: "LogEntry"))
+        }
+        guard let level = logEntry["level"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "level", typeName: "LogEntry"))
+        }
 
         return LogEntry(
             line: line,
@@ -1227,7 +1527,7 @@ enum BreezSDKMapper {
                 var logEntry = try asLogEntry(logEntry: val)
                 list.append(logEntry)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LogEntry")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LogEntry"))
             }
         }
         return list
@@ -1238,19 +1538,45 @@ enum BreezSDKMapper {
     }
 
     static func asLspInformation(lspInformation: [String: Any?]) throws -> LspInformation {
-        guard let id = lspInformation["id"] as? String else { throw SdkError.Generic(message: "Missing mandatory field id for type LspInformation") }
-        guard let name = lspInformation["name"] as? String else { throw SdkError.Generic(message: "Missing mandatory field name for type LspInformation") }
-        guard let widgetUrl = lspInformation["widgetUrl"] as? String else { throw SdkError.Generic(message: "Missing mandatory field widgetUrl for type LspInformation") }
-        guard let pubkey = lspInformation["pubkey"] as? String else { throw SdkError.Generic(message: "Missing mandatory field pubkey for type LspInformation") }
-        guard let host = lspInformation["host"] as? String else { throw SdkError.Generic(message: "Missing mandatory field host for type LspInformation") }
-        guard let channelCapacity = lspInformation["channelCapacity"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field channelCapacity for type LspInformation") }
-        guard let targetConf = lspInformation["targetConf"] as? Int32 else { throw SdkError.Generic(message: "Missing mandatory field targetConf for type LspInformation") }
-        guard let baseFeeMsat = lspInformation["baseFeeMsat"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field baseFeeMsat for type LspInformation") }
-        guard let feeRate = lspInformation["feeRate"] as? Double else { throw SdkError.Generic(message: "Missing mandatory field feeRate for type LspInformation") }
-        guard let timeLockDelta = lspInformation["timeLockDelta"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field timeLockDelta for type LspInformation") }
-        guard let minHtlcMsat = lspInformation["minHtlcMsat"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field minHtlcMsat for type LspInformation") }
-        guard let lspPubkey = lspInformation["lspPubkey"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field lspPubkey for type LspInformation") }
-        guard let openingFeeParamsListTmp = lspInformation["openingFeeParamsList"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field openingFeeParamsList for type LspInformation") }
+        guard let id = lspInformation["id"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "LspInformation"))
+        }
+        guard let name = lspInformation["name"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "LspInformation"))
+        }
+        guard let widgetUrl = lspInformation["widgetUrl"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "widgetUrl", typeName: "LspInformation"))
+        }
+        guard let pubkey = lspInformation["pubkey"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pubkey", typeName: "LspInformation"))
+        }
+        guard let host = lspInformation["host"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "host", typeName: "LspInformation"))
+        }
+        guard let channelCapacity = lspInformation["channelCapacity"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "channelCapacity", typeName: "LspInformation"))
+        }
+        guard let targetConf = lspInformation["targetConf"] as? Int32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "targetConf", typeName: "LspInformation"))
+        }
+        guard let baseFeeMsat = lspInformation["baseFeeMsat"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "baseFeeMsat", typeName: "LspInformation"))
+        }
+        guard let feeRate = lspInformation["feeRate"] as? Double else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeRate", typeName: "LspInformation"))
+        }
+        guard let timeLockDelta = lspInformation["timeLockDelta"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timeLockDelta", typeName: "LspInformation"))
+        }
+        guard let minHtlcMsat = lspInformation["minHtlcMsat"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minHtlcMsat", typeName: "LspInformation"))
+        }
+        guard let lspPubkey = lspInformation["lspPubkey"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "lspPubkey", typeName: "LspInformation"))
+        }
+        guard let openingFeeParamsListTmp = lspInformation["openingFeeParamsList"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "openingFeeParamsList", typeName: "LspInformation"))
+        }
         let openingFeeParamsList = try asOpeningFeeParamsMenu(openingFeeParamsMenu: openingFeeParamsListTmp)
 
         return LspInformation(
@@ -1295,7 +1621,7 @@ enum BreezSDKMapper {
                 var lspInformation = try asLspInformation(lspInformation: val)
                 list.append(lspInformation)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LspInformation")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LspInformation"))
             }
         }
         return list
@@ -1306,7 +1632,9 @@ enum BreezSDKMapper {
     }
 
     static func asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: [String: Any?]) throws -> MaxReverseSwapAmountResponse {
-        guard let totalSat = maxReverseSwapAmountResponse["totalSat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field totalSat for type MaxReverseSwapAmountResponse") }
+        guard let totalSat = maxReverseSwapAmountResponse["totalSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "totalSat", typeName: "MaxReverseSwapAmountResponse"))
+        }
 
         return MaxReverseSwapAmountResponse(
             totalSat: totalSat)
@@ -1325,7 +1653,7 @@ enum BreezSDKMapper {
                 var maxReverseSwapAmountResponse = try asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: val)
                 list.append(maxReverseSwapAmountResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type MaxReverseSwapAmountResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "MaxReverseSwapAmountResponse"))
             }
         }
         return list
@@ -1336,7 +1664,9 @@ enum BreezSDKMapper {
     }
 
     static func asMessageSuccessActionData(messageSuccessActionData: [String: Any?]) throws -> MessageSuccessActionData {
-        guard let message = messageSuccessActionData["message"] as? String else { throw SdkError.Generic(message: "Missing mandatory field message for type MessageSuccessActionData") }
+        guard let message = messageSuccessActionData["message"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "MessageSuccessActionData"))
+        }
 
         return MessageSuccessActionData(
             message: message)
@@ -1355,7 +1685,7 @@ enum BreezSDKMapper {
                 var messageSuccessActionData = try asMessageSuccessActionData(messageSuccessActionData: val)
                 list.append(messageSuccessActionData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type MessageSuccessActionData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "MessageSuccessActionData"))
             }
         }
         return list
@@ -1366,8 +1696,12 @@ enum BreezSDKMapper {
     }
 
     static func asMetadataItem(metadataItem: [String: Any?]) throws -> MetadataItem {
-        guard let key = metadataItem["key"] as? String else { throw SdkError.Generic(message: "Missing mandatory field key for type MetadataItem") }
-        guard let value = metadataItem["value"] as? String else { throw SdkError.Generic(message: "Missing mandatory field value for type MetadataItem") }
+        guard let key = metadataItem["key"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "key", typeName: "MetadataItem"))
+        }
+        guard let value = metadataItem["value"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "value", typeName: "MetadataItem"))
+        }
 
         return MetadataItem(
             key: key,
@@ -1389,7 +1723,7 @@ enum BreezSDKMapper {
                 var metadataItem = try asMetadataItem(metadataItem: val)
                 list.append(metadataItem)
             } else {
-                throw SdkError.Generic(message: "Unexpected type MetadataItem")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "MetadataItem"))
             }
         }
         return list
@@ -1400,19 +1734,41 @@ enum BreezSDKMapper {
     }
 
     static func asNodeState(nodeState: [String: Any?]) throws -> NodeState {
-        guard let id = nodeState["id"] as? String else { throw SdkError.Generic(message: "Missing mandatory field id for type NodeState") }
-        guard let blockHeight = nodeState["blockHeight"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field blockHeight for type NodeState") }
-        guard let channelsBalanceMsat = nodeState["channelsBalanceMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field channelsBalanceMsat for type NodeState") }
-        guard let onchainBalanceMsat = nodeState["onchainBalanceMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field onchainBalanceMsat for type NodeState") }
-        guard let utxosTmp = nodeState["utxos"] as? [[String: Any?]] else { throw SdkError.Generic(message: "Missing mandatory field utxos for type NodeState") }
+        guard let id = nodeState["id"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "NodeState"))
+        }
+        guard let blockHeight = nodeState["blockHeight"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "blockHeight", typeName: "NodeState"))
+        }
+        guard let channelsBalanceMsat = nodeState["channelsBalanceMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "channelsBalanceMsat", typeName: "NodeState"))
+        }
+        guard let onchainBalanceMsat = nodeState["onchainBalanceMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "onchainBalanceMsat", typeName: "NodeState"))
+        }
+        guard let utxosTmp = nodeState["utxos"] as? [[String: Any?]] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "utxos", typeName: "NodeState"))
+        }
         let utxos = try asUnspentTransactionOutputList(arr: utxosTmp)
 
-        guard let maxPayableMsat = nodeState["maxPayableMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field maxPayableMsat for type NodeState") }
-        guard let maxReceivableMsat = nodeState["maxReceivableMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field maxReceivableMsat for type NodeState") }
-        guard let maxSinglePaymentAmountMsat = nodeState["maxSinglePaymentAmountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field maxSinglePaymentAmountMsat for type NodeState") }
-        guard let maxChanReserveMsats = nodeState["maxChanReserveMsats"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field maxChanReserveMsats for type NodeState") }
-        guard let connectedPeers = nodeState["connectedPeers"] as? [String] else { throw SdkError.Generic(message: "Missing mandatory field connectedPeers for type NodeState") }
-        guard let inboundLiquidityMsats = nodeState["inboundLiquidityMsats"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field inboundLiquidityMsats for type NodeState") }
+        guard let maxPayableMsat = nodeState["maxPayableMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxPayableMsat", typeName: "NodeState"))
+        }
+        guard let maxReceivableMsat = nodeState["maxReceivableMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxReceivableMsat", typeName: "NodeState"))
+        }
+        guard let maxSinglePaymentAmountMsat = nodeState["maxSinglePaymentAmountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxSinglePaymentAmountMsat", typeName: "NodeState"))
+        }
+        guard let maxChanReserveMsats = nodeState["maxChanReserveMsats"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxChanReserveMsats", typeName: "NodeState"))
+        }
+        guard let connectedPeers = nodeState["connectedPeers"] as? [String] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "connectedPeers", typeName: "NodeState"))
+        }
+        guard let inboundLiquidityMsats = nodeState["inboundLiquidityMsats"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "inboundLiquidityMsats", typeName: "NodeState"))
+        }
 
         return NodeState(
             id: id,
@@ -1452,7 +1808,7 @@ enum BreezSDKMapper {
                 var nodeState = try asNodeState(nodeState: val)
                 list.append(nodeState)
             } else {
-                throw SdkError.Generic(message: "Unexpected type NodeState")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "NodeState"))
             }
         }
         return list
@@ -1463,8 +1819,16 @@ enum BreezSDKMapper {
     }
 
     static func asOpenChannelFeeRequest(openChannelFeeRequest: [String: Any?]) throws -> OpenChannelFeeRequest {
-        guard let amountMsat = openChannelFeeRequest["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type OpenChannelFeeRequest") }
-        let expiry = openChannelFeeRequest["expiry"] as? UInt32
+        guard let amountMsat = openChannelFeeRequest["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "OpenChannelFeeRequest"))
+        }
+        var expiry: UInt32?
+        if hasNonNilKey(data: openChannelFeeRequest, key: "expiry") {
+            guard let expiryTmp = openChannelFeeRequest["expiry"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "expiry"))
+            }
+            expiry = expiryTmp
+        }
 
         return OpenChannelFeeRequest(
             amountMsat: amountMsat,
@@ -1486,7 +1850,7 @@ enum BreezSDKMapper {
                 var openChannelFeeRequest = try asOpenChannelFeeRequest(openChannelFeeRequest: val)
                 list.append(openChannelFeeRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type OpenChannelFeeRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "OpenChannelFeeRequest"))
             }
         }
         return list
@@ -1497,7 +1861,9 @@ enum BreezSDKMapper {
     }
 
     static func asOpenChannelFeeResponse(openChannelFeeResponse: [String: Any?]) throws -> OpenChannelFeeResponse {
-        guard let feeMsat = openChannelFeeResponse["feeMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field feeMsat for type OpenChannelFeeResponse") }
+        guard let feeMsat = openChannelFeeResponse["feeMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeMsat", typeName: "OpenChannelFeeResponse"))
+        }
         var usedFeeParams: OpeningFeeParams?
         if let usedFeeParamsTmp = openChannelFeeResponse["usedFeeParams"] as? [String: Any?] {
             usedFeeParams = try asOpeningFeeParams(openingFeeParams: usedFeeParamsTmp)
@@ -1523,7 +1889,7 @@ enum BreezSDKMapper {
                 var openChannelFeeResponse = try asOpenChannelFeeResponse(openChannelFeeResponse: val)
                 list.append(openChannelFeeResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type OpenChannelFeeResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "OpenChannelFeeResponse"))
             }
         }
         return list
@@ -1534,12 +1900,24 @@ enum BreezSDKMapper {
     }
 
     static func asOpeningFeeParams(openingFeeParams: [String: Any?]) throws -> OpeningFeeParams {
-        guard let minMsat = openingFeeParams["minMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field minMsat for type OpeningFeeParams") }
-        guard let proportional = openingFeeParams["proportional"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field proportional for type OpeningFeeParams") }
-        guard let validUntil = openingFeeParams["validUntil"] as? String else { throw SdkError.Generic(message: "Missing mandatory field validUntil for type OpeningFeeParams") }
-        guard let maxIdleTime = openingFeeParams["maxIdleTime"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field maxIdleTime for type OpeningFeeParams") }
-        guard let maxClientToSelfDelay = openingFeeParams["maxClientToSelfDelay"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field maxClientToSelfDelay for type OpeningFeeParams") }
-        guard let promise = openingFeeParams["promise"] as? String else { throw SdkError.Generic(message: "Missing mandatory field promise for type OpeningFeeParams") }
+        guard let minMsat = openingFeeParams["minMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minMsat", typeName: "OpeningFeeParams"))
+        }
+        guard let proportional = openingFeeParams["proportional"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "proportional", typeName: "OpeningFeeParams"))
+        }
+        guard let validUntil = openingFeeParams["validUntil"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "validUntil", typeName: "OpeningFeeParams"))
+        }
+        guard let maxIdleTime = openingFeeParams["maxIdleTime"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxIdleTime", typeName: "OpeningFeeParams"))
+        }
+        guard let maxClientToSelfDelay = openingFeeParams["maxClientToSelfDelay"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxClientToSelfDelay", typeName: "OpeningFeeParams"))
+        }
+        guard let promise = openingFeeParams["promise"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "promise", typeName: "OpeningFeeParams"))
+        }
 
         return OpeningFeeParams(
             minMsat: minMsat,
@@ -1569,7 +1947,7 @@ enum BreezSDKMapper {
                 var openingFeeParams = try asOpeningFeeParams(openingFeeParams: val)
                 list.append(openingFeeParams)
             } else {
-                throw SdkError.Generic(message: "Unexpected type OpeningFeeParams")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "OpeningFeeParams"))
             }
         }
         return list
@@ -1580,7 +1958,9 @@ enum BreezSDKMapper {
     }
 
     static func asOpeningFeeParamsMenu(openingFeeParamsMenu: [String: Any?]) throws -> OpeningFeeParamsMenu {
-        guard let valuesTmp = openingFeeParamsMenu["values"] as? [[String: Any?]] else { throw SdkError.Generic(message: "Missing mandatory field values for type OpeningFeeParamsMenu") }
+        guard let valuesTmp = openingFeeParamsMenu["values"] as? [[String: Any?]] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "values", typeName: "OpeningFeeParamsMenu"))
+        }
         let values = try asOpeningFeeParamsList(arr: valuesTmp)
 
         return OpeningFeeParamsMenu(
@@ -1600,7 +1980,7 @@ enum BreezSDKMapper {
                 var openingFeeParamsMenu = try asOpeningFeeParamsMenu(openingFeeParamsMenu: val)
                 list.append(openingFeeParamsMenu)
             } else {
-                throw SdkError.Generic(message: "Unexpected type OpeningFeeParamsMenu")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "OpeningFeeParamsMenu"))
             }
         }
         return list
@@ -1611,18 +1991,38 @@ enum BreezSDKMapper {
     }
 
     static func asPayment(payment: [String: Any?]) throws -> Payment {
-        guard let id = payment["id"] as? String else { throw SdkError.Generic(message: "Missing mandatory field id for type Payment") }
-        guard let paymentTypeTmp = payment["paymentType"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentType for type Payment") }
+        guard let id = payment["id"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "Payment"))
+        }
+        guard let paymentTypeTmp = payment["paymentType"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentType", typeName: "Payment"))
+        }
         let paymentType = try asPaymentType(paymentType: paymentTypeTmp)
 
-        guard let paymentTime = payment["paymentTime"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field paymentTime for type Payment") }
-        guard let amountMsat = payment["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type Payment") }
-        guard let feeMsat = payment["feeMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field feeMsat for type Payment") }
-        guard let statusTmp = payment["status"] as? String else { throw SdkError.Generic(message: "Missing mandatory field status for type Payment") }
+        guard let paymentTime = payment["paymentTime"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTime", typeName: "Payment"))
+        }
+        guard let amountMsat = payment["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "Payment"))
+        }
+        guard let feeMsat = payment["feeMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeMsat", typeName: "Payment"))
+        }
+        guard let statusTmp = payment["status"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "Payment"))
+        }
         let status = try asPaymentStatus(paymentStatus: statusTmp)
 
-        let description = payment["description"] as? String
-        guard let detailsTmp = payment["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type Payment") }
+        var description: String?
+        if hasNonNilKey(data: payment, key: "description") {
+            guard let descriptionTmp = payment["description"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "description"))
+            }
+            description = descriptionTmp
+        }
+        guard let detailsTmp = payment["details"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "Payment"))
+        }
         let details = try asPaymentDetails(paymentDetails: detailsTmp)
 
         return Payment(
@@ -1657,7 +2057,7 @@ enum BreezSDKMapper {
                 var payment = try asPayment(payment: val)
                 list.append(payment)
             } else {
-                throw SdkError.Generic(message: "Unexpected type Payment")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "Payment"))
             }
         }
         return list
@@ -1668,8 +2068,12 @@ enum BreezSDKMapper {
     }
 
     static func asPaymentFailedData(paymentFailedData: [String: Any?]) throws -> PaymentFailedData {
-        guard let error = paymentFailedData["error"] as? String else { throw SdkError.Generic(message: "Missing mandatory field error for type PaymentFailedData") }
-        guard let nodeId = paymentFailedData["nodeId"] as? String else { throw SdkError.Generic(message: "Missing mandatory field nodeId for type PaymentFailedData") }
+        guard let error = paymentFailedData["error"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "error", typeName: "PaymentFailedData"))
+        }
+        guard let nodeId = paymentFailedData["nodeId"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "nodeId", typeName: "PaymentFailedData"))
+        }
         var invoice: LnInvoice?
         if let invoiceTmp = paymentFailedData["invoice"] as? [String: Any?] {
             invoice = try asLnInvoice(lnInvoice: invoiceTmp)
@@ -1697,7 +2101,7 @@ enum BreezSDKMapper {
                 var paymentFailedData = try asPaymentFailedData(paymentFailedData: val)
                 list.append(paymentFailedData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PaymentFailedData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentFailedData"))
             }
         }
         return list
@@ -1708,9 +2112,15 @@ enum BreezSDKMapper {
     }
 
     static func asPrepareRefundRequest(prepareRefundRequest: [String: Any?]) throws -> PrepareRefundRequest {
-        guard let swapAddress = prepareRefundRequest["swapAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field swapAddress for type PrepareRefundRequest") }
-        guard let toAddress = prepareRefundRequest["toAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field toAddress for type PrepareRefundRequest") }
-        guard let satPerVbyte = prepareRefundRequest["satPerVbyte"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field satPerVbyte for type PrepareRefundRequest") }
+        guard let swapAddress = prepareRefundRequest["swapAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "PrepareRefundRequest"))
+        }
+        guard let toAddress = prepareRefundRequest["toAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "PrepareRefundRequest"))
+        }
+        guard let satPerVbyte = prepareRefundRequest["satPerVbyte"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "PrepareRefundRequest"))
+        }
 
         return PrepareRefundRequest(
             swapAddress: swapAddress,
@@ -1734,7 +2144,7 @@ enum BreezSDKMapper {
                 var prepareRefundRequest = try asPrepareRefundRequest(prepareRefundRequest: val)
                 list.append(prepareRefundRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PrepareRefundRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRefundRequest"))
             }
         }
         return list
@@ -1745,8 +2155,12 @@ enum BreezSDKMapper {
     }
 
     static func asPrepareRefundResponse(prepareRefundResponse: [String: Any?]) throws -> PrepareRefundResponse {
-        guard let refundTxWeight = prepareRefundResponse["refundTxWeight"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field refundTxWeight for type PrepareRefundResponse") }
-        guard let refundTxFeeSat = prepareRefundResponse["refundTxFeeSat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field refundTxFeeSat for type PrepareRefundResponse") }
+        guard let refundTxWeight = prepareRefundResponse["refundTxWeight"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxWeight", typeName: "PrepareRefundResponse"))
+        }
+        guard let refundTxFeeSat = prepareRefundResponse["refundTxFeeSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxFeeSat", typeName: "PrepareRefundResponse"))
+        }
 
         return PrepareRefundResponse(
             refundTxWeight: refundTxWeight,
@@ -1768,7 +2182,7 @@ enum BreezSDKMapper {
                 var prepareRefundResponse = try asPrepareRefundResponse(prepareRefundResponse: val)
                 list.append(prepareRefundResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PrepareRefundResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRefundResponse"))
             }
         }
         return list
@@ -1779,8 +2193,12 @@ enum BreezSDKMapper {
     }
 
     static func asPrepareSweepRequest(prepareSweepRequest: [String: Any?]) throws -> PrepareSweepRequest {
-        guard let toAddress = prepareSweepRequest["toAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field toAddress for type PrepareSweepRequest") }
-        guard let satPerVbyte = prepareSweepRequest["satPerVbyte"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field satPerVbyte for type PrepareSweepRequest") }
+        guard let toAddress = prepareSweepRequest["toAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "PrepareSweepRequest"))
+        }
+        guard let satPerVbyte = prepareSweepRequest["satPerVbyte"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "PrepareSweepRequest"))
+        }
 
         return PrepareSweepRequest(
             toAddress: toAddress,
@@ -1802,7 +2220,7 @@ enum BreezSDKMapper {
                 var prepareSweepRequest = try asPrepareSweepRequest(prepareSweepRequest: val)
                 list.append(prepareSweepRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PrepareSweepRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSweepRequest"))
             }
         }
         return list
@@ -1813,8 +2231,12 @@ enum BreezSDKMapper {
     }
 
     static func asPrepareSweepResponse(prepareSweepResponse: [String: Any?]) throws -> PrepareSweepResponse {
-        guard let sweepTxWeight = prepareSweepResponse["sweepTxWeight"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field sweepTxWeight for type PrepareSweepResponse") }
-        guard let sweepTxFeeSat = prepareSweepResponse["sweepTxFeeSat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field sweepTxFeeSat for type PrepareSweepResponse") }
+        guard let sweepTxWeight = prepareSweepResponse["sweepTxWeight"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "sweepTxWeight", typeName: "PrepareSweepResponse"))
+        }
+        guard let sweepTxFeeSat = prepareSweepResponse["sweepTxFeeSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "sweepTxFeeSat", typeName: "PrepareSweepResponse"))
+        }
 
         return PrepareSweepResponse(
             sweepTxWeight: sweepTxWeight,
@@ -1836,7 +2258,7 @@ enum BreezSDKMapper {
                 var prepareSweepResponse = try asPrepareSweepResponse(prepareSweepResponse: val)
                 list.append(prepareSweepResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PrepareSweepResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSweepResponse"))
             }
         }
         return list
@@ -1847,8 +2269,12 @@ enum BreezSDKMapper {
     }
 
     static func asRate(rate: [String: Any?]) throws -> Rate {
-        guard let coin = rate["coin"] as? String else { throw SdkError.Generic(message: "Missing mandatory field coin for type Rate") }
-        guard let value = rate["value"] as? Double else { throw SdkError.Generic(message: "Missing mandatory field value for type Rate") }
+        guard let coin = rate["coin"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "coin", typeName: "Rate"))
+        }
+        guard let value = rate["value"] as? Double else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "value", typeName: "Rate"))
+        }
 
         return Rate(
             coin: coin,
@@ -1870,7 +2296,7 @@ enum BreezSDKMapper {
                 var rate = try asRate(rate: val)
                 list.append(rate)
             } else {
-                throw SdkError.Generic(message: "Unexpected type Rate")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "Rate"))
             }
         }
         return list
@@ -1903,7 +2329,7 @@ enum BreezSDKMapper {
                 var receiveOnchainRequest = try asReceiveOnchainRequest(receiveOnchainRequest: val)
                 list.append(receiveOnchainRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReceiveOnchainRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceiveOnchainRequest"))
             }
         }
         return list
@@ -1914,17 +2340,45 @@ enum BreezSDKMapper {
     }
 
     static func asReceivePaymentRequest(receivePaymentRequest: [String: Any?]) throws -> ReceivePaymentRequest {
-        guard let amountMsat = receivePaymentRequest["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type ReceivePaymentRequest") }
-        guard let description = receivePaymentRequest["description"] as? String else { throw SdkError.Generic(message: "Missing mandatory field description for type ReceivePaymentRequest") }
-        let preimage = receivePaymentRequest["preimage"] as? [UInt8]
+        guard let amountMsat = receivePaymentRequest["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "ReceivePaymentRequest"))
+        }
+        guard let description = receivePaymentRequest["description"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "ReceivePaymentRequest"))
+        }
+        var preimage: [UInt8]?
+        if hasNonNilKey(data: receivePaymentRequest, key: "preimage") {
+            guard let preimageTmp = receivePaymentRequest["preimage"] as? [UInt8] else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "preimage"))
+            }
+            preimage = preimageTmp
+        }
         var openingFeeParams: OpeningFeeParams?
         if let openingFeeParamsTmp = receivePaymentRequest["openingFeeParams"] as? [String: Any?] {
             openingFeeParams = try asOpeningFeeParams(openingFeeParams: openingFeeParamsTmp)
         }
 
-        let useDescriptionHash = receivePaymentRequest["useDescriptionHash"] as? Bool
-        let expiry = receivePaymentRequest["expiry"] as? UInt32
-        let cltv = receivePaymentRequest["cltv"] as? UInt32
+        var useDescriptionHash: Bool?
+        if hasNonNilKey(data: receivePaymentRequest, key: "useDescriptionHash") {
+            guard let useDescriptionHashTmp = receivePaymentRequest["useDescriptionHash"] as? Bool else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "useDescriptionHash"))
+            }
+            useDescriptionHash = useDescriptionHashTmp
+        }
+        var expiry: UInt32?
+        if hasNonNilKey(data: receivePaymentRequest, key: "expiry") {
+            guard let expiryTmp = receivePaymentRequest["expiry"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "expiry"))
+            }
+            expiry = expiryTmp
+        }
+        var cltv: UInt32?
+        if hasNonNilKey(data: receivePaymentRequest, key: "cltv") {
+            guard let cltvTmp = receivePaymentRequest["cltv"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "cltv"))
+            }
+            cltv = cltvTmp
+        }
 
         return ReceivePaymentRequest(
             amountMsat: amountMsat,
@@ -1956,7 +2410,7 @@ enum BreezSDKMapper {
                 var receivePaymentRequest = try asReceivePaymentRequest(receivePaymentRequest: val)
                 list.append(receivePaymentRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReceivePaymentRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceivePaymentRequest"))
             }
         }
         return list
@@ -1967,7 +2421,9 @@ enum BreezSDKMapper {
     }
 
     static func asReceivePaymentResponse(receivePaymentResponse: [String: Any?]) throws -> ReceivePaymentResponse {
-        guard let lnInvoiceTmp = receivePaymentResponse["lnInvoice"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field lnInvoice for type ReceivePaymentResponse") }
+        guard let lnInvoiceTmp = receivePaymentResponse["lnInvoice"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "lnInvoice", typeName: "ReceivePaymentResponse"))
+        }
         let lnInvoice = try asLnInvoice(lnInvoice: lnInvoiceTmp)
 
         var openingFeeParams: OpeningFeeParams?
@@ -1975,7 +2431,13 @@ enum BreezSDKMapper {
             openingFeeParams = try asOpeningFeeParams(openingFeeParams: openingFeeParamsTmp)
         }
 
-        let openingFeeMsat = receivePaymentResponse["openingFeeMsat"] as? UInt64
+        var openingFeeMsat: UInt64?
+        if hasNonNilKey(data: receivePaymentResponse, key: "openingFeeMsat") {
+            guard let openingFeeMsatTmp = receivePaymentResponse["openingFeeMsat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "openingFeeMsat"))
+            }
+            openingFeeMsat = openingFeeMsatTmp
+        }
 
         return ReceivePaymentResponse(
             lnInvoice: lnInvoice,
@@ -1999,7 +2461,7 @@ enum BreezSDKMapper {
                 var receivePaymentResponse = try asReceivePaymentResponse(receivePaymentResponse: val)
                 list.append(receivePaymentResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReceivePaymentResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceivePaymentResponse"))
             }
         }
         return list
@@ -2010,11 +2472,21 @@ enum BreezSDKMapper {
     }
 
     static func asRecommendedFees(recommendedFees: [String: Any?]) throws -> RecommendedFees {
-        guard let fastestFee = recommendedFees["fastestFee"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field fastestFee for type RecommendedFees") }
-        guard let halfHourFee = recommendedFees["halfHourFee"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field halfHourFee for type RecommendedFees") }
-        guard let hourFee = recommendedFees["hourFee"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field hourFee for type RecommendedFees") }
-        guard let economyFee = recommendedFees["economyFee"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field economyFee for type RecommendedFees") }
-        guard let minimumFee = recommendedFees["minimumFee"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field minimumFee for type RecommendedFees") }
+        guard let fastestFee = recommendedFees["fastestFee"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fastestFee", typeName: "RecommendedFees"))
+        }
+        guard let halfHourFee = recommendedFees["halfHourFee"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "halfHourFee", typeName: "RecommendedFees"))
+        }
+        guard let hourFee = recommendedFees["hourFee"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hourFee", typeName: "RecommendedFees"))
+        }
+        guard let economyFee = recommendedFees["economyFee"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "economyFee", typeName: "RecommendedFees"))
+        }
+        guard let minimumFee = recommendedFees["minimumFee"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minimumFee", typeName: "RecommendedFees"))
+        }
 
         return RecommendedFees(
             fastestFee: fastestFee,
@@ -2042,7 +2514,7 @@ enum BreezSDKMapper {
                 var recommendedFees = try asRecommendedFees(recommendedFees: val)
                 list.append(recommendedFees)
             } else {
-                throw SdkError.Generic(message: "Unexpected type RecommendedFees")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "RecommendedFees"))
             }
         }
         return list
@@ -2053,9 +2525,15 @@ enum BreezSDKMapper {
     }
 
     static func asRefundRequest(refundRequest: [String: Any?]) throws -> RefundRequest {
-        guard let swapAddress = refundRequest["swapAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field swapAddress for type RefundRequest") }
-        guard let toAddress = refundRequest["toAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field toAddress for type RefundRequest") }
-        guard let satPerVbyte = refundRequest["satPerVbyte"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field satPerVbyte for type RefundRequest") }
+        guard let swapAddress = refundRequest["swapAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "RefundRequest"))
+        }
+        guard let toAddress = refundRequest["toAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "RefundRequest"))
+        }
+        guard let satPerVbyte = refundRequest["satPerVbyte"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "RefundRequest"))
+        }
 
         return RefundRequest(
             swapAddress: swapAddress,
@@ -2079,7 +2557,7 @@ enum BreezSDKMapper {
                 var refundRequest = try asRefundRequest(refundRequest: val)
                 list.append(refundRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type RefundRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundRequest"))
             }
         }
         return list
@@ -2090,7 +2568,9 @@ enum BreezSDKMapper {
     }
 
     static func asRefundResponse(refundResponse: [String: Any?]) throws -> RefundResponse {
-        guard let refundTxId = refundResponse["refundTxId"] as? String else { throw SdkError.Generic(message: "Missing mandatory field refundTxId for type RefundResponse") }
+        guard let refundTxId = refundResponse["refundTxId"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxId", typeName: "RefundResponse"))
+        }
 
         return RefundResponse(
             refundTxId: refundTxId)
@@ -2109,7 +2589,7 @@ enum BreezSDKMapper {
                 var refundResponse = try asRefundResponse(refundResponse: val)
                 list.append(refundResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type RefundResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundResponse"))
             }
         }
         return list
@@ -2120,8 +2600,16 @@ enum BreezSDKMapper {
     }
 
     static func asReportPaymentFailureDetails(reportPaymentFailureDetails: [String: Any?]) throws -> ReportPaymentFailureDetails {
-        guard let paymentHash = reportPaymentFailureDetails["paymentHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type ReportPaymentFailureDetails") }
-        let comment = reportPaymentFailureDetails["comment"] as? String
+        guard let paymentHash = reportPaymentFailureDetails["paymentHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "ReportPaymentFailureDetails"))
+        }
+        var comment: String?
+        if hasNonNilKey(data: reportPaymentFailureDetails, key: "comment") {
+            guard let commentTmp = reportPaymentFailureDetails["comment"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "comment"))
+            }
+            comment = commentTmp
+        }
 
         return ReportPaymentFailureDetails(
             paymentHash: paymentHash,
@@ -2143,7 +2631,7 @@ enum BreezSDKMapper {
                 var reportPaymentFailureDetails = try asReportPaymentFailureDetails(reportPaymentFailureDetails: val)
                 list.append(reportPaymentFailureDetails)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReportPaymentFailureDetails")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReportPaymentFailureDetails"))
             }
         }
         return list
@@ -2154,7 +2642,13 @@ enum BreezSDKMapper {
     }
 
     static func asReverseSwapFeesRequest(reverseSwapFeesRequest: [String: Any?]) throws -> ReverseSwapFeesRequest {
-        let sendAmountSat = reverseSwapFeesRequest["sendAmountSat"] as? UInt64
+        var sendAmountSat: UInt64?
+        if hasNonNilKey(data: reverseSwapFeesRequest, key: "sendAmountSat") {
+            guard let sendAmountSatTmp = reverseSwapFeesRequest["sendAmountSat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "sendAmountSat"))
+            }
+            sendAmountSat = sendAmountSatTmp
+        }
 
         return ReverseSwapFeesRequest(
             sendAmountSat: sendAmountSat)
@@ -2173,7 +2667,7 @@ enum BreezSDKMapper {
                 var reverseSwapFeesRequest = try asReverseSwapFeesRequest(reverseSwapFeesRequest: val)
                 list.append(reverseSwapFeesRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReverseSwapFeesRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReverseSwapFeesRequest"))
             }
         }
         return list
@@ -2184,12 +2678,32 @@ enum BreezSDKMapper {
     }
 
     static func asReverseSwapInfo(reverseSwapInfo: [String: Any?]) throws -> ReverseSwapInfo {
-        guard let id = reverseSwapInfo["id"] as? String else { throw SdkError.Generic(message: "Missing mandatory field id for type ReverseSwapInfo") }
-        guard let claimPubkey = reverseSwapInfo["claimPubkey"] as? String else { throw SdkError.Generic(message: "Missing mandatory field claimPubkey for type ReverseSwapInfo") }
-        let lockupTxid = reverseSwapInfo["lockupTxid"] as? String
-        let claimTxid = reverseSwapInfo["claimTxid"] as? String
-        guard let onchainAmountSat = reverseSwapInfo["onchainAmountSat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field onchainAmountSat for type ReverseSwapInfo") }
-        guard let statusTmp = reverseSwapInfo["status"] as? String else { throw SdkError.Generic(message: "Missing mandatory field status for type ReverseSwapInfo") }
+        guard let id = reverseSwapInfo["id"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "ReverseSwapInfo"))
+        }
+        guard let claimPubkey = reverseSwapInfo["claimPubkey"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "claimPubkey", typeName: "ReverseSwapInfo"))
+        }
+        var lockupTxid: String?
+        if hasNonNilKey(data: reverseSwapInfo, key: "lockupTxid") {
+            guard let lockupTxidTmp = reverseSwapInfo["lockupTxid"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lockupTxid"))
+            }
+            lockupTxid = lockupTxidTmp
+        }
+        var claimTxid: String?
+        if hasNonNilKey(data: reverseSwapInfo, key: "claimTxid") {
+            guard let claimTxidTmp = reverseSwapInfo["claimTxid"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "claimTxid"))
+            }
+            claimTxid = claimTxidTmp
+        }
+        guard let onchainAmountSat = reverseSwapInfo["onchainAmountSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "onchainAmountSat", typeName: "ReverseSwapInfo"))
+        }
+        guard let statusTmp = reverseSwapInfo["status"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "ReverseSwapInfo"))
+        }
         let status = try asReverseSwapStatus(reverseSwapStatus: statusTmp)
 
         return ReverseSwapInfo(
@@ -2220,7 +2734,7 @@ enum BreezSDKMapper {
                 var reverseSwapInfo = try asReverseSwapInfo(reverseSwapInfo: val)
                 list.append(reverseSwapInfo)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReverseSwapInfo")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReverseSwapInfo"))
             }
         }
         return list
@@ -2231,13 +2745,31 @@ enum BreezSDKMapper {
     }
 
     static func asReverseSwapPairInfo(reverseSwapPairInfo: [String: Any?]) throws -> ReverseSwapPairInfo {
-        guard let min = reverseSwapPairInfo["min"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field min for type ReverseSwapPairInfo") }
-        guard let max = reverseSwapPairInfo["max"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field max for type ReverseSwapPairInfo") }
-        guard let feesHash = reverseSwapPairInfo["feesHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field feesHash for type ReverseSwapPairInfo") }
-        guard let feesPercentage = reverseSwapPairInfo["feesPercentage"] as? Double else { throw SdkError.Generic(message: "Missing mandatory field feesPercentage for type ReverseSwapPairInfo") }
-        guard let feesLockup = reverseSwapPairInfo["feesLockup"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field feesLockup for type ReverseSwapPairInfo") }
-        guard let feesClaim = reverseSwapPairInfo["feesClaim"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field feesClaim for type ReverseSwapPairInfo") }
-        let totalEstimatedFees = reverseSwapPairInfo["totalEstimatedFees"] as? UInt64
+        guard let min = reverseSwapPairInfo["min"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "min", typeName: "ReverseSwapPairInfo"))
+        }
+        guard let max = reverseSwapPairInfo["max"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "max", typeName: "ReverseSwapPairInfo"))
+        }
+        guard let feesHash = reverseSwapPairInfo["feesHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesHash", typeName: "ReverseSwapPairInfo"))
+        }
+        guard let feesPercentage = reverseSwapPairInfo["feesPercentage"] as? Double else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesPercentage", typeName: "ReverseSwapPairInfo"))
+        }
+        guard let feesLockup = reverseSwapPairInfo["feesLockup"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesLockup", typeName: "ReverseSwapPairInfo"))
+        }
+        guard let feesClaim = reverseSwapPairInfo["feesClaim"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesClaim", typeName: "ReverseSwapPairInfo"))
+        }
+        var totalEstimatedFees: UInt64?
+        if hasNonNilKey(data: reverseSwapPairInfo, key: "totalEstimatedFees") {
+            guard let totalEstimatedFeesTmp = reverseSwapPairInfo["totalEstimatedFees"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "totalEstimatedFees"))
+            }
+            totalEstimatedFees = totalEstimatedFeesTmp
+        }
 
         return ReverseSwapPairInfo(
             min: min,
@@ -2269,7 +2801,7 @@ enum BreezSDKMapper {
                 var reverseSwapPairInfo = try asReverseSwapPairInfo(reverseSwapPairInfo: val)
                 list.append(reverseSwapPairInfo)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReverseSwapPairInfo")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReverseSwapPairInfo"))
             }
         }
         return list
@@ -2280,7 +2812,9 @@ enum BreezSDKMapper {
     }
 
     static func asRouteHint(routeHint: [String: Any?]) throws -> RouteHint {
-        guard let hopsTmp = routeHint["hops"] as? [[String: Any?]] else { throw SdkError.Generic(message: "Missing mandatory field hops for type RouteHint") }
+        guard let hopsTmp = routeHint["hops"] as? [[String: Any?]] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hops", typeName: "RouteHint"))
+        }
         let hops = try asRouteHintHopList(arr: hopsTmp)
 
         return RouteHint(
@@ -2300,7 +2834,7 @@ enum BreezSDKMapper {
                 var routeHint = try asRouteHint(routeHint: val)
                 list.append(routeHint)
             } else {
-                throw SdkError.Generic(message: "Unexpected type RouteHint")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "RouteHint"))
             }
         }
         return list
@@ -2311,13 +2845,35 @@ enum BreezSDKMapper {
     }
 
     static func asRouteHintHop(routeHintHop: [String: Any?]) throws -> RouteHintHop {
-        guard let srcNodeId = routeHintHop["srcNodeId"] as? String else { throw SdkError.Generic(message: "Missing mandatory field srcNodeId for type RouteHintHop") }
-        guard let shortChannelId = routeHintHop["shortChannelId"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field shortChannelId for type RouteHintHop") }
-        guard let feesBaseMsat = routeHintHop["feesBaseMsat"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field feesBaseMsat for type RouteHintHop") }
-        guard let feesProportionalMillionths = routeHintHop["feesProportionalMillionths"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field feesProportionalMillionths for type RouteHintHop") }
-        guard let cltvExpiryDelta = routeHintHop["cltvExpiryDelta"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field cltvExpiryDelta for type RouteHintHop") }
-        let htlcMinimumMsat = routeHintHop["htlcMinimumMsat"] as? UInt64
-        let htlcMaximumMsat = routeHintHop["htlcMaximumMsat"] as? UInt64
+        guard let srcNodeId = routeHintHop["srcNodeId"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "srcNodeId", typeName: "RouteHintHop"))
+        }
+        guard let shortChannelId = routeHintHop["shortChannelId"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "shortChannelId", typeName: "RouteHintHop"))
+        }
+        guard let feesBaseMsat = routeHintHop["feesBaseMsat"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesBaseMsat", typeName: "RouteHintHop"))
+        }
+        guard let feesProportionalMillionths = routeHintHop["feesProportionalMillionths"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesProportionalMillionths", typeName: "RouteHintHop"))
+        }
+        guard let cltvExpiryDelta = routeHintHop["cltvExpiryDelta"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "cltvExpiryDelta", typeName: "RouteHintHop"))
+        }
+        var htlcMinimumMsat: UInt64?
+        if hasNonNilKey(data: routeHintHop, key: "htlcMinimumMsat") {
+            guard let htlcMinimumMsatTmp = routeHintHop["htlcMinimumMsat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "htlcMinimumMsat"))
+            }
+            htlcMinimumMsat = htlcMinimumMsatTmp
+        }
+        var htlcMaximumMsat: UInt64?
+        if hasNonNilKey(data: routeHintHop, key: "htlcMaximumMsat") {
+            guard let htlcMaximumMsatTmp = routeHintHop["htlcMaximumMsat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "htlcMaximumMsat"))
+            }
+            htlcMaximumMsat = htlcMaximumMsatTmp
+        }
 
         return RouteHintHop(
             srcNodeId: srcNodeId,
@@ -2349,7 +2905,7 @@ enum BreezSDKMapper {
                 var routeHintHop = try asRouteHintHop(routeHintHop: val)
                 list.append(routeHintHop)
             } else {
-                throw SdkError.Generic(message: "Unexpected type RouteHintHop")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "RouteHintHop"))
             }
         }
         return list
@@ -2360,10 +2916,18 @@ enum BreezSDKMapper {
     }
 
     static func asSendOnchainRequest(sendOnchainRequest: [String: Any?]) throws -> SendOnchainRequest {
-        guard let amountSat = sendOnchainRequest["amountSat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountSat for type SendOnchainRequest") }
-        guard let onchainRecipientAddress = sendOnchainRequest["onchainRecipientAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field onchainRecipientAddress for type SendOnchainRequest") }
-        guard let pairHash = sendOnchainRequest["pairHash"] as? String else { throw SdkError.Generic(message: "Missing mandatory field pairHash for type SendOnchainRequest") }
-        guard let satPerVbyte = sendOnchainRequest["satPerVbyte"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field satPerVbyte for type SendOnchainRequest") }
+        guard let amountSat = sendOnchainRequest["amountSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "SendOnchainRequest"))
+        }
+        guard let onchainRecipientAddress = sendOnchainRequest["onchainRecipientAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "onchainRecipientAddress", typeName: "SendOnchainRequest"))
+        }
+        guard let pairHash = sendOnchainRequest["pairHash"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pairHash", typeName: "SendOnchainRequest"))
+        }
+        guard let satPerVbyte = sendOnchainRequest["satPerVbyte"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "SendOnchainRequest"))
+        }
 
         return SendOnchainRequest(
             amountSat: amountSat,
@@ -2389,7 +2953,7 @@ enum BreezSDKMapper {
                 var sendOnchainRequest = try asSendOnchainRequest(sendOnchainRequest: val)
                 list.append(sendOnchainRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SendOnchainRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendOnchainRequest"))
             }
         }
         return list
@@ -2400,7 +2964,9 @@ enum BreezSDKMapper {
     }
 
     static func asSendOnchainResponse(sendOnchainResponse: [String: Any?]) throws -> SendOnchainResponse {
-        guard let reverseSwapInfoTmp = sendOnchainResponse["reverseSwapInfo"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field reverseSwapInfo for type SendOnchainResponse") }
+        guard let reverseSwapInfoTmp = sendOnchainResponse["reverseSwapInfo"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reverseSwapInfo", typeName: "SendOnchainResponse"))
+        }
         let reverseSwapInfo = try asReverseSwapInfo(reverseSwapInfo: reverseSwapInfoTmp)
 
         return SendOnchainResponse(
@@ -2420,7 +2986,7 @@ enum BreezSDKMapper {
                 var sendOnchainResponse = try asSendOnchainResponse(sendOnchainResponse: val)
                 list.append(sendOnchainResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SendOnchainResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendOnchainResponse"))
             }
         }
         return list
@@ -2431,8 +2997,16 @@ enum BreezSDKMapper {
     }
 
     static func asSendPaymentRequest(sendPaymentRequest: [String: Any?]) throws -> SendPaymentRequest {
-        guard let bolt11 = sendPaymentRequest["bolt11"] as? String else { throw SdkError.Generic(message: "Missing mandatory field bolt11 for type SendPaymentRequest") }
-        let amountMsat = sendPaymentRequest["amountMsat"] as? UInt64
+        guard let bolt11 = sendPaymentRequest["bolt11"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "SendPaymentRequest"))
+        }
+        var amountMsat: UInt64?
+        if hasNonNilKey(data: sendPaymentRequest, key: "amountMsat") {
+            guard let amountMsatTmp = sendPaymentRequest["amountMsat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "amountMsat"))
+            }
+            amountMsat = amountMsatTmp
+        }
 
         return SendPaymentRequest(
             bolt11: bolt11,
@@ -2454,7 +3028,7 @@ enum BreezSDKMapper {
                 var sendPaymentRequest = try asSendPaymentRequest(sendPaymentRequest: val)
                 list.append(sendPaymentRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SendPaymentRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendPaymentRequest"))
             }
         }
         return list
@@ -2465,7 +3039,9 @@ enum BreezSDKMapper {
     }
 
     static func asSendPaymentResponse(sendPaymentResponse: [String: Any?]) throws -> SendPaymentResponse {
-        guard let paymentTmp = sendPaymentResponse["payment"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field payment for type SendPaymentResponse") }
+        guard let paymentTmp = sendPaymentResponse["payment"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "SendPaymentResponse"))
+        }
         let payment = try asPayment(payment: paymentTmp)
 
         return SendPaymentResponse(
@@ -2485,7 +3061,7 @@ enum BreezSDKMapper {
                 var sendPaymentResponse = try asSendPaymentResponse(sendPaymentResponse: val)
                 list.append(sendPaymentResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SendPaymentResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendPaymentResponse"))
             }
         }
         return list
@@ -2496,8 +3072,12 @@ enum BreezSDKMapper {
     }
 
     static func asSendSpontaneousPaymentRequest(sendSpontaneousPaymentRequest: [String: Any?]) throws -> SendSpontaneousPaymentRequest {
-        guard let nodeId = sendSpontaneousPaymentRequest["nodeId"] as? String else { throw SdkError.Generic(message: "Missing mandatory field nodeId for type SendSpontaneousPaymentRequest") }
-        guard let amountMsat = sendSpontaneousPaymentRequest["amountMsat"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMsat for type SendSpontaneousPaymentRequest") }
+        guard let nodeId = sendSpontaneousPaymentRequest["nodeId"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "nodeId", typeName: "SendSpontaneousPaymentRequest"))
+        }
+        guard let amountMsat = sendSpontaneousPaymentRequest["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "SendSpontaneousPaymentRequest"))
+        }
 
         return SendSpontaneousPaymentRequest(
             nodeId: nodeId,
@@ -2519,7 +3099,7 @@ enum BreezSDKMapper {
                 var sendSpontaneousPaymentRequest = try asSendSpontaneousPaymentRequest(sendSpontaneousPaymentRequest: val)
                 list.append(sendSpontaneousPaymentRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SendSpontaneousPaymentRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendSpontaneousPaymentRequest"))
             }
         }
         return list
@@ -2530,7 +3110,9 @@ enum BreezSDKMapper {
     }
 
     static func asServiceHealthCheckResponse(serviceHealthCheckResponse: [String: Any?]) throws -> ServiceHealthCheckResponse {
-        guard let statusTmp = serviceHealthCheckResponse["status"] as? String else { throw SdkError.Generic(message: "Missing mandatory field status for type ServiceHealthCheckResponse") }
+        guard let statusTmp = serviceHealthCheckResponse["status"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "ServiceHealthCheckResponse"))
+        }
         let status = try asHealthCheckStatus(healthCheckStatus: statusTmp)
 
         return ServiceHealthCheckResponse(
@@ -2550,7 +3132,7 @@ enum BreezSDKMapper {
                 var serviceHealthCheckResponse = try asServiceHealthCheckResponse(serviceHealthCheckResponse: val)
                 list.append(serviceHealthCheckResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ServiceHealthCheckResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ServiceHealthCheckResponse"))
             }
         }
         return list
@@ -2561,7 +3143,9 @@ enum BreezSDKMapper {
     }
 
     static func asSignMessageRequest(signMessageRequest: [String: Any?]) throws -> SignMessageRequest {
-        guard let message = signMessageRequest["message"] as? String else { throw SdkError.Generic(message: "Missing mandatory field message for type SignMessageRequest") }
+        guard let message = signMessageRequest["message"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "SignMessageRequest"))
+        }
 
         return SignMessageRequest(
             message: message)
@@ -2580,7 +3164,7 @@ enum BreezSDKMapper {
                 var signMessageRequest = try asSignMessageRequest(signMessageRequest: val)
                 list.append(signMessageRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SignMessageRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SignMessageRequest"))
             }
         }
         return list
@@ -2591,7 +3175,9 @@ enum BreezSDKMapper {
     }
 
     static func asSignMessageResponse(signMessageResponse: [String: Any?]) throws -> SignMessageResponse {
-        guard let signature = signMessageResponse["signature"] as? String else { throw SdkError.Generic(message: "Missing mandatory field signature for type SignMessageResponse") }
+        guard let signature = signMessageResponse["signature"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "signature", typeName: "SignMessageResponse"))
+        }
 
         return SignMessageResponse(
             signature: signature)
@@ -2610,7 +3196,7 @@ enum BreezSDKMapper {
                 var signMessageResponse = try asSignMessageResponse(signMessageResponse: val)
                 list.append(signMessageResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SignMessageResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SignMessageResponse"))
             }
         }
         return list
@@ -2621,7 +3207,9 @@ enum BreezSDKMapper {
     }
 
     static func asStaticBackupRequest(staticBackupRequest: [String: Any?]) throws -> StaticBackupRequest {
-        guard let workingDir = staticBackupRequest["workingDir"] as? String else { throw SdkError.Generic(message: "Missing mandatory field workingDir for type StaticBackupRequest") }
+        guard let workingDir = staticBackupRequest["workingDir"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "workingDir", typeName: "StaticBackupRequest"))
+        }
 
         return StaticBackupRequest(
             workingDir: workingDir)
@@ -2640,7 +3228,7 @@ enum BreezSDKMapper {
                 var staticBackupRequest = try asStaticBackupRequest(staticBackupRequest: val)
                 list.append(staticBackupRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type StaticBackupRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "StaticBackupRequest"))
             }
         }
         return list
@@ -2651,7 +3239,13 @@ enum BreezSDKMapper {
     }
 
     static func asStaticBackupResponse(staticBackupResponse: [String: Any?]) throws -> StaticBackupResponse {
-        let backup = staticBackupResponse["backup"] as? [String]
+        var backup: [String]?
+        if hasNonNilKey(data: staticBackupResponse, key: "backup") {
+            guard let backupTmp = staticBackupResponse["backup"] as? [String] else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "backup"))
+            }
+            backup = backupTmp
+        }
 
         return StaticBackupResponse(
             backup: backup)
@@ -2670,7 +3264,7 @@ enum BreezSDKMapper {
                 var staticBackupResponse = try asStaticBackupResponse(staticBackupResponse: val)
                 list.append(staticBackupResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type StaticBackupResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "StaticBackupResponse"))
             }
         }
         return list
@@ -2681,28 +3275,76 @@ enum BreezSDKMapper {
     }
 
     static func asSwapInfo(swapInfo: [String: Any?]) throws -> SwapInfo {
-        guard let bitcoinAddress = swapInfo["bitcoinAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field bitcoinAddress for type SwapInfo") }
-        guard let createdAt = swapInfo["createdAt"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field createdAt for type SwapInfo") }
-        guard let lockHeight = swapInfo["lockHeight"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field lockHeight for type SwapInfo") }
-        guard let paymentHash = swapInfo["paymentHash"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field paymentHash for type SwapInfo") }
-        guard let preimage = swapInfo["preimage"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field preimage for type SwapInfo") }
-        guard let privateKey = swapInfo["privateKey"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field privateKey for type SwapInfo") }
-        guard let publicKey = swapInfo["publicKey"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field publicKey for type SwapInfo") }
-        guard let swapperPublicKey = swapInfo["swapperPublicKey"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field swapperPublicKey for type SwapInfo") }
-        guard let script = swapInfo["script"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field script for type SwapInfo") }
-        let bolt11 = swapInfo["bolt11"] as? String
-        guard let paidSats = swapInfo["paidSats"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field paidSats for type SwapInfo") }
-        guard let unconfirmedSats = swapInfo["unconfirmedSats"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field unconfirmedSats for type SwapInfo") }
-        guard let confirmedSats = swapInfo["confirmedSats"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field confirmedSats for type SwapInfo") }
-        guard let statusTmp = swapInfo["status"] as? String else { throw SdkError.Generic(message: "Missing mandatory field status for type SwapInfo") }
+        guard let bitcoinAddress = swapInfo["bitcoinAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bitcoinAddress", typeName: "SwapInfo"))
+        }
+        guard let createdAt = swapInfo["createdAt"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "createdAt", typeName: "SwapInfo"))
+        }
+        guard let lockHeight = swapInfo["lockHeight"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "lockHeight", typeName: "SwapInfo"))
+        }
+        guard let paymentHash = swapInfo["paymentHash"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "SwapInfo"))
+        }
+        guard let preimage = swapInfo["preimage"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "preimage", typeName: "SwapInfo"))
+        }
+        guard let privateKey = swapInfo["privateKey"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "privateKey", typeName: "SwapInfo"))
+        }
+        guard let publicKey = swapInfo["publicKey"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "publicKey", typeName: "SwapInfo"))
+        }
+        guard let swapperPublicKey = swapInfo["swapperPublicKey"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapperPublicKey", typeName: "SwapInfo"))
+        }
+        guard let script = swapInfo["script"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "script", typeName: "SwapInfo"))
+        }
+        var bolt11: String?
+        if hasNonNilKey(data: swapInfo, key: "bolt11") {
+            guard let bolt11Tmp = swapInfo["bolt11"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "bolt11"))
+            }
+            bolt11 = bolt11Tmp
+        }
+        guard let paidSats = swapInfo["paidSats"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paidSats", typeName: "SwapInfo"))
+        }
+        guard let unconfirmedSats = swapInfo["unconfirmedSats"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "unconfirmedSats", typeName: "SwapInfo"))
+        }
+        guard let confirmedSats = swapInfo["confirmedSats"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "confirmedSats", typeName: "SwapInfo"))
+        }
+        guard let statusTmp = swapInfo["status"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "SwapInfo"))
+        }
         let status = try asSwapStatus(swapStatus: statusTmp)
 
-        guard let refundTxIds = swapInfo["refundTxIds"] as? [String] else { throw SdkError.Generic(message: "Missing mandatory field refundTxIds for type SwapInfo") }
-        guard let unconfirmedTxIds = swapInfo["unconfirmedTxIds"] as? [String] else { throw SdkError.Generic(message: "Missing mandatory field unconfirmedTxIds for type SwapInfo") }
-        guard let confirmedTxIds = swapInfo["confirmedTxIds"] as? [String] else { throw SdkError.Generic(message: "Missing mandatory field confirmedTxIds for type SwapInfo") }
-        guard let minAllowedDeposit = swapInfo["minAllowedDeposit"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field minAllowedDeposit for type SwapInfo") }
-        guard let maxAllowedDeposit = swapInfo["maxAllowedDeposit"] as? Int64 else { throw SdkError.Generic(message: "Missing mandatory field maxAllowedDeposit for type SwapInfo") }
-        let lastRedeemError = swapInfo["lastRedeemError"] as? String
+        guard let refundTxIds = swapInfo["refundTxIds"] as? [String] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxIds", typeName: "SwapInfo"))
+        }
+        guard let unconfirmedTxIds = swapInfo["unconfirmedTxIds"] as? [String] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "unconfirmedTxIds", typeName: "SwapInfo"))
+        }
+        guard let confirmedTxIds = swapInfo["confirmedTxIds"] as? [String] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "confirmedTxIds", typeName: "SwapInfo"))
+        }
+        guard let minAllowedDeposit = swapInfo["minAllowedDeposit"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minAllowedDeposit", typeName: "SwapInfo"))
+        }
+        guard let maxAllowedDeposit = swapInfo["maxAllowedDeposit"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxAllowedDeposit", typeName: "SwapInfo"))
+        }
+        var lastRedeemError: String?
+        if hasNonNilKey(data: swapInfo, key: "lastRedeemError") {
+            guard let lastRedeemErrorTmp = swapInfo["lastRedeemError"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lastRedeemError"))
+            }
+            lastRedeemError = lastRedeemErrorTmp
+        }
         var channelOpeningFees: OpeningFeeParams?
         if let channelOpeningFeesTmp = swapInfo["channelOpeningFees"] as? [String: Any?] {
             channelOpeningFees = try asOpeningFeeParams(openingFeeParams: channelOpeningFeesTmp)
@@ -2766,7 +3408,7 @@ enum BreezSDKMapper {
                 var swapInfo = try asSwapInfo(swapInfo: val)
                 list.append(swapInfo)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SwapInfo")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SwapInfo"))
             }
         }
         return list
@@ -2777,8 +3419,12 @@ enum BreezSDKMapper {
     }
 
     static func asSweepRequest(sweepRequest: [String: Any?]) throws -> SweepRequest {
-        guard let toAddress = sweepRequest["toAddress"] as? String else { throw SdkError.Generic(message: "Missing mandatory field toAddress for type SweepRequest") }
-        guard let satPerVbyte = sweepRequest["satPerVbyte"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field satPerVbyte for type SweepRequest") }
+        guard let toAddress = sweepRequest["toAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "SweepRequest"))
+        }
+        guard let satPerVbyte = sweepRequest["satPerVbyte"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "SweepRequest"))
+        }
 
         return SweepRequest(
             toAddress: toAddress,
@@ -2800,7 +3446,7 @@ enum BreezSDKMapper {
                 var sweepRequest = try asSweepRequest(sweepRequest: val)
                 list.append(sweepRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SweepRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SweepRequest"))
             }
         }
         return list
@@ -2811,7 +3457,9 @@ enum BreezSDKMapper {
     }
 
     static func asSweepResponse(sweepResponse: [String: Any?]) throws -> SweepResponse {
-        guard let txid = sweepResponse["txid"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field txid for type SweepResponse") }
+        guard let txid = sweepResponse["txid"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txid", typeName: "SweepResponse"))
+        }
 
         return SweepResponse(
             txid: txid)
@@ -2830,7 +3478,7 @@ enum BreezSDKMapper {
                 var sweepResponse = try asSweepResponse(sweepResponse: val)
                 list.append(sweepResponse)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SweepResponse")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SweepResponse"))
             }
         }
         return list
@@ -2841,10 +3489,34 @@ enum BreezSDKMapper {
     }
 
     static func asSymbol(symbol: [String: Any?]) throws -> Symbol {
-        let grapheme = symbol["grapheme"] as? String
-        let template = symbol["template"] as? String
-        let rtl = symbol["rtl"] as? Bool
-        let position = symbol["position"] as? UInt32
+        var grapheme: String?
+        if hasNonNilKey(data: symbol, key: "grapheme") {
+            guard let graphemeTmp = symbol["grapheme"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "grapheme"))
+            }
+            grapheme = graphemeTmp
+        }
+        var template: String?
+        if hasNonNilKey(data: symbol, key: "template") {
+            guard let templateTmp = symbol["template"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "template"))
+            }
+            template = templateTmp
+        }
+        var rtl: Bool?
+        if hasNonNilKey(data: symbol, key: "rtl") {
+            guard let rtlTmp = symbol["rtl"] as? Bool else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "rtl"))
+            }
+            rtl = rtlTmp
+        }
+        var position: UInt32?
+        if hasNonNilKey(data: symbol, key: "position") {
+            guard let positionTmp = symbol["position"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "position"))
+            }
+            position = positionTmp
+        }
 
         return Symbol(
             grapheme: grapheme,
@@ -2870,7 +3542,7 @@ enum BreezSDKMapper {
                 var symbol = try asSymbol(symbol: val)
                 list.append(symbol)
             } else {
-                throw SdkError.Generic(message: "Unexpected type Symbol")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "Symbol"))
             }
         }
         return list
@@ -2881,11 +3553,21 @@ enum BreezSDKMapper {
     }
 
     static func asUnspentTransactionOutput(unspentTransactionOutput: [String: Any?]) throws -> UnspentTransactionOutput {
-        guard let txid = unspentTransactionOutput["txid"] as? [UInt8] else { throw SdkError.Generic(message: "Missing mandatory field txid for type UnspentTransactionOutput") }
-        guard let outnum = unspentTransactionOutput["outnum"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field outnum for type UnspentTransactionOutput") }
-        guard let amountMillisatoshi = unspentTransactionOutput["amountMillisatoshi"] as? UInt64 else { throw SdkError.Generic(message: "Missing mandatory field amountMillisatoshi for type UnspentTransactionOutput") }
-        guard let address = unspentTransactionOutput["address"] as? String else { throw SdkError.Generic(message: "Missing mandatory field address for type UnspentTransactionOutput") }
-        guard let reserved = unspentTransactionOutput["reserved"] as? Bool else { throw SdkError.Generic(message: "Missing mandatory field reserved for type UnspentTransactionOutput") }
+        guard let txid = unspentTransactionOutput["txid"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txid", typeName: "UnspentTransactionOutput"))
+        }
+        guard let outnum = unspentTransactionOutput["outnum"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "outnum", typeName: "UnspentTransactionOutput"))
+        }
+        guard let amountMillisatoshi = unspentTransactionOutput["amountMillisatoshi"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMillisatoshi", typeName: "UnspentTransactionOutput"))
+        }
+        guard let address = unspentTransactionOutput["address"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "UnspentTransactionOutput"))
+        }
+        guard let reserved = unspentTransactionOutput["reserved"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reserved", typeName: "UnspentTransactionOutput"))
+        }
 
         return UnspentTransactionOutput(
             txid: txid,
@@ -2913,7 +3595,7 @@ enum BreezSDKMapper {
                 var unspentTransactionOutput = try asUnspentTransactionOutput(unspentTransactionOutput: val)
                 list.append(unspentTransactionOutput)
             } else {
-                throw SdkError.Generic(message: "Unexpected type UnspentTransactionOutput")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "UnspentTransactionOutput"))
             }
         }
         return list
@@ -2924,8 +3606,12 @@ enum BreezSDKMapper {
     }
 
     static func asUrlSuccessActionData(urlSuccessActionData: [String: Any?]) throws -> UrlSuccessActionData {
-        guard let description = urlSuccessActionData["description"] as? String else { throw SdkError.Generic(message: "Missing mandatory field description for type UrlSuccessActionData") }
-        guard let url = urlSuccessActionData["url"] as? String else { throw SdkError.Generic(message: "Missing mandatory field url for type UrlSuccessActionData") }
+        guard let description = urlSuccessActionData["description"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "UrlSuccessActionData"))
+        }
+        guard let url = urlSuccessActionData["url"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "UrlSuccessActionData"))
+        }
 
         return UrlSuccessActionData(
             description: description,
@@ -2947,7 +3633,7 @@ enum BreezSDKMapper {
                 var urlSuccessActionData = try asUrlSuccessActionData(urlSuccessActionData: val)
                 list.append(urlSuccessActionData)
             } else {
-                throw SdkError.Generic(message: "Unexpected type UrlSuccessActionData")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "UrlSuccessActionData"))
             }
         }
         return list
@@ -2960,13 +3646,17 @@ enum BreezSDKMapper {
     static func asAesSuccessActionDataResult(aesSuccessActionDataResult: [String: Any?]) throws -> AesSuccessActionDataResult {
         let type = aesSuccessActionDataResult["type"] as! String
         if type == "decrypted" {
-            guard let dataTmp = aesSuccessActionDataResult["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type AesSuccessActionDataResult") }
+            guard let dataTmp = aesSuccessActionDataResult["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "AesSuccessActionDataResult"))
+            }
             let _data = try asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: dataTmp)
 
             return AesSuccessActionDataResult.decrypted(data: _data)
         }
         if type == "errorStatus" {
-            guard let _reason = aesSuccessActionDataResult["reason"] as? String else { throw SdkError.Generic(message: "Missing mandatory field reason for type AesSuccessActionDataResult") }
+            guard let _reason = aesSuccessActionDataResult["reason"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "AesSuccessActionDataResult"))
+            }
             return AesSuccessActionDataResult.errorStatus(reason: _reason)
         }
 
@@ -3004,7 +3694,7 @@ enum BreezSDKMapper {
                 var aesSuccessActionDataResult = try asAesSuccessActionDataResult(aesSuccessActionDataResult: val)
                 list.append(aesSuccessActionDataResult)
             } else {
-                throw SdkError.Generic(message: "Unexpected type AesSuccessActionDataResult")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionDataResult"))
             }
         }
         return list
@@ -3013,11 +3703,15 @@ enum BreezSDKMapper {
     static func asBreezEvent(breezEvent: [String: Any?]) throws -> BreezEvent {
         let type = breezEvent["type"] as! String
         if type == "newBlock" {
-            guard let _block = breezEvent["block"] as? UInt32 else { throw SdkError.Generic(message: "Missing mandatory field block for type BreezEvent") }
+            guard let _block = breezEvent["block"] as? UInt32 else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "block", typeName: "BreezEvent"))
+            }
             return BreezEvent.newBlock(block: _block)
         }
         if type == "invoicePaid" {
-            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type BreezEvent") }
+            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
+            }
             let _details = try asInvoicePaidDetails(invoicePaidDetails: detailsTmp)
 
             return BreezEvent.invoicePaid(details: _details)
@@ -3026,13 +3720,17 @@ enum BreezSDKMapper {
             return BreezEvent.synced
         }
         if type == "paymentSucceed" {
-            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type BreezEvent") }
+            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
+            }
             let _details = try asPayment(payment: detailsTmp)
 
             return BreezEvent.paymentSucceed(details: _details)
         }
         if type == "paymentFailed" {
-            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type BreezEvent") }
+            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
+            }
             let _details = try asPaymentFailedData(paymentFailedData: detailsTmp)
 
             return BreezEvent.paymentFailed(details: _details)
@@ -3044,7 +3742,9 @@ enum BreezSDKMapper {
             return BreezEvent.backupSucceeded
         }
         if type == "backupFailed" {
-            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field details for type BreezEvent") }
+            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
+            }
             let _details = try asBackupFailedData(backupFailedData: detailsTmp)
 
             return BreezEvent.backupFailed(details: _details)
@@ -3123,7 +3823,7 @@ enum BreezSDKMapper {
                 var breezEvent = try asBreezEvent(breezEvent: val)
                 list.append(breezEvent)
             } else {
-                throw SdkError.Generic(message: "Unexpected type BreezEvent")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "BreezEvent"))
             }
         }
         return list
@@ -3156,7 +3856,7 @@ enum BreezSDKMapper {
                 var buyBitcoinProvider = try asBuyBitcoinProvider(buyBitcoinProvider: val)
                 list.append(buyBitcoinProvider)
             } else {
-                throw SdkError.Generic(message: "Unexpected type BuyBitcoinProvider")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "BuyBitcoinProvider"))
             }
         }
         return list
@@ -3207,7 +3907,7 @@ enum BreezSDKMapper {
                 var channelState = try asChannelState(channelState: val)
                 list.append(channelState)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ChannelState")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ChannelState"))
             }
         }
         return list
@@ -3246,7 +3946,7 @@ enum BreezSDKMapper {
                 var environmentType = try asEnvironmentType(environmentType: val)
                 list.append(environmentType)
             } else {
-                throw SdkError.Generic(message: "Unexpected type EnvironmentType")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "EnvironmentType"))
             }
         }
         return list
@@ -3291,7 +3991,7 @@ enum BreezSDKMapper {
                 var feeratePreset = try asFeeratePreset(feeratePreset: val)
                 list.append(feeratePreset)
             } else {
-                throw SdkError.Generic(message: "Unexpected type FeeratePreset")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "FeeratePreset"))
             }
         }
         return list
@@ -3336,7 +4036,7 @@ enum BreezSDKMapper {
                 var healthCheckStatus = try asHealthCheckStatus(healthCheckStatus: val)
                 list.append(healthCheckStatus)
             } else {
-                throw SdkError.Generic(message: "Unexpected type HealthCheckStatus")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "HealthCheckStatus"))
             }
         }
         return list
@@ -3345,45 +4045,61 @@ enum BreezSDKMapper {
     static func asInputType(inputType: [String: Any?]) throws -> InputType {
         let type = inputType["type"] as! String
         if type == "bitcoinAddress" {
-            guard let addressTmp = inputType["address"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field address for type InputType") }
+            guard let addressTmp = inputType["address"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "InputType"))
+            }
             let _address = try asBitcoinAddressData(bitcoinAddressData: addressTmp)
 
             return InputType.bitcoinAddress(address: _address)
         }
         if type == "bolt11" {
-            guard let invoiceTmp = inputType["invoice"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field invoice for type InputType") }
+            guard let invoiceTmp = inputType["invoice"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "InputType"))
+            }
             let _invoice = try asLnInvoice(lnInvoice: invoiceTmp)
 
             return InputType.bolt11(invoice: _invoice)
         }
         if type == "nodeId" {
-            guard let _nodeId = inputType["nodeId"] as? String else { throw SdkError.Generic(message: "Missing mandatory field nodeId for type InputType") }
+            guard let _nodeId = inputType["nodeId"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "nodeId", typeName: "InputType"))
+            }
             return InputType.nodeId(nodeId: _nodeId)
         }
         if type == "url" {
-            guard let _url = inputType["url"] as? String else { throw SdkError.Generic(message: "Missing mandatory field url for type InputType") }
+            guard let _url = inputType["url"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "InputType"))
+            }
             return InputType.url(url: _url)
         }
         if type == "lnUrlPay" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type InputType") }
+            guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+            }
             let _data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
 
             return InputType.lnUrlPay(data: _data)
         }
         if type == "lnUrlWithdraw" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type InputType") }
+            guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+            }
             let _data = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: dataTmp)
 
             return InputType.lnUrlWithdraw(data: _data)
         }
         if type == "lnUrlAuth" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type InputType") }
+            guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+            }
             let _data = try asLnUrlAuthRequestData(lnUrlAuthRequestData: dataTmp)
 
             return InputType.lnUrlAuth(data: _data)
         }
         if type == "lnUrlError" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type InputType") }
+            guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+            }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
 
             return InputType.lnUrlError(data: _data)
@@ -3471,7 +4187,7 @@ enum BreezSDKMapper {
                 var inputType = try asInputType(inputType: val)
                 list.append(inputType)
             } else {
-                throw SdkError.Generic(message: "Unexpected type InputType")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "InputType"))
             }
         }
         return list
@@ -3483,7 +4199,9 @@ enum BreezSDKMapper {
             return LnUrlCallbackStatus.ok
         }
         if type == "errorStatus" {
-            guard let dataTmp = lnUrlCallbackStatus["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlCallbackStatus") }
+            guard let dataTmp = lnUrlCallbackStatus["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlCallbackStatus"))
+            }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
 
             return LnUrlCallbackStatus.errorStatus(data: _data)
@@ -3520,7 +4238,7 @@ enum BreezSDKMapper {
                 var lnUrlCallbackStatus = try asLnUrlCallbackStatus(lnUrlCallbackStatus: val)
                 list.append(lnUrlCallbackStatus)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlCallbackStatus")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlCallbackStatus"))
             }
         }
         return list
@@ -3529,19 +4247,25 @@ enum BreezSDKMapper {
     static func asLnUrlPayResult(lnUrlPayResult: [String: Any?]) throws -> LnUrlPayResult {
         let type = lnUrlPayResult["type"] as! String
         if type == "endpointSuccess" {
-            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlPayResult") }
+            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
+            }
             let _data = try asLnUrlPaySuccessData(lnUrlPaySuccessData: dataTmp)
 
             return LnUrlPayResult.endpointSuccess(data: _data)
         }
         if type == "endpointError" {
-            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlPayResult") }
+            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
+            }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
 
             return LnUrlPayResult.endpointError(data: _data)
         }
         if type == "payError" {
-            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlPayResult") }
+            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
+            }
             let _data = try asLnUrlPayErrorData(lnUrlPayErrorData: dataTmp)
 
             return LnUrlPayResult.payError(data: _data)
@@ -3589,7 +4313,7 @@ enum BreezSDKMapper {
                 var lnUrlPayResult = try asLnUrlPayResult(lnUrlPayResult: val)
                 list.append(lnUrlPayResult)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlPayResult")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayResult"))
             }
         }
         return list
@@ -3598,13 +4322,17 @@ enum BreezSDKMapper {
     static func asLnUrlWithdrawResult(lnUrlWithdrawResult: [String: Any?]) throws -> LnUrlWithdrawResult {
         let type = lnUrlWithdrawResult["type"] as! String
         if type == "ok" {
-            guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlWithdrawResult") }
+            guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
+            }
             let _data = try asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: dataTmp)
 
             return LnUrlWithdrawResult.ok(data: _data)
         }
         if type == "errorStatus" {
-            guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type LnUrlWithdrawResult") }
+            guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
+            }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
 
             return LnUrlWithdrawResult.errorStatus(data: _data)
@@ -3644,7 +4372,7 @@ enum BreezSDKMapper {
                 var lnUrlWithdrawResult = try asLnUrlWithdrawResult(lnUrlWithdrawResult: val)
                 list.append(lnUrlWithdrawResult)
             } else {
-                throw SdkError.Generic(message: "Unexpected type LnUrlWithdrawResult")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawResult"))
             }
         }
         return list
@@ -3695,7 +4423,7 @@ enum BreezSDKMapper {
                 var network = try asNetwork(network: val)
                 list.append(network)
             } else {
-                throw SdkError.Generic(message: "Unexpected type Network")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "Network"))
             }
         }
         return list
@@ -3704,7 +4432,9 @@ enum BreezSDKMapper {
     static func asNodeConfig(nodeConfig: [String: Any?]) throws -> NodeConfig {
         let type = nodeConfig["type"] as! String
         if type == "greenlight" {
-            guard let configTmp = nodeConfig["config"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field config for type NodeConfig") }
+            guard let configTmp = nodeConfig["config"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "config", typeName: "NodeConfig"))
+            }
             let _config = try asGreenlightNodeConfig(greenlightNodeConfig: configTmp)
 
             return NodeConfig.greenlight(config: _config)
@@ -3736,7 +4466,7 @@ enum BreezSDKMapper {
                 var nodeConfig = try asNodeConfig(nodeConfig: val)
                 list.append(nodeConfig)
             } else {
-                throw SdkError.Generic(message: "Unexpected type NodeConfig")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "NodeConfig"))
             }
         }
         return list
@@ -3745,7 +4475,9 @@ enum BreezSDKMapper {
     static func asNodeCredentials(nodeCredentials: [String: Any?]) throws -> NodeCredentials {
         let type = nodeCredentials["type"] as! String
         if type == "greenlight" {
-            guard let credentialsTmp = nodeCredentials["credentials"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field credentials for type NodeCredentials") }
+            guard let credentialsTmp = nodeCredentials["credentials"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "credentials", typeName: "NodeCredentials"))
+            }
             let _credentials = try asGreenlightCredentials(greenlightCredentials: credentialsTmp)
 
             return NodeCredentials.greenlight(credentials: _credentials)
@@ -3777,7 +4509,7 @@ enum BreezSDKMapper {
                 var nodeCredentials = try asNodeCredentials(nodeCredentials: val)
                 list.append(nodeCredentials)
             } else {
-                throw SdkError.Generic(message: "Unexpected type NodeCredentials")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "NodeCredentials"))
             }
         }
         return list
@@ -3786,13 +4518,17 @@ enum BreezSDKMapper {
     static func asPaymentDetails(paymentDetails: [String: Any?]) throws -> PaymentDetails {
         let type = paymentDetails["type"] as! String
         if type == "ln" {
-            guard let dataTmp = paymentDetails["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type PaymentDetails") }
+            guard let dataTmp = paymentDetails["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PaymentDetails"))
+            }
             let _data = try asLnPaymentDetails(lnPaymentDetails: dataTmp)
 
             return PaymentDetails.ln(data: _data)
         }
         if type == "closedChannel" {
-            guard let dataTmp = paymentDetails["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type PaymentDetails") }
+            guard let dataTmp = paymentDetails["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PaymentDetails"))
+            }
             let _data = try asClosedChannelPaymentDetails(closedChannelPaymentDetails: dataTmp)
 
             return PaymentDetails.closedChannel(data: _data)
@@ -3832,7 +4568,7 @@ enum BreezSDKMapper {
                 var paymentDetails = try asPaymentDetails(paymentDetails: val)
                 list.append(paymentDetails)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PaymentDetails")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentDetails"))
             }
         }
         return list
@@ -3877,7 +4613,7 @@ enum BreezSDKMapper {
                 var paymentStatus = try asPaymentStatus(paymentStatus: val)
                 list.append(paymentStatus)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PaymentStatus")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentStatus"))
             }
         }
         return list
@@ -3922,7 +4658,7 @@ enum BreezSDKMapper {
                 var paymentType = try asPaymentType(paymentType: val)
                 list.append(paymentType)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PaymentType")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentType"))
             }
         }
         return list
@@ -3967,7 +4703,7 @@ enum BreezSDKMapper {
                 var paymentTypeFilter = try asPaymentTypeFilter(paymentTypeFilter: val)
                 list.append(paymentTypeFilter)
             } else {
-                throw SdkError.Generic(message: "Unexpected type PaymentTypeFilter")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentTypeFilter"))
             }
         }
         return list
@@ -3976,7 +4712,9 @@ enum BreezSDKMapper {
     static func asReportIssueRequest(reportIssueRequest: [String: Any?]) throws -> ReportIssueRequest {
         let type = reportIssueRequest["type"] as! String
         if type == "paymentFailure" {
-            guard let dataTmp = reportIssueRequest["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type ReportIssueRequest") }
+            guard let dataTmp = reportIssueRequest["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "ReportIssueRequest"))
+            }
             let _data = try asReportPaymentFailureDetails(reportPaymentFailureDetails: dataTmp)
 
             return ReportIssueRequest.paymentFailure(data: _data)
@@ -4008,7 +4746,7 @@ enum BreezSDKMapper {
                 var reportIssueRequest = try asReportIssueRequest(reportIssueRequest: val)
                 list.append(reportIssueRequest)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReportIssueRequest")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReportIssueRequest"))
             }
         }
         return list
@@ -4065,7 +4803,7 @@ enum BreezSDKMapper {
                 var reverseSwapStatus = try asReverseSwapStatus(reverseSwapStatus: val)
                 list.append(reverseSwapStatus)
             } else {
-                throw SdkError.Generic(message: "Unexpected type ReverseSwapStatus")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReverseSwapStatus"))
             }
         }
         return list
@@ -4074,19 +4812,25 @@ enum BreezSDKMapper {
     static func asSuccessActionProcessed(successActionProcessed: [String: Any?]) throws -> SuccessActionProcessed {
         let type = successActionProcessed["type"] as! String
         if type == "aes" {
-            guard let resultTmp = successActionProcessed["result"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field result for type SuccessActionProcessed") }
+            guard let resultTmp = successActionProcessed["result"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "result", typeName: "SuccessActionProcessed"))
+            }
             let _result = try asAesSuccessActionDataResult(aesSuccessActionDataResult: resultTmp)
 
             return SuccessActionProcessed.aes(result: _result)
         }
         if type == "message" {
-            guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type SuccessActionProcessed") }
+            guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessActionProcessed"))
+            }
             let _data = try asMessageSuccessActionData(messageSuccessActionData: dataTmp)
 
             return SuccessActionProcessed.message(data: _data)
         }
         if type == "url" {
-            guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else { throw SdkError.Generic(message: "Missing mandatory field data for type SuccessActionProcessed") }
+            guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessActionProcessed"))
+            }
             let _data = try asUrlSuccessActionData(urlSuccessActionData: dataTmp)
 
             return SuccessActionProcessed.url(data: _data)
@@ -4134,7 +4878,7 @@ enum BreezSDKMapper {
                 var successActionProcessed = try asSuccessActionProcessed(successActionProcessed: val)
                 list.append(successActionProcessed)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SuccessActionProcessed")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SuccessActionProcessed"))
             }
         }
         return list
@@ -4173,9 +4917,29 @@ enum BreezSDKMapper {
                 var swapStatus = try asSwapStatus(swapStatus: val)
                 list.append(swapStatus)
             } else {
-                throw SdkError.Generic(message: "Unexpected type SwapStatus")
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SwapStatus"))
             }
         }
         return list
+    }
+
+    static func hasNonNilKey(data: [String: Any?], key: String) -> Bool {
+        if let val = data[key] {
+            return !(val == nil || val is NSNull)
+        }
+
+        return false
+    }
+
+    static func errMissingMandatoryField(fieldName: String, typeName: String) -> String {
+        return "Missing mandatory field \(fieldName) for type \(typeName)"
+    }
+
+    static func errUnexpectedType(typeName: String) -> String {
+        return "Unexpected type \(typeName)"
+    }
+
+    static func errUnexpectedValue(fieldName: String) -> String {
+        return "Unexpected value for optional field \(fieldName)"
     }
 }


### PR DESCRIPTION
Rerun the RN codegen to add optional field value validation. This update should prevent set optional values being passed to the SDK as **nil** if the value cast/conversion fails. Instead an error will be thrown. 

An example of this is calling `fetchReverseSwapFees` with a float value:
```
await fetchReverseSwapFees({ sendAmountSat: 50000.75 })
```
would return a valid response with a null `totalEstimatedFees`:
```
{
    "feesClaim": 12696, 
    "feesHash": "0a64d2ab96aaa630baa38f7a235511a29f7718759fd7784972397428ce055223", 
    "feesLockup": 14076, 
    "feesPercentage": 0.5, 
    "max": 25000000, 
    "min": 50000, 
    "totalEstimatedFees": null
}
```
whereas it should throw an error:
```
Error: Generic: Unexpected value for optional field sendAmountSat
```

Generator PR: breez/breez-sdk-rn-generator#18