### PR TITLE
Persist payment failure error

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -218,6 +218,7 @@ dictionary Payment {
     u64 amount_msat;
     u64 fee_msat;
     PaymentStatus status;
+    string? error;
     string? description;
     PaymentDetails details;
 };

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1657,6 +1657,7 @@ impl support::IntoDart for Payment {
             self.amount_msat.into_into_dart().into_dart(),
             self.fee_msat.into_into_dart().into_dart(),
             self.status.into_into_dart().into_dart(),
+            self.error.into_dart(),
             self.description.into_dart(),
             self.details.into_into_dart().into_dart(),
         ]

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -570,7 +570,7 @@ impl From<ReverseSwapError> for SendOnchainError {
 }
 
 /// Error returned by [BreezServices::send_payment] and [BreezServices::send_spontaneous_payment]
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum SendPaymentError {
     #[error("Invoice already paid")]
     AlreadyPaid,

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1453,6 +1453,7 @@ impl TryFrom<OffChainPayment> for Payment {
             amount_msat: amount_to_msat(&p.amount.unwrap_or_default()),
             fee_msat: 0,
             status: PaymentStatus::Complete,
+            error: None,
             description: ln_invoice.description,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
@@ -1491,6 +1492,7 @@ impl TryFrom<gl_client::signer::model::greenlight::Invoice> for Payment {
             amount_msat: amount_to_msat(&invoice.amount.unwrap_or_default()),
             fee_msat: 0,
             status: PaymentStatus::Complete,
+            error: None,
             description: ln_invoice.description,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
@@ -1544,6 +1546,7 @@ impl TryFrom<gl_client::signer::model::greenlight::Payment> for Payment {
             amount_msat: payment_amount,
             fee_msat: payment_amount_sent - payment_amount,
             status,
+            error: None,
             description,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
@@ -1581,6 +1584,7 @@ impl TryFrom<cln::ListinvoicesInvoices> for Payment {
             amount_msat: invoice.amount_msat.map(|a| a.msat).unwrap_or_default(),
             fee_msat: 0,
             status: PaymentStatus::Complete,
+            error: None,
             description: ln_invoice.description,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
@@ -1647,6 +1651,7 @@ impl TryFrom<cln::ListpaysPays> for Payment {
             },
             fee_msat: payment_amount_sent - payment_amount,
             status,
+            error: None,
             description: ln_invoice.map(|i| i.description).unwrap_or_default(),
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -620,8 +620,20 @@ pub struct Payment {
     pub amount_msat: u64,
     pub fee_msat: u64,
     pub status: PaymentStatus,
+    pub error: Option<String>,
     pub description: Option<String>,
     pub details: PaymentDetails,
+}
+
+/// Represents a payments external information.
+#[derive(Default)]
+pub struct PaymentExternalInfo {
+    pub lnurl_pay_success_action: Option<SuccessActionProcessed>,
+    pub lnurl_metadata: Option<String>,
+    pub ln_address: Option<String>,
+    pub lnurl_withdraw_endpoint: Option<String>,
+    pub attempted_amount_msat: Option<u64>,
+    pub attempted_error: Option<String>,
 }
 
 /// Represents a list payments request.

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -532,5 +532,14 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
         ",
         "ALTER TABLE payments_external_info ADD COLUMN failed_amount_msat INTEGER;",
         "ALTER TABLE payments_external_info RENAME COLUMN failed_amount_msat TO attempted_amount_msat;",
+        "
+        CREATE TRIGGER IF NOT EXISTS sync_requests_payments_external_info_update
+         AFTER UPDATE ON payments_external_info
+        BEGIN
+         INSERT INTO sync_requests(changed_table) VALUES('payments_external_info');
+        END;
+
+        ALTER TABLE payments_external_info ADD COLUMN attempted_error TEXT;
+        ",
     ]
 }

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -169,7 +169,8 @@ impl SqliteStorage {
           ln_address,
           lnurl_metadata,
           lnurl_withdraw_endpoint,
-          attempted_amount_msat
+          attempted_amount_msat,
+          attempted_error
          FROM remote_sync.payments_external_info
          WHERE payment_id NOT IN (SELECT payment_id FROM sync.payments_external_info);",
             [],

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -857,6 +857,7 @@ mod tests {
             amount_msat: 5000,
             fee_msat: 0,
             status: PaymentStatus::Complete,
+            error: None,
             description: Some("desc".to_string()),
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1149,6 +1149,7 @@ class Payment {
   final int amountMsat;
   final int feeMsat;
   final PaymentStatus status;
+  final String? error;
   final String? description;
   final PaymentDetails details;
 
@@ -1159,6 +1160,7 @@ class Payment {
     required this.amountMsat,
     required this.feeMsat,
     required this.status,
+    this.error,
     this.description,
     required this.details,
   });
@@ -3417,7 +3419,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   Payment _wire2api_payment(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    if (arr.length != 9) throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return Payment(
       id: _wire2api_String(arr[0]),
       paymentType: _wire2api_payment_type(arr[1]),
@@ -3425,8 +3427,9 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       amountMsat: _wire2api_u64(arr[3]),
       feeMsat: _wire2api_u64(arr[4]),
       status: _wire2api_payment_status(arr[5]),
-      description: _wire2api_opt_String(arr[6]),
-      details: _wire2api_payment_details(arr[7]),
+      error: _wire2api_opt_String(arr[6]),
+      description: _wire2api_opt_String(arr[7]),
+      details: _wire2api_payment_details(arr[8]),
     );
   }
 

--- a/libs/sdk-flutter/pubspec.lock
+++ b/libs/sdk-flutter/pubspec.lock
@@ -303,10 +303,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: d4872660c46d929f6b8a9ef4e7a7eff7e49bbf0c4ec3f385ee32df5119175139
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -415,10 +415,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      sha256: eeb2d1428ee7f4170e2bd498827296a18d4e7fc462b71727d111c0ac7707cfa6
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.1"
   pointycastle:
     dependency: transitive
     description:
@@ -657,5 +657,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.10.0"

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1822,6 +1822,7 @@ fun asPayment(payment: ReadableMap): Payment? {
     val amountMsat = payment.getDouble("amountMsat").toULong()
     val feeMsat = payment.getDouble("feeMsat").toULong()
     val status = payment.getString("status")?.let { asPaymentStatus(it) }!!
+    val error = if (hasNonNullKey(payment, "error")) payment.getString("error") else null
     val description = if (hasNonNullKey(payment, "description")) payment.getString("description") else null
     val details = payment.getMap("details")?.let { asPaymentDetails(it) }!!
     return Payment(
@@ -1831,6 +1832,7 @@ fun asPayment(payment: ReadableMap): Payment? {
         amountMsat,
         feeMsat,
         status,
+        error,
         description,
         details,
     )
@@ -1844,6 +1846,7 @@ fun readableMapOf(payment: Payment): ReadableMap {
         "amountMsat" to payment.amountMsat,
         "feeMsat" to payment.feeMsat,
         "status" to payment.status.name.lowercase(),
+        "error" to payment.error,
         "description" to payment.description,
         "details" to readableMapOf(payment.details),
     )

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2013,6 +2013,13 @@ enum BreezSDKMapper {
         }
         let status = try asPaymentStatus(paymentStatus: statusTmp)
 
+        var error: String?
+        if hasNonNilKey(data: payment, key: "error") {
+            guard let errorTmp = payment["error"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "error"))
+            }
+            error = errorTmp
+        }
         var description: String?
         if hasNonNilKey(data: payment, key: "description") {
             guard let descriptionTmp = payment["description"] as? String else {
@@ -2032,6 +2039,7 @@ enum BreezSDKMapper {
             amountMsat: amountMsat,
             feeMsat: feeMsat,
             status: status,
+            error: error,
             description: description,
             details: details
         )
@@ -2045,6 +2053,7 @@ enum BreezSDKMapper {
             "amountMsat": payment.amountMsat,
             "feeMsat": payment.feeMsat,
             "status": valueOf(paymentStatus: payment.status),
+            "error": payment.error == nil ? nil : payment.error,
             "description": payment.description == nil ? nil : payment.description,
             "details": dictionaryOf(paymentDetails: payment.details),
         ]

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -294,6 +294,7 @@ export type Payment = {
     amountMsat: number
     feeMsat: number
     status: PaymentStatus
+    error?: string
     description?: string
     details: PaymentDetails
 }


### PR DESCRIPTION
This PR adds the last payment failure error reason into the external info table. An added benefit of this is the error information is also included when reporting a payment failure.

Fixes #626 