### PR TITLE
Revert "Schedule signer if `GL::connect()` has seed and creds"

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -116,11 +116,7 @@ impl Greenlight {
                 match encrypted_creds {
                     Some(c) => {
                         persister.set_gl_credentials(c)?;
-                        let gl_node = Greenlight::new(config, seed, creds, persister).await?;
-                        // Make small API call to ensure the signer can be scheduled. This will fail if there are any network issues.
-                        // The other two scenarios (recover, register) already include a network call.
-                        gl_node.start().await?;
-                        Ok(gl_node)
+                        Greenlight::new(config, seed, creds, persister).await
                     }
                     None => {
                         return Err(anyhow!("Failed to encrypt credentials"));

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -116,7 +116,7 @@ impl Greenlight {
                 match encrypted_creds {
                     Some(c) => {
                         persister.set_gl_credentials(c)?;
-                        Greenlight::new(config, seed, creds, persister).await
+                        Greenlight::new(config, seed, creds, persister)
                     }
                     None => {
                         return Err(anyhow!("Failed to encrypt credentials"));
@@ -128,7 +128,7 @@ impl Greenlight {
         res
     }
 
-    async fn new(
+    fn new(
         sdk_config: Config,
         seed: Vec<u8>,
         connection_credentials: GreenlightCredentials,


### PR DESCRIPTION
Reverts breez/breez-sdk#596