### PR TITLE
fix: typo in README.md

### DIFF
--- a/libs/sdk-core/README.md
+++ b/libs/sdk-core/README.md
@@ -25,4 +25,4 @@ make android
 All artifacts are written to the libs/target directory.
 
 ## Test
-cargo test
+`cargo test`


### PR DESCRIPTION
format `cargo test`, didn't see it the first glance of README