### PR TITLE
set group_id in send_pay

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -835,7 +835,7 @@ impl NodeAPI for Greenlight {
                     payment_secret: Some(invoice.payment_secret.clone()),
                     partid: Some(part_id),
                     localinvreqid: None,
-                    groupid: None,
+                    groupid: Some(group_id),
                 })
                 .await?;
             part_id += 1;


### PR DESCRIPTION
The group_id was not set, which is the probable cause for this error:
![image](https://github.com/breez/breez-sdk/assets/15966593/ae49e96e-9974-4fe6-8114-6d6c96b9ce29)
