### PR TITLE
Improve sync payments

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -879,11 +879,7 @@ impl BreezServices {
         self.connect_lsp_peer(node_pubkey).await?;
 
         // First query the changes since last sync time.
-        let since_timestamp = self
-            .persister
-            .get_last_sync_time()?
-            .or_else(|| self.persister.last_payment_timestamp().ok())
-            .unwrap_or(0);
+        let since_timestamp = self.persister.get_last_sync_time()?.unwrap_or(0);
         let new_data = &self
             .node_api
             .pull_changed(since_timestamp, balance_changed)

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -53,6 +53,20 @@ impl SqliteStorage {
             None => None,
         })
     }
+
+    pub fn set_last_sync_time(&self, t: u64) -> PersistResult<()> {
+        self.update_cached_item("last_sync_time".to_string(), t.to_string())?;
+        Ok(())
+    }
+
+    pub fn get_last_sync_time(&self) -> PersistResult<Option<u64>> {
+        let state_str = self.get_cached_item("last_sync_time".to_string())?;
+        Ok(match state_str {
+            Some(str) => str.as_str().parse::<u64>().ok(),
+            None => None,
+        })
+    }
+
     pub fn set_gl_credentials(&self, creds: Vec<u8>) -> PersistResult<()> {
         self.update_cached_item("gl_credentials".to_string(), hex::encode(creds))?;
         Ok(())


### PR DESCRIPTION
Synchronises payments using the cached `last_payment_timestamp` from the previous sync.

~~**Open question:** Maybe its better to cache the `last_payment_timestamp` as the `last_sync_time` at the end on the sync. Then we know for sure that that is the last payment time to sync from in the next sync and payments can be safely added to the table outside of the sync without messing up the last_sync_time. This also avoids clock errors between the SDK and GL when syncing based on the local clock.~~

Fixes #704 