### PR TITLE
CLI: Pretty-format dev command results

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1211,7 +1211,7 @@ impl NodeAPI for Greenlight {
                     .list_peers(cln::ListpeersRequest::default())
                     .await?
                     .into_inner();
-                Ok(format!("{resp:?}"))
+                Ok(format!("{resp:#?}"))
             }
             NodeCommand::ListPeerChannels => {
                 let resp = self
@@ -1220,7 +1220,7 @@ impl NodeAPI for Greenlight {
                     .list_peer_channels(cln::ListpeerchannelsRequest::default())
                     .await?
                     .into_inner();
-                Ok(format!("{resp:?}"))
+                Ok(format!("{resp:#?}"))
             }
             NodeCommand::ListFunds => {
                 let resp = self
@@ -1229,7 +1229,7 @@ impl NodeAPI for Greenlight {
                     .list_funds(cln::ListfundsRequest::default())
                     .await?
                     .into_inner();
-                Ok(format!("{resp:?}"))
+                Ok(format!("{resp:#?}"))
             }
             NodeCommand::ListPayments => {
                 let resp = self
@@ -1238,7 +1238,7 @@ impl NodeAPI for Greenlight {
                     .list_pays(cln::ListpaysRequest::default())
                     .await?
                     .into_inner();
-                Ok(format!("{resp:?}"))
+                Ok(format!("{resp:#?}"))
             }
             NodeCommand::ListInvoices => {
                 let resp = self
@@ -1247,7 +1247,7 @@ impl NodeAPI for Greenlight {
                     .list_invoices(cln::ListinvoicesRequest::default())
                     .await?
                     .into_inner();
-                Ok(format!("{resp:?}"))
+                Ok(format!("{resp:#?}"))
             }
             NodeCommand::CloseAllChannels => {
                 let peers_res = self
@@ -1269,7 +1269,7 @@ impl NodeAPI for Greenlight {
                     .getinfo(cln::GetinfoRequest::default())
                     .await?
                     .into_inner();
-                Ok(format!("{resp:?}"))
+                Ok(format!("{resp:#?}"))
             }
             NodeCommand::Stop => {
                 let resp = self
@@ -1278,7 +1278,7 @@ impl NodeAPI for Greenlight {
                     .stop(cln::StopRequest::default())
                     .await?
                     .into_inner();
-                Ok(format!("{resp:?}"))
+                Ok(format!("{resp:#?}"))
             }
         }
     }

--- a/tools/sdk-cli/src/main.rs
+++ b/tools/sdk-cli/src/main.rs
@@ -75,7 +75,12 @@ async fn main() -> Result<()> {
 
 fn show_results(res: Result<String>) {
     match res {
-        Ok(inner) => println!("{inner}"),
+        Ok(inner) => {
+            // Un-escape newlines and quotes, to accurately print strings containing pretty-printed protobuf structs
+            let sanitized = inner.replace("\\n", "\n");
+            let sanitized = sanitized.replace("\\\"", "\"");
+            println!("{sanitized}");
+        },
         Err(err) => eprintln!("Error: {err}"),
     }
 }


### PR DESCRIPTION
The protobuf structs (dev command results) already derive `Debug`, which means that `println!("{res:#?})` will pretty-print them, with each field and inner struct indented.

However, since we don't print that directly, but return it as a String from `sdk.execute_dev_command()`, we have to un-escape a few characters.

So, as a result of this PR:
- `sdk.execute_dev_command()` returns a debug-like (indented) string representation of the structs
- the SDK CLI pretty-prints these dev command results