### PR TITLE
Switch gl-client to the 202301-vls-0.11 branch (VLS 0.11.0rc1)

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with",
  "strum",
  "strum_macros",
  "tempfile",
@@ -1290,7 +1290,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.1.9"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=556eedf47a837b71c4277ba6ee84322f5cbd80de#556eedf47a837b71c4277ba6ee84322f5cbd80de"
+source = "git+https://github.com/Blockstream/greenlight.git?branch=202301-vls-0.11#166a80769378b111d81a51d7de29266a507bd1fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1774,6 +1774,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e009e1c0c21f66378b491bb40f548682138c63e09db6f3a05af59f8804bb9f4a"
 dependencies = [
  "bitcoin 0.29.2",
+]
+
+[[package]]
+name = "lightning"
+version = "0.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a0f2155316f1570446a0447c993480673f840748c8ed25bbc59dfc442ac770"
+dependencies = [
+ "bitcoin 0.29.2",
  "hex",
  "regex",
 ]
@@ -1797,6 +1806,20 @@ dependencies = [
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
  "lightning 0.0.115",
+ "num-traits",
+ "secp256k1 0.24.3",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788c0158526ec27a502043c2911ea6ea58fdc656bdf8749484942c07b790d23"
+dependencies = [
+ "bech32",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
+ "lightning 0.0.116",
  "num-traits",
  "secp256k1 0.24.3",
 ]
@@ -2879,21 +2902,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
@@ -2905,20 +2913,8 @@ dependencies = [
  "indexmap 2.1.0",
  "serde",
  "serde_json",
- "serde_with_macros 3.4.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -3485,9 +3481,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "txoo"
-version = "0.6.1"
+version = "0.6.2-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b35482e5bf458fa43996535afbca884b2562ab6419e20686340bb19f5305b30"
+checksum = "74fb0ae52e565a5e1364ed50933a2a884f2e6330e8ffe9ac32ec6c4084bd3a3a"
 dependencies = [
  "bitcoin 0.29.2",
  "log",
@@ -3728,9 +3724,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vls-core"
-version = "0.10.1"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7465dd7f8cc004b67c52c6610ebf157695a93daf33f6a69c1b06b0f4e1fecbc0"
+checksum = "71c9571f43c1d63d301e4f88892cc7bd570b28fb6d44e8af3fac86bce210d8f0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3742,36 +3738,37 @@ dependencies = [
  "hashbrown 0.8.2",
  "hex",
  "itertools",
- "lightning 0.0.115",
- "lightning-invoice 0.23.0",
+ "lightning 0.0.116",
+ "lightning-invoice 0.24.0",
  "log",
  "scopeguard",
  "serde",
  "serde_bolt 0.3.1",
  "serde_derive",
- "serde_with 2.3.3",
+ "serde_with",
  "txoo",
 ]
 
 [[package]]
 name = "vls-persist"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86279e60e9dcdd3bcc135b7979655f1c80c6b99c38fee25d390725bfc5a24994"
+checksum = "2bad8154243b9db47c8cd0efc3513f07499faa7e31f25c8e7027a13241362605"
 dependencies = [
  "hex",
  "log",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
+ "tempfile",
  "vls-core",
 ]
 
 [[package]]
 name = "vls-protocol"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e525ef3cb95a27b240662fb518ea283d25b1f51afe899f0f253747acc284f4"
+checksum = "9c2b2f877b5ee624f38a61fb37fad38678514176a01da925aa265a70a977df70"
 dependencies = [
  "as-any",
  "bitcoin-consensus-derive",
@@ -3779,13 +3776,14 @@ dependencies = [
  "hex",
  "log",
  "serde_bolt 0.3.1",
+ "txoo",
 ]
 
 [[package]]
 name = "vls-protocol-signer"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a766ac452520406eed1e7d8ad1c744156fc3ceaf6bdcefe3f3a44bd5f5ea0b29"
+checksum = "98a720d79fa6a2da1c5ed528312eacd15fa1b7af1d8dc4caa8775222e817ac21"
 dependencies = [
  "bit-vec",
  "log",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -18,7 +18,7 @@ bip21 = "0.2"
 bitcoin = "0.29.2"
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "556eedf47a837b71c4277ba6ee84322f5cbd80de" }
+], branch = "202301-vls-0.11" }
 zbase32 = "0.1.2"
 base64 = "0.13.0"
 chrono = "0.4"

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
- "serde_with 3.3.0",
+ "serde_with",
  "strum",
  "strum_macros",
  "tempfile",
@@ -1203,7 +1203,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.1.9"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=556eedf47a837b71c4277ba6ee84322f5cbd80de#556eedf47a837b71c4277ba6ee84322f5cbd80de"
+source = "git+https://github.com/Blockstream/greenlight.git?branch=202301-vls-0.11#166a80769378b111d81a51d7de29266a507bd1fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1681,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.115"
+version = "0.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e009e1c0c21f66378b491bb40f548682138c63e09db6f3a05af59f8804bb9f4a"
+checksum = "90a0f2155316f1570446a0447c993480673f840748c8ed25bbc59dfc442ac770"
 dependencies = [
  "bitcoin 0.29.2",
  "hex",
@@ -1701,14 +1701,14 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e44b0e2822c8811470137d2339fdfe67a699b3248bb1606d1d02eb6a1e9f0a"
+checksum = "1788c0158526ec27a502043c2911ea6ea58fdc656bdf8749484942c07b790d23"
 dependencies = [
  "bech32",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
- "lightning 0.0.115",
+ "lightning 0.0.116",
  "num-traits",
  "secp256k1 0.24.3",
 ]
@@ -2751,21 +2751,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
@@ -2777,20 +2762,8 @@ dependencies = [
  "indexmap 2.0.0",
  "serde",
  "serde_json",
- "serde_with_macros 3.3.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.29",
 ]
 
 [[package]]
@@ -3292,9 +3265,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "txoo"
-version = "0.6.1"
+version = "0.6.2-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b35482e5bf458fa43996535afbca884b2562ab6419e20686340bb19f5305b30"
+checksum = "74fb0ae52e565a5e1364ed50933a2a884f2e6330e8ffe9ac32ec6c4084bd3a3a"
 dependencies = [
  "bitcoin 0.29.2",
  "log",
@@ -3402,9 +3375,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vls-core"
-version = "0.10.1"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7465dd7f8cc004b67c52c6610ebf157695a93daf33f6a69c1b06b0f4e1fecbc0"
+checksum = "71c9571f43c1d63d301e4f88892cc7bd570b28fb6d44e8af3fac86bce210d8f0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3416,36 +3389,37 @@ dependencies = [
  "hashbrown 0.8.2",
  "hex",
  "itertools",
- "lightning 0.0.115",
- "lightning-invoice 0.23.0",
+ "lightning 0.0.116",
+ "lightning-invoice 0.24.0",
  "log",
  "scopeguard",
  "serde",
  "serde_bolt 0.3.1",
  "serde_derive",
- "serde_with 2.3.3",
+ "serde_with",
  "txoo",
 ]
 
 [[package]]
 name = "vls-persist"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86279e60e9dcdd3bcc135b7979655f1c80c6b99c38fee25d390725bfc5a24994"
+checksum = "2bad8154243b9db47c8cd0efc3513f07499faa7e31f25c8e7027a13241362605"
 dependencies = [
  "hex",
  "log",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
+ "tempfile",
  "vls-core",
 ]
 
 [[package]]
 name = "vls-protocol"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e525ef3cb95a27b240662fb518ea283d25b1f51afe899f0f253747acc284f4"
+checksum = "9c2b2f877b5ee624f38a61fb37fad38678514176a01da925aa265a70a977df70"
 dependencies = [
  "as-any",
  "bitcoin-consensus-derive",
@@ -3453,13 +3427,14 @@ dependencies = [
  "hex",
  "log",
  "serde_bolt 0.3.1",
+ "txoo",
 ]
 
 [[package]]
 name = "vls-protocol-signer"
-version = "0.10.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a766ac452520406eed1e7d8ad1c744156fc3ceaf6bdcefe3f3a44bd5f5ea0b29"
+checksum = "98a720d79fa6a2da1c5ed528312eacd15fa1b7af1d8dc4caa8775222e817ac21"
 dependencies = [
  "bit-vec",
  "log",


### PR DESCRIPTION
This PR switches `gl-client` to the `202301-vls-0.11` [branch](https://github.com/Blockstream/greenlight/commits/202301-vls-0.11/), which uses VLS 0.11.0rc1.

This is a trial branch, e.g. not meant to be merged. Instead, it's meant to try out the new VLS version and provide feedback.