### PR TITLE
Save open channel fee only when needed

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2125,11 +2125,11 @@ impl Receiver for PaymentReceiver {
                 )
                 .await?;
             info!("Payment registered");
+            // Make sure we save the large amount so we can deduce the fees later.
+            self.persister
+                .insert_open_channel_payment_info(&parsed_invoice.payment_hash, req.amount_msat)?;
         }
 
-        // Make sure we save the large amount so we can deduce the fees later.
-        self.persister
-            .insert_open_channel_payment_info(&parsed_invoice.payment_hash, req.amount_msat)?;
         // return the signed, converted invoice with hints
         Ok(ReceivePaymentResponse {
             ln_invoice: parsed_invoice,


### PR DESCRIPTION
It looks like we unnecessarily persist the payer amount also when no channel is needed. Here we change that to persist only when needed and saving space in the sync db.