### PR TITLE
Chain service: Add support for an optional fallback mempool.space URL

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -124,6 +124,7 @@ interface NodeConfig {
 dictionary Config {
     string breezserver;
     string mempoolspace_url;
+    string mempoolspace_fallback_url;
     string working_dir;
     Network network;
     u32 payment_timeout_sec;

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -124,7 +124,7 @@ interface NodeConfig {
 dictionary Config {
     string breezserver;
     string mempoolspace_url;
-    string mempoolspace_fallback_url;
+    string? mempoolspace_fallback_url;
     string working_dir;
     Network network;
     u32 payment_timeout_sec;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1697,8 +1697,9 @@ impl BreezServicesBuilder {
         persister.init()?;
 
         // mempool space is used to monitor the chain
-        let chain_service = Arc::new(MempoolSpace::from_base_url(
+        let chain_service = Arc::new(MempoolSpace::from_base_url_with_fallback(
             self.config.mempoolspace_url.clone(),
+            self.config.mempoolspace_fallback_url.clone(),
         ));
 
         let mut node_api = self.node_api.clone();

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -661,6 +661,7 @@ impl Wire2Api<Config> for wire_Config {
         Config {
             breezserver: self.breezserver.wire2api(),
             mempoolspace_url: self.mempoolspace_url.wire2api(),
+            mempoolspace_fallback_url: self.mempoolspace_fallback_url.wire2api(),
             working_dir: self.working_dir.wire2api(),
             network: self.network.wire2api(),
             payment_timeout_sec: self.payment_timeout_sec.wire2api(),
@@ -971,6 +972,7 @@ pub struct wire_CheckMessageRequest {
 pub struct wire_Config {
     breezserver: *mut wire_uint_8_list,
     mempoolspace_url: *mut wire_uint_8_list,
+    mempoolspace_fallback_url: *mut wire_uint_8_list,
     working_dir: *mut wire_uint_8_list,
     network: i32,
     payment_timeout_sec: u32,
@@ -1280,6 +1282,7 @@ impl NewWithNullPtr for wire_Config {
         Self {
             breezserver: core::ptr::null_mut(),
             mempoolspace_url: core::ptr::null_mut(),
+            mempoolspace_fallback_url: core::ptr::null_mut(),
             working_dir: core::ptr::null_mut(),
             network: Default::default(),
             payment_timeout_sec: Default::default(),

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1063,7 +1063,7 @@ impl support::IntoDart for Config {
         vec![
             self.breezserver.into_into_dart().into_dart(),
             self.mempoolspace_url.into_into_dart().into_dart(),
-            self.mempoolspace_fallback_url.into_into_dart().into_dart(),
+            self.mempoolspace_fallback_url.into_dart(),
             self.working_dir.into_into_dart().into_dart(),
             self.network.into_into_dart().into_dart(),
             self.payment_timeout_sec.into_into_dart().into_dart(),

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1063,6 +1063,7 @@ impl support::IntoDart for Config {
         vec![
             self.breezserver.into_into_dart().into_dart(),
             self.mempoolspace_url.into_into_dart().into_dart(),
+            self.mempoolspace_fallback_url.into_into_dart().into_dart(),
             self.working_dir.into_into_dart().into_dart(),
             self.network.into_into_dart().into_dart(),
             self.payment_timeout_sec.into_into_dart().into_dart(),

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -301,8 +301,9 @@ mod tests {
 
     #[test]
     async fn test_recommended_fees() -> Result<()> {
-        let ms = Box::new(MempoolSpace::from_base_url(
+        let ms = Box::new(MempoolSpace::from_base_url_with_fallback(
             "https://mempool.space".to_string(),
+            None,
         ));
         let fees = ms.recommended_fees().await?;
         assert!(fees.economy_fee > 0);
@@ -318,14 +319,15 @@ mod tests {
     async fn test_fallback() -> Result<()> {
         let unreachable_mempool_space = "https://mempool-url-unreachable.space".to_string();
 
-        let ms = Box::new(MempoolSpace::from_base_url(
+        let ms = Box::new(MempoolSpace::from_base_url_with_fallback(
             unreachable_mempool_space.clone(),
+            None,
         ));
         assert!(ms.recommended_fees().await.is_err());
 
         let ms = Box::new(MempoolSpace::from_base_url_with_fallback(
             unreachable_mempool_space,
-            "https://mempool.emzy.de".to_string(),
+            Some("https://mempool.emzy.de".to_string()),
         ));
         assert!(ms.recommended_fees().await.is_ok());
 
@@ -334,7 +336,8 @@ mod tests {
 
     #[test]
     async fn test_address_transactions() -> Result<()> {
-        let ms = MempoolSpace::from_base_url("https://mempool.space".to_string());
+        let ms =
+            MempoolSpace::from_base_url_with_fallback("https://mempool.space".to_string(), None);
         let txs = ms
             .address_transactions("bc1qvhykeqcpdzu0pdvy99xnh9ckhwzcfskct6h6l2".to_string())
             .await?;

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -211,18 +211,13 @@ impl Default for MempoolSpace {
 }
 
 impl MempoolSpace {
-    #[allow(dead_code)]
-    pub fn from_base_url(base_url: String) -> MempoolSpace {
+    pub fn from_base_url_with_fallback(
+        base_url: String,
+        fallback_base_url: Option<String>,
+    ) -> MempoolSpace {
         MempoolSpace {
             base_url,
-            fallback_base_url: None,
-        }
-    }
-
-    pub fn from_base_url_with_fallback(base_url: String, fallback_url: String) -> MempoolSpace {
-        MempoolSpace {
-            base_url,
-            fallback_base_url: Some(fallback_url),
+            fallback_base_url,
         }
     }
 

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -228,6 +228,19 @@ pub async fn parse(input: &str) -> Result<InputType> {
     Err(anyhow!("Unrecognized input type"))
 }
 
+pub(crate) async fn post_and_log_response(url: &str, body: Option<String>) -> Result<String> {
+    debug!("Making POST request to: {url}");
+
+    let mut req = reqwest::Client::new().post(url);
+    if let Some(body) = body {
+        req = req.body(body);
+    }
+    let raw_body = req.send().await?.text().await?;
+    debug!("Received raw response body: {raw_body}");
+
+    Ok(raw_body)
+}
+
 /// Makes a GET request to the specified `url` and logs on DEBUG:
 /// - the URL
 /// - the raw response body

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -432,6 +432,7 @@ pub struct LogEntry {
 pub struct Config {
     pub breezserver: String,
     pub mempoolspace_url: String,
+    pub mempoolspace_fallback_url: String,
     /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
     /// the folder should exist before starting the SDK.
     pub working_dir: String,
@@ -451,6 +452,7 @@ impl Config {
         Config {
             breezserver: "https://bs1.breez.technology:443".to_string(),
             mempoolspace_url: "https://mempool.space".to_string(),
+            mempoolspace_fallback_url: "https://mempool.emzy.de".to_string(),
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,
@@ -466,6 +468,7 @@ impl Config {
         Config {
             breezserver: "https://bs1-st.breez.technology:443".to_string(),
             mempoolspace_url: "https://mempool.space".to_string(),
+            mempoolspace_fallback_url: "https://mempool.emzy.de".to_string(),
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -432,7 +432,7 @@ pub struct LogEntry {
 pub struct Config {
     pub breezserver: String,
     pub mempoolspace_url: String,
-    pub mempoolspace_fallback_url: String,
+    pub mempoolspace_fallback_url: Option<String>,
     /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
     /// the folder should exist before starting the SDK.
     pub working_dir: String,
@@ -452,7 +452,7 @@ impl Config {
         Config {
             breezserver: "https://bs1.breez.technology:443".to_string(),
             mempoolspace_url: "https://mempool.space".to_string(),
-            mempoolspace_fallback_url: "https://mempool.emzy.de".to_string(),
+            mempoolspace_fallback_url: Some("https://mempool.emzy.de".to_string()),
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,
@@ -468,7 +468,7 @@ impl Config {
         Config {
             breezserver: "https://bs1-st.breez.technology:443".to_string(),
             mempoolspace_url: "https://mempool.space".to_string(),
-            mempoolspace_fallback_url: "https://mempool.emzy.de".to_string(),
+            mempoolspace_fallback_url: Some("https://mempool.emzy.de".to_string()),
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -48,6 +48,7 @@ typedef struct wire_NodeConfig {
 typedef struct wire_Config {
   struct wire_uint_8_list *breezserver;
   struct wire_uint_8_list *mempoolspace_url;
+  struct wire_uint_8_list *mempoolspace_fallback_url;
   struct wire_uint_8_list *working_dir;
   int32_t network;
   uint32_t payment_timeout_sec;

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -434,6 +434,7 @@ extension SDKConfig on Config {
   Config copyWith({
     String? breezserver,
     String? mempoolspaceUrl,
+    String? mempoolspaceFallbackUrl,
     String? workingDir,
     Network? network,
     int? paymentTimeoutSec,
@@ -446,6 +447,7 @@ extension SDKConfig on Config {
     return Config(
       breezserver: breezserver ?? this.breezserver,
       mempoolspaceUrl: mempoolspaceUrl ?? this.mempoolspaceUrl,
+      mempoolspaceFallbackUrl: mempoolspaceFallbackUrl ?? this.mempoolspaceFallbackUrl,
       workingDir: workingDir ?? this.workingDir,
       network: network ?? this.network,
       paymentTimeoutSec: paymentTimeoutSec ?? this.paymentTimeoutSec,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -458,6 +458,7 @@ class ClosedChannelPaymentDetails {
 class Config {
   final String breezserver;
   final String mempoolspaceUrl;
+  final String mempoolspaceFallbackUrl;
 
   /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
   /// the folder should exist before starting the SDK.
@@ -477,6 +478,7 @@ class Config {
   const Config({
     required this.breezserver,
     required this.mempoolspaceUrl,
+    required this.mempoolspaceFallbackUrl,
     required this.workingDir,
     required this.network,
     required this.paymentTimeoutSec,
@@ -2916,18 +2918,19 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   Config _wire2api_config(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return Config(
       breezserver: _wire2api_String(arr[0]),
       mempoolspaceUrl: _wire2api_String(arr[1]),
-      workingDir: _wire2api_String(arr[2]),
-      network: _wire2api_network(arr[3]),
-      paymentTimeoutSec: _wire2api_u32(arr[4]),
-      defaultLspId: _wire2api_opt_String(arr[5]),
-      apiKey: _wire2api_opt_String(arr[6]),
-      maxfeePercent: _wire2api_f64(arr[7]),
-      exemptfeeMsat: _wire2api_u64(arr[8]),
-      nodeConfig: _wire2api_node_config(arr[9]),
+      mempoolspaceFallbackUrl: _wire2api_String(arr[2]),
+      workingDir: _wire2api_String(arr[3]),
+      network: _wire2api_network(arr[4]),
+      paymentTimeoutSec: _wire2api_u32(arr[5]),
+      defaultLspId: _wire2api_opt_String(arr[6]),
+      apiKey: _wire2api_opt_String(arr[7]),
+      maxfeePercent: _wire2api_f64(arr[8]),
+      exemptfeeMsat: _wire2api_u64(arr[9]),
+      nodeConfig: _wire2api_node_config(arr[10]),
     );
   }
 
@@ -4269,6 +4272,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_config(Config apiObj, wire_Config wireObj) {
     wireObj.breezserver = api2wire_String(apiObj.breezserver);
     wireObj.mempoolspace_url = api2wire_String(apiObj.mempoolspaceUrl);
+    wireObj.mempoolspace_fallback_url = api2wire_String(apiObj.mempoolspaceFallbackUrl);
     wireObj.working_dir = api2wire_String(apiObj.workingDir);
     wireObj.network = api2wire_network(apiObj.network);
     wireObj.payment_timeout_sec = api2wire_u32(apiObj.paymentTimeoutSec);
@@ -5709,6 +5713,8 @@ final class wire_Config extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> breezserver;
 
   external ffi.Pointer<wire_uint_8_list> mempoolspace_url;
+
+  external ffi.Pointer<wire_uint_8_list> mempoolspace_fallback_url;
 
   external ffi.Pointer<wire_uint_8_list> working_dir;
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -458,7 +458,7 @@ class ClosedChannelPaymentDetails {
 class Config {
   final String breezserver;
   final String mempoolspaceUrl;
-  final String mempoolspaceFallbackUrl;
+  final String? mempoolspaceFallbackUrl;
 
   /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
   /// the folder should exist before starting the SDK.
@@ -478,7 +478,7 @@ class Config {
   const Config({
     required this.breezserver,
     required this.mempoolspaceUrl,
-    required this.mempoolspaceFallbackUrl,
+    this.mempoolspaceFallbackUrl,
     required this.workingDir,
     required this.network,
     required this.paymentTimeoutSec,
@@ -2922,7 +2922,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return Config(
       breezserver: _wire2api_String(arr[0]),
       mempoolspaceUrl: _wire2api_String(arr[1]),
-      mempoolspaceFallbackUrl: _wire2api_String(arr[2]),
+      mempoolspaceFallbackUrl: _wire2api_opt_String(arr[2]),
       workingDir: _wire2api_String(arr[3]),
       network: _wire2api_network(arr[4]),
       paymentTimeoutSec: _wire2api_u32(arr[5]),
@@ -4272,7 +4272,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_config(Config apiObj, wire_Config wireObj) {
     wireObj.breezserver = api2wire_String(apiObj.breezserver);
     wireObj.mempoolspace_url = api2wire_String(apiObj.mempoolspaceUrl);
-    wireObj.mempoolspace_fallback_url = api2wire_String(apiObj.mempoolspaceFallbackUrl);
+    wireObj.mempoolspace_fallback_url = api2wire_opt_String(apiObj.mempoolspaceFallbackUrl);
     wireObj.working_dir = api2wire_String(apiObj.workingDir);
     wireObj.network = api2wire_network(apiObj.network);
     wireObj.payment_timeout_sec = api2wire_u32(apiObj.paymentTimeoutSec);

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -374,6 +374,7 @@ fun asConfig(config: ReadableMap): Config? {
             arrayOf(
                 "breezserver",
                 "mempoolspaceUrl",
+                "mempoolspaceFallbackUrl",
                 "workingDir",
                 "network",
                 "paymentTimeoutSec",
@@ -387,6 +388,7 @@ fun asConfig(config: ReadableMap): Config? {
     }
     val breezserver = config.getString("breezserver")!!
     val mempoolspaceUrl = config.getString("mempoolspaceUrl")!!
+    val mempoolspaceFallbackUrl = config.getString("mempoolspaceFallbackUrl")!!
     val workingDir = config.getString("workingDir")!!
     val network = config.getString("network")?.let { asNetwork(it) }!!
     val paymentTimeoutSec = config.getInt("paymentTimeoutSec").toUInt()
@@ -398,6 +400,7 @@ fun asConfig(config: ReadableMap): Config? {
     return Config(
         breezserver,
         mempoolspaceUrl,
+        mempoolspaceFallbackUrl,
         workingDir,
         network,
         paymentTimeoutSec,
@@ -413,6 +416,7 @@ fun readableMapOf(config: Config): ReadableMap {
     return readableMapOf(
         "breezserver" to config.breezserver,
         "mempoolspaceUrl" to config.mempoolspaceUrl,
+        "mempoolspaceFallbackUrl" to config.mempoolspaceFallbackUrl,
         "workingDir" to config.workingDir,
         "network" to config.network.name.lowercase(),
         "paymentTimeoutSec" to config.paymentTimeoutSec,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -397,6 +397,9 @@ enum BreezSDKMapper {
         guard let mempoolspaceUrl = config["mempoolspaceUrl"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "mempoolspaceUrl", typeName: "Config"))
         }
+        guard let mempoolspaceFallbackUrl = config["mempoolspaceFallbackUrl"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "mempoolspaceFallbackUrl", typeName: "Config"))
+        }
         guard let workingDir = config["workingDir"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "workingDir", typeName: "Config"))
         }
@@ -436,6 +439,7 @@ enum BreezSDKMapper {
         return Config(
             breezserver: breezserver,
             mempoolspaceUrl: mempoolspaceUrl,
+            mempoolspaceFallbackUrl: mempoolspaceFallbackUrl,
             workingDir: workingDir,
             network: network,
             paymentTimeoutSec: paymentTimeoutSec,
@@ -451,6 +455,7 @@ enum BreezSDKMapper {
         return [
             "breezserver": config.breezserver,
             "mempoolspaceUrl": config.mempoolspaceUrl,
+            "mempoolspaceFallbackUrl": config.mempoolspaceFallbackUrl,
             "workingDir": config.workingDir,
             "network": valueOf(network: config.network),
             "paymentTimeoutSec": config.paymentTimeoutSec,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -71,6 +71,7 @@ export type ClosedChannelPaymentDetails = {
 export type Config = {
     breezserver: string
     mempoolspaceUrl: string
+    mempoolspaceFallbackUrl: string
     workingDir: string
     network: Network
     paymentTimeoutSec: number


### PR DESCRIPTION
This PR adds an optional fallback URL for a 2nd mempool.space instance.

It is called automatically if the call to the main mempool instance fails. If the fallback call also fails, the error is propagated to the caller.