### PR TITLE
Use a non-zero timeout in our HTTP clients

### DIFF
--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -1,4 +1,4 @@
-use crate::input_parser::get_parse_and_log_response;
+use crate::input_parser::{get_parse_and_log_response, get_reqwest_client};
 use anyhow::{anyhow, Result};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::{OutPoint, Txid};
@@ -228,16 +228,12 @@ impl ChainService for MempoolSpace {
     }
 
     async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>> {
-        Ok(
-            reqwest::get(format!("{}/api/tx/{txid}/outspends", self.base_url))
-                .await?
-                .json()
-                .await?,
-        )
+        let url = format!("{}/api/tx/{txid}/outspends", self.base_url);
+        Ok(get_reqwest_client()?.get(url).send().await?.json().await?)
     }
 
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String> {
-        let client = reqwest::Client::new();
+        let client = get_reqwest_client()?;
         let txid_or_error = client
             .post(format!("{}/api/tx", self.base_url))
             .body(hex::encode(tx))

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -378,7 +378,7 @@ fn lnurl_decode(encoded: &str) -> LnUrlResult<(String, String, Option<String>)> 
 /// Creates an HTTP client with a built-in connection timeout
 pub(crate) fn get_reqwest_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_secs(30))
         .build()
         .map_err(Into::into)
 }

--- a/libs/sdk-core/src/swap_out/boltzswap.rs
+++ b/libs/sdk-core/src/swap_out/boltzswap.rs
@@ -9,9 +9,9 @@ use serde_json::json;
 
 use const_format::concatcp;
 use reqwest::header::CONTENT_TYPE;
-use reqwest::{Body, Client};
+use reqwest::Body;
 
-use crate::input_parser::get_parse_and_log_response;
+use crate::input_parser::{get_parse_and_log_response, get_reqwest_client};
 use crate::models::ReverseSwapPairInfo;
 use crate::swap_out::reverseswap::CreateReverseSwapResponse;
 use crate::{ReverseSwapServiceAPI, RouteHint, RouteHintHop};
@@ -244,7 +244,7 @@ impl ReverseSwapServiceAPI for BoltzApi {
         pair_hash: String,
         routing_node: String,
     ) -> ReverseSwapResult<BoltzApiCreateReverseSwapResponse> {
-        Client::new()
+        get_reqwest_client()?
             .post(CREATE_REVERSE_SWAP_ENDPOINT)
             .header(CONTENT_TYPE, "application/json")
             .body(build_boltz_reverse_swap_args(
@@ -283,7 +283,7 @@ impl ReverseSwapServiceAPI for BoltzApi {
     /// Boltz API errors (e.g. providing an invalid ID arg) are returned as a successful response of
     /// type [BoltzApiCreateReverseSwapResponse::BoltzApiError]
     async fn get_boltz_status(&self, id: String) -> ReverseSwapResult<BoltzApiReverseSwapStatus> {
-        Client::new()
+        get_reqwest_client()?
             .post(GET_SWAP_STATUS_ENDPOINT)
             .header(CONTENT_TYPE, "application/json")
             .body(Body::from(json!({ "id": id }).to_string()))
@@ -307,7 +307,7 @@ impl ReverseSwapServiceAPI for BoltzApi {
     }
 
     async fn get_route_hints(&self, routing_node_id: String) -> ReverseSwapResult<Vec<RouteHint>> {
-        Client::new()
+        get_reqwest_client()?
             .post(GET_ROUTE_HINTS_ENDPOINT)
             .header(CONTENT_TYPE, "application/json")
             .body(Body::from(


### PR DESCRIPTION
The default `reqwest` Client, which we use for HTTP requests, has no timeout. This means a faulty endpoint we connect to may hang our client indefinitely. This PR adds a default timeout to all `reqwest` clients we use.

Related to https://github.com/breez/monitoring-setup/pull/18