### PR TITLE
Reverting reqwest version to 0.11.20

### DIFF
--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -39,7 +39,7 @@ rusqlite = { version = "0.29", features = [
     "hooks",
 ] }
 rusqlite_migration = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11.20", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tonic = { version = "^0.8", features = [


### PR DESCRIPTION
Fixes a CI issue for breez/breez-sdk-docs#126