### PR TITLE
Emit the InvoicePaid event before the sync

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1234,9 +1234,6 @@ impl BreezServices {
                                                           .insert_or_update_payments(&vec![payment.clone().unwrap()]);
                                                       debug!("paid invoice was added to payments list {:?}", res);
                                                   }
-                                                  if let Err(e) = cloned.do_sync(true).await {
-                                                        error!("failed to sync after paid invoice: {:?}", e);
-                                                  }
                                                   _ = cloned.on_event(BreezEvent::InvoicePaid {
                                                       details: InvoicePaidDetails {
                                                           payment_hash: hex::encode(p.payment_hash),
@@ -1244,6 +1241,9 @@ impl BreezServices {
                                                           payment,
                                                       },
                                                   }).await;
+                                                  if let Err(e) = cloned.do_sync(true).await {
+                                                      error!("failed to sync after paid invoice: {:?}", e);
+                                                  }
                                               }
                                           }
                                           Ok(None) => {


### PR DESCRIPTION
This PR changes the emitting of the `InvoicePaid` event to happen before the sync and `Synced` event. 

The `InvoicePaid` event is self contained and includes all the details of the payment directly from Greenlight. The payment is persisted before the event so any payment listing or lookup by hash will be successful. The sync then goes on to synchronise the local state and node info, once completed then emits a `Synced` event.

Changing the order that events are emitted gives the client a more immediate feedback that the payment is completed, which can then update it's node balance from the `Synced` event. Testing this a few times in the CLI shows the `InvoicePaid` event is emitted 2 - 2.5 secs before the `Synced` event.

These events are non-blocking as they occur outside of any client request.

Is there anything obvious I've missed as to why the `InvoicePaid` event shouldn't be emitted first?

```
[2023-11-28 20:00:18.312 INFO breez_sdk_cli::command_handlers:44] Received Breez event: InvoicePaid { details: InvoicePaidDetails { ... } }
[2023-11-28 20:00:18.312 DEBUG gl_client::node::service:143] Sending request Request { method: POST, uri: /cln.Node/Getinfo }
...
[2023-11-28 20:00:19.441 DEBUG gl_client::node::service:143] Sending request Request { method: POST, uri: /cln.Node/Getinfo }
[2023-11-28 20:00:19.441 DEBUG gl_client::node::service:143] Sending request Request { method: POST, uri: /cln.Node/ListFunds }
[2023-11-28 20:00:19.441 DEBUG gl_client::node::service:143] Sending request Request { method: POST, uri: /cln.Node/ListClosedChannels }
[2023-11-28 20:00:19.441 DEBUG gl_client::node::service:143] Sending request Request { method: POST, uri: /cln.Node/ListPeers }
...
[2023-11-28 20:00:20.316 DEBUG gl_client::node::service:143] Sending request Request { method: POST, uri: /cln.Node/ListInvoices }
[2023-11-28 20:00:20.516 DEBUG gl_client::node::service:143] Sending request Request { method: POST, uri: /cln.Node/ListPays }
....
[2023-11-28 20:00:20.910 INFO breez_sdk_cli::command_handlers:44] Received Breez event: Synced
```