### PR TITLE
CI: upgrade to macos-13

### DIFF
--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     if: ${{ !inputs.use-dummy-binaries }}
-    runs-on: macOS-latest
+    runs-on: macOS-13
     name: build ${{ matrix.target }}
     strategy:
       matrix:
@@ -70,7 +70,7 @@ jobs:
           libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a
   
   merge:
-    runs-on: macOS-latest
+    runs-on: macOS-13
     needs: build
     name: build darwin-universal
     steps:

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     if: ${{ !inputs.use-dummy-binaries }}
-    runs-on: macOS-latest
+    runs-on: macOS-13
     name: build ${{ matrix.target }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
   
   build-bindings:
     name: Test sdk-bindings
-    runs-on: macOS-latest
+    runs-on: macOS-13
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -178,7 +178,7 @@ jobs:
   
   react-native:
     name: Check react native
-    runs-on: macOS-latest
+    runs-on: macOS-13
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -222,7 +222,7 @@ jobs:
 
   flutter:
     name: Check flutter
-    runs-on: macOS-latest
+    runs-on: macOS-13
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/publish-csharp.yml
+++ b/.github/workflows/publish-csharp.yml
@@ -107,7 +107,7 @@ jobs:
           windows-latest,
           ubuntu-latest,
           ubuntu-20.04,
-          macOS-latest,
+          macOS-13,
         ]
     steps:
       - name: Checkout breez-sdk repo

--- a/.github/workflows/publish-kotlin-mpp.yml
+++ b/.github/workflows/publish-kotlin-mpp.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-package:
-    runs-on: macOS-latest
+    runs-on: macOS-13
     steps:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   build-macos-wheels:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
Changing the runner to macos-13 in the main CI fixes the react native binding generation check.
I figured it's a good idea to upgrade all runners to macos-13, because we've been running into more issues with the macos-latest version lately.
It's still in beta though, so not sure whether things will break again soon. 