### PR TITLE
[sdk-flutter] fetch node data on new block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: fmt clippy codegen
+all: fmt codegen clippy
 
 fmt:
 	cd libs && cargo fmt -- --check

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -78,8 +78,8 @@ pub(crate) fn get_utxos(address: String, transactions: Vec<OnchainTx>) -> Result
     // Calculate confirmed amount associated with this address
     let mut spent_outputs: Vec<OutPoint> = Vec::new();
     let mut utxos: Vec<Utxo> = Vec::new();
-    for (_, tx) in transactions.iter().enumerate() {
-        for (_, vin) in tx.vin.iter().enumerate() {
+    for tx in transactions.iter() {
+        for vin in tx.vin.iter() {
             if vin.prevout.scriptpubkey_address == address.clone() {
                 spent_outputs.push(OutPoint {
                     txid: Txid::from_hex(vin.txid.as_str())?,
@@ -89,7 +89,7 @@ pub(crate) fn get_utxos(address: String, transactions: Vec<OnchainTx>) -> Result
         }
     }
 
-    for (_i, tx) in transactions.iter().enumerate() {
+    for tx in transactions.iter() {
         for (index, vout) in tx.vout.iter().enumerate() {
             if vout.scriptpubkey_address == address {
                 let outpoint = OutPoint {

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -1165,11 +1165,11 @@ pub(crate) mod tests {
 
             assert_eq!(pd.metadata_vec()?.len(), 3);
             assert_eq!(
-                pd.metadata_vec()?.get(0).ok_or("Key not found")?.key,
+                pd.metadata_vec()?.first().ok_or("Key not found")?.key,
                 "text/plain"
             );
             assert_eq!(
-                pd.metadata_vec()?.get(0).ok_or("Key not found")?.value,
+                pd.metadata_vec()?.first().ok_or("Key not found")?.value,
                 "WRhtV"
             );
             assert_eq!(
@@ -1207,11 +1207,11 @@ pub(crate) mod tests {
 
             assert_eq!(pd.metadata_vec()?.len(), 3);
             assert_eq!(
-                pd.metadata_vec()?.get(0).ok_or("Key not found")?.key,
+                pd.metadata_vec()?.first().ok_or("Key not found")?.key,
                 "text/plain"
             );
             assert_eq!(
-                pd.metadata_vec()?.get(0).ok_or("Key not found")?.value,
+                pd.metadata_vec()?.first().ok_or("Key not found")?.value,
                 "WRhtV"
             );
             assert_eq!(
@@ -1404,11 +1404,11 @@ pub(crate) mod tests {
 
             assert_eq!(pd.metadata_vec()?.len(), 3);
             assert_eq!(
-                pd.metadata_vec()?.get(0).ok_or("Key not found")?.key,
+                pd.metadata_vec()?.first().ok_or("Key not found")?.key,
                 "text/plain"
             );
             assert_eq!(
-                pd.metadata_vec()?.get(0).ok_or("Key not found")?.value,
+                pd.metadata_vec()?.first().ok_or("Key not found")?.value,
                 "WRhtV"
             );
             assert_eq!(

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -24,6 +24,9 @@ class BreezSDK {
   void initialize() {
     /// Listen to BreezEvent's(new block, invoice paid, synced)
     _lnToolkit.breezEventsStream().listen((event) async {
+      if (event is BreezEvent_NewBlock) {
+        await fetchNodeData();
+      }
       if (event is BreezEvent_InvoicePaid) {
         _invoicePaidStream.add(event.details);
         await fetchNodeData();


### PR DESCRIPTION
We currently do not emit the node info when a new block arrives for the flutter sdk. This is useful for calculating the payment expiry for pending payments.

This pr also includes small fixes for the sdk and for the makefile.