### PR TITLE
make short_channel_id optional

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -293,9 +293,9 @@ dictionary LnPaymentDetails {
 };
 
 dictionary ClosedChannelPaymentDetails {
-    string short_channel_id;
     ChannelState state;
     string funding_txid;
+    string? short_channel_id;
     string? closing_txid;
 };
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2042,12 +2042,19 @@ impl Receiver for PaymentReceiver {
                         .find(|&c| c.state == ChannelState::Opened)
                         .ok_or_else(|| anyhow!("No open channel found"))?;
                     let hint = active_channel
-                        .clone()
                         .alias_remote
-                        .unwrap_or(active_channel.clone().short_channel_id);
+                        .clone()
+                        .or(active_channel.short_channel_id.clone());
 
-                    short_channel_id = Some(parse_short_channel_id(&hint)?);
-                    info!("Found channel ID: {short_channel_id:?} {active_channel:?}");
+                    short_channel_id = match hint {
+                        None => None,
+                        Some(hint) => {
+                            let scid = parse_short_channel_id(&hint)?;
+                            info!("Found channel ID: {scid:?} {active_channel:?}");
+                            Some(scid)
+                        }
+                    };
+
                     break;
                 }
             }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1044,9 +1044,9 @@ impl rust2dart::IntoIntoDart<CheckMessageResponse> for CheckMessageResponse {
 impl support::IntoDart for ClosedChannelPaymentDetails {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.short_channel_id.into_into_dart().into_dart(),
             self.state.into_into_dart().into_dart(),
             self.funding_txid.into_into_dart().into_dart(),
+            self.short_channel_id.into_dart(),
             self.closing_txid.into_dart(),
         ]
         .into_dart()

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1810,7 +1810,7 @@ impl From<cln::ListpeersPeersChannels> for Channel {
         };
 
         Channel {
-            short_channel_id: c.short_channel_id.unwrap_or_default(),
+            short_channel_id: c.short_channel_id,
             state,
             funding_txid: c.funding_txid.map(hex::encode).unwrap_or_default(),
             spendable_msat: c.spendable_msat.unwrap_or_default().msat,
@@ -1884,9 +1884,7 @@ impl TryFrom<ListclosedchannelsClosedchannels> for Channel {
         // To keep the conversion simple and fast, some closing-related fields (closed_at, closing_txid)
         // are left empty here in the conversion, but populated later (via chain service lookup, or DB lookup)
         Ok(Channel {
-            short_channel_id: c
-                .short_channel_id
-                .ok_or(anyhow!("short_channel_id is missing"))?,
+            short_channel_id: c.short_channel_id,
             state: ChannelState::Closed,
             funding_txid: hex::encode(c.funding_txid),
             spendable_msat: c

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -727,9 +727,9 @@ pub struct LnPaymentDetails {
 /// Represents the funds that were on the user side of the channel at the time it was closed.
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
 pub struct ClosedChannelPaymentDetails {
-    pub short_channel_id: String,
     pub state: ChannelState,
     pub funding_txid: String,
+    pub short_channel_id: Option<String>,
     /// Can be empty for older closed channels.
     pub closing_txid: Option<String>,
 }
@@ -1114,7 +1114,7 @@ impl OpeningFeeParamsMenu {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Channel {
     pub funding_txid: String,
-    pub short_channel_id: String,
+    pub short_channel_id: Option<String>,
     pub state: ChannelState,
     pub spendable_msat: u64,
     pub receivable_msat: u64,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -436,17 +436,17 @@ class CheckMessageResponse {
 
 /// Represents the funds that were on the user side of the channel at the time it was closed.
 class ClosedChannelPaymentDetails {
-  final String shortChannelId;
   final ChannelState state;
   final String fundingTxid;
+  final String? shortChannelId;
 
   /// Can be empty for older closed channels.
   final String? closingTxid;
 
   const ClosedChannelPaymentDetails({
-    required this.shortChannelId,
     required this.state,
     required this.fundingTxid,
+    this.shortChannelId,
     this.closingTxid,
   });
 }
@@ -2975,9 +2975,9 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     final arr = raw as List<dynamic>;
     if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ClosedChannelPaymentDetails(
-      shortChannelId: _wire2api_String(arr[0]),
-      state: _wire2api_channel_state(arr[1]),
-      fundingTxid: _wire2api_String(arr[2]),
+      state: _wire2api_channel_state(arr[0]),
+      fundingTxid: _wire2api_String(arr[1]),
+      shortChannelId: _wire2api_opt_String(arr[2]),
       closingTxid: _wire2api_opt_String(arr[3]),
     );
   }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -319,7 +319,6 @@ fun asClosedChannelPaymentDetails(closedChannelPaymentDetails: ReadableMap): Clo
     if (!validateMandatoryFields(
             closedChannelPaymentDetails,
             arrayOf(
-                "shortChannelId",
                 "state",
                 "fundingTxid",
             ),
@@ -327,9 +326,18 @@ fun asClosedChannelPaymentDetails(closedChannelPaymentDetails: ReadableMap): Clo
     ) {
         return null
     }
-    val shortChannelId = closedChannelPaymentDetails.getString("shortChannelId")!!
     val state = closedChannelPaymentDetails.getString("state")?.let { asChannelState(it) }!!
     val fundingTxid = closedChannelPaymentDetails.getString("fundingTxid")!!
+    val shortChannelId =
+        if (hasNonNullKey(
+                closedChannelPaymentDetails,
+                "shortChannelId",
+            )
+        ) {
+            closedChannelPaymentDetails.getString("shortChannelId")
+        } else {
+            null
+        }
     val closingTxid =
         if (hasNonNullKey(
                 closedChannelPaymentDetails,
@@ -341,18 +349,18 @@ fun asClosedChannelPaymentDetails(closedChannelPaymentDetails: ReadableMap): Clo
             null
         }
     return ClosedChannelPaymentDetails(
-        shortChannelId,
         state,
         fundingTxid,
+        shortChannelId,
         closingTxid,
     )
 }
 
 fun readableMapOf(closedChannelPaymentDetails: ClosedChannelPaymentDetails): ReadableMap {
     return readableMapOf(
-        "shortChannelId" to closedChannelPaymentDetails.shortChannelId,
         "state" to closedChannelPaymentDetails.state.name.lowercase(),
         "fundingTxid" to closedChannelPaymentDetails.fundingTxid,
+        "shortChannelId" to closedChannelPaymentDetails.shortChannelId,
         "closingTxid" to closedChannelPaymentDetails.closingTxid,
     )
 }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -337,9 +337,6 @@ enum BreezSDKMapper {
     }
 
     static func asClosedChannelPaymentDetails(closedChannelPaymentDetails: [String: Any?]) throws -> ClosedChannelPaymentDetails {
-        guard let shortChannelId = closedChannelPaymentDetails["shortChannelId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "shortChannelId", typeName: "ClosedChannelPaymentDetails"))
-        }
         guard let stateTmp = closedChannelPaymentDetails["state"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "state", typeName: "ClosedChannelPaymentDetails"))
         }
@@ -347,6 +344,13 @@ enum BreezSDKMapper {
 
         guard let fundingTxid = closedChannelPaymentDetails["fundingTxid"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fundingTxid", typeName: "ClosedChannelPaymentDetails"))
+        }
+        var shortChannelId: String?
+        if hasNonNilKey(data: closedChannelPaymentDetails, key: "shortChannelId") {
+            guard let shortChannelIdTmp = closedChannelPaymentDetails["shortChannelId"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "shortChannelId"))
+            }
+            shortChannelId = shortChannelIdTmp
         }
         var closingTxid: String?
         if hasNonNilKey(data: closedChannelPaymentDetails, key: "closingTxid") {
@@ -357,18 +361,18 @@ enum BreezSDKMapper {
         }
 
         return ClosedChannelPaymentDetails(
-            shortChannelId: shortChannelId,
             state: state,
             fundingTxid: fundingTxid,
+            shortChannelId: shortChannelId,
             closingTxid: closingTxid
         )
     }
 
     static func dictionaryOf(closedChannelPaymentDetails: ClosedChannelPaymentDetails) -> [String: Any?] {
         return [
-            "shortChannelId": closedChannelPaymentDetails.shortChannelId,
             "state": valueOf(channelState: closedChannelPaymentDetails.state),
             "fundingTxid": closedChannelPaymentDetails.fundingTxid,
+            "shortChannelId": closedChannelPaymentDetails.shortChannelId == nil ? nil : closedChannelPaymentDetails.shortChannelId,
             "closingTxid": closedChannelPaymentDetails.closingTxid == nil ? nil : closedChannelPaymentDetails.closingTxid,
         ]
     }

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -62,9 +62,9 @@ export type CheckMessageResponse = {
 }
 
 export type ClosedChannelPaymentDetails = {
-    shortChannelId: string
     state: ChannelState
     fundingTxid: string
+    shortChannelId?: string
     closingTxid?: string
 }
 


### PR DESCRIPTION
short_channel_id is only set when the channel is confirmed onchain. This commit makes the short_channel_id optional, to match reality.

Should fix the error `short_channel_id is missing`.

The database column was already nullable.