### PR TITLE
Pin ktlint version to avoid random fluctuations in GH CI runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,7 +203,7 @@ jobs:
         working-directory: libs/sdk-react-native 
         run: |
           yarn global add tslint typescript
-          brew install kotlin ktlint swiftformat
+          brew install kotlin ktlint@1.1.1 swiftformat
           make react-native-codegen
 
       - name: Check git status

--- a/libs/sdk-react-native/DEVELOPING.md
+++ b/libs/sdk-react-native/DEVELOPING.md
@@ -17,7 +17,7 @@ export ANDROID_NDK_HOME=<your android ndk directory>
 
 To lint the result of the code generation ktlint, swiftformat and tslint need to be installed:
 ```bash
-brew install kotlin ktlint swiftformat
+brew install kotlin ktlint@1.1.1 swiftformat
 yarn global add tslint typescript
 ```
 


### PR DESCRIPTION
As described [here](https://github.com/breez/breez-sdk/pull/758#issuecomment-1912930109), the `ktlint` version used by the CI randomly alternates between 1.0.1 and 1.1.1. This causes valid formatting to appear invalid and vice-versa.

This PR proposes to explicitly set the version when `brew install`ing it.

Another solution tried in https://github.com/breez/breez-sdk/pull/756 is to use a different macos base image, where this doesn't appear to happen. I tested it by running the CI 7x, and the `ktlint` check was successful every time.