### PR TITLE
Store LNURL-pay domain

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -285,6 +285,7 @@ dictionary LnPaymentDetails {
     boolean keysend;
     string bolt11;
     SuccessActionProcessed? lnurl_success_action;
+    string? lnurl_pay_domain;
     string? lnurl_metadata;
     string? ln_address;
     string? lnurl_withdraw_endpoint;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -387,11 +387,16 @@ impl BreezServices {
                     None => None,
                 };
 
+                let lnurl_pay_domain = match req.data.ln_address {
+                    Some(_) => None,
+                    None => Some(req.data.domain),
+                };
                 // Store SA (if available) + LN Address in separate table, associated to payment_hash
                 self.persister.insert_payment_external_info(
                     &details.payment_hash,
                     PaymentExternalInfo {
                         lnurl_pay_success_action: maybe_sa_processed.clone(),
+                        lnurl_pay_domain,
                         lnurl_metadata: Some(req.data.metadata_str),
                         ln_address: req.data.ln_address,
                         lnurl_withdraw_endpoint: None,
@@ -439,6 +444,7 @@ impl BreezServices {
                 &data.invoice.payment_hash,
                 PaymentExternalInfo {
                     lnurl_pay_success_action: None,
+                    lnurl_pay_domain: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: Some(lnurl_w_endpoint),
@@ -990,6 +996,7 @@ impl BreezServices {
                         keysend: false,
                         bolt11: invoice.bolt11.clone(),
                         lnurl_success_action: None,
+                        lnurl_pay_domain: None,
                         ln_address: None,
                         lnurl_metadata: None,
                         lnurl_withdraw_endpoint: None,
@@ -1006,6 +1013,7 @@ impl BreezServices {
             &invoice.payment_hash,
             PaymentExternalInfo {
                 lnurl_pay_success_action: None,
+                lnurl_pay_domain: None,
                 lnurl_metadata: None,
                 ln_address: None,
                 lnurl_withdraw_endpoint: None,
@@ -2289,6 +2297,7 @@ pub(crate) mod tests {
                         keysend: false,
                         bolt11: "1111".to_string(),
                         lnurl_success_action: None,
+                        lnurl_pay_domain: None,
                         lnurl_metadata: None,
                         ln_address: None,
                         lnurl_withdraw_endpoint: None,
@@ -2316,6 +2325,7 @@ pub(crate) mod tests {
                         keysend: false,
                         bolt11: "1111".to_string(),
                         lnurl_success_action: None,
+                        lnurl_pay_domain: None,
                         lnurl_metadata: None,
                         ln_address: None,
                         lnurl_withdraw_endpoint: Some(test_lnurl_withdraw_endpoint.to_string()),
@@ -2343,6 +2353,7 @@ pub(crate) mod tests {
                         keysend: false,
                         bolt11: "123".to_string(),
                         lnurl_success_action: Some(sa.clone()),
+                        lnurl_pay_domain: None,
                         lnurl_metadata: Some(lnurl_metadata.to_string()),
                         ln_address: Some(test_ln_address.to_string()),
                         lnurl_withdraw_endpoint: None,
@@ -2370,6 +2381,7 @@ pub(crate) mod tests {
                         keysend: false,
                         bolt11: "312".to_string(),
                         lnurl_success_action: None,
+                        lnurl_pay_domain: None,
                         lnurl_metadata: None,
                         ln_address: None,
                         lnurl_withdraw_endpoint: None,
@@ -2390,6 +2402,7 @@ pub(crate) mod tests {
             payment_hash_with_lnurl_success_action,
             PaymentExternalInfo {
                 lnurl_pay_success_action: Some(sa.clone()),
+                lnurl_pay_domain: None,
                 lnurl_metadata: Some(lnurl_metadata.to_string()),
                 ln_address: Some(test_ln_address.to_string()),
                 lnurl_withdraw_endpoint: None,
@@ -2401,6 +2414,7 @@ pub(crate) mod tests {
             payment_hash_lnurl_withdraw,
             PaymentExternalInfo {
                 lnurl_pay_success_action: None,
+                lnurl_pay_domain: None,
                 lnurl_metadata: None,
                 ln_address: None,
                 lnurl_withdraw_endpoint: Some(test_lnurl_withdraw_endpoint.to_string()),
@@ -2464,8 +2478,8 @@ pub(crate) mod tests {
                 if lnurl_success_action == &Some(sa)));
         assert!(matches!(
                 &sent[0].details,
-                PaymentDetails::Ln {data: LnPaymentDetails {ln_address, ..}}
-                if ln_address == &Some(test_ln_address.to_string())));
+                PaymentDetails::Ln {data: LnPaymentDetails {lnurl_pay_domain, ln_address, ..}}
+                if lnurl_pay_domain.is_none() && ln_address == &Some(test_ln_address.to_string())));
         assert!(matches!(
                 &received[1].details,
                 PaymentDetails::Ln {data: LnPaymentDetails {lnurl_withdraw_endpoint, ..}}

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1248,6 +1248,7 @@ impl support::IntoDart for LnPaymentDetails {
             self.keysend.into_into_dart().into_dart(),
             self.bolt11.into_into_dart().into_dart(),
             self.lnurl_success_action.into_dart(),
+            self.lnurl_pay_domain.into_dart(),
             self.ln_address.into_dart(),
             self.lnurl_metadata.into_dart(),
             self.lnurl_withdraw_endpoint.into_dart(),

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1521,6 +1521,7 @@ impl TryFrom<OffChainPayment> for Payment {
                     keysend: false,
                     bolt11: p.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
+                    lnurl_pay_domain: None,     // For received payments, this is None
                     lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -1562,6 +1563,7 @@ impl TryFrom<gl_client::signer::model::greenlight::Invoice> for Payment {
                     keysend: false,
                     bolt11: invoice.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
+                    lnurl_pay_domain: None,     // For received payments, this is None
                     lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -1618,6 +1620,7 @@ impl TryFrom<gl_client::signer::model::greenlight::Payment> for Payment {
                     keysend: payment.bolt11.is_empty(),
                     bolt11: payment.bolt11,
                     lnurl_success_action: None,
+                    lnurl_pay_domain: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -1661,6 +1664,7 @@ impl TryFrom<cln::ListinvoicesInvoices> for Payment {
                     keysend: false,
                     bolt11: invoice.bolt11.unwrap_or_default(),
                     lnurl_success_action: None, // For received payments, this is None
+                    lnurl_pay_domain: None,     // For received payments, this is None
                     lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -1727,6 +1731,7 @@ impl TryFrom<cln::ListpaysPays> for Payment {
                     keysend: payment.bolt11.is_none(),
                     bolt11: payment.bolt11.unwrap_or_default(),
                     lnurl_success_action: None,
+                    lnurl_pay_domain: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -709,7 +709,7 @@ pub struct LnPaymentDetails {
     /// the endpoint returns a success action
     pub lnurl_success_action: Option<SuccessActionProcessed>,
 
-    /// Only set for [PaymentType::Sent] payments if it is not a payment to a Lightning Adddress
+    /// Only set for [PaymentType::Sent] payments if it is not a payment to a Lightning Address
     pub lnurl_pay_domain: Option<String>,
 
     /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -639,6 +639,7 @@ pub struct Payment {
 #[derive(Default)]
 pub struct PaymentExternalInfo {
     pub lnurl_pay_success_action: Option<SuccessActionProcessed>,
+    pub lnurl_pay_domain: Option<String>,
     pub lnurl_metadata: Option<String>,
     pub ln_address: Option<String>,
     pub lnurl_withdraw_endpoint: Option<String>,
@@ -707,6 +708,9 @@ pub struct LnPaymentDetails {
     /// Only set for [PaymentType::Sent] payments that are part of a LNURL-pay workflow where
     /// the endpoint returns a success action
     pub lnurl_success_action: Option<SuccessActionProcessed>,
+
+    /// Only set for [PaymentType::Sent] payments if it is not a payment to a Lightning Adddress
+    pub lnurl_pay_domain: Option<String>,
 
     /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address
     pub ln_address: Option<String>,

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -548,5 +548,6 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
           updated_at TEXT DEFAULT CURRENT_TIMESTAMP
          ) STRICT;
         ",
+       "ALTER TABLE payments_external_info ADD COLUMN lnurl_pay_domain TEXT;",
     ]
 }

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -170,7 +170,8 @@ impl SqliteStorage {
               lnurl_metadata,
               lnurl_withdraw_endpoint,
               attempted_amount_msat,
-              attempted_error
+              attempted_error,
+              lnurl_pay_domain
              FROM remote_sync.payments_external_info
              WHERE payment_id NOT IN (SELECT payment_id FROM sync.payments_external_info);",
             [],

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -868,6 +868,7 @@ mod tests {
                     keysend: false,
                     bolt11: "".to_string(),
                     lnurl_success_action: None,
+                    lnurl_pay_domain: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -695,6 +695,9 @@ class LnPaymentDetails {
   /// the endpoint returns a success action
   final SuccessActionProcessed? lnurlSuccessAction;
 
+  /// Only set for [PaymentType::Sent] payments if it is not a payment to a Lightning Address
+  final String? lnurlPayDomain;
+
   /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address
   final String? lnAddress;
 
@@ -718,6 +721,7 @@ class LnPaymentDetails {
     required this.keysend,
     required this.bolt11,
     this.lnurlSuccessAction,
+    this.lnurlPayDomain,
     this.lnAddress,
     this.lnurlMetadata,
     this.lnurlWithdrawEndpoint,
@@ -3178,7 +3182,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LnPaymentDetails _wire2api_ln_payment_details(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 12) throw Exception('unexpected arr length: expect 12 but see ${arr.length}');
+    if (arr.length != 13) throw Exception('unexpected arr length: expect 13 but see ${arr.length}');
     return LnPaymentDetails(
       paymentHash: _wire2api_String(arr[0]),
       label: _wire2api_String(arr[1]),
@@ -3187,11 +3191,12 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       keysend: _wire2api_bool(arr[4]),
       bolt11: _wire2api_String(arr[5]),
       lnurlSuccessAction: _wire2api_opt_box_autoadd_success_action_processed(arr[6]),
-      lnAddress: _wire2api_opt_String(arr[7]),
-      lnurlMetadata: _wire2api_opt_String(arr[8]),
-      lnurlWithdrawEndpoint: _wire2api_opt_String(arr[9]),
-      swapInfo: _wire2api_opt_box_autoadd_swap_info(arr[10]),
-      pendingExpirationBlock: _wire2api_opt_box_autoadd_u32(arr[11]),
+      lnurlPayDomain: _wire2api_opt_String(arr[7]),
+      lnAddress: _wire2api_opt_String(arr[8]),
+      lnurlMetadata: _wire2api_opt_String(arr[9]),
+      lnurlWithdrawEndpoint: _wire2api_opt_String(arr[10]),
+      swapInfo: _wire2api_opt_box_autoadd_swap_info(arr[11]),
+      pendingExpirationBlock: _wire2api_opt_box_autoadd_u32(arr[12]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKListener.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKListener.kt
@@ -4,7 +4,7 @@ import breez_sdk.BreezEvent
 import breez_sdk.EventListener
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 
-class BreezSDKListener(private val emitter: RCTDeviceEventEmitter): EventListener {
+class BreezSDKListener(private val emitter: RCTDeviceEventEmitter) : EventListener {
     companion object {
         var emitterName = "breezSdkEvent"
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKLogStream.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKLogStream.kt
@@ -4,7 +4,7 @@ import breez_sdk.LogEntry
 import breez_sdk.LogStream
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 
-class BreezSDKLogStream(private val emitter: RCTDeviceEventEmitter): LogStream {
+class BreezSDKLogStream(private val emitter: RCTDeviceEventEmitter) : LogStream {
     companion object {
         var emitterName = "breezSdkLog"
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -852,6 +852,7 @@ fun asLnPaymentDetails(lnPaymentDetails: ReadableMap): LnPaymentDetails? {
         } else {
             null
         }
+    val lnurlPayDomain = if (hasNonNullKey(lnPaymentDetails, "lnurlPayDomain")) lnPaymentDetails.getString("lnurlPayDomain") else null
     val lnurlMetadata = if (hasNonNullKey(lnPaymentDetails, "lnurlMetadata")) lnPaymentDetails.getString("lnurlMetadata") else null
     val lnAddress = if (hasNonNullKey(lnPaymentDetails, "lnAddress")) lnPaymentDetails.getString("lnAddress") else null
     val lnurlWithdrawEndpoint =
@@ -883,6 +884,7 @@ fun asLnPaymentDetails(lnPaymentDetails: ReadableMap): LnPaymentDetails? {
         keysend,
         bolt11,
         lnurlSuccessAction,
+        lnurlPayDomain,
         lnurlMetadata,
         lnAddress,
         lnurlWithdrawEndpoint,
@@ -900,6 +902,7 @@ fun readableMapOf(lnPaymentDetails: LnPaymentDetails): ReadableMap {
         "keysend" to lnPaymentDetails.keysend,
         "bolt11" to lnPaymentDetails.bolt11,
         "lnurlSuccessAction" to lnPaymentDetails.lnurlSuccessAction?.let { readableMapOf(it) },
+        "lnurlPayDomain" to lnPaymentDetails.lnurlPayDomain,
         "lnurlMetadata" to lnPaymentDetails.lnurlMetadata,
         "lnAddress" to lnPaymentDetails.lnAddress,
         "lnurlWithdrawEndpoint" to lnPaymentDetails.lnurlWithdrawEndpoint,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -109,7 +109,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         executor.execute {
             try {
                 val envTypeTmp = asEnvironmentType(envType)
-                val nodeConfigTmp = asNodeConfig(nodeConfig) ?: run { throw SdkException.Generic(errMissingMandatoryField("nodeConfig", "NodeConfig")) }
+                val nodeConfigTmp =
+                    asNodeConfig(
+                        nodeConfig,
+                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("nodeConfig", "NodeConfig")) }
                 val res = defaultConfig(envTypeTmp, apiKey, nodeConfigTmp)
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
 
@@ -255,7 +258,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val lnUrlPayRequest = asLnUrlPayRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "LnUrlPayRequest")) }
+                val lnUrlPayRequest =
+                    asLnUrlPayRequest(
+                        req,
+                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "LnUrlPayRequest")) }
                 val res = getBreezServices().payLnurl(lnUrlPayRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -309,7 +315,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val reqTmp = asReportIssueRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ReportIssueRequest")) }
+                val reqTmp =
+                    asReportIssueRequest(
+                        req,
+                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ReportIssueRequest")) }
                 getBreezServices().reportIssue(reqTmp)
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
@@ -678,7 +687,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val refundRequest = asRefundRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "RefundRequest")) }
+                val refundRequest =
+                    asRefundRequest(
+                        req,
+                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "RefundRequest")) }
                 val res = getBreezServices().refund(refundRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -807,7 +819,10 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val buyBitcoinRequest = asBuyBitcoinRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "BuyBitcoinRequest")) }
+                val buyBitcoinRequest =
+                    asBuyBitcoinRequest(
+                        req,
+                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "BuyBitcoinRequest")) }
                 val res = getBreezServices().buyBitcoin(buyBitcoinRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKPackage.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKPackage.kt
@@ -1,4 +1,4 @@
-package com.breezsdk;
+package com.breezsdk
 
 import android.view.View
 import com.facebook.react.ReactPackage
@@ -8,11 +8,9 @@ import com.facebook.react.uimanager.ReactShadowNode
 import com.facebook.react.uimanager.ViewManager
 
 class BreezSDKPackage : ReactPackage {
-    override fun createViewManagers(
-        reactContext: ReactApplicationContext
-    ): MutableList<ViewManager<View, ReactShadowNode<*>>> = mutableListOf()
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<ViewManager<View, ReactShadowNode<*>>> =
+        mutableListOf()
 
-    override fun createNativeModules(
-        reactContext: ReactApplicationContext
-    ): MutableList<NativeModule> = listOf(BreezSDKModule(reactContext)).toMutableList()
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> =
+        listOf(BreezSDKModule(reactContext)).toMutableList()
 }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -937,6 +937,13 @@ enum BreezSDKMapper {
             lnurlSuccessAction = try asSuccessActionProcessed(successActionProcessed: lnurlSuccessActionTmp)
         }
 
+        var lnurlPayDomain: String?
+        if hasNonNilKey(data: lnPaymentDetails, key: "lnurlPayDomain") {
+            guard let lnurlPayDomainTmp = lnPaymentDetails["lnurlPayDomain"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlPayDomain"))
+            }
+            lnurlPayDomain = lnurlPayDomainTmp
+        }
         var lnurlMetadata: String?
         if hasNonNilKey(data: lnPaymentDetails, key: "lnurlMetadata") {
             guard let lnurlMetadataTmp = lnPaymentDetails["lnurlMetadata"] as? String else {
@@ -979,6 +986,7 @@ enum BreezSDKMapper {
             keysend: keysend,
             bolt11: bolt11,
             lnurlSuccessAction: lnurlSuccessAction,
+            lnurlPayDomain: lnurlPayDomain,
             lnurlMetadata: lnurlMetadata,
             lnAddress: lnAddress,
             lnurlWithdrawEndpoint: lnurlWithdrawEndpoint,
@@ -996,6 +1004,7 @@ enum BreezSDKMapper {
             "keysend": lnPaymentDetails.keysend,
             "bolt11": lnPaymentDetails.bolt11,
             "lnurlSuccessAction": lnPaymentDetails.lnurlSuccessAction == nil ? nil : dictionaryOf(successActionProcessed: lnPaymentDetails.lnurlSuccessAction!),
+            "lnurlPayDomain": lnPaymentDetails.lnurlPayDomain == nil ? nil : lnPaymentDetails.lnurlPayDomain,
             "lnurlMetadata": lnPaymentDetails.lnurlMetadata == nil ? nil : lnPaymentDetails.lnurlMetadata,
             "lnAddress": lnPaymentDetails.lnAddress == nil ? nil : lnPaymentDetails.lnAddress,
             "lnurlWithdrawEndpoint": lnPaymentDetails.lnurlWithdrawEndpoint == nil ? nil : lnPaymentDetails.lnurlWithdrawEndpoint,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -145,6 +145,7 @@ export type LnPaymentDetails = {
     keysend: boolean
     bolt11: string
     lnurlSuccessAction?: SuccessActionProcessed
+    lnurlPayDomain?: string
     lnurlMetadata?: string
     lnAddress?: string
     lnurlWithdrawEndpoint?: string


### PR DESCRIPTION
Hi, please review my proposal for storing and exposing an LNURL-pay domain. I recommend storing either the lightning address or LNURL-pay domain, as having both doesn't make sense. We can then repurpose the `sync.payments_external_info.ln_address` database field to store one of the values (though the field should be renamed).

If the concept is acceptable, I can proceed with preparing the code for production.

Close #729.