### PR TITLE
Bump Node version from 16 (EOL) to 20 in CI step

### DIFF
--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -35,9 +35,9 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
           scope: '@breeztech'
 


### PR DESCRIPTION
Address CI warnings that point to an EOL Nodejs version:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.