### PR TITLE
Expand result of open_channel_fee SDK method

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -468,13 +468,13 @@ dictionary LspInformation {
 };
 
 dictionary OpenChannelFeeRequest {
-    u64 amount_msat;
+    u64? amount_msat;
     u32? expiry = null;
 };
 
 dictionary OpenChannelFeeResponse {
-    u64 fee_msat;
-    OpeningFeeParams? used_fee_params;
+    u64? fee_msat;
+    OpeningFeeParams fee_params;
 };
 
 enum SwapStatus {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -652,18 +652,18 @@ impl BreezServices {
     ) -> SdkResult<OpenChannelFeeResponse> {
         let lsp_info = self.lsp_info().await?;
         let fee_params = lsp_info
-            .cheapest_open_channel_fee(req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS))?.clone();
+            .cheapest_open_channel_fee(req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS))?
+            .clone();
 
         let node_state = self.node_info()?;
-        let fee_msat = req.amount_msat
-            .map(|req_amount_msat| {
-                match node_state.inbound_liquidity_msats >= req_amount_msat {
-                    // In case we have enough inbound liquidity we return zero fee.
-                    true => 0,
-                    // Otherwise we need to calculate the fee for opening a new channel.
-                    false => fee_params.get_channel_fees_msat_for(req_amount_msat)
-                }
-            });
+        let fee_msat = req.amount_msat.map(|req_amount_msat| {
+            match node_state.inbound_liquidity_msats >= req_amount_msat {
+                // In case we have enough inbound liquidity we return zero fee.
+                true => 0,
+                // Otherwise we need to calculate the fee for opening a new channel.
+                false => fee_params.get_channel_fees_msat_for(req_amount_msat),
+            }
+        });
 
         Ok(OpenChannelFeeResponse {
             fee_msat,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -645,41 +645,29 @@ impl BreezServices {
     }
 
     /// Gets the fees required to open a channel for a given amount.
-    /// If there is no channel needed, returns 0.
-    /// If there is a channel needed, returns the required open channel fees, with a fee params object
-    /// to pass to methods that require a channel open, like receive_payment, or receive_onchain.
+    /// If no channel is needed, returns 0. If a channel is needed, returns the required opening fees.
     pub async fn open_channel_fee(
         &self,
         req: OpenChannelFeeRequest,
     ) -> SdkResult<OpenChannelFeeResponse> {
         let lsp_info = self.lsp_info().await?;
-        let opening_fees = lsp_info.opening_fee_params_list.get_cheapest_opening_fee_params()?;
-
-        let recv_beyond_inbound_liquidity_min_fee_sat = opening_fees.min_msat / 1_000;
-        let recv_beyond_inbound_liquidity_fee_percentage = (opening_fees.proportional as f32) * 100_f32 / 1_000_000_f32;
+        let fee_params = lsp_info
+            .cheapest_open_channel_fee(req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS))?.clone();
 
         let node_state = self.node_info()?;
-        let inbound_liquidity_sat = node_state.inbound_liquidity_msats / 1000;
-
-        let (fee_msat, used_fee_params) = match node_state.inbound_liquidity_msats >= req.amount_msat {
-            // In case we have enough inbound liquidity we return zero fee.
-            true => (0, None),
-            false => {
-                // Otherwise we need to calculate the fee for opening a new channel.
-                let lsp_info = self.lsp_info().await?;
-                let used_fee_params = lsp_info
-                    .cheapest_open_channel_fee(req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS))?;
-                let fee_msat = used_fee_params.get_channel_fees_msat_for(req.amount_msat);
-                (fee_msat, Some(used_fee_params.clone()))
-            }
-        };
+        let fee_msat = req.amount_msat
+            .map(|req_amount_msat| {
+                match node_state.inbound_liquidity_msats >= req_amount_msat {
+                    // In case we have enough inbound liquidity we return zero fee.
+                    true => 0,
+                    // Otherwise we need to calculate the fee for opening a new channel.
+                    false => fee_params.get_channel_fees_msat_for(req_amount_msat)
+                }
+            });
 
         Ok(OpenChannelFeeResponse {
-            recv_beyond_inbound_liquidity_fee_percentage,
-            recv_beyond_inbound_liquidity_min_fee_sat,
-            inbound_liquidity_sat,
             fee_msat,
-            used_fee_params,
+            fee_params,
         })
     }
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -652,28 +652,34 @@ impl BreezServices {
         &self,
         req: OpenChannelFeeRequest,
     ) -> SdkResult<OpenChannelFeeResponse> {
-        // get the node state to fetch the current inbound liquidity.
-        let node_state = self.persister.get_node_state()?.ok_or(SdkError::Generic {
-            err: "Node info not found".into(),
-        })?;
-
-        // In case we have enough inbound liquidity we return zero fee.
-        if node_state.inbound_liquidity_msats >= req.amount_msat {
-            return Ok(OpenChannelFeeResponse {
-                fee_msat: 0,
-                used_fee_params: None,
-            });
-        }
-
-        // Otherwise we need to calculate the fee for opening a new channel.
         let lsp_info = self.lsp_info().await?;
-        let used_fee_params = lsp_info
-            .cheapest_open_channel_fee(req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS))?;
-        let fee_msat = used_fee_params.get_channel_fees_msat_for(req.amount_msat);
+        let opening_fees = lsp_info.opening_fee_params_list.get_cheapest_opening_fee_params()?;
+
+        let recv_beyond_inbound_liquidity_min_fee_sat = opening_fees.min_msat / 1_000;
+        let recv_beyond_inbound_liquidity_fee_percentage = (opening_fees.proportional as f32) * 100_f32 / 1_000_000_f32;
+
+        let node_state = self.node_info()?;
+        let inbound_liquidity_sat = node_state.inbound_liquidity_msats / 1000;
+
+        let (fee_msat, used_fee_params) = match node_state.inbound_liquidity_msats >= req.amount_msat {
+            // In case we have enough inbound liquidity we return zero fee.
+            true => (0, None),
+            false => {
+                // Otherwise we need to calculate the fee for opening a new channel.
+                let lsp_info = self.lsp_info().await?;
+                let used_fee_params = lsp_info
+                    .cheapest_open_channel_fee(req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS))?;
+                let fee_msat = used_fee_params.get_channel_fees_msat_for(req.amount_msat);
+                (fee_msat, Some(used_fee_params.clone()))
+            }
+        };
 
         Ok(OpenChannelFeeResponse {
+            recv_beyond_inbound_liquidity_fee_percentage,
+            recv_beyond_inbound_liquidity_min_fee_sat,
+            inbound_liquidity_sat,
             fee_msat,
-            used_fee_params: Some(used_fee_params.clone()),
+            used_fee_params,
         })
     }
 

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -1112,7 +1112,7 @@ pub struct wire_MetadataFilter {
 #[repr(C)]
 #[derive(Clone)]
 pub struct wire_OpenChannelFeeRequest {
-    amount_msat: u64,
+    amount_msat: *mut u64,
     expiry: *mut u32,
 }
 
@@ -1519,7 +1519,7 @@ pub extern "C" fn inflate_NodeConfig_Greenlight() -> *mut NodeConfigKind {
 impl NewWithNullPtr for wire_OpenChannelFeeRequest {
     fn new_with_null_ptr() -> Self {
         Self {
-            amount_msat: Default::default(),
+            amount_msat: core::ptr::null_mut(),
             expiry: core::ptr::null_mut(),
         }
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1609,8 +1609,8 @@ impl rust2dart::IntoIntoDart<NodeState> for NodeState {
 impl support::IntoDart for OpenChannelFeeResponse {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.fee_msat.into_into_dart().into_dart(),
-            self.used_fee_params.into_dart(),
+            self.fee_msat.into_dart(),
+            self.fee_params.into_into_dart().into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -885,7 +885,17 @@ pub struct OpenChannelFeeRequest {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenChannelFeeResponse {
+    /// Opening fee percentage, for receiving more than the inbound liquidity. Assumes the cheapest LSP feerate.
+    pub recv_beyond_inbound_liquidity_fee_percentage: f32,
+    /// Minimum opening fee, for receiving more than the inbound liquidity. Assumes the cheapest LSP feerate.
+    pub recv_beyond_inbound_liquidity_min_fee_sat: u64,
+    /// The current inbound liquidity.
+    pub inbound_liquidity_sat: u64,
+
+    /// Opening fee for the amount set in the [OpenChannelFeeRequest]
     pub fee_msat: u64,
+    /// Opening fee params, if a channel needs to be opened, for receiving the amount set in the
+    /// [OpenChannelFeeRequest]
     pub used_fee_params: Option<OpeningFeeParams>,
 }
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -879,24 +879,17 @@ pub struct StaticBackupResponse {
 }
 
 pub struct OpenChannelFeeRequest {
-    pub amount_msat: u64,
+    pub amount_msat: Option<u64>,
     pub expiry: Option<u32>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OpenChannelFeeResponse {
-    /// Opening fee percentage, for receiving more than the inbound liquidity. Assumes the cheapest LSP feerate.
-    pub recv_beyond_inbound_liquidity_fee_percentage: f32,
-    /// Minimum opening fee, for receiving more than the inbound liquidity. Assumes the cheapest LSP feerate.
-    pub recv_beyond_inbound_liquidity_min_fee_sat: u64,
-    /// The current inbound liquidity.
-    pub inbound_liquidity_sat: u64,
-
-    /// Opening fee for the amount set in the [OpenChannelFeeRequest]
-    pub fee_msat: u64,
-    /// Opening fee params, if a channel needs to be opened, for receiving the amount set in the
-    /// [OpenChannelFeeRequest]
-    pub used_fee_params: Option<OpeningFeeParams>,
+    /// Opening fee for receiving the amount set in the [OpenChannelFeeRequest], in case it was set.
+    /// It may be zero if no new channel needs to be opened.
+    pub fee_msat: Option<u64>,
+    /// The fee params for receiving more than the current inbound liquidity.
+    pub fee_params: OpeningFeeParams,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -231,7 +231,7 @@ typedef struct wire_RefundRequest {
 } wire_RefundRequest;
 
 typedef struct wire_OpenChannelFeeRequest {
-  uint64_t amount_msat;
+  uint64_t *amount_msat;
   uint32_t *expiry;
 } wire_OpenChannelFeeRequest;
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1105,22 +1105,26 @@ class NodeState {
 }
 
 class OpenChannelFeeRequest {
-  final int amountMsat;
+  final int? amountMsat;
   final int? expiry;
 
   const OpenChannelFeeRequest({
-    required this.amountMsat,
+    this.amountMsat,
     this.expiry,
   });
 }
 
 class OpenChannelFeeResponse {
-  final int feeMsat;
-  final OpeningFeeParams? usedFeeParams;
+  /// Opening fee for receiving the amount set in the [OpenChannelFeeRequest], in case it was set.
+  /// It may be zero if no new channel needs to be opened.
+  final int? feeMsat;
+
+  /// The fee params for receiving more than the current inbound liquidity.
+  final OpeningFeeParams feeParams;
 
   const OpenChannelFeeResponse({
-    required this.feeMsat,
-    this.usedFeeParams,
+    this.feeMsat,
+    required this.feeParams,
   });
 }
 
@@ -3421,8 +3425,8 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     final arr = raw as List<dynamic>;
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpenChannelFeeResponse(
-      feeMsat: _wire2api_u64(arr[0]),
-      usedFeeParams: _wire2api_opt_box_autoadd_opening_fee_params(arr[1]),
+      feeMsat: _wire2api_opt_box_autoadd_u64(arr[0]),
+      feeParams: _wire2api_opening_fee_params(arr[1]),
     );
   }
 
@@ -4442,7 +4446,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_open_channel_fee_request(
       OpenChannelFeeRequest apiObj, wire_OpenChannelFeeRequest wireObj) {
-    wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
+    wireObj.amount_msat = api2wire_opt_box_autoadd_u64(apiObj.amountMsat);
     wireObj.expiry = api2wire_opt_box_autoadd_u32(apiObj.expiry);
   }
 
@@ -6088,8 +6092,7 @@ final class wire_RefundRequest extends ffi.Struct {
 }
 
 final class wire_OpenChannelFeeRequest extends ffi.Struct {
-  @ffi.Uint64()
-  external int amount_msat;
+  external ffi.Pointer<ffi.Uint64> amount_msat;
 
   external ffi.Pointer<ffi.Uint32> expiry;
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1697,14 +1697,21 @@ fun asNodeStateList(arr: ReadableArray): List<NodeState> {
 fun asOpenChannelFeeRequest(openChannelFeeRequest: ReadableMap): OpenChannelFeeRequest? {
     if (!validateMandatoryFields(
             openChannelFeeRequest,
-            arrayOf(
-                "amountMsat",
-            ),
+            arrayOf(),
         )
     ) {
         return null
     }
-    val amountMsat = openChannelFeeRequest.getDouble("amountMsat").toULong()
+    val amountMsat =
+        if (hasNonNullKey(
+                openChannelFeeRequest,
+                "amountMsat",
+            )
+        ) {
+            openChannelFeeRequest.getDouble("amountMsat").toULong()
+        } else {
+            null
+        }
     val expiry = if (hasNonNullKey(openChannelFeeRequest, "expiry")) openChannelFeeRequest.getInt("expiry").toUInt() else null
     return OpenChannelFeeRequest(
         amountMsat,
@@ -1734,31 +1741,24 @@ fun asOpenChannelFeeResponse(openChannelFeeResponse: ReadableMap): OpenChannelFe
     if (!validateMandatoryFields(
             openChannelFeeResponse,
             arrayOf(
-                "feeMsat",
+                "feeParams",
             ),
         )
     ) {
         return null
     }
-    val feeMsat = openChannelFeeResponse.getDouble("feeMsat").toULong()
-    val usedFeeParams =
-        if (hasNonNullKey(openChannelFeeResponse, "usedFeeParams")) {
-            openChannelFeeResponse.getMap("usedFeeParams")?.let {
-                asOpeningFeeParams(it)
-            }
-        } else {
-            null
-        }
+    val feeMsat = if (hasNonNullKey(openChannelFeeResponse, "feeMsat")) openChannelFeeResponse.getDouble("feeMsat").toULong() else null
+    val feeParams = openChannelFeeResponse.getMap("feeParams")?.let { asOpeningFeeParams(it) }!!
     return OpenChannelFeeResponse(
         feeMsat,
-        usedFeeParams,
+        feeParams,
     )
 }
 
 fun readableMapOf(openChannelFeeResponse: OpenChannelFeeResponse): ReadableMap {
     return readableMapOf(
         "feeMsat" to openChannelFeeResponse.feeMsat,
-        "usedFeeParams" to openChannelFeeResponse.usedFeeParams?.let { readableMapOf(it) },
+        "feeParams" to readableMapOf(openChannelFeeResponse.feeParams),
     )
 }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1874,8 +1874,12 @@ enum BreezSDKMapper {
     }
 
     static func asOpenChannelFeeRequest(openChannelFeeRequest: [String: Any?]) throws -> OpenChannelFeeRequest {
-        guard let amountMsat = openChannelFeeRequest["amountMsat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "OpenChannelFeeRequest"))
+        var amountMsat: UInt64?
+        if hasNonNilKey(data: openChannelFeeRequest, key: "amountMsat") {
+            guard let amountMsatTmp = openChannelFeeRequest["amountMsat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "amountMsat"))
+            }
+            amountMsat = amountMsatTmp
         }
         var expiry: UInt32?
         if hasNonNilKey(data: openChannelFeeRequest, key: "expiry") {
@@ -1893,7 +1897,7 @@ enum BreezSDKMapper {
 
     static func dictionaryOf(openChannelFeeRequest: OpenChannelFeeRequest) -> [String: Any?] {
         return [
-            "amountMsat": openChannelFeeRequest.amountMsat,
+            "amountMsat": openChannelFeeRequest.amountMsat == nil ? nil : openChannelFeeRequest.amountMsat,
             "expiry": openChannelFeeRequest.expiry == nil ? nil : openChannelFeeRequest.expiry,
         ]
     }
@@ -1916,24 +1920,28 @@ enum BreezSDKMapper {
     }
 
     static func asOpenChannelFeeResponse(openChannelFeeResponse: [String: Any?]) throws -> OpenChannelFeeResponse {
-        guard let feeMsat = openChannelFeeResponse["feeMsat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeMsat", typeName: "OpenChannelFeeResponse"))
+        var feeMsat: UInt64?
+        if hasNonNilKey(data: openChannelFeeResponse, key: "feeMsat") {
+            guard let feeMsatTmp = openChannelFeeResponse["feeMsat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "feeMsat"))
+            }
+            feeMsat = feeMsatTmp
         }
-        var usedFeeParams: OpeningFeeParams?
-        if let usedFeeParamsTmp = openChannelFeeResponse["usedFeeParams"] as? [String: Any?] {
-            usedFeeParams = try asOpeningFeeParams(openingFeeParams: usedFeeParamsTmp)
+        guard let feeParamsTmp = openChannelFeeResponse["feeParams"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeParams", typeName: "OpenChannelFeeResponse"))
         }
+        let feeParams = try asOpeningFeeParams(openingFeeParams: feeParamsTmp)
 
         return OpenChannelFeeResponse(
             feeMsat: feeMsat,
-            usedFeeParams: usedFeeParams
+            feeParams: feeParams
         )
     }
 
     static func dictionaryOf(openChannelFeeResponse: OpenChannelFeeResponse) -> [String: Any?] {
         return [
-            "feeMsat": openChannelFeeResponse.feeMsat,
-            "usedFeeParams": openChannelFeeResponse.usedFeeParams == nil ? nil : dictionaryOf(openingFeeParams: openChannelFeeResponse.usedFeeParams!),
+            "feeMsat": openChannelFeeResponse.feeMsat == nil ? nil : openChannelFeeResponse.feeMsat,
+            "feeParams": dictionaryOf(openingFeeParams: openChannelFeeResponse.feeParams),
         ]
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -272,13 +272,13 @@ export type NodeState = {
 }
 
 export type OpenChannelFeeRequest = {
-    amountMsat: number
+    amountMsat?: number
     expiry?: number
 }
 
 export type OpenChannelFeeResponse = {
-    feeMsat: number
-    usedFeeParams?: OpeningFeeParams
+    feeMsat?: number
+    feeParams: OpeningFeeParams
 }
 
 export type OpeningFeeParams = {

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -193,7 +193,7 @@ pub(crate) enum Commands {
 
     OpenChannelFee {
         /// The received amount
-        amount_msat: u64,
+        amount_msat: Option<u64>,
 
         /// The expiration of the fee returned
         expiry: Option<u32>,


### PR DESCRIPTION
This PR expands `OpenChannelFeeResponse` to include fee params that may help the user better estimate the opening fee for higher received amounts.

Before, `open_channel_fee` showed the fee and fee params for a chosen received amount.

With this PR, the result contains 3 new fields

```rust
/// Opening fee percentage, for receiving more than the inbound liquidity. Assumes the cheapest LSP feerate.
pub recv_beyond_inbound_liquidity_fee_percentage: f32,
/// Minimum opening fee, for receiving more than the inbound liquidity. Assumes the cheapest LSP feerate.
pub recv_beyond_inbound_liquidity_min_fee_sat: u64,
/// The current inbound liquidity.
pub inbound_liquidity_sat: u64,
```