### PR TITLE
Add BreezSDK.swift as an on demand resource on Flutter plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.9'
+          flutter-version: '3.16.1'
           channel: 'stable'
 
       - name: Flutter bridge codegen

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -100,7 +100,7 @@ jobs:
       bindings-android: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.flutter-package-version }}
       bindings-ios: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version }}
       kotlin: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version }}
-      swift: false
+      swift: ${{ !!needs.pre-setup.outputs.flutter-package-version }}
       python: ${{ !!needs.pre-setup.outputs.python-package-version }}
       csharp: ${{ !!needs.pre-setup.outputs.csharp-package-version }}
       golang: ${{ !!needs.pre-setup.outputs.golang-package-version }}
@@ -247,6 +247,7 @@ jobs:
     needs:
       - setup
       - build-bindings-android
+      - build-language-bindings
     if: ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -9,11 +9,11 @@ on:
       ref:
         description: 'commit/tag/branch reference'
         required: true
-        type: string        
+        type: string
       package-version:
         description: 'version for the flutter package (MAJOR.MINOR.BUILD) (no v prefix)'
         required: true
-        type: string        
+        type: string
       publish:
         description: 'value indicating whether to commit/tag a release.'
         required: true
@@ -45,10 +45,10 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.9'
-          channel: 'stable'                      
+          flutter-version: '3.16.1'
+          channel: 'stable'
 
-      - name: Copy package files        
+      - name: Copy package files
         working-directory: flutter
         run: |
           rm -f ../breez-sdk/libs/sdk-flutter/ios/breez_sdk.podspec.dev
@@ -81,13 +81,13 @@ jobs:
             flutter/*
             !flutter/.git
 
-      - name: Tag the Flutter package        
+      - name: Tag the Flutter package
         working-directory: flutter
         if: ${{ inputs.publish }}
         run: |
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
-          git add .          
+          git add .
           git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
           git push
           git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -67,6 +67,11 @@ jobs:
           name: sdk-bindings-android-jniLibs
           path: flutter/android/src/main/jniLibs
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: bindings-swift
+          path: flutter/ios/bindings-swift/Sources/BreezSDK/
+
       - name: Set package version
         working-directory: flutter
         run: |

--- a/libs/sdk-flutter/ios/breez_sdk.podspec
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec
@@ -1,26 +1,24 @@
-#
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint breez_sdk.podspec` to validate before publishing.
-#
 Pod::Spec.new do |s|
-    s.name             = 'breez_sdk'
-    s.version          = '0.2.10'
-    s.summary          = 'BreezSDK flutter plugin.'
-    s.description      = <<-DESC
-    BreezSDK flutter plugin.
-                         DESC
-    s.homepage         = 'https://breez.technology'
-    s.license          = { :file => '../LICENSE' }
-    s.author           = { 'Breez' => 'contact@breez.technology' }
-    s.source           = { :path => '.' }
-    s.source_files = 'Classes/**/*'
-    s.dependency 'Flutter'
-    s.platform = :ios, '9.0'
-    s.static_framework = true  
-  
-    # Flutter.framework does not contain a i386 slice.
-    s.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-    s.swift_version = '5.0'  
-    s.vendored_frameworks = "bindings-swift/breez_sdkFFI.xcframework"
-  end
-  
+  s.name             = 'breez_sdk'
+  s.version          = '0.2.10'
+  s.summary          = 'BreezSDK flutter plugin.'
+  s.description      = <<-DESC
+  BreezSDK flutter plugin.
+                       DESC
+  s.homepage         = 'https://breez.technology'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Breez' => 'contact@breez.technology' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.on_demand_resources = { 'BreezSDK' => 'bindings-swift/Sources/BreezSDK/BreezSDK.swift' }
+  s.dependency 'Flutter'
+  s.platform = :ios, '9.0'
+  s.static_framework = true
+
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.swift_version = '5.0'
+  s.vendored_frameworks = "bindings-swift/breez_sdkFFI.xcframework"
+end

--- a/libs/sdk-flutter/ios/breez_sdk.podspec
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
     s.name             = 'breez_sdk'
-    s.version          = '0.1.9'
+    s.version          = '0.2.10'
     s.summary          = 'BreezSDK flutter plugin.'
     s.description      = <<-DESC
     BreezSDK flutter plugin.

--- a/libs/sdk-flutter/ios/breez_sdk.podspec.production
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec.production
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'breez_sdk'
-  s.version          = '0.2.9'
+  s.version          = '0.2.10'
   s.summary          = 'BreezSDK flutter plugin.'
   s.description      = <<-DESC
   BreezSDK flutter plugin.
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'  
-  s.dependency "breez_sdkFFI", "0.2.9"
+  s.dependency "breez_sdkFFI", "0.2.10"
 end

--- a/libs/sdk-flutter/ios/breez_sdk.podspec.production
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec.production
@@ -1,7 +1,5 @@
-#
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint breez_sdk.podspec` to validate before publishing.
-#
 Pod::Spec.new do |s|
   s.name             = 'breez_sdk'
   s.version          = '0.2.10'
@@ -14,12 +12,13 @@ Pod::Spec.new do |s|
   s.author           = { 'Breez' => 'contact@breez.technology' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
+  s.on_demand_resources = { 'BreezSDK' => 'bindings-swift/Sources/BreezSDK/BreezSDK.swift' }
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
-  s.static_framework = true  
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.swift_version = '5.0'  
+  s.swift_version = '5.0'
   s.dependency "breez_sdkFFI", "0.2.10"
 end

--- a/libs/sdk-flutter/pubspec.lock
+++ b/libs/sdk-flutter/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
+      sha256: "67d591d602906ef9201caf93452495ad1812bea2074f04e25dbd7c133785821b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   build_runner_core:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "723b4021e903217dfc445ec4cf5b42e27975aece1fc4ebbc1ca6329c2d9fb54e"
+      sha256: "69acb7007eb2a31dc901512bfe0f7b767168be34cb734835d54c070bfa74c1b2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.7.0"
+    version: "8.8.0"
   characters:
     dependency: transitive
     description:
@@ -157,18 +157,18 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
+      sha256: b2151ce26a06171005b379ecff6e08d34c470180ffe16b8e14b6d52be292b55f
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: abd7625e16f51f554ea244d090292945ec4d4be7bfbaf2ec8cccea568919d334
+      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   fake_async:
     dependency: transitive
     description:
@@ -303,10 +303,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: d4872660c46d929f6b8a9ef4e7a7eff7e49bbf0c4ec3f385ee32df5119175139
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -383,10 +383,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -415,10 +415,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: eeb2d1428ee7f4170e2bd498827296a18d4e7fc462b71727d111c0ac7707cfa6
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "6.0.2"
   pointycastle:
     dependency: transitive
     description:
@@ -524,18 +524,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -564,10 +564,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   timing:
     dependency: transitive
     description:
@@ -620,10 +620,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -649,5 +649,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"
   flutter: ">=3.10.0"

--- a/libs/sdk-flutter/pubspec.yaml
+++ b/libs/sdk-flutter/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   flutter_lints: ^3.0.1
   # The following dependencies are required by flutter_rust_bridge_codegen to
   # be defined under dev_dependencies to generate Dart files
-  build_runner: ^2.4.6
+  build_runner: ^2.4.7
   ffigen: <9.0.0 # flutter_rust_bridge requirement
 
 # For information on the generic Dart part of this file, see the

--- a/libs/sdk-flutter/pubspec.yaml
+++ b/libs/sdk-flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: breez_sdk
 description: A new flutter plugin project.
-version: 0.2.9
+version: 0.2.10
 publish_to: none
 
 environment:


### PR DESCRIPTION
Importing `breez-sdk-swift` package natively on a **Flutter** project that also depended on `breez-sdk-flutter` Flutter plugin was causing `.xcframework` dependency conflicts. 

To overcome this issue and prevent unnecessary import of the Swift package, we decided to add `BreezSDK.swift` as an on demand resource on **Flutter** plugin. 

With this change, `BreezSDK.swift` will be accessible natively by adding it as a **Compile Source** under **Build Phases** through **XCode**.

### Changelist
- Add `BreezSDK.swift `as an on demand resource on **Flutter** plugin
  - Both `.podspec` files now use the same format with this change, which can make reviewing it a bit hard. To clarify, only addition is: 
  `s.on_demand_resources = { 'BreezSDK' => 'bindings-swift/Sources/BreezSDK/BreezSDK.swift' }`
- Use **Flutter** 3.16.1 on CI workflows
- Update dependencies to latest
- Updated flutter plugin & pod version
