### PR TITLE
Fix reqwest pinning

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
  "breez-sdk-core",
  "camino",
  "flutter_rust_bridge",
- "lightning-invoice 0.23.0",
+ "lightning-invoice 0.26.0",
  "log",
  "once_cell",
  "thiserror",
@@ -1296,7 +1296,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.5",
  "bech32",
- "bitcoin 0.29.2",
+ "bitcoin 0.30.2",
  "bytes",
  "chacha20poly1305",
  "cln-grpc",
@@ -2480,9 +2480,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -2509,7 +2509,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
@@ -3100,27 +3099,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -39,7 +39,8 @@ rusqlite = { version = "0.29", features = [
     "hooks",
 ] }
 rusqlite_migration = "1.0"
-reqwest = { version = "0.11.20", features = ["json"] }
+# Pin the reqwest dependency until macOS linker issue is fixed: https://github.com/seanmonstar/reqwest/issues/2006
+reqwest = { version = "=0.11.20", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tonic = { version = "^0.8", features = [


### PR DESCRIPTION
Unfortunately the cargo versioning rules are not very intuitive.

From [the docs](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio):

> ```toml
> [dependencies]
>time = "0.1.12"
>```
>The string "0.1.12" is a version requirement. Although it looks like a specific version of the time crate, it actually specifies a range of versions and allows [SemVer](https://semver.org/) compatible updates. An update is allowed if the new version number does not modify the left-most non-zero number in the major, minor, patch grouping. In this case, if we ran cargo update time, cargo should update us to version 0.1.13 if it is the latest 0.1.z release, but would not update us to 0.2.0.


This means that
```toml
reqwest = { version = "0.11.20", features = ["json"] }
```

would allow, for example, version `0.11.22`.

However, we want to limit it to `0.11.20` at the most, which can be done with

```toml
reqwest = { version = "=0.11.20", features = ["json"] }
```