### PR TITLE
Use Android bindings via Gradle in Flutter package

### DIFF
--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -97,7 +97,7 @@ jobs:
       bindings-windows: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version }}
       bindings-darwin: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
       bindings-linux: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version}}
-      bindings-android: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.flutter-package-version }}
+      bindings-android: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.golang-package-version }}
       bindings-ios: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version }}
       kotlin: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.flutter-package-version }}
       swift: ${{ !!needs.pre-setup.outputs.flutter-package-version }}
@@ -246,7 +246,6 @@ jobs:
   publish-flutter:
     needs:
       - setup
-      - build-bindings-android
       - build-language-bindings
     if: ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -168,8 +168,7 @@ jobs:
     uses: ./.github/workflows/build-language-bindings.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
-      # ref: ${{ needs.setup.outputs.ref }}
-      ref: 0.2.12 # for testing, build 0.2.12 language bindings to match 0.2.12 gradle dependency
+      ref: ${{ needs.setup.outputs.ref }}
       kotlin: ${{ needs.setup.outputs.kotlin == 'true'}}
       csharp: ${{ needs.setup.outputs.csharp == 'true'}}
       golang: ${{ needs.setup.outputs.golang == 'true'}}

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -168,7 +168,8 @@ jobs:
     uses: ./.github/workflows/build-language-bindings.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
-      ref: ${{ needs.setup.outputs.ref }}
+      # ref: ${{ needs.setup.outputs.ref }}
+      ref: 0.2.12 # for testing, build 0.2.12 language bindings to match 0.2.12 gradle dependency
       kotlin: ${{ needs.setup.outputs.kotlin == 'true'}}
       csharp: ${{ needs.setup.outputs.csharp == 'true'}}
       golang: ${{ needs.setup.outputs.golang == 'true'}}

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -79,7 +79,7 @@ jobs:
           sed -i.bak -e "s/s.version          = .*/s.version          = '${{ inputs.package-version }}'/" ios/breez_sdk.podspec
           rm pubspec.yaml.bak
           rm android/build.gradle.bak
-          ios/breez_sdk.podspec.bak
+          rm ios/breez_sdk.podspec.bak
 
       - name: Archive flutter release
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout breez-sdk-flutter repo
         uses: actions/checkout@v3
         with:
-          repository: breez/breez-sdk-flutter          
+          repository: breez/breez-sdk-flutter
           ssh-key: ${{ secrets.REPO_SSH_KEY }}
           fetch-depth: 0
           path: flutter
@@ -50,21 +50,16 @@ jobs:
       - name: Copy package files
         working-directory: flutter
         run: |
-          rm -f ../breez-sdk/libs/sdk-flutter/ios/breez_sdk.podspec.dev
           rm -r ios
           rm -r android
           rm -r lib
           cp -r ../breez-sdk/libs/sdk-flutter/ios .
           mv ios/breez_sdk.podspec.production ios/breez_sdk.podspec
           cp -r ../breez-sdk/libs/sdk-flutter/android .
+          mv android/build.gradle.production android/build.gradle
           cp -r ../breez-sdk/libs/sdk-flutter/lib .
           cp ../breez-sdk/libs/sdk-flutter/pubspec.yaml .
           cp ../breez-sdk/libs/sdk-flutter/pubspec.lock .  
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: sdk-bindings-android-jniLibs
-          path: flutter/android/src/main/jniLibs
 
       - uses: actions/download-artifact@v3
         with:
@@ -80,7 +75,11 @@ jobs:
         working-directory: flutter
         run: |
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
+          sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
+          sed -i.bak -e "s/s.version          = .*/s.version          = '${{ inputs.package-version }}'/" ios/breez_sdk.podspec
           rm pubspec.yaml.bak
+          rm android/build.gradle.bak
+          ios/breez_sdk.podspec.bak
 
       - name: Archive flutter release
         uses: actions/upload-artifact@v3
@@ -90,14 +89,14 @@ jobs:
             flutter/*
             !flutter/.git
 
-      - name: Tag the Flutter package
-        working-directory: flutter
-        if: ${{ inputs.publish }}
-        run: |
-          git config --global user.email github-actions@github.com
-          git config --global user.name github-actions
-          git add .
-          git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
-          git push
-          git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
-          git push --tags
+      # - name: Tag the Flutter package
+      #   working-directory: flutter
+      #   if: ${{ inputs.publish }}
+      #   run: |
+      #     git config --global user.email github-actions@github.com
+      #     git config --global user.name github-actions
+      #     git add .
+      #     git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
+      #     git push
+      #     git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
+      #     git push --tags

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -89,14 +89,14 @@ jobs:
             flutter/*
             !flutter/.git
 
-      # - name: Tag the Flutter package
-      #   working-directory: flutter
-      #   if: ${{ inputs.publish }}
-      #   run: |
-      #     git config --global user.email github-actions@github.com
-      #     git config --global user.name github-actions
-      #     git add .
-      #     git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
-      #     git push
-      #     git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
-      #     git push --tags
+      - name: Tag the Flutter package
+        working-directory: flutter
+        if: ${{ inputs.publish }}
+        run: |
+          git config --global user.email github-actions@github.com
+          git config --global user.name github-actions
+          git add .
+          git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
+          git push
+          git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
+          git push --tags

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -1,0 +1,52 @@
+group 'com.breez.breez_sdk'
+version '0.2.12'
+
+buildscript {
+    ext.kotlin_version = '1.7.10'
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url("https://mvn.breez.technology/releases") }
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 31
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
+    defaultConfig {
+        minSdkVersion 21
+    }
+}
+
+dependencies {
+    implementation("breez_sdk:bindings-android:$version")
+    implementation 'net.java.dev.jna:jna:5.8.0@aar'
+}

--- a/libs/sdk-flutter/android/settings.gradle
+++ b/libs/sdk-flutter/android/settings.gradle
@@ -1,1 +1,8 @@
 rootProject.name = 'breez_sdk'
+
+dependencyResolutionManagement {
+    repositories {
+        maven { url("https://mvn.breez.technology/releases") }
+    }
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+}


### PR DESCRIPTION
This is a precursor to publishing the flutter package to [pub.dev](https://pub.dev/) which has a 100MB package size limit. In order to meet that size limit, we need to remove the binary bindings which are currently bundled with the flutter package. Instead, we need to pull them in from our Gradle repo. We already do that for the iOS part: There we pull the binaries from CocoaPods.

_What I did to test:_

- Building the 0.2.12 version of the breez-sdk for flutter (but with gradle dependency instead of bundled jniLibs: https://github.com/breez/breez-sdk/actions/runs/7479393930
- Setting up a fresh Flutter project
- Calling the SDK method `mnemonicToSeed` via Flutter in `main.dart` to see if the Flutter APIs work.
- Calling the SDK method `mnemonicToSeed` via Kotlin in `MainActivity.kt` to see if the bundled Kotlin APIs work

I don't have a working setup of c-breez at the moment. The ultimate test would be to see if c-breez runs normally using the new setup. Will try to get that done soon. In the meantime, please let me know your feedback on the PR! 🙏 