### PR TITLE
rename sweep to redeem_onchain_funds

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -658,7 +658,7 @@ enum BuyBitcoinProvider {
 
 dictionary PrepareSweepRequest {
     string to_address;
-    u64 sat_per_vbyte;
+    u32 sat_per_vbyte;
 };
 
 dictionary PrepareSweepResponse {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -656,22 +656,22 @@ enum BuyBitcoinProvider {
     "Moonpay",
 };
 
-dictionary PrepareSweepRequest {
+dictionary PrepareRedeemOnchainFundsRequest {
     string to_address;
     u32 sat_per_vbyte;
 };
 
-dictionary PrepareSweepResponse {
-    u64 sweep_tx_weight;
-    u64 sweep_tx_fee_sat;
+dictionary PrepareRedeemOnchainFundsResponse {
+    u64 tx_weight;
+    u64 tx_fee_sat;
 };
 
-dictionary SweepRequest {
+dictionary RedeemOnchainFundsRequest {
     string to_address;
     u32 sat_per_vbyte;
 };
 
-dictionary SweepResponse {
+dictionary RedeemOnchainFundsResponse {
     sequence<u8> txid;
 };
 
@@ -777,7 +777,7 @@ interface BlockingBreezServices {
    sequence<Payment> list_payments(ListPaymentsRequest req);
 
    [Throws=SdkError]
-   SweepResponse sweep(SweepRequest req);
+   RedeemOnchainFundsResponse redeem_onchain_funds(RedeemOnchainFundsRequest req);
 
    [Throws=SdkError]
    sequence<Rate> fetch_fiat_rates();
@@ -852,7 +852,7 @@ interface BlockingBreezServices {
    BuyBitcoinResponse buy_bitcoin(BuyBitcoinRequest req);
 
    [Throws=SdkError]
-   PrepareSweepResponse prepare_sweep(PrepareSweepRequest req);
+   PrepareRedeemOnchainFundsResponse prepare_redeem_onchain_funds(PrepareRedeemOnchainFundsRequest req);
 };
 
 namespace breez_sdk {  

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -14,15 +14,16 @@ use breez_sdk_core::{
     MaxReverseSwapAmountResponse, MessageSuccessActionData, MetadataItem, Network, NodeConfig,
     NodeCredentials, NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse, OpeningFeeParams,
     OpeningFeeParamsMenu, Payment, PaymentDetails, PaymentFailedData, PaymentStatus, PaymentType,
-    PaymentTypeFilter, PrepareRefundRequest, PrepareRefundResponse, PrepareSweepRequest,
-    PrepareSweepResponse, Rate, ReceiveOnchainRequest, ReceivePaymentRequest,
-    ReceivePaymentResponse, RecommendedFees, RefundRequest, RefundResponse, ReportIssueRequest,
+    PaymentTypeFilter, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
+    PrepareRefundRequest, PrepareRefundResponse, Rate, ReceiveOnchainRequest,
+    ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees, RedeemOnchainFundsRequest,
+    RedeemOnchainFundsResponse, RefundRequest, RefundResponse, ReportIssueRequest,
     ReportPaymentFailureDetails, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
     ReverseSwapStatus, RouteHint, RouteHintHop, SendOnchainRequest, SendOnchainResponse,
     SendPaymentRequest, SendPaymentResponse, SendSpontaneousPaymentRequest,
     ServiceHealthCheckResponse, SignMessageRequest, SignMessageResponse, StaticBackupRequest,
-    StaticBackupResponse, SuccessActionProcessed, SwapInfo, SwapStatus, SweepRequest,
-    SweepResponse, Symbol, TlvEntry, UnspentTransactionOutput, UrlSuccessActionData,
+    StaticBackupResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol, TlvEntry,
+    UnspentTransactionOutput, UrlSuccessActionData,
 };
 use log::{Level, LevelFilter, Metadata, Record};
 use once_cell::sync::{Lazy, OnceCell};
@@ -195,8 +196,11 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.report_issue(req))
     }
 
-    pub fn sweep(&self, req: SweepRequest) -> SdkResult<SweepResponse> {
-        rt().block_on(self.breez_services.sweep(req))
+    pub fn redeem_onchain_funds(
+        &self,
+        req: RedeemOnchainFundsRequest,
+    ) -> SdkResult<RedeemOnchainFundsResponse> {
+        rt().block_on(self.breez_services.redeem_onchain_funds(req))
     }
 
     pub fn fetch_fiat_rates(&self) -> SdkResult<Vec<Rate>> {
@@ -315,8 +319,11 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.buy_bitcoin(req))
     }
 
-    pub fn prepare_sweep(&self, req: PrepareSweepRequest) -> SdkResult<PrepareSweepResponse> {
-        rt().block_on(self.breez_services.prepare_sweep(req))
+    pub fn prepare_redeem_onchain_funds(
+        &self,
+        req: PrepareRedeemOnchainFundsRequest,
+    ) -> SdkResult<PrepareRedeemOnchainFundsResponse> {
+        rt().block_on(self.breez_services.prepare_redeem_onchain_funds(req))
     }
 }
 

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -35,13 +35,14 @@ use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     EnvironmentType, ListPaymentsRequest, LnUrlCallbackStatus, LnUrlPayRequest,
     LnUrlWithdrawRequest, LnUrlWithdrawResult, MaxReverseSwapAmountResponse, NodeConfig,
-    NodeCredentials, OpenChannelFeeRequest, OpenChannelFeeResponse, PrepareRefundRequest,
-    PrepareRefundResponse, PrepareSweepRequest, PrepareSweepResponse, ReceiveOnchainRequest,
-    ReceivePaymentRequest, ReceivePaymentResponse, RefundRequest, RefundResponse,
+    NodeCredentials, OpenChannelFeeRequest, OpenChannelFeeResponse,
+    PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, PrepareRefundRequest,
+    PrepareRefundResponse, ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse,
+    RedeemOnchainFundsRequest, RedeemOnchainFundsResponse, RefundRequest, RefundResponse,
     ReportIssueRequest, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
     SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
     SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SignMessageRequest,
-    SignMessageResponse, StaticBackupRequest, StaticBackupResponse, SweepRequest, SweepResponse,
+    SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
 };
 
 /*
@@ -359,16 +360,23 @@ pub fn buy_bitcoin(req: BuyBitcoinRequest) -> Result<BuyBitcoinResponse> {
         .map_err(anyhow::Error::new::<ReceiveOnchainError>)
 }
 
-/// See [BreezServices::sweep]
-pub fn sweep(req: SweepRequest) -> Result<SweepResponse> {
-    block_on(async { get_breez_services().await?.sweep(req).await })
+/// See [BreezServices::redeem_onchain_funds]
+pub fn redeem_onchain_funds(req: RedeemOnchainFundsRequest) -> Result<RedeemOnchainFundsResponse> {
+    block_on(async { get_breez_services().await?.redeem_onchain_funds(req).await })
         .map_err(anyhow::Error::new::<SdkError>)
 }
 
-/// See [BreezServices::prepare_sweep]
-pub fn prepare_sweep(req: PrepareSweepRequest) -> Result<PrepareSweepResponse> {
-    block_on(async { get_breez_services().await?.prepare_sweep(req).await })
-        .map_err(anyhow::Error::new::<SdkError>)
+/// See [BreezServices::prepare_redeem_onchain_funds]
+pub fn prepare_redeem_onchain_funds(
+    req: PrepareRedeemOnchainFundsRequest,
+) -> Result<PrepareRedeemOnchainFundsResponse> {
+    block_on(async {
+        get_breez_services()
+            .await?
+            .prepare_redeem_onchain_funds(req)
+            .await
+    })
+    .map_err(anyhow::Error::new::<SdkError>)
 }
 
 /*  Refundables API's */

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -576,20 +576,26 @@ impl BreezServices {
         Ok(self.persister.get_payment_by_hash(&hash)?)
     }
 
-    /// Sweep on-chain funds to the specified on-chain address, with the given feerate
-    pub async fn sweep(&self, req: SweepRequest) -> SdkResult<SweepResponse> {
+    /// Redeem on-chain funds from closed channels to the specified on-chain address, with the given feerate
+    pub async fn redeem_onchain_funds(
+        &self,
+        req: RedeemOnchainFundsRequest,
+    ) -> SdkResult<RedeemOnchainFundsResponse> {
         self.start_node().await?;
         let txid = self
             .node_api
-            .sweep(req.to_address, req.sat_per_vbyte)
+            .redeem_onchain_funds(req.to_address, req.sat_per_vbyte)
             .await?;
         self.sync().await?;
-        Ok(SweepResponse { txid })
+        Ok(RedeemOnchainFundsResponse { txid })
     }
 
-    pub async fn prepare_sweep(&self, req: PrepareSweepRequest) -> SdkResult<PrepareSweepResponse> {
+    pub async fn prepare_redeem_onchain_funds(
+        &self,
+        req: PrepareRedeemOnchainFundsRequest,
+    ) -> SdkResult<PrepareRedeemOnchainFundsResponse> {
         self.start_node().await?;
-        let response = self.node_api.prepare_sweep(req).await?;
+        let response = self.node_api.prepare_redeem_onchain_funds(req).await?;
         Ok(response)
     }
 

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -1092,7 +1092,7 @@ pub struct wire_PrepareRefundRequest {
 #[derive(Clone)]
 pub struct wire_PrepareSweepRequest {
     to_address: *mut wire_uint_8_list,
-    sat_per_vbyte: u64,
+    sat_per_vbyte: u32,
 }
 
 #[repr(C)]

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -210,13 +210,16 @@ pub extern "C" fn wire_buy_bitcoin(port_: i64, req: *mut wire_BuyBitcoinRequest)
 }
 
 #[no_mangle]
-pub extern "C" fn wire_sweep(port_: i64, req: *mut wire_SweepRequest) {
-    wire_sweep_impl(port_, req)
+pub extern "C" fn wire_redeem_onchain_funds(port_: i64, req: *mut wire_RedeemOnchainFundsRequest) {
+    wire_redeem_onchain_funds_impl(port_, req)
 }
 
 #[no_mangle]
-pub extern "C" fn wire_prepare_sweep(port_: i64, req: *mut wire_PrepareSweepRequest) {
-    wire_prepare_sweep_impl(port_, req)
+pub extern "C" fn wire_prepare_redeem_onchain_funds(
+    port_: i64,
+    req: *mut wire_PrepareRedeemOnchainFundsRequest,
+) {
+    wire_prepare_redeem_onchain_funds_impl(port_, req)
 }
 
 #[no_mangle]
@@ -337,13 +340,14 @@ pub extern "C" fn new_box_autoadd_opening_fee_params_0() -> *mut wire_OpeningFee
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_prepare_refund_request_0() -> *mut wire_PrepareRefundRequest {
-    support::new_leak_box_ptr(wire_PrepareRefundRequest::new_with_null_ptr())
+pub extern "C" fn new_box_autoadd_prepare_redeem_onchain_funds_request_0(
+) -> *mut wire_PrepareRedeemOnchainFundsRequest {
+    support::new_leak_box_ptr(wire_PrepareRedeemOnchainFundsRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_prepare_sweep_request_0() -> *mut wire_PrepareSweepRequest {
-    support::new_leak_box_ptr(wire_PrepareSweepRequest::new_with_null_ptr())
+pub extern "C" fn new_box_autoadd_prepare_refund_request_0() -> *mut wire_PrepareRefundRequest {
+    support::new_leak_box_ptr(wire_PrepareRefundRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -354,6 +358,12 @@ pub extern "C" fn new_box_autoadd_receive_onchain_request_0() -> *mut wire_Recei
 #[no_mangle]
 pub extern "C" fn new_box_autoadd_receive_payment_request_0() -> *mut wire_ReceivePaymentRequest {
     support::new_leak_box_ptr(wire_ReceivePaymentRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn new_box_autoadd_redeem_onchain_funds_request_0(
+) -> *mut wire_RedeemOnchainFundsRequest {
+    support::new_leak_box_ptr(wire_RedeemOnchainFundsRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -402,11 +412,6 @@ pub extern "C" fn new_box_autoadd_sign_message_request_0() -> *mut wire_SignMess
 #[no_mangle]
 pub extern "C" fn new_box_autoadd_static_backup_request_0() -> *mut wire_StaticBackupRequest {
     support::new_leak_box_ptr(wire_StaticBackupRequest::new_with_null_ptr())
-}
-
-#[no_mangle]
-pub extern "C" fn new_box_autoadd_sweep_request_0() -> *mut wire_SweepRequest {
-    support::new_leak_box_ptr(wire_SweepRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -539,16 +544,16 @@ impl Wire2Api<OpeningFeeParams> for *mut wire_OpeningFeeParams {
         Wire2Api::<OpeningFeeParams>::wire2api(*wrap).into()
     }
 }
+impl Wire2Api<PrepareRedeemOnchainFundsRequest> for *mut wire_PrepareRedeemOnchainFundsRequest {
+    fn wire2api(self) -> PrepareRedeemOnchainFundsRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<PrepareRedeemOnchainFundsRequest>::wire2api(*wrap).into()
+    }
+}
 impl Wire2Api<PrepareRefundRequest> for *mut wire_PrepareRefundRequest {
     fn wire2api(self) -> PrepareRefundRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<PrepareRefundRequest>::wire2api(*wrap).into()
-    }
-}
-impl Wire2Api<PrepareSweepRequest> for *mut wire_PrepareSweepRequest {
-    fn wire2api(self) -> PrepareSweepRequest {
-        let wrap = unsafe { support::box_from_leak_ptr(self) };
-        Wire2Api::<PrepareSweepRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<ReceiveOnchainRequest> for *mut wire_ReceiveOnchainRequest {
@@ -561,6 +566,12 @@ impl Wire2Api<ReceivePaymentRequest> for *mut wire_ReceivePaymentRequest {
     fn wire2api(self) -> ReceivePaymentRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<ReceivePaymentRequest>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<RedeemOnchainFundsRequest> for *mut wire_RedeemOnchainFundsRequest {
+    fn wire2api(self) -> RedeemOnchainFundsRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<RedeemOnchainFundsRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<RefundRequest> for *mut wire_RefundRequest {
@@ -615,12 +626,6 @@ impl Wire2Api<StaticBackupRequest> for *mut wire_StaticBackupRequest {
     fn wire2api(self) -> StaticBackupRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<StaticBackupRequest>::wire2api(*wrap).into()
-    }
-}
-impl Wire2Api<SweepRequest> for *mut wire_SweepRequest {
-    fn wire2api(self) -> SweepRequest {
-        let wrap = unsafe { support::box_from_leak_ptr(self) };
-        Wire2Api::<SweepRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<u32> for *mut u32 {
@@ -803,18 +808,18 @@ impl Wire2Api<OpeningFeeParams> for wire_OpeningFeeParams {
     }
 }
 
-impl Wire2Api<PrepareRefundRequest> for wire_PrepareRefundRequest {
-    fn wire2api(self) -> PrepareRefundRequest {
-        PrepareRefundRequest {
-            swap_address: self.swap_address.wire2api(),
+impl Wire2Api<PrepareRedeemOnchainFundsRequest> for wire_PrepareRedeemOnchainFundsRequest {
+    fn wire2api(self) -> PrepareRedeemOnchainFundsRequest {
+        PrepareRedeemOnchainFundsRequest {
             to_address: self.to_address.wire2api(),
             sat_per_vbyte: self.sat_per_vbyte.wire2api(),
         }
     }
 }
-impl Wire2Api<PrepareSweepRequest> for wire_PrepareSweepRequest {
-    fn wire2api(self) -> PrepareSweepRequest {
-        PrepareSweepRequest {
+impl Wire2Api<PrepareRefundRequest> for wire_PrepareRefundRequest {
+    fn wire2api(self) -> PrepareRefundRequest {
+        PrepareRefundRequest {
+            swap_address: self.swap_address.wire2api(),
             to_address: self.to_address.wire2api(),
             sat_per_vbyte: self.sat_per_vbyte.wire2api(),
         }
@@ -837,6 +842,14 @@ impl Wire2Api<ReceivePaymentRequest> for wire_ReceivePaymentRequest {
             use_description_hash: self.use_description_hash.wire2api(),
             expiry: self.expiry.wire2api(),
             cltv: self.cltv.wire2api(),
+        }
+    }
+}
+impl Wire2Api<RedeemOnchainFundsRequest> for wire_RedeemOnchainFundsRequest {
+    fn wire2api(self) -> RedeemOnchainFundsRequest {
+        RedeemOnchainFundsRequest {
+            to_address: self.to_address.wire2api(),
+            sat_per_vbyte: self.sat_per_vbyte.wire2api(),
         }
     }
 }
@@ -916,14 +929,6 @@ impl Wire2Api<StaticBackupRequest> for wire_StaticBackupRequest {
     fn wire2api(self) -> StaticBackupRequest {
         StaticBackupRequest {
             working_dir: self.working_dir.wire2api(),
-        }
-    }
-}
-impl Wire2Api<SweepRequest> for wire_SweepRequest {
-    fn wire2api(self) -> SweepRequest {
-        SweepRequest {
-            to_address: self.to_address.wire2api(),
-            sat_per_vbyte: self.sat_per_vbyte.wire2api(),
         }
     }
 }
@@ -1082,15 +1087,15 @@ pub struct wire_OpeningFeeParams {
 
 #[repr(C)]
 #[derive(Clone)]
-pub struct wire_PrepareRefundRequest {
-    swap_address: *mut wire_uint_8_list,
+pub struct wire_PrepareRedeemOnchainFundsRequest {
     to_address: *mut wire_uint_8_list,
     sat_per_vbyte: u32,
 }
 
 #[repr(C)]
 #[derive(Clone)]
-pub struct wire_PrepareSweepRequest {
+pub struct wire_PrepareRefundRequest {
+    swap_address: *mut wire_uint_8_list,
     to_address: *mut wire_uint_8_list,
     sat_per_vbyte: u32,
 }
@@ -1111,6 +1116,13 @@ pub struct wire_ReceivePaymentRequest {
     use_description_hash: *mut bool,
     expiry: *mut u32,
     cltv: *mut u32,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_RedeemOnchainFundsRequest {
+    to_address: *mut wire_uint_8_list,
+    sat_per_vbyte: u32,
 }
 
 #[repr(C)]
@@ -1168,13 +1180,6 @@ pub struct wire_SignMessageRequest {
 #[derive(Clone)]
 pub struct wire_StaticBackupRequest {
     working_dir: *mut wire_uint_8_list,
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_SweepRequest {
-    to_address: *mut wire_uint_8_list,
-    sat_per_vbyte: u32,
 }
 
 #[repr(C)]
@@ -1487,6 +1492,21 @@ impl Default for wire_OpeningFeeParams {
     }
 }
 
+impl NewWithNullPtr for wire_PrepareRedeemOnchainFundsRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            to_address: core::ptr::null_mut(),
+            sat_per_vbyte: Default::default(),
+        }
+    }
+}
+
+impl Default for wire_PrepareRedeemOnchainFundsRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_PrepareRefundRequest {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -1498,21 +1518,6 @@ impl NewWithNullPtr for wire_PrepareRefundRequest {
 }
 
 impl Default for wire_PrepareRefundRequest {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-
-impl NewWithNullPtr for wire_PrepareSweepRequest {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            to_address: core::ptr::null_mut(),
-            sat_per_vbyte: Default::default(),
-        }
-    }
-}
-
-impl Default for wire_PrepareSweepRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1547,6 +1552,21 @@ impl NewWithNullPtr for wire_ReceivePaymentRequest {
 }
 
 impl Default for wire_ReceivePaymentRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_RedeemOnchainFundsRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            to_address: core::ptr::null_mut(),
+            sat_per_vbyte: Default::default(),
+        }
+    }
+}
+
+impl Default for wire_RedeemOnchainFundsRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
@@ -1692,21 +1712,6 @@ impl NewWithNullPtr for wire_StaticBackupRequest {
 }
 
 impl Default for wire_StaticBackupRequest {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-
-impl NewWithNullPtr for wire_SweepRequest {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            to_address: core::ptr::null_mut(),
-            sat_per_vbyte: Default::default(),
-        }
-    }
-}
-
-impl Default for wire_SweepRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -86,13 +86,15 @@ use crate::models::PaymentDetails;
 use crate::models::PaymentStatus;
 use crate::models::PaymentType;
 use crate::models::PaymentTypeFilter;
+use crate::models::PrepareRedeemOnchainFundsRequest;
+use crate::models::PrepareRedeemOnchainFundsResponse;
 use crate::models::PrepareRefundRequest;
 use crate::models::PrepareRefundResponse;
-use crate::models::PrepareSweepRequest;
-use crate::models::PrepareSweepResponse;
 use crate::models::ReceiveOnchainRequest;
 use crate::models::ReceivePaymentRequest;
 use crate::models::ReceivePaymentResponse;
+use crate::models::RedeemOnchainFundsRequest;
+use crate::models::RedeemOnchainFundsResponse;
 use crate::models::RefundRequest;
 use crate::models::RefundResponse;
 use crate::models::ReportIssueRequest;
@@ -111,8 +113,6 @@ use crate::models::StaticBackupRequest;
 use crate::models::StaticBackupResponse;
 use crate::models::SwapInfo;
 use crate::models::SwapStatus;
-use crate::models::SweepRequest;
-use crate::models::SweepResponse;
 use crate::models::TlvEntry;
 use crate::models::UnspentTransactionOutput;
 
@@ -627,32 +627,35 @@ fn wire_buy_bitcoin_impl(port_: MessagePort, req: impl Wire2Api<BuyBitcoinReques
         },
     )
 }
-fn wire_sweep_impl(port_: MessagePort, req: impl Wire2Api<SweepRequest> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, SweepResponse, _>(
+fn wire_redeem_onchain_funds_impl(
+    port_: MessagePort,
+    req: impl Wire2Api<RedeemOnchainFundsRequest> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, RedeemOnchainFundsResponse, _>(
         WrapInfo {
-            debug_name: "sweep",
+            debug_name: "redeem_onchain_funds",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
         move || {
             let api_req = req.wire2api();
-            move |task_callback| sweep(api_req)
+            move |task_callback| redeem_onchain_funds(api_req)
         },
     )
 }
-fn wire_prepare_sweep_impl(
+fn wire_prepare_redeem_onchain_funds_impl(
     port_: MessagePort,
-    req: impl Wire2Api<PrepareSweepRequest> + UnwindSafe,
+    req: impl Wire2Api<PrepareRedeemOnchainFundsRequest> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, PrepareSweepResponse, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, PrepareRedeemOnchainFundsResponse, _>(
         WrapInfo {
-            debug_name: "prepare_sweep",
+            debug_name: "prepare_redeem_onchain_funds",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
         move || {
             let api_req = req.wire2api();
-            move |task_callback| prepare_sweep(api_req)
+            move |task_callback| prepare_redeem_onchain_funds(api_req)
         },
     )
 }
@@ -1739,6 +1742,24 @@ impl rust2dart::IntoIntoDart<PaymentType> for PaymentType {
     }
 }
 
+impl support::IntoDart for PrepareRedeemOnchainFundsResponse {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.tx_weight.into_into_dart().into_dart(),
+            self.tx_fee_sat.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for PrepareRedeemOnchainFundsResponse {}
+impl rust2dart::IntoIntoDart<PrepareRedeemOnchainFundsResponse>
+    for PrepareRedeemOnchainFundsResponse
+{
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
 impl support::IntoDart for PrepareRefundResponse {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -1750,22 +1771,6 @@ impl support::IntoDart for PrepareRefundResponse {
 }
 impl support::IntoDartExceptPrimitive for PrepareRefundResponse {}
 impl rust2dart::IntoIntoDart<PrepareRefundResponse> for PrepareRefundResponse {
-    fn into_into_dart(self) -> Self {
-        self
-    }
-}
-
-impl support::IntoDart for PrepareSweepResponse {
-    fn into_dart(self) -> support::DartAbi {
-        vec![
-            self.sweep_tx_weight.into_into_dart().into_dart(),
-            self.sweep_tx_fee_sat.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl support::IntoDartExceptPrimitive for PrepareSweepResponse {}
-impl rust2dart::IntoIntoDart<PrepareSweepResponse> for PrepareSweepResponse {
     fn into_into_dart(self) -> Self {
         self
     }
@@ -1818,6 +1823,18 @@ impl support::IntoDart for RecommendedFees {
 }
 impl support::IntoDartExceptPrimitive for RecommendedFees {}
 impl rust2dart::IntoIntoDart<RecommendedFees> for RecommendedFees {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for RedeemOnchainFundsResponse {
+    fn into_dart(self) -> support::DartAbi {
+        vec![self.txid.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for RedeemOnchainFundsResponse {}
+impl rust2dart::IntoIntoDart<RedeemOnchainFundsResponse> for RedeemOnchainFundsResponse {
     fn into_into_dart(self) -> Self {
         self
     }
@@ -2053,18 +2070,6 @@ impl support::IntoDart for SwapStatus {
 }
 impl support::IntoDartExceptPrimitive for SwapStatus {}
 impl rust2dart::IntoIntoDart<SwapStatus> for SwapStatus {
-    fn into_into_dart(self) -> Self {
-        self
-    }
-}
-
-impl support::IntoDart for SweepResponse {
-    fn into_dart(self) -> support::DartAbi {
-        vec![self.txid.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl support::IntoDartExceptPrimitive for SweepResponse {}
-impl rust2dart::IntoIntoDart<SweepResponse> for SweepResponse {
     fn into_into_dart(self) -> Self {
         self
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1004,7 +1004,7 @@ impl NodeAPI for Greenlight {
         let witness_input_size: u64 = 110;
         let tx_weight = tx.strippedsize() as u64 * WITNESS_SCALE_FACTOR as u64
             + witness_input_size * txins.len() as u64;
-        let fee: u64 = tx_weight * req.sat_per_vbyte / WITNESS_SCALE_FACTOR as u64;
+        let fee: u64 = tx_weight * req.sat_per_vbyte as u64 / WITNESS_SCALE_FACTOR as u64;
         if fee >= amount {
             return Err(NodeError::Generic(anyhow!(
                 "Insufficient funds to pay fees"

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -878,13 +878,13 @@ pub struct BuyBitcoinResponse {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SweepRequest {
+pub struct RedeemOnchainFundsRequest {
     pub to_address: String,
     pub sat_per_vbyte: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SweepResponse {
+pub struct RedeemOnchainFundsResponse {
     pub txid: Vec<u8>,
 }
 
@@ -1298,21 +1298,21 @@ pub enum BuyBitcoinProvider {
     Moonpay,
 }
 
-/// We need to prepare a sweep transaction to know what fee will be charged in satoshis this
-/// model holds the request data which consists of the address to sweep to and the fee rate in
+/// We need to prepare a redeem_onchain_funds transaction to know what fee will be charged in satoshis.
+/// This model holds the request data which consists of the address to redeem on-chain funds to and the fee rate in.
 /// satoshis per vbyte which will be converted to absolute satoshis.
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
-pub struct PrepareSweepRequest {
+pub struct PrepareRedeemOnchainFundsRequest {
     pub to_address: String,
     pub sat_per_vbyte: u32,
 }
 
-/// We need to prepare a sweep transaction to know what a fee it will be charged in satoshis
+/// We need to prepare a redeem_onchain_funds transaction to know what a fee it will be charged in satoshis
 /// this model holds the response data, which consists of the weight and the absolute fee in sats
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
-pub struct PrepareSweepResponse {
-    pub sweep_tx_weight: u64,
-    pub sweep_tx_fee_sat: u64,
+pub struct PrepareRedeemOnchainFundsResponse {
+    pub tx_weight: u64,
+    pub tx_fee_sat: u64,
 }
 
 impl FromStr for BuyBitcoinProvider {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1304,7 +1304,7 @@ pub enum BuyBitcoinProvider {
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
 pub struct PrepareSweepRequest {
     pub to_address: String,
-    pub sat_per_vbyte: u64,
+    pub sat_per_vbyte: u32,
 }
 
 /// We need to prepare a sweep transaction to know what a fee it will be charged in satoshis

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,6 +1,6 @@
 use crate::{
     invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
-    NodeCredentials, Payment, PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse,
+    NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
     RouteHintHop, SyncResponse, TlvEntry,
 };
 use anyhow::Result;
@@ -89,8 +89,8 @@ pub trait NodeAPI: Send + Sync {
         max_hops: u32,
         last_hop: Option<&RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>>;
-    async fn sweep(&self, to_address: String, sat_per_vbyte: u32) -> NodeResult<Vec<u8>>;
-    async fn prepare_sweep(&self, req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse>;
+    async fn redeem_onchain_funds(&self, to_address: String, sat_per_vbyte: u32) -> NodeResult<Vec<u8>>;
+    async fn prepare_redeem_onchain_funds(&self, req: PrepareRedeemOnchainFundsRequest) -> NodeResult<PrepareRedeemOnchainFundsResponse>;
     async fn start_signer(&self, shutdown: mpsc::Receiver<()>);
     async fn list_peers(&self) -> NodeResult<Vec<Peer>>;
     async fn connect_peer(&self, node_id: String, addr: String) -> NodeResult<()>;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -40,7 +40,7 @@ use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
     parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
-    PaymentResponse, Peer, PrepareSweepRequest, PrepareSweepResponse, RouteHint, RouteHintHop,
+    PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHint, RouteHintHop,
 };
 use crate::{OpeningFeeParams, OpeningFeeParamsMenu};
 use crate::{ReceivePaymentRequest, SwapInfo};
@@ -337,11 +337,11 @@ impl NodeAPI for MockNodeAPI {
         Ok("".to_string())
     }
 
-    async fn sweep(&self, _to_address: String, _sat_per_vbyte: u32) -> NodeResult<Vec<u8>> {
+    async fn redeem_onchain_funds(&self, _to_address: String, _sat_per_vbyte: u32) -> NodeResult<Vec<u8>> {
         Ok(rand_vec_u8(32))
     }
 
-    async fn prepare_sweep(&self, _req: PrepareSweepRequest) -> NodeResult<PrepareSweepResponse> {
+    async fn prepare_redeem_onchain_funds(&self, _req: PrepareRedeemOnchainFundsRequest) -> NodeResult<PrepareRedeemOnchainFundsResponse> {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -315,12 +315,12 @@ class BreezSDK {
   }
 
   /// Withdraw on-chain funds in the wallet to an external btc address
-  Future<SweepResponse> sweep({
-    required SweepRequest req,
+  Future<RedeemOnchainFundsResponse> redeemOnchainFunds({
+    required RedeemOnchainFundsRequest req,
   }) async {
-    final sweepResponse = await _lnToolkit.sweep(req: req);
+    final redeemOnchainFundsResponse = await _lnToolkit.redeemOnchainFunds(req: req);
     await listPayments(req: const ListPaymentsRequest());
-    return sweepResponse;
+    return redeemOnchainFundsResponse;
   }
 
   /// Returns the max amount that can be sent on-chain using the send_onchain method.
@@ -382,10 +382,10 @@ class BreezSDK {
   /// Fetches the current recommended fees
   Future<RecommendedFees> recommendedFees() async => await _lnToolkit.recommendedFees();
 
-  Future<PrepareSweepResponse> prepareSweep({
-    required PrepareSweepRequest req,
+  Future<PrepareRedeemOnchainFundsResponse> prepareRedeemOnchainFunds({
+    required PrepareRedeemOnchainFundsRequest req,
   }) async =>
-      _lnToolkit.prepareSweep(req: req);
+      _lnToolkit.prepareRedeemOnchainFunds(req: req);
 
   /* Support API's */
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -216,15 +216,17 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kBuyBitcoinConstMeta;
 
-  /// See [BreezServices::sweep]
-  Future<SweepResponse> sweep({required SweepRequest req, dynamic hint});
+  /// See [BreezServices::redeem_onchain_funds]
+  Future<RedeemOnchainFundsResponse> redeemOnchainFunds(
+      {required RedeemOnchainFundsRequest req, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kSweepConstMeta;
+  FlutterRustBridgeTaskConstMeta get kRedeemOnchainFundsConstMeta;
 
-  /// See [BreezServices::prepare_sweep]
-  Future<PrepareSweepResponse> prepareSweep({required PrepareSweepRequest req, dynamic hint});
+  /// See [BreezServices::prepare_redeem_onchain_funds]
+  Future<PrepareRedeemOnchainFundsResponse> prepareRedeemOnchainFunds(
+      {required PrepareRedeemOnchainFundsRequest req, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kPrepareSweepConstMeta;
+  FlutterRustBridgeTaskConstMeta get kPrepareRedeemOnchainFundsConstMeta;
 
   /// See [BreezServices::list_refundables]
   Future<List<SwapInfo>> listRefundables({dynamic hint});
@@ -1209,6 +1211,31 @@ enum PaymentTypeFilter {
   ClosedChannel,
 }
 
+/// We need to prepare a redeem_onchain_funds transaction to know what fee will be charged in satoshis.
+/// This model holds the request data which consists of the address to redeem on-chain funds to and the fee rate in.
+/// satoshis per vbyte which will be converted to absolute satoshis.
+class PrepareRedeemOnchainFundsRequest {
+  final String toAddress;
+  final int satPerVbyte;
+
+  const PrepareRedeemOnchainFundsRequest({
+    required this.toAddress,
+    required this.satPerVbyte,
+  });
+}
+
+/// We need to prepare a redeem_onchain_funds transaction to know what a fee it will be charged in satoshis
+/// this model holds the response data, which consists of the weight and the absolute fee in sats
+class PrepareRedeemOnchainFundsResponse {
+  final int txWeight;
+  final int txFeeSat;
+
+  const PrepareRedeemOnchainFundsResponse({
+    required this.txWeight,
+    required this.txFeeSat,
+  });
+}
+
 class PrepareRefundRequest {
   final String swapAddress;
   final String toAddress;
@@ -1228,31 +1255,6 @@ class PrepareRefundResponse {
   const PrepareRefundResponse({
     required this.refundTxWeight,
     required this.refundTxFeeSat,
-  });
-}
-
-/// We need to prepare a sweep transaction to know what fee will be charged in satoshis this
-/// model holds the request data which consists of the address to sweep to and the fee rate in
-/// satoshis per vbyte which will be converted to absolute satoshis.
-class PrepareSweepRequest {
-  final String toAddress;
-  final int satPerVbyte;
-
-  const PrepareSweepRequest({
-    required this.toAddress,
-    required this.satPerVbyte,
-  });
-}
-
-/// We need to prepare a sweep transaction to know what a fee it will be charged in satoshis
-/// this model holds the response data, which consists of the weight and the absolute fee in sats
-class PrepareSweepResponse {
-  final int sweepTxWeight;
-  final int sweepTxFeeSat;
-
-  const PrepareSweepResponse({
-    required this.sweepTxWeight,
-    required this.sweepTxFeeSat,
   });
 }
 
@@ -1338,6 +1340,24 @@ class RecommendedFees {
     required this.hourFee,
     required this.economyFee,
     required this.minimumFee,
+  });
+}
+
+class RedeemOnchainFundsRequest {
+  final String toAddress;
+  final int satPerVbyte;
+
+  const RedeemOnchainFundsRequest({
+    required this.toAddress,
+    required this.satPerVbyte,
+  });
+}
+
+class RedeemOnchainFundsResponse {
+  final Uint8List txid;
+
+  const RedeemOnchainFundsResponse({
+    required this.txid,
   });
 }
 
@@ -1709,24 +1729,6 @@ enum SwapStatus {
   /// the earliest confirmed transaction. This means the only way to spend the funds from this address is by
   /// broadcasting a refund transaction.
   Expired,
-}
-
-class SweepRequest {
-  final String toAddress;
-  final int satPerVbyte;
-
-  const SweepRequest({
-    required this.toAddress,
-    required this.satPerVbyte,
-  });
-}
-
-class SweepResponse {
-  final Uint8List txid;
-
-  const SweepResponse({
-    required this.txid,
-  });
 }
 
 /// Settings for the symbol representation of a currency
@@ -2463,37 +2465,40 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: ["req"],
       );
 
-  Future<SweepResponse> sweep({required SweepRequest req, dynamic hint}) {
-    var arg0 = _platform.api2wire_box_autoadd_sweep_request(req);
+  Future<RedeemOnchainFundsResponse> redeemOnchainFunds(
+      {required RedeemOnchainFundsRequest req, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_redeem_onchain_funds_request(req);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_sweep(port_, arg0),
-      parseSuccessData: _wire2api_sweep_response,
+      callFfi: (port_) => _platform.inner.wire_redeem_onchain_funds(port_, arg0),
+      parseSuccessData: _wire2api_redeem_onchain_funds_response,
       parseErrorData: _wire2api_FrbAnyhowException,
-      constMeta: kSweepConstMeta,
+      constMeta: kRedeemOnchainFundsConstMeta,
       argValues: [req],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kSweepConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "sweep",
+  FlutterRustBridgeTaskConstMeta get kRedeemOnchainFundsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "redeem_onchain_funds",
         argNames: ["req"],
       );
 
-  Future<PrepareSweepResponse> prepareSweep({required PrepareSweepRequest req, dynamic hint}) {
-    var arg0 = _platform.api2wire_box_autoadd_prepare_sweep_request(req);
+  Future<PrepareRedeemOnchainFundsResponse> prepareRedeemOnchainFunds(
+      {required PrepareRedeemOnchainFundsRequest req, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_prepare_redeem_onchain_funds_request(req);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_prepare_sweep(port_, arg0),
-      parseSuccessData: _wire2api_prepare_sweep_response,
+      callFfi: (port_) => _platform.inner.wire_prepare_redeem_onchain_funds(port_, arg0),
+      parseSuccessData: _wire2api_prepare_redeem_onchain_funds_response,
       parseErrorData: _wire2api_FrbAnyhowException,
-      constMeta: kPrepareSweepConstMeta,
+      constMeta: kPrepareRedeemOnchainFundsConstMeta,
       argValues: [req],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kPrepareSweepConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "prepare_sweep",
+  FlutterRustBridgeTaskConstMeta get kPrepareRedeemOnchainFundsConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "prepare_redeem_onchain_funds",
         argNames: ["req"],
       );
 
@@ -3482,21 +3487,21 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return PaymentType.values[raw as int];
   }
 
+  PrepareRedeemOnchainFundsResponse _wire2api_prepare_redeem_onchain_funds_response(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return PrepareRedeemOnchainFundsResponse(
+      txWeight: _wire2api_u64(arr[0]),
+      txFeeSat: _wire2api_u64(arr[1]),
+    );
+  }
+
   PrepareRefundResponse _wire2api_prepare_refund_response(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PrepareRefundResponse(
       refundTxWeight: _wire2api_u32(arr[0]),
       refundTxFeeSat: _wire2api_u64(arr[1]),
-    );
-  }
-
-  PrepareSweepResponse _wire2api_prepare_sweep_response(dynamic raw) {
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return PrepareSweepResponse(
-      sweepTxWeight: _wire2api_u64(arr[0]),
-      sweepTxFeeSat: _wire2api_u64(arr[1]),
     );
   }
 
@@ -3528,6 +3533,14 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       hourFee: _wire2api_u64(arr[2]),
       economyFee: _wire2api_u64(arr[3]),
       minimumFee: _wire2api_u64(arr[4]),
+    );
+  }
+
+  RedeemOnchainFundsResponse _wire2api_redeem_onchain_funds_response(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return RedeemOnchainFundsResponse(
+      txid: _wire2api_uint_8_list(arr[0]),
     );
   }
 
@@ -3681,14 +3694,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   SwapStatus _wire2api_swap_status(dynamic raw) {
     return SwapStatus.values[raw as int];
-  }
-
-  SweepResponse _wire2api_sweep_response(dynamic raw) {
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return SweepResponse(
-      txid: _wire2api_uint_8_list(arr[0]),
-    );
   }
 
   Symbol _wire2api_symbol(dynamic raw) {
@@ -3912,17 +3917,18 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
-  ffi.Pointer<wire_PrepareRefundRequest> api2wire_box_autoadd_prepare_refund_request(
-      PrepareRefundRequest raw) {
-    final ptr = inner.new_box_autoadd_prepare_refund_request_0();
-    _api_fill_to_wire_prepare_refund_request(raw, ptr.ref);
+  ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest>
+      api2wire_box_autoadd_prepare_redeem_onchain_funds_request(PrepareRedeemOnchainFundsRequest raw) {
+    final ptr = inner.new_box_autoadd_prepare_redeem_onchain_funds_request_0();
+    _api_fill_to_wire_prepare_redeem_onchain_funds_request(raw, ptr.ref);
     return ptr;
   }
 
   @protected
-  ffi.Pointer<wire_PrepareSweepRequest> api2wire_box_autoadd_prepare_sweep_request(PrepareSweepRequest raw) {
-    final ptr = inner.new_box_autoadd_prepare_sweep_request_0();
-    _api_fill_to_wire_prepare_sweep_request(raw, ptr.ref);
+  ffi.Pointer<wire_PrepareRefundRequest> api2wire_box_autoadd_prepare_refund_request(
+      PrepareRefundRequest raw) {
+    final ptr = inner.new_box_autoadd_prepare_refund_request_0();
+    _api_fill_to_wire_prepare_refund_request(raw, ptr.ref);
     return ptr;
   }
 
@@ -3939,6 +3945,14 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
       ReceivePaymentRequest raw) {
     final ptr = inner.new_box_autoadd_receive_payment_request_0();
     _api_fill_to_wire_receive_payment_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<wire_RedeemOnchainFundsRequest> api2wire_box_autoadd_redeem_onchain_funds_request(
+      RedeemOnchainFundsRequest raw) {
+    final ptr = inner.new_box_autoadd_redeem_onchain_funds_request_0();
+    _api_fill_to_wire_redeem_onchain_funds_request(raw, ptr.ref);
     return ptr;
   }
 
@@ -4005,13 +4019,6 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   ffi.Pointer<wire_StaticBackupRequest> api2wire_box_autoadd_static_backup_request(StaticBackupRequest raw) {
     final ptr = inner.new_box_autoadd_static_backup_request_0();
     _api_fill_to_wire_static_backup_request(raw, ptr.ref);
-    return ptr;
-  }
-
-  @protected
-  ffi.Pointer<wire_SweepRequest> api2wire_box_autoadd_sweep_request(SweepRequest raw) {
-    final ptr = inner.new_box_autoadd_sweep_request_0();
-    _api_fill_to_wire_sweep_request(raw, ptr.ref);
     return ptr;
   }
 
@@ -4173,14 +4180,14 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_opening_fee_params(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_prepare_redeem_onchain_funds_request(
+      PrepareRedeemOnchainFundsRequest apiObj, ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest> wireObj) {
+    _api_fill_to_wire_prepare_redeem_onchain_funds_request(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_prepare_refund_request(
       PrepareRefundRequest apiObj, ffi.Pointer<wire_PrepareRefundRequest> wireObj) {
     _api_fill_to_wire_prepare_refund_request(apiObj, wireObj.ref);
-  }
-
-  void _api_fill_to_wire_box_autoadd_prepare_sweep_request(
-      PrepareSweepRequest apiObj, ffi.Pointer<wire_PrepareSweepRequest> wireObj) {
-    _api_fill_to_wire_prepare_sweep_request(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_receive_onchain_request(
@@ -4191,6 +4198,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_box_autoadd_receive_payment_request(
       ReceivePaymentRequest apiObj, ffi.Pointer<wire_ReceivePaymentRequest> wireObj) {
     _api_fill_to_wire_receive_payment_request(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_box_autoadd_redeem_onchain_funds_request(
+      RedeemOnchainFundsRequest apiObj, ffi.Pointer<wire_RedeemOnchainFundsRequest> wireObj) {
+    _api_fill_to_wire_redeem_onchain_funds_request(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_refund_request(
@@ -4236,11 +4248,6 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_box_autoadd_static_backup_request(
       StaticBackupRequest apiObj, ffi.Pointer<wire_StaticBackupRequest> wireObj) {
     _api_fill_to_wire_static_backup_request(apiObj, wireObj.ref);
-  }
-
-  void _api_fill_to_wire_box_autoadd_sweep_request(
-      SweepRequest apiObj, ffi.Pointer<wire_SweepRequest> wireObj) {
-    _api_fill_to_wire_sweep_request(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_buy_bitcoin_request(BuyBitcoinRequest apiObj, wire_BuyBitcoinRequest wireObj) {
@@ -4354,14 +4361,15 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.promise = api2wire_String(apiObj.promise);
   }
 
-  void _api_fill_to_wire_prepare_refund_request(
-      PrepareRefundRequest apiObj, wire_PrepareRefundRequest wireObj) {
-    wireObj.swap_address = api2wire_String(apiObj.swapAddress);
+  void _api_fill_to_wire_prepare_redeem_onchain_funds_request(
+      PrepareRedeemOnchainFundsRequest apiObj, wire_PrepareRedeemOnchainFundsRequest wireObj) {
     wireObj.to_address = api2wire_String(apiObj.toAddress);
     wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
   }
 
-  void _api_fill_to_wire_prepare_sweep_request(PrepareSweepRequest apiObj, wire_PrepareSweepRequest wireObj) {
+  void _api_fill_to_wire_prepare_refund_request(
+      PrepareRefundRequest apiObj, wire_PrepareRefundRequest wireObj) {
+    wireObj.swap_address = api2wire_String(apiObj.swapAddress);
     wireObj.to_address = api2wire_String(apiObj.toAddress);
     wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
   }
@@ -4380,6 +4388,12 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.use_description_hash = api2wire_opt_box_autoadd_bool(apiObj.useDescriptionHash);
     wireObj.expiry = api2wire_opt_box_autoadd_u32(apiObj.expiry);
     wireObj.cltv = api2wire_opt_box_autoadd_u32(apiObj.cltv);
+  }
+
+  void _api_fill_to_wire_redeem_onchain_funds_request(
+      RedeemOnchainFundsRequest apiObj, wire_RedeemOnchainFundsRequest wireObj) {
+    wireObj.to_address = api2wire_String(apiObj.toAddress);
+    wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
   }
 
   void _api_fill_to_wire_refund_request(RefundRequest apiObj, wire_RefundRequest wireObj) {
@@ -4434,11 +4448,6 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_static_backup_request(StaticBackupRequest apiObj, wire_StaticBackupRequest wireObj) {
     wireObj.working_dir = api2wire_String(apiObj.workingDir);
-  }
-
-  void _api_fill_to_wire_sweep_request(SweepRequest apiObj, wire_SweepRequest wireObj) {
-    wireObj.to_address = api2wire_String(apiObj.toAddress);
-    wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
   }
 
   void _api_fill_to_wire_tlv_entry(TlvEntry apiObj, wire_TlvEntry wireObj) {
@@ -5106,35 +5115,38 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_buy_bitcoin =
       _wire_buy_bitcoinPtr.asFunction<void Function(int, ffi.Pointer<wire_BuyBitcoinRequest>)>();
 
-  void wire_sweep(
+  void wire_redeem_onchain_funds(
     int port_,
-    ffi.Pointer<wire_SweepRequest> req,
+    ffi.Pointer<wire_RedeemOnchainFundsRequest> req,
   ) {
-    return _wire_sweep(
+    return _wire_redeem_onchain_funds(
       port_,
       req,
     );
   }
 
-  late final _wire_sweepPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SweepRequest>)>>('wire_sweep');
-  late final _wire_sweep = _wire_sweepPtr.asFunction<void Function(int, ffi.Pointer<wire_SweepRequest>)>();
+  late final _wire_redeem_onchain_fundsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_RedeemOnchainFundsRequest>)>>(
+          'wire_redeem_onchain_funds');
+  late final _wire_redeem_onchain_funds = _wire_redeem_onchain_fundsPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_RedeemOnchainFundsRequest>)>();
 
-  void wire_prepare_sweep(
+  void wire_prepare_redeem_onchain_funds(
     int port_,
-    ffi.Pointer<wire_PrepareSweepRequest> req,
+    ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest> req,
   ) {
-    return _wire_prepare_sweep(
+    return _wire_prepare_redeem_onchain_funds(
       port_,
       req,
     );
   }
 
-  late final _wire_prepare_sweepPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_PrepareSweepRequest>)>>(
-          'wire_prepare_sweep');
-  late final _wire_prepare_sweep =
-      _wire_prepare_sweepPtr.asFunction<void Function(int, ffi.Pointer<wire_PrepareSweepRequest>)>();
+  late final _wire_prepare_redeem_onchain_fundsPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest>)>>(
+      'wire_prepare_redeem_onchain_funds');
+  late final _wire_prepare_redeem_onchain_funds = _wire_prepare_redeem_onchain_fundsPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest>)>();
 
   void wire_list_refundables(
     int port_,
@@ -5408,6 +5420,18 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_opening_fee_params_0 =
       _new_box_autoadd_opening_fee_params_0Ptr.asFunction<ffi.Pointer<wire_OpeningFeeParams> Function()>();
 
+  ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest>
+      new_box_autoadd_prepare_redeem_onchain_funds_request_0() {
+    return _new_box_autoadd_prepare_redeem_onchain_funds_request_0();
+  }
+
+  late final _new_box_autoadd_prepare_redeem_onchain_funds_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest> Function()>>(
+          'new_box_autoadd_prepare_redeem_onchain_funds_request_0');
+  late final _new_box_autoadd_prepare_redeem_onchain_funds_request_0 =
+      _new_box_autoadd_prepare_redeem_onchain_funds_request_0Ptr
+          .asFunction<ffi.Pointer<wire_PrepareRedeemOnchainFundsRequest> Function()>();
+
   ffi.Pointer<wire_PrepareRefundRequest> new_box_autoadd_prepare_refund_request_0() {
     return _new_box_autoadd_prepare_refund_request_0();
   }
@@ -5417,16 +5441,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'new_box_autoadd_prepare_refund_request_0');
   late final _new_box_autoadd_prepare_refund_request_0 = _new_box_autoadd_prepare_refund_request_0Ptr
       .asFunction<ffi.Pointer<wire_PrepareRefundRequest> Function()>();
-
-  ffi.Pointer<wire_PrepareSweepRequest> new_box_autoadd_prepare_sweep_request_0() {
-    return _new_box_autoadd_prepare_sweep_request_0();
-  }
-
-  late final _new_box_autoadd_prepare_sweep_request_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_PrepareSweepRequest> Function()>>(
-          'new_box_autoadd_prepare_sweep_request_0');
-  late final _new_box_autoadd_prepare_sweep_request_0 = _new_box_autoadd_prepare_sweep_request_0Ptr
-      .asFunction<ffi.Pointer<wire_PrepareSweepRequest> Function()>();
 
   ffi.Pointer<wire_ReceiveOnchainRequest> new_box_autoadd_receive_onchain_request_0() {
     return _new_box_autoadd_receive_onchain_request_0();
@@ -5447,6 +5461,17 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'new_box_autoadd_receive_payment_request_0');
   late final _new_box_autoadd_receive_payment_request_0 = _new_box_autoadd_receive_payment_request_0Ptr
       .asFunction<ffi.Pointer<wire_ReceivePaymentRequest> Function()>();
+
+  ffi.Pointer<wire_RedeemOnchainFundsRequest> new_box_autoadd_redeem_onchain_funds_request_0() {
+    return _new_box_autoadd_redeem_onchain_funds_request_0();
+  }
+
+  late final _new_box_autoadd_redeem_onchain_funds_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_RedeemOnchainFundsRequest> Function()>>(
+          'new_box_autoadd_redeem_onchain_funds_request_0');
+  late final _new_box_autoadd_redeem_onchain_funds_request_0 =
+      _new_box_autoadd_redeem_onchain_funds_request_0Ptr
+          .asFunction<ffi.Pointer<wire_RedeemOnchainFundsRequest> Function()>();
 
   ffi.Pointer<wire_RefundRequest> new_box_autoadd_refund_request_0() {
     return _new_box_autoadd_refund_request_0();
@@ -5539,16 +5564,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'new_box_autoadd_static_backup_request_0');
   late final _new_box_autoadd_static_backup_request_0 = _new_box_autoadd_static_backup_request_0Ptr
       .asFunction<ffi.Pointer<wire_StaticBackupRequest> Function()>();
-
-  ffi.Pointer<wire_SweepRequest> new_box_autoadd_sweep_request_0() {
-    return _new_box_autoadd_sweep_request_0();
-  }
-
-  late final _new_box_autoadd_sweep_request_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SweepRequest> Function()>>(
-          'new_box_autoadd_sweep_request_0');
-  late final _new_box_autoadd_sweep_request_0 =
-      _new_box_autoadd_sweep_request_0Ptr.asFunction<ffi.Pointer<wire_SweepRequest> Function()>();
 
   ffi.Pointer<ffi.Uint32> new_box_autoadd_u32_0(
     int value,
@@ -5917,14 +5932,14 @@ final class wire_BuyBitcoinRequest extends ffi.Struct {
   external ffi.Pointer<wire_OpeningFeeParams> opening_fee_params;
 }
 
-final class wire_SweepRequest extends ffi.Struct {
+final class wire_RedeemOnchainFundsRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> to_address;
 
   @ffi.Uint32()
   external int sat_per_vbyte;
 }
 
-final class wire_PrepareSweepRequest extends ffi.Struct {
+final class wire_PrepareRedeemOnchainFundsRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> to_address;
 
   @ffi.Uint32()

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -4363,7 +4363,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_prepare_sweep_request(PrepareSweepRequest apiObj, wire_PrepareSweepRequest wireObj) {
     wireObj.to_address = api2wire_String(apiObj.toAddress);
-    wireObj.sat_per_vbyte = api2wire_u64(apiObj.satPerVbyte);
+    wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
   }
 
   void _api_fill_to_wire_receive_onchain_request(
@@ -5927,7 +5927,7 @@ final class wire_SweepRequest extends ffi.Struct {
 final class wire_PrepareSweepRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> to_address;
 
-  @ffi.Uint64()
+  @ffi.Uint32()
   external int sat_per_vbyte;
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1993,7 +1993,7 @@ fun asPrepareSweepRequest(prepareSweepRequest: ReadableMap): PrepareSweepRequest
         return null
     }
     val toAddress = prepareSweepRequest.getString("toAddress")!!
-    val satPerVbyte = prepareSweepRequest.getDouble("satPerVbyte").toULong()
+    val satPerVbyte = prepareSweepRequest.getInt("satPerVbyte").toUInt()
     return PrepareSweepRequest(
         toAddress,
         satPerVbyte,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1903,6 +1903,80 @@ fun asPaymentFailedDataList(arr: ReadableArray): List<PaymentFailedData> {
     return list
 }
 
+fun asPrepareRedeemOnchainFundsRequest(prepareRedeemOnchainFundsRequest: ReadableMap): PrepareRedeemOnchainFundsRequest? {
+    if (!validateMandatoryFields(
+            prepareRedeemOnchainFundsRequest,
+            arrayOf(
+                "toAddress",
+                "satPerVbyte",
+            ),
+        )
+    ) {
+        return null
+    }
+    val toAddress = prepareRedeemOnchainFundsRequest.getString("toAddress")!!
+    val satPerVbyte = prepareRedeemOnchainFundsRequest.getInt("satPerVbyte").toUInt()
+    return PrepareRedeemOnchainFundsRequest(
+        toAddress,
+        satPerVbyte,
+    )
+}
+
+fun readableMapOf(prepareRedeemOnchainFundsRequest: PrepareRedeemOnchainFundsRequest): ReadableMap {
+    return readableMapOf(
+        "toAddress" to prepareRedeemOnchainFundsRequest.toAddress,
+        "satPerVbyte" to prepareRedeemOnchainFundsRequest.satPerVbyte,
+    )
+}
+
+fun asPrepareRedeemOnchainFundsRequestList(arr: ReadableArray): List<PrepareRedeemOnchainFundsRequest> {
+    val list = ArrayList<PrepareRedeemOnchainFundsRequest>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asPrepareRedeemOnchainFundsRequest(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
+fun asPrepareRedeemOnchainFundsResponse(prepareRedeemOnchainFundsResponse: ReadableMap): PrepareRedeemOnchainFundsResponse? {
+    if (!validateMandatoryFields(
+            prepareRedeemOnchainFundsResponse,
+            arrayOf(
+                "txWeight",
+                "txFeeSat",
+            ),
+        )
+    ) {
+        return null
+    }
+    val txWeight = prepareRedeemOnchainFundsResponse.getDouble("txWeight").toULong()
+    val txFeeSat = prepareRedeemOnchainFundsResponse.getDouble("txFeeSat").toULong()
+    return PrepareRedeemOnchainFundsResponse(
+        txWeight,
+        txFeeSat,
+    )
+}
+
+fun readableMapOf(prepareRedeemOnchainFundsResponse: PrepareRedeemOnchainFundsResponse): ReadableMap {
+    return readableMapOf(
+        "txWeight" to prepareRedeemOnchainFundsResponse.txWeight,
+        "txFeeSat" to prepareRedeemOnchainFundsResponse.txFeeSat,
+    )
+}
+
+fun asPrepareRedeemOnchainFundsResponseList(arr: ReadableArray): List<PrepareRedeemOnchainFundsResponse> {
+    val list = ArrayList<PrepareRedeemOnchainFundsResponse>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asPrepareRedeemOnchainFundsResponse(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
 fun asPrepareRefundRequest(prepareRefundRequest: ReadableMap): PrepareRefundRequest? {
     if (!validateMandatoryFields(
             prepareRefundRequest,
@@ -1975,80 +2049,6 @@ fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse>
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
-fun asPrepareSweepRequest(prepareSweepRequest: ReadableMap): PrepareSweepRequest? {
-    if (!validateMandatoryFields(
-            prepareSweepRequest,
-            arrayOf(
-                "toAddress",
-                "satPerVbyte",
-            ),
-        )
-    ) {
-        return null
-    }
-    val toAddress = prepareSweepRequest.getString("toAddress")!!
-    val satPerVbyte = prepareSweepRequest.getInt("satPerVbyte").toUInt()
-    return PrepareSweepRequest(
-        toAddress,
-        satPerVbyte,
-    )
-}
-
-fun readableMapOf(prepareSweepRequest: PrepareSweepRequest): ReadableMap {
-    return readableMapOf(
-        "toAddress" to prepareSweepRequest.toAddress,
-        "satPerVbyte" to prepareSweepRequest.satPerVbyte,
-    )
-}
-
-fun asPrepareSweepRequestList(arr: ReadableArray): List<PrepareSweepRequest> {
-    val list = ArrayList<PrepareSweepRequest>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asPrepareSweepRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
-fun asPrepareSweepResponse(prepareSweepResponse: ReadableMap): PrepareSweepResponse? {
-    if (!validateMandatoryFields(
-            prepareSweepResponse,
-            arrayOf(
-                "sweepTxWeight",
-                "sweepTxFeeSat",
-            ),
-        )
-    ) {
-        return null
-    }
-    val sweepTxWeight = prepareSweepResponse.getDouble("sweepTxWeight").toULong()
-    val sweepTxFeeSat = prepareSweepResponse.getDouble("sweepTxFeeSat").toULong()
-    return PrepareSweepResponse(
-        sweepTxWeight,
-        sweepTxFeeSat,
-    )
-}
-
-fun readableMapOf(prepareSweepResponse: PrepareSweepResponse): ReadableMap {
-    return readableMapOf(
-        "sweepTxWeight" to prepareSweepResponse.sweepTxWeight,
-        "sweepTxFeeSat" to prepareSweepResponse.sweepTxFeeSat,
-    )
-}
-
-fun asPrepareSweepResponseList(arr: ReadableArray): List<PrepareSweepResponse> {
-    val list = ArrayList<PrepareSweepResponse>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asPrepareSweepResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
@@ -2315,6 +2315,76 @@ fun asRecommendedFeesList(arr: ReadableArray): List<RecommendedFees> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRecommendedFees(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
+fun asRedeemOnchainFundsRequest(redeemOnchainFundsRequest: ReadableMap): RedeemOnchainFundsRequest? {
+    if (!validateMandatoryFields(
+            redeemOnchainFundsRequest,
+            arrayOf(
+                "toAddress",
+                "satPerVbyte",
+            ),
+        )
+    ) {
+        return null
+    }
+    val toAddress = redeemOnchainFundsRequest.getString("toAddress")!!
+    val satPerVbyte = redeemOnchainFundsRequest.getInt("satPerVbyte").toUInt()
+    return RedeemOnchainFundsRequest(
+        toAddress,
+        satPerVbyte,
+    )
+}
+
+fun readableMapOf(redeemOnchainFundsRequest: RedeemOnchainFundsRequest): ReadableMap {
+    return readableMapOf(
+        "toAddress" to redeemOnchainFundsRequest.toAddress,
+        "satPerVbyte" to redeemOnchainFundsRequest.satPerVbyte,
+    )
+}
+
+fun asRedeemOnchainFundsRequestList(arr: ReadableArray): List<RedeemOnchainFundsRequest> {
+    val list = ArrayList<RedeemOnchainFundsRequest>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asRedeemOnchainFundsRequest(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
+fun asRedeemOnchainFundsResponse(redeemOnchainFundsResponse: ReadableMap): RedeemOnchainFundsResponse? {
+    if (!validateMandatoryFields(
+            redeemOnchainFundsResponse,
+            arrayOf(
+                "txid",
+            ),
+        )
+    ) {
+        return null
+    }
+    val txid = redeemOnchainFundsResponse.getArray("txid")?.let { asUByteList(it) }!!
+    return RedeemOnchainFundsResponse(
+        txid,
+    )
+}
+
+fun readableMapOf(redeemOnchainFundsResponse: RedeemOnchainFundsResponse): ReadableMap {
+    return readableMapOf(
+        "txid" to readableArrayOf(redeemOnchainFundsResponse.txid),
+    )
+}
+
+fun asRedeemOnchainFundsResponseList(arr: ReadableArray): List<RedeemOnchainFundsResponse> {
+    val list = ArrayList<RedeemOnchainFundsResponse>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asRedeemOnchainFundsResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
@@ -3156,76 +3226,6 @@ fun asSwapInfoList(arr: ReadableArray): List<SwapInfo> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asSwapInfo(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
-fun asSweepRequest(sweepRequest: ReadableMap): SweepRequest? {
-    if (!validateMandatoryFields(
-            sweepRequest,
-            arrayOf(
-                "toAddress",
-                "satPerVbyte",
-            ),
-        )
-    ) {
-        return null
-    }
-    val toAddress = sweepRequest.getString("toAddress")!!
-    val satPerVbyte = sweepRequest.getInt("satPerVbyte").toUInt()
-    return SweepRequest(
-        toAddress,
-        satPerVbyte,
-    )
-}
-
-fun readableMapOf(sweepRequest: SweepRequest): ReadableMap {
-    return readableMapOf(
-        "toAddress" to sweepRequest.toAddress,
-        "satPerVbyte" to sweepRequest.satPerVbyte,
-    )
-}
-
-fun asSweepRequestList(arr: ReadableArray): List<SweepRequest> {
-    val list = ArrayList<SweepRequest>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asSweepRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
-fun asSweepResponse(sweepResponse: ReadableMap): SweepResponse? {
-    if (!validateMandatoryFields(
-            sweepResponse,
-            arrayOf(
-                "txid",
-            ),
-        )
-    ) {
-        return null
-    }
-    val txid = sweepResponse.getArray("txid")?.let { asUByteList(it) }!!
-    return SweepResponse(
-        txid,
-    )
-}
-
-fun readableMapOf(sweepResponse: SweepResponse): ReadableMap {
-    return readableMapOf(
-        "txid" to readableArrayOf(sweepResponse.txid),
-    )
-}
-
-fun asSweepResponseList(arr: ReadableArray): List<SweepResponse> {
-    val list = ArrayList<SweepResponse>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asSweepResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -439,14 +439,17 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun sweep(
+    fun redeemOnchainFunds(
         req: ReadableMap,
         promise: Promise,
     ) {
         executor.execute {
             try {
-                val sweepRequest = asSweepRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "SweepRequest")) }
-                val res = getBreezServices().sweep(sweepRequest)
+                val redeemOnchainFundsRequest =
+                    asRedeemOnchainFundsRequest(req) ?: run {
+                        throw SdkException.Generic(errMissingMandatoryField("req", "RedeemOnchainFundsRequest"))
+                    }
+                val res = getBreezServices().redeemOnchainFunds(redeemOnchainFundsRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
                 promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
@@ -798,17 +801,17 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
-    fun prepareSweep(
+    fun prepareRedeemOnchainFunds(
         req: ReadableMap,
         promise: Promise,
     ) {
         executor.execute {
             try {
-                val prepareSweepRequest =
-                    asPrepareSweepRequest(req) ?: run {
-                        throw SdkException.Generic(errMissingMandatoryField("req", "PrepareSweepRequest"))
+                val prepareRedeemOnchainFundsRequest =
+                    asPrepareRedeemOnchainFundsRequest(req) ?: run {
+                        throw SdkException.Generic(errMissingMandatoryField("req", "PrepareRedeemOnchainFundsRequest"))
                     }
-                val res = getBreezServices().prepareSweep(prepareSweepRequest)
+                val res = getBreezServices().prepareRedeemOnchainFunds(prepareRedeemOnchainFundsRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
                 promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2120,6 +2120,82 @@ enum BreezSDKMapper {
         return paymentFailedDataList.map { v -> [String: Any?] in dictionaryOf(paymentFailedData: v) }
     }
 
+    static func asPrepareRedeemOnchainFundsRequest(prepareRedeemOnchainFundsRequest: [String: Any?]) throws -> PrepareRedeemOnchainFundsRequest {
+        guard let toAddress = prepareRedeemOnchainFundsRequest["toAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "PrepareRedeemOnchainFundsRequest"))
+        }
+        guard let satPerVbyte = prepareRedeemOnchainFundsRequest["satPerVbyte"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "PrepareRedeemOnchainFundsRequest"))
+        }
+
+        return PrepareRedeemOnchainFundsRequest(
+            toAddress: toAddress,
+            satPerVbyte: satPerVbyte
+        )
+    }
+
+    static func dictionaryOf(prepareRedeemOnchainFundsRequest: PrepareRedeemOnchainFundsRequest) -> [String: Any?] {
+        return [
+            "toAddress": prepareRedeemOnchainFundsRequest.toAddress,
+            "satPerVbyte": prepareRedeemOnchainFundsRequest.satPerVbyte,
+        ]
+    }
+
+    static func asPrepareRedeemOnchainFundsRequestList(arr: [Any]) throws -> [PrepareRedeemOnchainFundsRequest] {
+        var list = [PrepareRedeemOnchainFundsRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var prepareRedeemOnchainFundsRequest = try asPrepareRedeemOnchainFundsRequest(prepareRedeemOnchainFundsRequest: val)
+                list.append(prepareRedeemOnchainFundsRequest)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRedeemOnchainFundsRequest"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(prepareRedeemOnchainFundsRequestList: [PrepareRedeemOnchainFundsRequest]) -> [Any] {
+        return prepareRedeemOnchainFundsRequestList.map { v -> [String: Any?] in dictionaryOf(prepareRedeemOnchainFundsRequest: v) }
+    }
+
+    static func asPrepareRedeemOnchainFundsResponse(prepareRedeemOnchainFundsResponse: [String: Any?]) throws -> PrepareRedeemOnchainFundsResponse {
+        guard let txWeight = prepareRedeemOnchainFundsResponse["txWeight"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txWeight", typeName: "PrepareRedeemOnchainFundsResponse"))
+        }
+        guard let txFeeSat = prepareRedeemOnchainFundsResponse["txFeeSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txFeeSat", typeName: "PrepareRedeemOnchainFundsResponse"))
+        }
+
+        return PrepareRedeemOnchainFundsResponse(
+            txWeight: txWeight,
+            txFeeSat: txFeeSat
+        )
+    }
+
+    static func dictionaryOf(prepareRedeemOnchainFundsResponse: PrepareRedeemOnchainFundsResponse) -> [String: Any?] {
+        return [
+            "txWeight": prepareRedeemOnchainFundsResponse.txWeight,
+            "txFeeSat": prepareRedeemOnchainFundsResponse.txFeeSat,
+        ]
+    }
+
+    static func asPrepareRedeemOnchainFundsResponseList(arr: [Any]) throws -> [PrepareRedeemOnchainFundsResponse] {
+        var list = [PrepareRedeemOnchainFundsResponse]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var prepareRedeemOnchainFundsResponse = try asPrepareRedeemOnchainFundsResponse(prepareRedeemOnchainFundsResponse: val)
+                list.append(prepareRedeemOnchainFundsResponse)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRedeemOnchainFundsResponse"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(prepareRedeemOnchainFundsResponseList: [PrepareRedeemOnchainFundsResponse]) -> [Any] {
+        return prepareRedeemOnchainFundsResponseList.map { v -> [String: Any?] in dictionaryOf(prepareRedeemOnchainFundsResponse: v) }
+    }
+
     static func asPrepareRefundRequest(prepareRefundRequest: [String: Any?]) throws -> PrepareRefundRequest {
         guard let swapAddress = prepareRefundRequest["swapAddress"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "PrepareRefundRequest"))
@@ -2199,82 +2275,6 @@ enum BreezSDKMapper {
 
     static func arrayOf(prepareRefundResponseList: [PrepareRefundResponse]) -> [Any] {
         return prepareRefundResponseList.map { v -> [String: Any?] in dictionaryOf(prepareRefundResponse: v) }
-    }
-
-    static func asPrepareSweepRequest(prepareSweepRequest: [String: Any?]) throws -> PrepareSweepRequest {
-        guard let toAddress = prepareSweepRequest["toAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "PrepareSweepRequest"))
-        }
-        guard let satPerVbyte = prepareSweepRequest["satPerVbyte"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "PrepareSweepRequest"))
-        }
-
-        return PrepareSweepRequest(
-            toAddress: toAddress,
-            satPerVbyte: satPerVbyte
-        )
-    }
-
-    static func dictionaryOf(prepareSweepRequest: PrepareSweepRequest) -> [String: Any?] {
-        return [
-            "toAddress": prepareSweepRequest.toAddress,
-            "satPerVbyte": prepareSweepRequest.satPerVbyte,
-        ]
-    }
-
-    static func asPrepareSweepRequestList(arr: [Any]) throws -> [PrepareSweepRequest] {
-        var list = [PrepareSweepRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareSweepRequest = try asPrepareSweepRequest(prepareSweepRequest: val)
-                list.append(prepareSweepRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSweepRequest"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(prepareSweepRequestList: [PrepareSweepRequest]) -> [Any] {
-        return prepareSweepRequestList.map { v -> [String: Any?] in dictionaryOf(prepareSweepRequest: v) }
-    }
-
-    static func asPrepareSweepResponse(prepareSweepResponse: [String: Any?]) throws -> PrepareSweepResponse {
-        guard let sweepTxWeight = prepareSweepResponse["sweepTxWeight"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "sweepTxWeight", typeName: "PrepareSweepResponse"))
-        }
-        guard let sweepTxFeeSat = prepareSweepResponse["sweepTxFeeSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "sweepTxFeeSat", typeName: "PrepareSweepResponse"))
-        }
-
-        return PrepareSweepResponse(
-            sweepTxWeight: sweepTxWeight,
-            sweepTxFeeSat: sweepTxFeeSat
-        )
-    }
-
-    static func dictionaryOf(prepareSweepResponse: PrepareSweepResponse) -> [String: Any?] {
-        return [
-            "sweepTxWeight": prepareSweepResponse.sweepTxWeight,
-            "sweepTxFeeSat": prepareSweepResponse.sweepTxFeeSat,
-        ]
-    }
-
-    static func asPrepareSweepResponseList(arr: [Any]) throws -> [PrepareSweepResponse] {
-        var list = [PrepareSweepResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareSweepResponse = try asPrepareSweepResponse(prepareSweepResponse: val)
-                list.append(prepareSweepResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSweepResponse"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(prepareSweepResponseList: [PrepareSweepResponse]) -> [Any] {
-        return prepareSweepResponseList.map { v -> [String: Any?] in dictionaryOf(prepareSweepResponse: v) }
     }
 
     static func asRate(rate: [String: Any?]) throws -> Rate {
@@ -2531,6 +2531,76 @@ enum BreezSDKMapper {
 
     static func arrayOf(recommendedFeesList: [RecommendedFees]) -> [Any] {
         return recommendedFeesList.map { v -> [String: Any?] in dictionaryOf(recommendedFees: v) }
+    }
+
+    static func asRedeemOnchainFundsRequest(redeemOnchainFundsRequest: [String: Any?]) throws -> RedeemOnchainFundsRequest {
+        guard let toAddress = redeemOnchainFundsRequest["toAddress"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "RedeemOnchainFundsRequest"))
+        }
+        guard let satPerVbyte = redeemOnchainFundsRequest["satPerVbyte"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "RedeemOnchainFundsRequest"))
+        }
+
+        return RedeemOnchainFundsRequest(
+            toAddress: toAddress,
+            satPerVbyte: satPerVbyte
+        )
+    }
+
+    static func dictionaryOf(redeemOnchainFundsRequest: RedeemOnchainFundsRequest) -> [String: Any?] {
+        return [
+            "toAddress": redeemOnchainFundsRequest.toAddress,
+            "satPerVbyte": redeemOnchainFundsRequest.satPerVbyte,
+        ]
+    }
+
+    static func asRedeemOnchainFundsRequestList(arr: [Any]) throws -> [RedeemOnchainFundsRequest] {
+        var list = [RedeemOnchainFundsRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var redeemOnchainFundsRequest = try asRedeemOnchainFundsRequest(redeemOnchainFundsRequest: val)
+                list.append(redeemOnchainFundsRequest)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "RedeemOnchainFundsRequest"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(redeemOnchainFundsRequestList: [RedeemOnchainFundsRequest]) -> [Any] {
+        return redeemOnchainFundsRequestList.map { v -> [String: Any?] in dictionaryOf(redeemOnchainFundsRequest: v) }
+    }
+
+    static func asRedeemOnchainFundsResponse(redeemOnchainFundsResponse: [String: Any?]) throws -> RedeemOnchainFundsResponse {
+        guard let txid = redeemOnchainFundsResponse["txid"] as? [UInt8] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txid", typeName: "RedeemOnchainFundsResponse"))
+        }
+
+        return RedeemOnchainFundsResponse(
+            txid: txid)
+    }
+
+    static func dictionaryOf(redeemOnchainFundsResponse: RedeemOnchainFundsResponse) -> [String: Any?] {
+        return [
+            "txid": redeemOnchainFundsResponse.txid,
+        ]
+    }
+
+    static func asRedeemOnchainFundsResponseList(arr: [Any]) throws -> [RedeemOnchainFundsResponse] {
+        var list = [RedeemOnchainFundsResponse]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var redeemOnchainFundsResponse = try asRedeemOnchainFundsResponse(redeemOnchainFundsResponse: val)
+                list.append(redeemOnchainFundsResponse)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "RedeemOnchainFundsResponse"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(redeemOnchainFundsResponseList: [RedeemOnchainFundsResponse]) -> [Any] {
+        return redeemOnchainFundsResponseList.map { v -> [String: Any?] in dictionaryOf(redeemOnchainFundsResponse: v) }
     }
 
     static func asRefundRequest(refundRequest: [String: Any?]) throws -> RefundRequest {
@@ -3431,76 +3501,6 @@ enum BreezSDKMapper {
 
     static func arrayOf(swapInfoList: [SwapInfo]) -> [Any] {
         return swapInfoList.map { v -> [String: Any?] in dictionaryOf(swapInfo: v) }
-    }
-
-    static func asSweepRequest(sweepRequest: [String: Any?]) throws -> SweepRequest {
-        guard let toAddress = sweepRequest["toAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "SweepRequest"))
-        }
-        guard let satPerVbyte = sweepRequest["satPerVbyte"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "SweepRequest"))
-        }
-
-        return SweepRequest(
-            toAddress: toAddress,
-            satPerVbyte: satPerVbyte
-        )
-    }
-
-    static func dictionaryOf(sweepRequest: SweepRequest) -> [String: Any?] {
-        return [
-            "toAddress": sweepRequest.toAddress,
-            "satPerVbyte": sweepRequest.satPerVbyte,
-        ]
-    }
-
-    static func asSweepRequestList(arr: [Any]) throws -> [SweepRequest] {
-        var list = [SweepRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sweepRequest = try asSweepRequest(sweepRequest: val)
-                list.append(sweepRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SweepRequest"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(sweepRequestList: [SweepRequest]) -> [Any] {
-        return sweepRequestList.map { v -> [String: Any?] in dictionaryOf(sweepRequest: v) }
-    }
-
-    static func asSweepResponse(sweepResponse: [String: Any?]) throws -> SweepResponse {
-        guard let txid = sweepResponse["txid"] as? [UInt8] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txid", typeName: "SweepResponse"))
-        }
-
-        return SweepResponse(
-            txid: txid)
-    }
-
-    static func dictionaryOf(sweepResponse: SweepResponse) -> [String: Any?] {
-        return [
-            "txid": sweepResponse.txid,
-        ]
-    }
-
-    static func asSweepResponseList(arr: [Any]) throws -> [SweepResponse] {
-        var list = [SweepResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sweepResponse = try asSweepResponse(sweepResponse: val)
-                list.append(sweepResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SweepResponse"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(sweepResponseList: [SweepResponse]) -> [Any] {
-        return sweepResponseList.map { v -> [String: Any?] in dictionaryOf(sweepResponse: v) }
     }
 
     static func asSymbol(symbol: [String: Any?]) throws -> Symbol {

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2205,7 +2205,7 @@ enum BreezSDKMapper {
         guard let toAddress = prepareSweepRequest["toAddress"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "toAddress", typeName: "PrepareSweepRequest"))
         }
-        guard let satPerVbyte = prepareSweepRequest["satPerVbyte"] as? UInt64 else {
+        guard let satPerVbyte = prepareSweepRequest["satPerVbyte"] as? UInt32 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "PrepareSweepRequest"))
         }
 

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -139,7 +139,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    sweep: (NSDictionary*)req
+    redeemOnchainFunds: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )
@@ -276,7 +276,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    prepareSweep: (NSDictionary*)req
+    prepareRedeemOnchainFunds: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -312,12 +312,12 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
-    @objc(sweep:resolve:reject:)
-    func sweep(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(redeemOnchainFunds:resolve:reject:)
+    func redeemOnchainFunds(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            let sweepRequest = try BreezSDKMapper.asSweepRequest(sweepRequest: req)
-            var res = try getBreezServices().sweep(req: sweepRequest)
-            resolve(BreezSDKMapper.dictionaryOf(sweepResponse: res))
+            let redeemOnchainFundsRequest = try BreezSDKMapper.asRedeemOnchainFundsRequest(redeemOnchainFundsRequest: req)
+            var res = try getBreezServices().redeemOnchainFunds(req: redeemOnchainFundsRequest)
+            resolve(BreezSDKMapper.dictionaryOf(redeemOnchainFundsResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
@@ -582,12 +582,12 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
-    @objc(prepareSweep:resolve:reject:)
-    func prepareSweep(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(prepareRedeemOnchainFunds:resolve:reject:)
+    func prepareRedeemOnchainFunds(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            let prepareSweepRequest = try BreezSDKMapper.asPrepareSweepRequest(prepareSweepRequest: req)
-            var res = try getBreezServices().prepareSweep(req: prepareSweepRequest)
-            resolve(BreezSDKMapper.dictionaryOf(prepareSweepResponse: res))
+            let prepareRedeemOnchainFundsRequest = try BreezSDKMapper.asPrepareRedeemOnchainFundsRequest(prepareRedeemOnchainFundsRequest: req)
+            var res = try getBreezServices().prepareRedeemOnchainFunds(req: prepareRedeemOnchainFundsRequest)
+            resolve(BreezSDKMapper.dictionaryOf(prepareRedeemOnchainFundsResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -305,6 +305,16 @@ export type PaymentFailedData = {
     invoice?: LnInvoice
 }
 
+export type PrepareRedeemOnchainFundsRequest = {
+    toAddress: string
+    satPerVbyte: number
+}
+
+export type PrepareRedeemOnchainFundsResponse = {
+    txWeight: number
+    txFeeSat: number
+}
+
 export type PrepareRefundRequest = {
     swapAddress: string
     toAddress: string
@@ -314,16 +324,6 @@ export type PrepareRefundRequest = {
 export type PrepareRefundResponse = {
     refundTxWeight: number
     refundTxFeeSat: number
-}
-
-export type PrepareSweepRequest = {
-    toAddress: string
-    satPerVbyte: number
-}
-
-export type PrepareSweepResponse = {
-    sweepTxWeight: number
-    sweepTxFeeSat: number
 }
 
 export type Rate = {
@@ -357,6 +357,15 @@ export type RecommendedFees = {
     hourFee: number
     economyFee: number
     minimumFee: number
+}
+
+export type RedeemOnchainFundsRequest = {
+    toAddress: string
+    satPerVbyte: number
+}
+
+export type RedeemOnchainFundsResponse = {
+    txid: number[]
 }
 
 export type RefundRequest = {
@@ -479,15 +488,6 @@ export type SwapInfo = {
     maxAllowedDeposit: number
     lastRedeemError?: string
     channelOpeningFees?: OpeningFeeParams
-}
-
-export type SweepRequest = {
-    toAddress: string
-    satPerVbyte: number
-}
-
-export type SweepResponse = {
-    txid: number[]
 }
 
 export type SymbolType = {
@@ -886,8 +886,8 @@ export const listPayments = async (req: ListPaymentsRequest): Promise<Payment[]>
     return response
 }
 
-export const sweep = async (req: SweepRequest): Promise<SweepResponse> => {
-    const response = await BreezSDK.sweep(req)
+export const redeemOnchainFunds = async (req: RedeemOnchainFundsRequest): Promise<RedeemOnchainFundsResponse> => {
+    const response = await BreezSDK.redeemOnchainFunds(req)
     return response
 }
 
@@ -1007,7 +1007,7 @@ export const buyBitcoin = async (req: BuyBitcoinRequest): Promise<BuyBitcoinResp
     return response
 }
 
-export const prepareSweep = async (req: PrepareSweepRequest): Promise<PrepareSweepResponse> => {
-    const response = await BreezSDK.prepareSweep(req)
+export const prepareRedeemOnchainFunds = async (req: PrepareRedeemOnchainFundsRequest): Promise<PrepareRedeemOnchainFundsResponse> => {
+    const response = await BreezSDK.prepareRedeemOnchainFunds(req)
     return response
 }

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -6,10 +6,10 @@ use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
     parse, BreezEvent, BreezServices, BuyBitcoinRequest, CheckMessageRequest, EventListener,
     GreenlightCredentials, ListPaymentsRequest, LnUrlPayRequest, LnUrlWithdrawRequest,
-    PrepareRefundRequest, ReceiveOnchainRequest, ReceivePaymentRequest, RefundRequest,
-    ReportIssueRequest, ReportPaymentFailureDetails, ReverseSwapFeesRequest, SendOnchainRequest,
-    SendPaymentRequest, SendSpontaneousPaymentRequest, SignMessageRequest, StaticBackupRequest,
-    SweepRequest,
+    PrepareRefundRequest, PrepareSweepRequest, ReceiveOnchainRequest, ReceivePaymentRequest,
+    RefundRequest, ReportIssueRequest, ReportPaymentFailureDetails, ReverseSwapFeesRequest,
+    SendOnchainRequest, SendPaymentRequest, SendSpontaneousPaymentRequest, SignMessageRequest,
+    StaticBackupRequest, SweepRequest,
 };
 use breez_sdk_core::{Config, GreenlightNodeConfig, NodeConfig};
 use once_cell::sync::OnceCell;
@@ -248,13 +248,13 @@ pub(crate) async fn handle_command(
             to_address,
             sat_per_vbyte,
         } => {
-            sdk()?
-                .sweep(SweepRequest {
+            let resp = sdk()?
+                .prepare_sweep(PrepareSweepRequest {
                     to_address,
                     sat_per_vbyte,
                 })
                 .await?;
-            Ok("Onchain funds were swept succesfully".to_string())
+            serde_json::to_string_pretty(&resp).map_err(|e| e.into())
         }
         Commands::ListLsps {} => {
             let lsps = sdk()?.list_lsps().await?;

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -6,10 +6,10 @@ use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
     parse, BreezEvent, BreezServices, BuyBitcoinRequest, CheckMessageRequest, EventListener,
     GreenlightCredentials, ListPaymentsRequest, LnUrlPayRequest, LnUrlWithdrawRequest,
-    PrepareRefundRequest, PrepareSweepRequest, ReceiveOnchainRequest, ReceivePaymentRequest,
-    RefundRequest, ReportIssueRequest, ReportPaymentFailureDetails, ReverseSwapFeesRequest,
-    SendOnchainRequest, SendPaymentRequest, SendSpontaneousPaymentRequest, SignMessageRequest,
-    StaticBackupRequest, SweepRequest,
+    PrepareRedeemOnchainFundsRequest, PrepareRefundRequest, ReceiveOnchainRequest,
+    ReceivePaymentRequest, RedeemOnchainFundsRequest, RefundRequest, ReportIssueRequest,
+    ReportPaymentFailureDetails, ReverseSwapFeesRequest, SendOnchainRequest, SendPaymentRequest,
+    SendSpontaneousPaymentRequest, SignMessageRequest, StaticBackupRequest,
 };
 use breez_sdk_core::{Config, GreenlightNodeConfig, NodeConfig};
 use once_cell::sync::OnceCell;
@@ -232,24 +232,24 @@ pub(crate) async fn handle_command(
             let payment = sdk()?.payment_by_hash(hash).await?;
             serde_json::to_string_pretty(&payment).map_err(|e| e.into())
         }
-        Commands::Sweep {
-            to_address,
-            sat_per_vbyte,
-        } => {
-            sdk()?
-                .sweep(SweepRequest {
-                    to_address,
-                    sat_per_vbyte,
-                })
-                .await?;
-            Ok("Onchain funds were swept successfully".to_string())
-        }
-        Commands::PrepareSweep {
+        Commands::RedeemOnchainFunds {
             to_address,
             sat_per_vbyte,
         } => {
             let resp = sdk()?
-                .prepare_sweep(PrepareSweepRequest {
+                .redeem_onchain_funds(RedeemOnchainFundsRequest {
+                    to_address,
+                    sat_per_vbyte,
+                })
+                .await?;
+            serde_json::to_string_pretty(&resp).map_err(|e| e.into())
+        }
+        Commands::PrepareRedeemOnchainFunds {
+            to_address,
+            sat_per_vbyte,
+        } => {
+            let resp = sdk()?
+                .prepare_redeem_onchain_funds(PrepareRedeemOnchainFundsRequest {
                     to_address,
                     sat_per_vbyte,
                 })

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -152,16 +152,16 @@ pub(crate) enum Commands {
     },
 
     /// Send on-chain funds to an external address
-    Sweep {
-        /// The sweep destination address
+    RedeemOnchainFunds {
+        /// The redeem_onchain_funds destination address
         to_address: String,
 
-        /// The fee rate for the sweep transaction
+        /// The fee rate for the redeem_onchain_funds transaction
         sat_per_vbyte: u32,
     },
 
     /// Calculate the fee (in sats) for a potential transaction
-    PrepareSweep {
+    PrepareRedeemOnchainFunds {
         /// The destination address
         to_address: String,
 


### PR DESCRIPTION
In order to avoid confusion about sweep which implies sending funds from the closing address to the internal wallet. By renaming it to withdraw we indicate that it is sending the funds out. 