### PR TITLE
Use Swift bindings via CocoaPods in Flutter package

### DIFF
--- a/libs/sdk-flutter/ios/breez_sdk.podspec
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.on_demand_resources = { 'BreezSDK' => 'bindings-swift/Sources/BreezSDK/BreezSDK.swift' }
   s.dependency 'Flutter'
-  s.platform = :ios, '9.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.

--- a/libs/sdk-flutter/ios/breez_sdk.podspec.production
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec.production
@@ -10,15 +10,14 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://breez.technology'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Breez' => 'contact@breez.technology' }
-  s.source           = { :path => '.' }
+  s.source           = { :git => "https://github.com/breez/breez-sdk-flutter.git", :tag => "#{s.version}" }
   s.source_files = 'Classes/**/*'
-  s.on_demand_resources = { 'BreezSDK' => 'bindings-swift/Sources/BreezSDK/BreezSDK.swift' }
   s.dependency 'Flutter'
-  s.platform = :ios, '9.0'
+  s.platform = :ios, '11.0'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
-  s.dependency "breez_sdkFFI", "0.2.12"
+  s.dependency "BreezSDK", "#{s.version}"
 end


### PR DESCRIPTION
- #717 cont.

> We already do that for the iOS part: There we pull the binaries from CocoaPods.

This wasn't actually the case for iOS, the built binaries were previously added as an on demand resource.

Swift bindings are now pulled via CocoaPods with this PR.