### PR TITLE
Ensure outgoing payment exists in greenlight.

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -323,7 +323,7 @@ impl Greenlight {
                 .await?
                 .into_inner();
             if response.pays.is_empty() {
-                warn!("fetch outgoing payment failed, retrying in 100ms...");
+                debug!("fetch outgoing payment failed, retrying in 100ms...");
                 sleep(Duration::from_millis(100)).await;
             }
             retry += 1;

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -312,7 +312,7 @@ impl Greenlight {
         payment_hash: Vec<u8>,
     ) -> Result<cln::ListpaysPays> {
         let mut response = cln::ListpaysResponse::default();
-        let retry = 0;
+        let mut retry = 0;
         let max_retries = 20;
         while response.pays.is_empty() && retry < max_retries {
             response = cln_client
@@ -326,6 +326,7 @@ impl Greenlight {
                 warn!("fetch outgoing payment failed, retrying in 100ms...");
                 sleep(Duration::from_millis(100)).await;
             }
+            retry += 1;
         }
 
         if response.pays.is_empty() {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -318,6 +318,7 @@ impl Greenlight {
             response = cln_client
                 .list_pays(cln::ListpaysRequest {
                     payment_hash: Some(payment_hash.clone()),
+                    status: Some(cln::listpays_request::ListpaysStatus::Complete.into()),
                     ..cln::ListpaysRequest::default()
                 })
                 .await?

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -307,6 +307,33 @@ impl Greenlight {
         }
     }
 
+    async fn fetch_outgoing_payment_with_retry(
+        mut cln_client: node::ClnClient,
+        payment_hash: Vec<u8>,
+    ) -> Result<cln::ListpaysPays> {
+        let mut response = cln::ListpaysResponse::default();
+        let retry = 0;
+        let max_retries = 20;
+        while response.pays.is_empty() && retry < max_retries {
+            response = cln_client
+                .list_pays(cln::ListpaysRequest {
+                    payment_hash: Some(payment_hash.clone()),
+                    ..cln::ListpaysRequest::default()
+                })
+                .await?
+                .into_inner();
+            if response.pays.is_empty() {
+                warn!("fetch outgoing payment failed, retrying in 100ms...");
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+
+        if response.pays.is_empty() {
+            return Err(anyhow!("Payment not found"));
+        }
+        Ok(response.pays[0].clone())
+    }
+
     async fn fetch_channels_and_balance_with_retry(
         cln_client: node::ClnClient,
         persister: Arc<SqliteStorage>,
@@ -841,11 +868,7 @@ impl NodeAPI for Greenlight {
         })
     }
 
-    async fn send_payment(
-        &self,
-        bolt11: String,
-        amount_msat: Option<u64>,
-    ) -> NodeResult<PaymentResponse> {
+    async fn send_payment(&self, bolt11: String, amount_msat: Option<u64>) -> NodeResult<Payment> {
         let mut description = None;
         if !bolt11.is_empty() {
             let invoice = parse_invoice(&bolt11)?;
@@ -870,14 +893,19 @@ impl NodeAPI for Greenlight {
                 msat: self.sdk_config.exemptfee_msat,
             }),
         };
-        client.pay(request).await?.into_inner().try_into()
+        let result: cln::PayResponse = client.pay(request).await?.into_inner();
+
+        // Before returning from send_payment we need to make sure it is persisted in the backend node.
+        // We do so by polling for the payment.
+        let payment = Self::fetch_outgoing_payment_with_retry(client, result.payment_hash).await?;
+        payment.try_into()
     }
 
     async fn send_spontaneous_payment(
         &self,
         node_id: String,
         amount_msat: u64,
-    ) -> NodeResult<PaymentResponse> {
+    ) -> NodeResult<Payment> {
         let mut client: node::ClnClient = self.get_node_client().await?;
         let request = cln::KeysendRequest {
             destination: hex::decode(node_id)?,
@@ -893,7 +921,12 @@ impl NodeAPI for Greenlight {
             retry_for: Some(self.sdk_config.payment_timeout_sec),
             maxdelay: None,
         };
-        client.key_send(request).await?.into_inner().try_into()
+        let result = client.key_send(request).await?.into_inner();
+
+        // Before returning from send_payment we need to make sure it is persisted in the backend node.
+        // We do so by polling for the payment.
+        let payment = Self::fetch_outgoing_payment_with_retry(client, result.payment_hash).await?;
+        payment.try_into()
     }
 
     async fn start(&self) -> NodeResult<String> {

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,6 +1,6 @@
 use crate::{
     invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
-    NodeCredentials, PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse,
+    NodeCredentials, Payment, PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse,
     RouteHintHop, SyncResponse,
 };
 use anyhow::Result;
@@ -68,16 +68,12 @@ pub trait NodeAPI: Send + Sync {
         balance_changed: bool,
     ) -> NodeResult<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_msat` is only needed when the invoice doesn't specify an amount
-    async fn send_payment(
-        &self,
-        bolt11: String,
-        amount_msat: Option<u64>,
-    ) -> NodeResult<PaymentResponse>;
+    async fn send_payment(&self, bolt11: String, amount_msat: Option<u64>) -> NodeResult<Payment>;
     async fn send_spontaneous_payment(
         &self,
         node_id: String,
         amount_msat: u64,
-    ) -> NodeResult<PaymentResponse>;
+    ) -> NodeResult<Payment>;
     async fn start(&self) -> NodeResult<String>;
 
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -318,22 +318,18 @@ impl NodeAPI for MockNodeAPI {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
-    async fn send_payment(
-        &self,
-        bolt11: String,
-        _amount_msat: Option<u64>,
-    ) -> NodeResult<PaymentResponse> {
+    async fn send_payment(&self, bolt11: String, _amount_msat: Option<u64>) -> NodeResult<Payment> {
         let payment = self.add_dummy_payment_for(bolt11, None, None).await?;
-        Ok(payment.try_into()?)
+        Ok(payment)
     }
 
     async fn send_spontaneous_payment(
         &self,
         _node_id: String,
         _amount_msat: u64,
-    ) -> NodeResult<PaymentResponse> {
+    ) -> NodeResult<Payment> {
         let payment = self.add_dummy_payment_rand().await?;
-        Ok(payment.try_into()?)
+        Ok(payment)
     }
 
     async fn start(&self) -> NodeResult<String> {


### PR DESCRIPTION
It seems that if send_payment is used concurrently there is still a chance that when the gl API is returned the next sync would not fetch it from greenlight.
In order to ensure the payment exists we attempt to fetch the payment from greenlight until we get a result.
As part of this PR I changes also the NodeAPI trait to return Payment instead of PaymentResponse which opens the option later (not as part of this PR) to invoke the sync after paying in the background and return immediately after paying which will reduce ~2 seconds from the payment time.