### PR TITLE
Move early-return check to top of method

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1478,12 +1478,12 @@ fn update_payment_expirations(
     payments: Vec<Payment>,
     htlc_list: Vec<Htlc>,
 ) -> NodeResult<Vec<Payment>> {
-    let mut payments_res: Vec<Payment> = Vec::new();
     if htlc_list.is_empty() {
         return Ok(payments);
     }
 
-    for mut payment in payments.clone() {
+    let mut payments_res: Vec<Payment> = Vec::new();
+    for mut payment in payments {
         if payment.status == PaymentStatus::Pending {
             let new_data = payment.clone().details;
             if let PaymentDetails::Ln { data } = new_data {


### PR DESCRIPTION
This pattern (having early return checks as early as possible) prevents issues like the one fixed in `0.2.15`.

(PR is on top of `0.2.15`, so marking as draft until `0.2.15` is merged into `main`).