### PR TITLE
enhancement: sort fiat currencies by name

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -587,12 +587,13 @@ impl BreezServices {
         Ok(response)
     }
 
-    /// Fetch live rates of fiat currencies
+    /// Fetch live rates of fiat currencies, sorted by their name
     pub async fn fetch_fiat_rates(&self) -> SdkResult<Vec<Rate>> {
         self.fiat_api.fetch_fiat_rates().await
     }
 
-    /// List all supported fiat currencies for which there is a known exchange rate.
+    /// Fetch a list of all supported fiat currencies for which there is a known exchange rate
+    /// List is sorted by the canonical name of the currency
     pub async fn list_fiat_currencies(&self) -> SdkResult<Vec<FiatCurrency>> {
         self.fiat_api.list_fiat_currencies().await
     }

--- a/libs/sdk-core/src/fiat.rs
+++ b/libs/sdk-core/src/fiat.rs
@@ -93,9 +93,10 @@ impl FiatAPI for BreezServer {
             .map_err(|e| SdkError::ServiceConnectivity {
                 err: format!("Fetch rates request failed: {e}"),
             })?;
-        Ok(response
-            .into_inner()
-            .rates
+
+        let mut rates = response.into_inner().rates;
+        rates.sort_by(|a, b| a.coin.cmp(&b.coin));
+        Ok(rates
             .into_iter()
             .map(|r| Rate {
                 coin: r.coin,

--- a/libs/sdk-core/src/fiat.rs
+++ b/libs/sdk-core/src/fiat.rs
@@ -79,6 +79,7 @@ impl FiatAPI for BreezServer {
                 fiat_currency_list.push(convert_to_fiat_currency_with_id(key, value));
             }
         }
+        fiat_currency_list.sort_by(|a, b| a.info.name.cmp(&b.info.name));
         Ok(fiat_currency_list)
     }
 


### PR DESCRIPTION
The result of `list_fiat_currencies` was unsorted as addressed in issue #680. Changed to sort by the canonical name of the currency.