### PR TITLE
RN iOS emitter fix

### DIFF
--- a/libs/sdk-react-native/ios/BreezSDKListener.swift
+++ b/libs/sdk-react-native/ios/BreezSDKListener.swift
@@ -1,17 +1,11 @@
 import Foundation
 import BreezSDK
 
-class BreezSDKListener: NSObject, EventListener {
-    var emitter: RCTEventEmitter
-    
+class BreezSDKListener: EventListener {
     static let emitterName: String = "breezSdkEvent"
     
-    init(emitter: RCTEventEmitter) {
-        self.emitter = emitter
-    }
-    
     func onEvent(e: BreezEvent) {
-        self.emitter.sendEvent(withName: BreezSDKListener.emitterName, 
-                               body: BreezSDKMapper.dictionaryOf(breezEvent: e))
+        RNBreezSDK.emitter.sendEvent(withName: BreezSDKListener.emitterName,
+                                     body: BreezSDKMapper.dictionaryOf(breezEvent: e))
     }
 }

--- a/libs/sdk-react-native/ios/BreezSDKLogStream.swift
+++ b/libs/sdk-react-native/ios/BreezSDKLogStream.swift
@@ -1,17 +1,11 @@
 import Foundation
 import BreezSDK
 
-class BreezSDKLogStream: NSObject, LogStream {
-    var emitter: RCTEventEmitter
-    
+class BreezSDKLogStream: LogStream {
     static let emitterName: String = "breezSdkLog"
     
-    init(emitter: RCTEventEmitter) {
-        self.emitter = emitter
-    }
-    
     func log(l: LogEntry) {
-        self.emitter.sendEvent(withName: BreezSDKLogStream.emitterName, 
-                               body: BreezSDKMapper.dictionaryOf(logEntry: l))
+        RNBreezSDK.emitter.sendEvent(withName: BreezSDKLogStream.emitterName,
+                                     body: BreezSDKMapper.dictionaryOf(logEntry: l))
     }
 }

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -5,6 +5,8 @@ import Foundation
 class RNBreezSDK: RCTEventEmitter {
     static let TAG: String = "BreezSDK"
 
+    public static var emitter: RCTEventEmitter!
+
     private var breezServices: BlockingBreezServices!
 
     static var breezSdkDirectory: URL {
@@ -16,6 +18,11 @@ class RNBreezSDK: RCTEventEmitter {
         }
 
         return breezSdkDirectory
+    }
+
+    override init() {
+        super.init()
+        RNBreezSDK.emitter = self
     }
 
     @objc
@@ -107,7 +114,7 @@ class RNBreezSDK: RCTEventEmitter {
     @objc(setLogStream:reject:)
     func setLogStream(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            try BreezSDK.setLogStream(logStream: BreezSDKLogStream(emitter: self))
+            try BreezSDK.setLogStream(logStream: BreezSDKLogStream())
             resolve(["status": "ok"])
         } catch let err {
             rejectErr(err: err, reject: reject)
@@ -126,7 +133,7 @@ class RNBreezSDK: RCTEventEmitter {
 
             try ensureWorkingDir(workingDir: configTmp.workingDir)
 
-            breezServices = try BreezSDK.connect(config: configTmp, seed: seed, listener: BreezSDKListener(emitter: self))
+            breezServices = try BreezSDK.connect(config: configTmp, seed: seed, listener: BreezSDKListener())
             resolve(["status": "ok"])
         } catch let err {
             rejectErr(err: err, reject: reject)


### PR DESCRIPTION
This PR reruns the RN code generator to change the iOS native module initialisation to set the static class emitter variable. The static emitter variable can then be used to emit events by the SDK event listener and log stream over the react native bridge. 

Generator PR https://github.com/breez/breez-sdk-rn-generator/pull/19
Fixes #699 