### PR TITLE
Split `Payment` struct depending on method 

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -216,7 +216,7 @@ enum PaymentType {
     "ClosedChannel"
 };
 
-dictionary Payment {
+dictionary PaymentListItem {
     string id;
     PaymentType payment_type;    
     i64 payment_time;    
@@ -227,6 +227,15 @@ dictionary Payment {
     string? description;
     PaymentDetails details;
     string? metadata;
+};
+
+dictionary PendingPayment {
+    string id;
+    i64 payment_time;    
+    u64 amount_msat;
+    u64 fee_msat;
+    string? description;
+    PaymentDetails details;
 };
 
 dictionary ListPaymentsRequest {
@@ -360,7 +369,7 @@ dictionary LogEntry {
 dictionary InvoicePaidDetails {
     string payment_hash;
     string bolt11;
-    Payment? payment;
+    PaymentListItem? payment;
 };
 
 dictionary PaymentFailedData {
@@ -378,7 +387,7 @@ interface BreezEvent {
     NewBlock(u32 block);
     InvoicePaid(InvoicePaidDetails details);
     Synced();
-    PaymentSucceed(Payment details);
+    PaymentSucceed(PendingPayment details);
     PaymentFailed(PaymentFailedData details);
     BackupStarted();
     BackupSucceeded(); 
@@ -697,7 +706,7 @@ dictionary SendSpontaneousPaymentRequest {
 };
 
 dictionary SendPaymentResponse {
-    Payment payment;
+    PaymentListItem payment;
 };
 
 dictionary MaxReverseSwapAmountResponse {
@@ -781,10 +790,10 @@ interface BlockingBreezServices {
    void backup();
 
    [Throws=SdkError]
-   sequence<Payment> list_payments(ListPaymentsRequest req);
+   sequence<PaymentListItem> list_payments(ListPaymentsRequest req);
 
    [Throws=SdkError]
-   Payment? payment_by_hash(string hash);
+   PaymentListItem? payment_by_hash(string hash);
 
    [Throws=SdkError]
    void set_payment_metadata(string hash, string metadata);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -13,17 +13,17 @@ use breez_sdk_core::{
     LocaleOverrides, LocalizedName, LogEntry, LogStream, LspInformation,
     MaxReverseSwapAmountResponse, MessageSuccessActionData, MetadataFilter, MetadataItem, Network,
     NodeConfig, NodeCredentials, NodeState, OpenChannelFeeRequest, OpenChannelFeeResponse,
-    OpeningFeeParams, OpeningFeeParamsMenu, Payment, PaymentDetails, PaymentFailedData,
-    PaymentStatus, PaymentType, PaymentTypeFilter, PrepareRedeemOnchainFundsRequest,
-    PrepareRedeemOnchainFundsResponse, PrepareRefundRequest, PrepareRefundResponse, Rate,
-    ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees,
-    RedeemOnchainFundsRequest, RedeemOnchainFundsResponse, RefundRequest, RefundResponse,
-    ReportIssueRequest, ReportPaymentFailureDetails, ReverseSwapFeesRequest, ReverseSwapInfo,
-    ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop, SendOnchainRequest,
-    SendOnchainResponse, SendPaymentRequest, SendPaymentResponse, SendSpontaneousPaymentRequest,
-    ServiceHealthCheckResponse, SignMessageRequest, SignMessageResponse, StaticBackupRequest,
-    StaticBackupResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol, TlvEntry,
-    UnspentTransactionOutput, UrlSuccessActionData,
+    OpeningFeeParams, OpeningFeeParamsMenu, PaymentDetails, PaymentFailedData, PaymentListItem,
+    PaymentStatus, PaymentType, PaymentTypeFilter, PendingPayment,
+    PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, PrepareRefundRequest,
+    PrepareRefundResponse, Rate, ReceiveOnchainRequest, ReceivePaymentRequest,
+    ReceivePaymentResponse, RecommendedFees, RedeemOnchainFundsRequest, RedeemOnchainFundsResponse,
+    RefundRequest, RefundResponse, ReportIssueRequest, ReportPaymentFailureDetails,
+    ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint,
+    RouteHintHop, SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
+    SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SignMessageRequest,
+    SignMessageResponse, StaticBackupRequest, StaticBackupResponse, SuccessActionProcessed,
+    SwapInfo, SwapStatus, Symbol, TlvEntry, UnspentTransactionOutput, UrlSuccessActionData,
 };
 use log::{Level, LevelFilter, Metadata, Record};
 use once_cell::sync::{Lazy, OnceCell};
@@ -162,11 +162,11 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.backup())
     }
 
-    pub fn list_payments(&self, req: ListPaymentsRequest) -> SdkResult<Vec<Payment>> {
+    pub fn list_payments(&self, req: ListPaymentsRequest) -> SdkResult<Vec<PaymentListItem>> {
         rt().block_on(self.breez_services.list_payments(req))
     }
 
-    pub fn payment_by_hash(&self, hash: String) -> SdkResult<Option<Payment>> {
+    pub fn payment_by_hash(&self, hash: String) -> SdkResult<Option<PaymentListItem>> {
         rt().block_on(self.breez_services.payment_by_hash(hash))
     }
 

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -30,7 +30,7 @@ use crate::input_parser::{self, InputType, LnUrlAuthRequestData};
 use crate::invoice::{self, LNInvoice};
 use crate::lnurl::pay::model::LnUrlPayResult;
 use crate::lsp::LspInformation;
-use crate::models::{Config, LogEntry, NodeState, Payment, SwapInfo};
+use crate::models::{Config, LogEntry, NodeState, PaymentListItem, SwapInfo};
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     EnvironmentType, ListPaymentsRequest, LnUrlCallbackStatus, LnUrlPayRequest,
@@ -250,13 +250,13 @@ pub fn parse_input(input: String) -> Result<InputType> {
 /*  Payment API's */
 
 /// See [BreezServices::list_payments]
-pub fn list_payments(req: ListPaymentsRequest) -> Result<Vec<Payment>> {
+pub fn list_payments(req: ListPaymentsRequest) -> Result<Vec<PaymentListItem>> {
     block_on(async { get_breez_services().await?.list_payments(req).await })
         .map_err(anyhow::Error::new::<SdkError>)
 }
 
 /// See [BreezServices::list_payments]
-pub fn payment_by_hash(hash: String) -> Result<Option<Payment>> {
+pub fn payment_by_hash(hash: String) -> Result<Option<PaymentListItem>> {
     block_on(async { get_breez_services().await?.payment_by_hash(hash).await })
         .map_err(anyhow::Error::new::<SdkError>)
 }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -51,7 +51,7 @@ use crate::lnurl::withdraw::validate_lnurl_withdraw;
 use crate::lsp::LspInformation;
 use crate::models::{
     parse_short_channel_id, ChannelState, ClosedChannelPaymentDetails, Config, EnvironmentType,
-    FiatAPI, LnUrlCallbackStatus, LspAPI, NodeState, Payment, PaymentDetails, PaymentType,
+    FiatAPI, LnUrlCallbackStatus, LspAPI, NodeState, PaymentDetails, PaymentType, PendingPayment,
     ReverseSwapPairInfo, ReverseSwapServiceAPI, SwapInfo, SwapperAPI,
     INVOICE_PAYMENT_FEE_EXPIRY_SECONDS,
 };
@@ -81,7 +81,7 @@ pub enum BreezEvent {
     /// Indicates that the local SDK state has just been sync-ed with the remote components
     Synced,
     /// Indicates that an outgoing payment has been completed successfully
-    PaymentSucceed { details: Payment },
+    PaymentSucceed { details: PendingPayment },
     /// Indicates that an outgoing payment has been failed to complete
     PaymentFailed { details: PaymentFailedData },
     /// Indicates that the backup process has just started
@@ -109,7 +109,7 @@ pub struct PaymentFailedData {
 pub struct InvoicePaidDetails {
     pub payment_hash: String,
     pub bolt11: String,
-    pub payment: Option<Payment>,
+    pub payment: Option<PaymentListItem>,
 }
 
 pub trait LogStream: Send + Sync {
@@ -571,12 +571,12 @@ impl BreezServices {
     }
 
     /// List payments matching the given filters, as retrieved from persistent storage
-    pub async fn list_payments(&self, req: ListPaymentsRequest) -> SdkResult<Vec<Payment>> {
+    pub async fn list_payments(&self, req: ListPaymentsRequest) -> SdkResult<Vec<PaymentListItem>> {
         Ok(self.persister.list_payments(req)?)
     }
 
     /// Fetch a specific payment by its hash.
-    pub async fn payment_by_hash(&self, hash: String) -> SdkResult<Option<Payment>> {
+    pub async fn payment_by_hash(&self, hash: String) -> SdkResult<Option<PaymentListItem>> {
         Ok(self.persister.get_payment_by_hash(&hash)?)
     }
 
@@ -913,7 +913,7 @@ impl BreezServices {
         }
 
         //fetch closed_channel and convert them to Payment items.
-        let mut closed_channel_payments: Vec<Payment> = vec![];
+        let mut closed_channel_payments: Vec<PaymentListItem> = vec![];
         for closed_channel in
             self.persister.list_channels()?.into_iter().filter(|c| {
                 c.state == ChannelState::Closed || c.state == ChannelState::PendingClose
@@ -979,7 +979,7 @@ impl BreezServices {
         amount_msat: u64,
     ) -> Result<(), SendPaymentError> {
         self.persister.insert_or_update_payments(
-            &[Payment {
+            &[PaymentListItem {
                 id: invoice.payment_hash.clone(),
                 payment_type: PaymentType::Sent,
                 payment_time: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as i64,
@@ -1030,8 +1030,8 @@ impl BreezServices {
         &self,
         node_id: String,
         invoice: Option<LNInvoice>,
-        payment_res: Result<Payment, SendPaymentError>,
-    ) -> Result<Payment, SendPaymentError> {
+        payment_res: Result<PendingPayment, SendPaymentError>,
+    ) -> Result<PaymentListItem, SendPaymentError> {
         self.do_sync(payment_res.is_ok()).await?;
         match payment_res {
             Ok(payment) => {
@@ -1039,7 +1039,7 @@ impl BreezServices {
                     details: payment.clone(),
                 })
                 .await?;
-                Ok(payment)
+                Ok(payment.to_persisted(PaymentStatus::Complete, None))
             }
             Err(e) => {
                 if let Some(invoice) = invoice.clone() {
@@ -1262,7 +1262,7 @@ impl BreezServices {
                                           Ok(Some(i)) => {
                                               debug!("invoice stream got new invoice");
                                               if let Some(gl_client::signer::model::greenlight::incoming_payment::Details::Offchain(p)) = i.details {
-                                                  let payment: Option<crate::models::Payment> = p.clone().try_into().ok();
+                                                  let payment: Option<crate::models::PaymentListItem> = p.clone().try_into().ok();
                                                   if payment.is_some() {
                                                       let res = cloned
                                                           .persister
@@ -1499,7 +1499,7 @@ impl BreezServices {
     async fn closed_channel_to_transaction(
         &self,
         channel: crate::models::Channel,
-    ) -> Result<Payment> {
+    ) -> Result<PaymentListItem> {
         let (payment_time, closing_txid) = match (channel.closed_at, channel.closing_txid.clone()) {
             (Some(closed_at), Some(closing_txid)) => (closed_at as i64, Some(closing_txid)),
             (_, _) => {
@@ -1525,7 +1525,7 @@ impl BreezServices {
             }
         };
 
-        Ok(Payment {
+        Ok(PaymentListItem {
             id: channel.funding_txid.clone(),
             payment_type: PaymentType::ClosedChannel,
             payment_time,
@@ -2220,7 +2220,9 @@ pub(crate) mod tests {
     use crate::fiat::Rate;
     use crate::lnurl::pay::model::MessageSuccessActionData;
     use crate::lnurl::pay::model::SuccessActionProcessed;
-    use crate::models::{LnPaymentDetails, NodeState, Payment, PaymentDetails, PaymentTypeFilter};
+    use crate::models::{
+        LnPaymentDetails, NodeState, PaymentDetails, PaymentListItem, PaymentTypeFilter,
+    };
     use crate::node_api::NodeAPI;
     use crate::{
         input_parser, parse_short_channel_id, test_utils::*, BuyBitcoinProvider, BuyBitcoinRequest,
@@ -2309,7 +2311,7 @@ pub(crate) mod tests {
             status: ReverseSwapStatus::CompletedConfirmed,
         };
         let dummy_transactions = vec![
-            Payment {
+            PaymentListItem {
                 id: "1111".to_string(),
                 payment_type: PaymentType::Received,
                 payment_time: 100000,
@@ -2338,7 +2340,7 @@ pub(crate) mod tests {
                 },
                 metadata: None,
             },
-            Payment {
+            PaymentListItem {
                 id: payment_hash_lnurl_withdraw.to_string(),
                 payment_type: PaymentType::Received,
                 payment_time: 150000,
@@ -2367,7 +2369,7 @@ pub(crate) mod tests {
                 },
                 metadata: None,
             },
-            Payment {
+            PaymentListItem {
                 id: payment_hash_with_lnurl_success_action.to_string(),
                 payment_type: PaymentType::Sent,
                 payment_time: 200000,
@@ -2396,7 +2398,7 @@ pub(crate) mod tests {
                 },
                 metadata: None,
             },
-            Payment {
+            PaymentListItem {
                 id: hex::encode(payment_hash_swap.clone()),
                 payment_type: PaymentType::Received,
                 payment_time: 250000,
@@ -2425,7 +2427,7 @@ pub(crate) mod tests {
                 },
                 metadata: None,
             },
-            Payment {
+            PaymentListItem {
                 id: hex::encode(payment_hash_rev_swap.clone()),
                 payment_type: PaymentType::Sent,
                 payment_time: 300000,
@@ -2673,7 +2675,7 @@ pub(crate) mod tests {
     /// Build node service for tests with a list of known payments
     pub(crate) async fn breez_services_with(
         node_api: Option<Arc<dyn NodeAPI>>,
-        known_payments: Vec<Payment>,
+        known_payments: Vec<PaymentListItem>,
     ) -> Result<Arc<BreezServices>> {
         let node_api =
             node_api.unwrap_or_else(|| Arc::new(MockNodeAPI::new(get_dummy_node_state())));

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -82,11 +82,12 @@ use crate::models::OpenChannelFeeRequest;
 use crate::models::OpenChannelFeeResponse;
 use crate::models::OpeningFeeParams;
 use crate::models::OpeningFeeParamsMenu;
-use crate::models::Payment;
 use crate::models::PaymentDetails;
+use crate::models::PaymentListItem;
 use crate::models::PaymentStatus;
 use crate::models::PaymentType;
 use crate::models::PaymentTypeFilter;
+use crate::models::PendingPayment;
 use crate::models::PrepareRedeemOnchainFundsRequest;
 use crate::models::PrepareRedeemOnchainFundsResponse;
 use crate::models::PrepareRefundRequest;
@@ -418,7 +419,7 @@ fn wire_list_payments_impl(
     port_: MessagePort,
     req: impl Wire2Api<ListPaymentsRequest> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<Payment>, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<PaymentListItem>, _>(
         WrapInfo {
             debug_name: "list_payments",
             port: Some(port_),
@@ -431,7 +432,7 @@ fn wire_list_payments_impl(
     )
 }
 fn wire_payment_by_hash_impl(port_: MessagePort, hash: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<Payment>, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<PaymentListItem>, _>(
         WrapInfo {
             debug_name: "payment_by_hash",
             port: Some(port_),
@@ -1674,30 +1675,6 @@ impl rust2dart::IntoIntoDart<OpeningFeeParamsMenu> for OpeningFeeParamsMenu {
     }
 }
 
-impl support::IntoDart for Payment {
-    fn into_dart(self) -> support::DartAbi {
-        vec![
-            self.id.into_into_dart().into_dart(),
-            self.payment_type.into_into_dart().into_dart(),
-            self.payment_time.into_into_dart().into_dart(),
-            self.amount_msat.into_into_dart().into_dart(),
-            self.fee_msat.into_into_dart().into_dart(),
-            self.status.into_into_dart().into_dart(),
-            self.error.into_dart(),
-            self.description.into_dart(),
-            self.details.into_into_dart().into_dart(),
-            self.metadata.into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl support::IntoDartExceptPrimitive for Payment {}
-impl rust2dart::IntoIntoDart<Payment> for Payment {
-    fn into_into_dart(self) -> Self {
-        self
-    }
-}
-
 impl support::IntoDart for PaymentDetails {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -1726,6 +1703,30 @@ impl support::IntoDart for PaymentFailedData {
 }
 impl support::IntoDartExceptPrimitive for PaymentFailedData {}
 impl rust2dart::IntoIntoDart<PaymentFailedData> for PaymentFailedData {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for PaymentListItem {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.id.into_into_dart().into_dart(),
+            self.payment_type.into_into_dart().into_dart(),
+            self.payment_time.into_into_dart().into_dart(),
+            self.amount_msat.into_into_dart().into_dart(),
+            self.fee_msat.into_into_dart().into_dart(),
+            self.status.into_into_dart().into_dart(),
+            self.error.into_dart(),
+            self.description.into_dart(),
+            self.details.into_into_dart().into_dart(),
+            self.metadata.into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for PaymentListItem {}
+impl rust2dart::IntoIntoDart<PaymentListItem> for PaymentListItem {
     fn into_into_dart(self) -> Self {
         self
     }
@@ -1760,6 +1761,26 @@ impl support::IntoDart for PaymentType {
 }
 impl support::IntoDartExceptPrimitive for PaymentType {}
 impl rust2dart::IntoIntoDart<PaymentType> for PaymentType {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for PendingPayment {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.id.into_into_dart().into_dart(),
+            self.payment_time.into_into_dart().into_dart(),
+            self.amount_msat.into_into_dart().into_dart(),
+            self.fee_msat.into_into_dart().into_dart(),
+            self.description.into_dart(),
+            self.details.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for PendingPayment {}
+impl rust2dart::IntoIntoDart<PendingPayment> for PendingPayment {
     fn into_into_dart(self) -> Self {
         self
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -880,7 +880,11 @@ impl NodeAPI for Greenlight {
         })
     }
 
-    async fn send_payment(&self, bolt11: String, amount_msat: Option<u64>) -> NodeResult<Payment> {
+    async fn send_payment(
+        &self,
+        bolt11: String,
+        amount_msat: Option<u64>,
+    ) -> NodeResult<PendingPayment> {
         let mut description = None;
         if !bolt11.is_empty() {
             let invoice = parse_invoice(&bolt11)?;
@@ -918,7 +922,7 @@ impl NodeAPI for Greenlight {
         node_id: String,
         amount_msat: u64,
         extra_tlvs: Option<Vec<TlvEntry>>,
-    ) -> NodeResult<Payment> {
+    ) -> NodeResult<PendingPayment> {
         let mut client: node::ClnClient = self.get_node_client().await?;
         let request = cln::KeysendRequest {
             destination: hex::decode(node_id)?,
@@ -1431,7 +1435,7 @@ async fn pull_transactions(
     since_timestamp: u64,
     client: node::ClnClient,
     htlc_list: Vec<Htlc>,
-) -> NodeResult<Vec<Payment>> {
+) -> NodeResult<Vec<PaymentListItem>> {
     let mut c = client.clone();
 
     // list invoices
@@ -1440,7 +1444,7 @@ async fn pull_transactions(
         .await?
         .into_inner();
     // construct the received transactions by filtering the invoices to those paid and beyond the filter timestamp
-    let received_transactions: NodeResult<Vec<Payment>> = invoices
+    let received_transactions: NodeResult<Vec<PaymentListItem>> = invoices
         .invoices
         .into_iter()
         .filter(|i| {
@@ -1457,17 +1461,21 @@ async fn pull_transactions(
         .into_inner();
     trace!("list payments (unfiltered): {:?}", payments);
     // construct the payment transactions (pending and complete)
-    let outbound_transactions: NodeResult<Vec<Payment>> = payments
+    let outbound_transactions: NodeResult<Vec<PaymentListItem>> = payments
         .pays
         .into_iter()
         .filter(|p| p.created_at > since_timestamp)
-        .map(TryInto::try_into)
+        .map(|gl_payment| {
+            let payment_status = gl_payment.status().into();
+            TryInto::<PendingPayment>::try_into(gl_payment)
+                .map(|p| p.to_persisted(payment_status, None))
+        })
         .collect();
 
-    let outbound_transactions: NodeResult<Vec<Payment>> =
+    let outbound_transactions: NodeResult<Vec<PaymentListItem>> =
         update_payment_expirations(outbound_transactions?, htlc_list);
 
-    let mut transactions: Vec<Payment> = Vec::new();
+    let mut transactions: Vec<PaymentListItem> = Vec::new();
     transactions.extend(received_transactions?);
     transactions.extend(outbound_transactions?);
 
@@ -1475,10 +1483,10 @@ async fn pull_transactions(
 }
 
 fn update_payment_expirations(
-    payments: Vec<Payment>,
+    payments: Vec<PaymentListItem>,
     htlc_list: Vec<Htlc>,
-) -> NodeResult<Vec<Payment>> {
-    let mut payments_res: Vec<Payment> = Vec::new();
+) -> NodeResult<Vec<PaymentListItem>> {
+    let mut payments_res: Vec<PaymentListItem> = Vec::new();
     if htlc_list.is_empty() {
         return Ok(payments);
     }
@@ -1504,12 +1512,12 @@ fn update_payment_expirations(
 }
 
 //pub(crate) fn offchain_payment_to_transaction
-impl TryFrom<OffChainPayment> for Payment {
+impl TryFrom<OffChainPayment> for PaymentListItem {
     type Error = NodeError;
 
     fn try_from(p: OffChainPayment) -> std::result::Result<Self, Self::Error> {
         let ln_invoice = parse_invoice(&p.bolt11)?;
-        Ok(Payment {
+        Ok(PaymentListItem {
             id: hex::encode(p.payment_hash.clone()),
             payment_type: PaymentType::Received,
             payment_time: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as i64,
@@ -1545,14 +1553,14 @@ impl TryFrom<OffChainPayment> for Payment {
 }
 
 /// Construct a lightning transaction from an invoice
-impl TryFrom<gl_client::signer::model::greenlight::Invoice> for Payment {
+impl TryFrom<gl_client::signer::model::greenlight::Invoice> for PaymentListItem {
     type Error = NodeError;
 
     fn try_from(
         invoice: gl_client::signer::model::greenlight::Invoice,
     ) -> std::result::Result<Self, Self::Error> {
         let ln_invoice = parse_invoice(&invoice.bolt11)?;
-        Ok(Payment {
+        Ok(PaymentListItem {
             id: hex::encode(invoice.payment_hash.clone()),
             payment_type: PaymentType::Received,
             payment_time: invoice.payment_time as i64,
@@ -1595,7 +1603,7 @@ impl From<PayStatus> for PaymentStatus {
 }
 
 /// Construct a lightning transaction from an invoice
-impl TryFrom<gl_client::signer::model::greenlight::Payment> for Payment {
+impl TryFrom<gl_client::signer::model::greenlight::Payment> for PendingPayment {
     type Error = NodeError;
 
     fn try_from(
@@ -1608,16 +1616,12 @@ impl TryFrom<gl_client::signer::model::greenlight::Payment> for Payment {
 
         let payment_amount = amount_to_msat(&payment.amount.clone().unwrap_or_default());
         let payment_amount_sent = amount_to_msat(&payment.amount_sent.clone().unwrap_or_default());
-        let status = payment.status().into();
 
-        Ok(Payment {
+        Ok(PendingPayment {
             id: hex::encode(payment.payment_hash.clone()),
-            payment_type: PaymentType::Sent,
             payment_time: payment.created_at as i64,
             amount_msat: payment_amount,
             fee_msat: payment_amount_sent - payment_amount,
-            status,
-            error: None,
             description,
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
@@ -1637,13 +1641,12 @@ impl TryFrom<gl_client::signer::model::greenlight::Payment> for Payment {
                     pending_expiration_block: None,
                 },
             },
-            metadata: None,
         })
     }
 }
 
 /// Construct a lightning transaction from an invoice
-impl TryFrom<cln::ListinvoicesInvoices> for Payment {
+impl TryFrom<cln::ListinvoicesInvoices> for PaymentListItem {
     type Error = NodeError;
 
     fn try_from(invoice: cln::ListinvoicesInvoices) -> std::result::Result<Self, Self::Error> {
@@ -1652,7 +1655,7 @@ impl TryFrom<cln::ListinvoicesInvoices> for Payment {
             .as_ref()
             .ok_or(InvoiceError::Generic(anyhow!("No bolt11 invoice")))
             .and_then(|b| parse_invoice(b))?;
-        Ok(Payment {
+        Ok(PaymentListItem {
             id: hex::encode(invoice.payment_hash.clone()),
             payment_type: PaymentType::Received,
             payment_time: invoice.paid_at.map(|i| i as i64).unwrap_or_default(),
@@ -1697,7 +1700,7 @@ impl From<ListpaysPaysStatus> for PaymentStatus {
     }
 }
 
-impl TryFrom<cln::ListpaysPays> for Payment {
+impl TryFrom<cln::ListpaysPays> for PendingPayment {
     type Error = NodeError;
 
     fn try_from(payment: cln::ListpaysPays) -> NodeResult<Self, Self::Error> {
@@ -1718,9 +1721,8 @@ impl TryFrom<cln::ListpaysPays> for Payment {
             .unwrap_or_default();
         let status = payment.status().into();
 
-        Ok(Payment {
+        Ok(PendingPayment {
             id: hex::encode(payment.payment_hash.clone()),
-            payment_type: PaymentType::Sent,
             payment_time: payment.completed_at.unwrap_or(payment.created_at) as i64,
             amount_msat: match status {
                 PaymentStatus::Complete => payment_amount,
@@ -1729,8 +1731,6 @@ impl TryFrom<cln::ListpaysPays> for Payment {
                     .map_or(0, |i| i.amount_msat.unwrap_or_default()),
             },
             fee_msat: payment_amount_sent - payment_amount,
-            status,
-            error: None,
             description: ln_invoice.map(|i| i.description).unwrap_or_default(),
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
@@ -1750,8 +1750,37 @@ impl TryFrom<cln::ListpaysPays> for Payment {
                     pending_expiration_block: None,
                 },
             },
-            metadata: None,
         })
+    }
+}
+
+impl PendingPayment {
+    pub fn to_persisted(&self, status: PaymentStatus, error: Option<String>) -> PaymentListItem {
+        PaymentListItem {
+            id: self.id.clone(),
+            payment_type: PaymentType::Sent,
+            payment_time: self.payment_time,
+            amount_msat: self.amount_msat,
+            fee_msat: self.fee_msat,
+            status,
+            error,
+            description: self.description.clone(),
+            details: self.details.clone(),
+            metadata: None,
+        }
+    }
+}
+
+impl From<PaymentListItem> for PendingPayment {
+    fn from(p: PaymentListItem) -> Self {
+        PendingPayment {
+            id: p.id.clone(),
+            payment_time: p.payment_time,
+            amount_msat: p.amount_msat,
+            fee_msat: p.fee_msat,
+            description: p.description.clone(),
+            details: p.details.clone(),
+        }
     }
 }
 

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -1183,7 +1183,7 @@ mod tests {
             .add_dummy_payment_for(bolt11, Some(preimage), Some(PayStatus::Pending))
             .await?;
 
-        let known_payments: Vec<crate::models::Payment> = vec![model_payment];
+        let known_payments: Vec<crate::models::PaymentListItem> = vec![model_payment];
         let mock_breez_services = crate::breez_services::tests::breez_services_with(
             Some(Arc::new(mock_node_api)),
             known_payments,
@@ -1266,7 +1266,7 @@ mod tests {
             .add_dummy_payment_for(bolt11, Some(preimage), Some(PayStatus::Pending))
             .await?;
 
-        let known_payments: Vec<crate::models::Payment> = vec![model_payment];
+        let known_payments: Vec<crate::models::PaymentListItem> = vec![model_payment];
         let mock_breez_services = crate::breez_services::tests::breez_services_with(
             Some(Arc::new(mock_node_api)),
             known_payments,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -621,7 +621,7 @@ pub struct NodeState {
 /// Internal response to a [NodeAPI::pull_changed] call
 pub struct SyncResponse {
     pub node_state: NodeState,
-    pub payments: Vec<crate::models::Payment>,
+    pub payments: Vec<crate::models::PaymentListItem>,
     pub channels: Vec<crate::models::Channel>,
 }
 
@@ -633,9 +633,9 @@ pub enum PaymentStatus {
     Failed = 2,
 }
 
-/// Represents a payment, including its [PaymentType] and [PaymentDetails]
+/// Represents a persisted payment, including its [PaymentType] and [PaymentDetails]
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
-pub struct Payment {
+pub struct PaymentListItem {
     pub id: String,
     pub payment_type: PaymentType,
     /// Epoch time, in seconds
@@ -647,6 +647,19 @@ pub struct Payment {
     pub description: Option<String>,
     pub details: PaymentDetails,
     pub metadata: Option<String>,
+}
+
+/// Represents a sent and pending payment, not yet persisted into the storage,
+/// including its [PaymentType] and [PaymentDetails]
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+pub struct PendingPayment {
+    pub id: String,
+    /// Epoch time, in seconds
+    pub payment_time: i64,
+    pub amount_msat: u64,
+    pub fee_msat: u64,
+    pub description: Option<String>,
+    pub details: PaymentDetails,
 }
 
 /// Represents a payments external information.
@@ -844,7 +857,7 @@ pub struct SendSpontaneousPaymentRequest {
 /// Represents a send payment response.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SendPaymentResponse {
-    pub payment: Payment,
+    pub payment: PaymentListItem,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -883,7 +896,7 @@ pub trait SupportAPI: Send + Sync {
     async fn report_payment_failure(
         &self,
         node_state: NodeState,
-        payment: Payment,
+        payment: PaymentListItem,
         lsp_id: Option<String>,
         comment: Option<String>,
     ) -> SdkResult<()>;

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,7 +1,7 @@
 use crate::{
     invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
-    NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
-    RouteHintHop, SyncResponse, TlvEntry,
+    NodeCredentials, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
+    RouteHintHop, SyncResponse, TlvEntry, PendingPayment,
 };
 use anyhow::Result;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
@@ -68,13 +68,13 @@ pub trait NodeAPI: Send + Sync {
         balance_changed: bool,
     ) -> NodeResult<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_msat` is only needed when the invoice doesn't specify an amount
-    async fn send_payment(&self, bolt11: String, amount_msat: Option<u64>) -> NodeResult<Payment>;
+    async fn send_payment(&self, bolt11: String, amount_msat: Option<u64>) -> NodeResult<PendingPayment>;
     async fn send_spontaneous_payment(
         &self,
         node_id: String,
         amount_msat: u64,
         extra_tlvs: Option<Vec<TlvEntry>>,
-    ) -> NodeResult<Payment>;
+    ) -> NodeResult<PendingPayment>;
     async fn start(&self) -> NodeResult<String>;
 
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain

--- a/libs/sdk-core/src/support.rs
+++ b/libs/sdk-core/src/support.rs
@@ -3,7 +3,9 @@ use std::time::SystemTime;
 use crate::error::SdkResult;
 use crate::grpc::{BreezStatusRequest, ReportPaymentFailureRequest};
 use crate::{breez_services::BreezServer, error::SdkError};
-use crate::{HealthCheckStatus, NodeState, Payment, ServiceHealthCheckResponse, SupportAPI};
+use crate::{
+    HealthCheckStatus, NodeState, PaymentListItem, ServiceHealthCheckResponse, SupportAPI,
+};
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -12,7 +14,7 @@ use tonic::Request;
 #[derive(Serialize, Deserialize)]
 struct PaymentFailureReport {
     pub node_state: NodeState,
-    pub payment: Payment,
+    pub payment: PaymentListItem,
 }
 
 impl TryFrom<i32> for HealthCheckStatus {
@@ -48,7 +50,7 @@ impl SupportAPI for BreezServer {
     async fn report_payment_failure(
         &self,
         node_state: NodeState,
-        payment: Payment,
+        payment: PaymentListItem,
         lsp_id: Option<String>,
         comment: Option<String>,
     ) -> SdkResult<()> {

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -850,7 +850,7 @@ mod tests {
 
         // add a payment with the same hash and test that the swapper updates the paid_amount for
         // the swap.
-        let payment = Payment {
+        let payment = PaymentListItem {
             id: hex::encode(swap_info.payment_hash.clone()),
             payment_type: PaymentType::Received,
             payment_time: 0,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -33,14 +33,14 @@ use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentNotificationResponse, RegisterPaymentReply};
 use crate::invoice::{InvoiceError, InvoiceResult};
 use crate::lsp::LspInformation;
-use crate::models::{FiatAPI, LspAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse, TlvEntry};
+use crate::models::{FiatAPI, LspAPI, NodeState, PaymentListItem, Swap, SwapperAPI, SyncResponse, TlvEntry};
 use crate::moonpay::MoonPayApi;
 use crate::node_api::{NodeAPI, NodeError, NodeResult};
 use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
     parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
-    PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHint, RouteHintHop,
+    PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHint, RouteHintHop, PendingPayment
 };
 use crate::{OpeningFeeParams, OpeningFeeParamsMenu};
 use crate::{ReceivePaymentRequest, SwapInfo};
@@ -218,10 +218,10 @@ impl ChainService for MockChainService {
     }
 }
 
-impl TryFrom<Payment> for crate::models::PaymentResponse {
+impl TryFrom<PendingPayment> for crate::models::PaymentResponse {
     type Error = anyhow::Error;
 
-    fn try_from(payment: Payment) -> std::result::Result<Self, Self::Error> {
+    fn try_from(payment: PendingPayment) -> std::result::Result<Self, Self::Error> {
         let payment_hash: String = match payment.details.clone() {
             crate::models::PaymentDetails::Ln { data } => data.payment_hash,
             _ => "".into(),
@@ -308,7 +308,8 @@ impl NodeAPI for MockNodeAPI {
                 .await
                 .iter()
                 .cloned()
-                .flat_map(TryInto::try_into)
+                .flat_map(|gl_payment| {
+                })
                 .collect(),
             channels: Vec::new(),
         })
@@ -318,8 +319,8 @@ impl NodeAPI for MockNodeAPI {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
-    async fn send_payment(&self, bolt11: String, _amount_msat: Option<u64>) -> NodeResult<Payment> {
-        let payment = self.add_dummy_payment_for(bolt11, None, None).await?;
+    async fn send_payment(&self, bolt11: String, _amount_msat: Option<u64>) -> NodeResult<PendingPayment> {
+        let payment: PendingPayment = self.add_dummy_payment_for(bolt11, None, None).await?.into();
         Ok(payment)
     }
 
@@ -328,8 +329,8 @@ impl NodeAPI for MockNodeAPI {
         _node_id: String,
         _amount_msat: u64,
         _extra_tlvs: Option<Vec<TlvEntry>>,
-    ) -> NodeResult<Payment> {
-        let payment = self.add_dummy_payment_rand().await?;
+    ) -> NodeResult<PendingPayment> {
+        let payment: PendingPayment = self.add_dummy_payment_rand().await?.into();
         Ok(payment)
     }
 
@@ -451,7 +452,7 @@ impl MockNodeAPI {
         bolt11: String,
         preimage: Option<sha256::Hash>,
         status: Option<PayStatus>,
-    ) -> NodeResult<Payment> {
+    ) -> NodeResult<PaymentListItem> {
         let inv = bolt11
             .parse::<lightning_invoice::Bolt11Invoice>()
             .map_err(|e| NodeError::Generic(anyhow::Error::new(e)))?;
@@ -460,7 +461,7 @@ impl MockNodeAPI {
     }
 
     /// Adds a dummy payment with random attributes.
-    pub(crate) async fn add_dummy_payment_rand(&self) -> NodeResult<Payment> {
+    pub(crate) async fn add_dummy_payment_rand(&self) -> NodeResult<PaymentListItem> {
         let preimage = sha256::Hash::hash(&rand_vec_u8(10));
         let inv = rand_invoice_with_description_hash_and_preimage("test".into(), preimage)?;
 
@@ -473,7 +474,7 @@ impl MockNodeAPI {
         inv: lightning_invoice::Bolt11Invoice,
         preimage: Option<sha256::Hash>,
         status: Option<PayStatus>,
-    ) -> NodeResult<Payment> {
+    ) -> NodeResult<PaymentListItem> {
         let gl_payment = gl_client::signer::model::greenlight::Payment {
             payment_hash: hex::decode(inv.payment_hash().to_hex())?,
             bolt11: inv.to_string(),
@@ -505,7 +506,7 @@ impl MockNodeAPI {
     async fn save_payment_for_future_sync_updates(
         &self,
         gl_payment: gl_client::signer::model::greenlight::Payment,
-    ) -> NodeResult<Payment> {
+    ) -> NodeResult<PaymentListItem> {
         let mut cloud_payments = self.cloud_payments.lock().await;
 
         // Only store it if a payment with the same ID doesn't already exist
@@ -529,7 +530,9 @@ impl MockNodeAPI {
             }
         };
 
-        gl_payment.try_into()
+        let payment_status = gl_payment.status().into();
+        let pending_payment: PendingPayment = gl_payment.try_into()?;
+        Ok(pending_payment.to_persisted(payment_status, None))
     }
 
     pub fn set_on_send_custom_message(

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -354,7 +354,7 @@ mixin _$BreezEvent {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -366,7 +366,7 @@ mixin _$BreezEvent {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -378,7 +378,7 @@ mixin _$BreezEvent {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -508,7 +508,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -523,7 +523,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -538,7 +538,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -677,7 +677,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -692,7 +692,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -707,7 +707,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -820,7 +820,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -835,7 +835,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -850,7 +850,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -923,7 +923,7 @@ abstract class _$$BreezEvent_PaymentSucceedImplCopyWith<$Res> {
           _$BreezEvent_PaymentSucceedImpl value, $Res Function(_$BreezEvent_PaymentSucceedImpl) then) =
       __$$BreezEvent_PaymentSucceedImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({Payment details});
+  $Res call({PendingPayment details});
 }
 
 /// @nodoc
@@ -943,7 +943,7 @@ class __$$BreezEvent_PaymentSucceedImplCopyWithImpl<$Res>
       details: null == details
           ? _value.details
           : details // ignore: cast_nullable_to_non_nullable
-              as Payment,
+              as PendingPayment,
     ));
   }
 }
@@ -954,7 +954,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
   const _$BreezEvent_PaymentSucceedImpl({required this.details});
 
   @override
-  final Payment details;
+  final PendingPayment details;
 
   @override
   String toString() {
@@ -984,7 +984,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -999,7 +999,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -1014,7 +1014,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -1078,9 +1078,10 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
 }
 
 abstract class BreezEvent_PaymentSucceed implements BreezEvent {
-  const factory BreezEvent_PaymentSucceed({required final Payment details}) = _$BreezEvent_PaymentSucceedImpl;
+  const factory BreezEvent_PaymentSucceed({required final PendingPayment details}) =
+      _$BreezEvent_PaymentSucceedImpl;
 
-  Payment get details;
+  PendingPayment get details;
   @JsonKey(ignore: true)
   _$$BreezEvent_PaymentSucceedImplCopyWith<_$BreezEvent_PaymentSucceedImpl> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1153,7 +1154,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -1168,7 +1169,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -1183,7 +1184,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -1297,7 +1298,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -1312,7 +1313,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -1327,7 +1328,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -1435,7 +1436,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -1450,7 +1451,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -1465,7 +1466,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
@@ -1599,7 +1600,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
-    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PendingPayment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
@@ -1614,7 +1615,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
-    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PendingPayment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
@@ -1629,7 +1630,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
-    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PendingPayment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -641,7 +641,14 @@ fun asInvoicePaidDetails(invoicePaidDetails: ReadableMap): InvoicePaidDetails? {
     }
     val paymentHash = invoicePaidDetails.getString("paymentHash")!!
     val bolt11 = invoicePaidDetails.getString("bolt11")!!
-    val payment = if (hasNonNullKey(invoicePaidDetails, "payment")) invoicePaidDetails.getMap("payment")?.let { asPayment(it) } else null
+    val payment =
+        if (hasNonNullKey(invoicePaidDetails, "payment")) {
+            invoicePaidDetails.getMap("payment")?.let {
+                asPaymentListItem(it)
+            }
+        } else {
+            null
+        }
     return InvoicePaidDetails(
         paymentHash,
         bolt11,
@@ -1880,72 +1887,6 @@ fun asOpeningFeeParamsMenuList(arr: ReadableArray): List<OpeningFeeParamsMenu> {
     return list
 }
 
-fun asPayment(payment: ReadableMap): Payment? {
-    if (!validateMandatoryFields(
-            payment,
-            arrayOf(
-                "id",
-                "paymentType",
-                "paymentTime",
-                "amountMsat",
-                "feeMsat",
-                "status",
-                "details",
-            ),
-        )
-    ) {
-        return null
-    }
-    val id = payment.getString("id")!!
-    val paymentType = payment.getString("paymentType")?.let { asPaymentType(it) }!!
-    val paymentTime = payment.getDouble("paymentTime").toLong()
-    val amountMsat = payment.getDouble("amountMsat").toULong()
-    val feeMsat = payment.getDouble("feeMsat").toULong()
-    val status = payment.getString("status")?.let { asPaymentStatus(it) }!!
-    val error = if (hasNonNullKey(payment, "error")) payment.getString("error") else null
-    val description = if (hasNonNullKey(payment, "description")) payment.getString("description") else null
-    val details = payment.getMap("details")?.let { asPaymentDetails(it) }!!
-    val metadata = if (hasNonNullKey(payment, "metadata")) payment.getString("metadata") else null
-    return Payment(
-        id,
-        paymentType,
-        paymentTime,
-        amountMsat,
-        feeMsat,
-        status,
-        error,
-        description,
-        details,
-        metadata,
-    )
-}
-
-fun readableMapOf(payment: Payment): ReadableMap {
-    return readableMapOf(
-        "id" to payment.id,
-        "paymentType" to payment.paymentType.name.lowercase(),
-        "paymentTime" to payment.paymentTime,
-        "amountMsat" to payment.amountMsat,
-        "feeMsat" to payment.feeMsat,
-        "status" to payment.status.name.lowercase(),
-        "error" to payment.error,
-        "description" to payment.description,
-        "details" to readableMapOf(payment.details),
-        "metadata" to payment.metadata,
-    )
-}
-
-fun asPaymentList(arr: ReadableArray): List<Payment> {
-    val list = ArrayList<Payment>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asPayment(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
 fun asPaymentFailedData(paymentFailedData: ReadableMap): PaymentFailedData? {
     if (!validateMandatoryFields(
             paymentFailedData,
@@ -1980,6 +1921,124 @@ fun asPaymentFailedDataList(arr: ReadableArray): List<PaymentFailedData> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asPaymentFailedData(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
+fun asPaymentListItem(paymentListItem: ReadableMap): PaymentListItem? {
+    if (!validateMandatoryFields(
+            paymentListItem,
+            arrayOf(
+                "id",
+                "paymentType",
+                "paymentTime",
+                "amountMsat",
+                "feeMsat",
+                "status",
+                "details",
+            ),
+        )
+    ) {
+        return null
+    }
+    val id = paymentListItem.getString("id")!!
+    val paymentType = paymentListItem.getString("paymentType")?.let { asPaymentType(it) }!!
+    val paymentTime = paymentListItem.getDouble("paymentTime").toLong()
+    val amountMsat = paymentListItem.getDouble("amountMsat").toULong()
+    val feeMsat = paymentListItem.getDouble("feeMsat").toULong()
+    val status = paymentListItem.getString("status")?.let { asPaymentStatus(it) }!!
+    val error = if (hasNonNullKey(paymentListItem, "error")) paymentListItem.getString("error") else null
+    val description = if (hasNonNullKey(paymentListItem, "description")) paymentListItem.getString("description") else null
+    val details = paymentListItem.getMap("details")?.let { asPaymentDetails(it) }!!
+    val metadata = if (hasNonNullKey(paymentListItem, "metadata")) paymentListItem.getString("metadata") else null
+    return PaymentListItem(
+        id,
+        paymentType,
+        paymentTime,
+        amountMsat,
+        feeMsat,
+        status,
+        error,
+        description,
+        details,
+        metadata,
+    )
+}
+
+fun readableMapOf(paymentListItem: PaymentListItem): ReadableMap {
+    return readableMapOf(
+        "id" to paymentListItem.id,
+        "paymentType" to paymentListItem.paymentType.name.lowercase(),
+        "paymentTime" to paymentListItem.paymentTime,
+        "amountMsat" to paymentListItem.amountMsat,
+        "feeMsat" to paymentListItem.feeMsat,
+        "status" to paymentListItem.status.name.lowercase(),
+        "error" to paymentListItem.error,
+        "description" to paymentListItem.description,
+        "details" to readableMapOf(paymentListItem.details),
+        "metadata" to paymentListItem.metadata,
+    )
+}
+
+fun asPaymentListItemList(arr: ReadableArray): List<PaymentListItem> {
+    val list = ArrayList<PaymentListItem>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asPaymentListItem(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
+fun asPendingPayment(pendingPayment: ReadableMap): PendingPayment? {
+    if (!validateMandatoryFields(
+            pendingPayment,
+            arrayOf(
+                "id",
+                "paymentTime",
+                "amountMsat",
+                "feeMsat",
+                "details",
+            ),
+        )
+    ) {
+        return null
+    }
+    val id = pendingPayment.getString("id")!!
+    val paymentTime = pendingPayment.getDouble("paymentTime").toLong()
+    val amountMsat = pendingPayment.getDouble("amountMsat").toULong()
+    val feeMsat = pendingPayment.getDouble("feeMsat").toULong()
+    val description = if (hasNonNullKey(pendingPayment, "description")) pendingPayment.getString("description") else null
+    val details = pendingPayment.getMap("details")?.let { asPaymentDetails(it) }!!
+    return PendingPayment(
+        id,
+        paymentTime,
+        amountMsat,
+        feeMsat,
+        description,
+        details,
+    )
+}
+
+fun readableMapOf(pendingPayment: PendingPayment): ReadableMap {
+    return readableMapOf(
+        "id" to pendingPayment.id,
+        "paymentTime" to pendingPayment.paymentTime,
+        "amountMsat" to pendingPayment.amountMsat,
+        "feeMsat" to pendingPayment.feeMsat,
+        "description" to pendingPayment.description,
+        "details" to readableMapOf(pendingPayment.details),
+    )
+}
+
+fun asPendingPaymentList(arr: ReadableArray): List<PendingPayment> {
+    val list = ArrayList<PendingPayment>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asPendingPayment(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }
@@ -2952,7 +3011,7 @@ fun asSendPaymentResponse(sendPaymentResponse: ReadableMap): SendPaymentResponse
     ) {
         return null
     }
-    val payment = sendPaymentResponse.getMap("payment")?.let { asPayment(it) }!!
+    val payment = sendPaymentResponse.getMap("payment")?.let { asPaymentListItem(it) }!!
     return SendPaymentResponse(
         payment,
     )
@@ -3531,7 +3590,7 @@ fun asBreezEvent(breezEvent: ReadableMap): BreezEvent? {
         return BreezEvent.Synced
     }
     if (type == "paymentSucceed") {
-        return BreezEvent.PaymentSucceed(breezEvent.getMap("details")?.let { asPayment(it) }!!)
+        return BreezEvent.PaymentSucceed(breezEvent.getMap("details")?.let { asPendingPayment(it) }!!)
     }
     if (type == "paymentFailed") {
         return BreezEvent.PaymentFailed(breezEvent.getMap("details")?.let { asPaymentFailedData(it) }!!)
@@ -4174,7 +4233,7 @@ fun pushToArray(
         is LspInformation -> array.pushMap(readableMapOf(value))
         is MetadataFilter -> array.pushMap(readableMapOf(value))
         is OpeningFeeParams -> array.pushMap(readableMapOf(value))
-        is Payment -> array.pushMap(readableMapOf(value))
+        is PaymentListItem -> array.pushMap(readableMapOf(value))
         is PaymentTypeFilter -> array.pushString(value.name.lowercase())
         is Rate -> array.pushMap(readableMapOf(value))
         is ReverseSwapInfo -> array.pushMap(readableMapOf(value))

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -109,10 +109,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         executor.execute {
             try {
                 val envTypeTmp = asEnvironmentType(envType)
-                val nodeConfigTmp =
-                    asNodeConfig(
-                        nodeConfig,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("nodeConfig", "NodeConfig")) }
+                val nodeConfigTmp = asNodeConfig(nodeConfig) ?: run { throw SdkException.Generic(errMissingMandatoryField("nodeConfig", "NodeConfig")) }
                 val res = defaultConfig(envTypeTmp, apiKey, nodeConfigTmp)
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
 
@@ -258,10 +255,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val lnUrlPayRequest =
-                    asLnUrlPayRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "LnUrlPayRequest")) }
+                val lnUrlPayRequest = asLnUrlPayRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "LnUrlPayRequest")) }
                 val res = getBreezServices().payLnurl(lnUrlPayRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -315,10 +309,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val reqTmp =
-                    asReportIssueRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ReportIssueRequest")) }
+                val reqTmp = asReportIssueRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ReportIssueRequest")) }
                 getBreezServices().reportIssue(reqTmp)
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
@@ -687,10 +678,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val refundRequest =
-                    asRefundRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "RefundRequest")) }
+                val refundRequest = asRefundRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "RefundRequest")) }
                 val res = getBreezServices().refund(refundRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -819,10 +807,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val buyBitcoinRequest =
-                    asBuyBitcoinRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "BuyBitcoinRequest")) }
+                val buyBitcoinRequest = asBuyBitcoinRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "BuyBitcoinRequest")) }
                 val res = getBreezServices().buyBitcoin(buyBitcoinRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -685,9 +685,9 @@ enum BreezSDKMapper {
         guard let bolt11 = invoicePaidDetails["bolt11"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "InvoicePaidDetails"))
         }
-        var payment: Payment?
+        var payment: PaymentListItem?
         if let paymentTmp = invoicePaidDetails["payment"] as? [String: Any?] {
-            payment = try asPayment(payment: paymentTmp)
+            payment = try asPaymentListItem(paymentListItem: paymentTmp)
         }
 
         return InvoicePaidDetails(
@@ -701,7 +701,7 @@ enum BreezSDKMapper {
         return [
             "paymentHash": invoicePaidDetails.paymentHash,
             "bolt11": invoicePaidDetails.bolt11,
-            "payment": invoicePaidDetails.payment == nil ? nil : dictionaryOf(payment: invoicePaidDetails.payment!),
+            "payment": invoicePaidDetails.payment == nil ? nil : dictionaryOf(paymentListItem: invoicePaidDetails.payment!),
         ]
     }
 
@@ -2073,102 +2073,6 @@ enum BreezSDKMapper {
         return openingFeeParamsMenuList.map { v -> [String: Any?] in dictionaryOf(openingFeeParamsMenu: v) }
     }
 
-    static func asPayment(payment: [String: Any?]) throws -> Payment {
-        guard let id = payment["id"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "Payment"))
-        }
-        guard let paymentTypeTmp = payment["paymentType"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentType", typeName: "Payment"))
-        }
-        let paymentType = try asPaymentType(paymentType: paymentTypeTmp)
-
-        guard let paymentTime = payment["paymentTime"] as? Int64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTime", typeName: "Payment"))
-        }
-        guard let amountMsat = payment["amountMsat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "Payment"))
-        }
-        guard let feeMsat = payment["feeMsat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeMsat", typeName: "Payment"))
-        }
-        guard let statusTmp = payment["status"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "Payment"))
-        }
-        let status = try asPaymentStatus(paymentStatus: statusTmp)
-
-        var error: String?
-        if hasNonNilKey(data: payment, key: "error") {
-            guard let errorTmp = payment["error"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "error"))
-            }
-            error = errorTmp
-        }
-        var description: String?
-        if hasNonNilKey(data: payment, key: "description") {
-            guard let descriptionTmp = payment["description"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "description"))
-            }
-            description = descriptionTmp
-        }
-        guard let detailsTmp = payment["details"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "Payment"))
-        }
-        let details = try asPaymentDetails(paymentDetails: detailsTmp)
-
-        var metadata: String?
-        if hasNonNilKey(data: payment, key: "metadata") {
-            guard let metadataTmp = payment["metadata"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "metadata"))
-            }
-            metadata = metadataTmp
-        }
-
-        return Payment(
-            id: id,
-            paymentType: paymentType,
-            paymentTime: paymentTime,
-            amountMsat: amountMsat,
-            feeMsat: feeMsat,
-            status: status,
-            error: error,
-            description: description,
-            details: details,
-            metadata: metadata
-        )
-    }
-
-    static func dictionaryOf(payment: Payment) -> [String: Any?] {
-        return [
-            "id": payment.id,
-            "paymentType": valueOf(paymentType: payment.paymentType),
-            "paymentTime": payment.paymentTime,
-            "amountMsat": payment.amountMsat,
-            "feeMsat": payment.feeMsat,
-            "status": valueOf(paymentStatus: payment.status),
-            "error": payment.error == nil ? nil : payment.error,
-            "description": payment.description == nil ? nil : payment.description,
-            "details": dictionaryOf(paymentDetails: payment.details),
-            "metadata": payment.metadata == nil ? nil : payment.metadata,
-        ]
-    }
-
-    static func asPaymentList(arr: [Any]) throws -> [Payment] {
-        var list = [Payment]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var payment = try asPayment(payment: val)
-                list.append(payment)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Payment"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(paymentList: [Payment]) -> [Any] {
-        return paymentList.map { v -> [String: Any?] in dictionaryOf(payment: v) }
-    }
-
     static func asPaymentFailedData(paymentFailedData: [String: Any?]) throws -> PaymentFailedData {
         guard let error = paymentFailedData["error"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "error", typeName: "PaymentFailedData"))
@@ -2211,6 +2115,165 @@ enum BreezSDKMapper {
 
     static func arrayOf(paymentFailedDataList: [PaymentFailedData]) -> [Any] {
         return paymentFailedDataList.map { v -> [String: Any?] in dictionaryOf(paymentFailedData: v) }
+    }
+
+    static func asPaymentListItem(paymentListItem: [String: Any?]) throws -> PaymentListItem {
+        guard let id = paymentListItem["id"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "PaymentListItem"))
+        }
+        guard let paymentTypeTmp = paymentListItem["paymentType"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentType", typeName: "PaymentListItem"))
+        }
+        let paymentType = try asPaymentType(paymentType: paymentTypeTmp)
+
+        guard let paymentTime = paymentListItem["paymentTime"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTime", typeName: "PaymentListItem"))
+        }
+        guard let amountMsat = paymentListItem["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "PaymentListItem"))
+        }
+        guard let feeMsat = paymentListItem["feeMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeMsat", typeName: "PaymentListItem"))
+        }
+        guard let statusTmp = paymentListItem["status"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "PaymentListItem"))
+        }
+        let status = try asPaymentStatus(paymentStatus: statusTmp)
+
+        var error: String?
+        if hasNonNilKey(data: paymentListItem, key: "error") {
+            guard let errorTmp = paymentListItem["error"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "error"))
+            }
+            error = errorTmp
+        }
+        var description: String?
+        if hasNonNilKey(data: paymentListItem, key: "description") {
+            guard let descriptionTmp = paymentListItem["description"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "description"))
+            }
+            description = descriptionTmp
+        }
+        guard let detailsTmp = paymentListItem["details"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "PaymentListItem"))
+        }
+        let details = try asPaymentDetails(paymentDetails: detailsTmp)
+
+        var metadata: String?
+        if hasNonNilKey(data: paymentListItem, key: "metadata") {
+            guard let metadataTmp = paymentListItem["metadata"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "metadata"))
+            }
+            metadata = metadataTmp
+        }
+
+        return PaymentListItem(
+            id: id,
+            paymentType: paymentType,
+            paymentTime: paymentTime,
+            amountMsat: amountMsat,
+            feeMsat: feeMsat,
+            status: status,
+            error: error,
+            description: description,
+            details: details,
+            metadata: metadata
+        )
+    }
+
+    static func dictionaryOf(paymentListItem: PaymentListItem) -> [String: Any?] {
+        return [
+            "id": paymentListItem.id,
+            "paymentType": valueOf(paymentType: paymentListItem.paymentType),
+            "paymentTime": paymentListItem.paymentTime,
+            "amountMsat": paymentListItem.amountMsat,
+            "feeMsat": paymentListItem.feeMsat,
+            "status": valueOf(paymentStatus: paymentListItem.status),
+            "error": paymentListItem.error == nil ? nil : paymentListItem.error,
+            "description": paymentListItem.description == nil ? nil : paymentListItem.description,
+            "details": dictionaryOf(paymentDetails: paymentListItem.details),
+            "metadata": paymentListItem.metadata == nil ? nil : paymentListItem.metadata,
+        ]
+    }
+
+    static func asPaymentListItemList(arr: [Any]) throws -> [PaymentListItem] {
+        var list = [PaymentListItem]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var paymentListItem = try asPaymentListItem(paymentListItem: val)
+                list.append(paymentListItem)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentListItem"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(paymentListItemList: [PaymentListItem]) -> [Any] {
+        return paymentListItemList.map { v -> [String: Any?] in dictionaryOf(paymentListItem: v) }
+    }
+
+    static func asPendingPayment(pendingPayment: [String: Any?]) throws -> PendingPayment {
+        guard let id = pendingPayment["id"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "PendingPayment"))
+        }
+        guard let paymentTime = pendingPayment["paymentTime"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTime", typeName: "PendingPayment"))
+        }
+        guard let amountMsat = pendingPayment["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "PendingPayment"))
+        }
+        guard let feeMsat = pendingPayment["feeMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeMsat", typeName: "PendingPayment"))
+        }
+        var description: String?
+        if hasNonNilKey(data: pendingPayment, key: "description") {
+            guard let descriptionTmp = pendingPayment["description"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "description"))
+            }
+            description = descriptionTmp
+        }
+        guard let detailsTmp = pendingPayment["details"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "PendingPayment"))
+        }
+        let details = try asPaymentDetails(paymentDetails: detailsTmp)
+
+        return PendingPayment(
+            id: id,
+            paymentTime: paymentTime,
+            amountMsat: amountMsat,
+            feeMsat: feeMsat,
+            description: description,
+            details: details
+        )
+    }
+
+    static func dictionaryOf(pendingPayment: PendingPayment) -> [String: Any?] {
+        return [
+            "id": pendingPayment.id,
+            "paymentTime": pendingPayment.paymentTime,
+            "amountMsat": pendingPayment.amountMsat,
+            "feeMsat": pendingPayment.feeMsat,
+            "description": pendingPayment.description == nil ? nil : pendingPayment.description,
+            "details": dictionaryOf(paymentDetails: pendingPayment.details),
+        ]
+    }
+
+    static func asPendingPaymentList(arr: [Any]) throws -> [PendingPayment] {
+        var list = [PendingPayment]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var pendingPayment = try asPendingPayment(pendingPayment: val)
+                list.append(pendingPayment)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PendingPayment"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(pendingPaymentList: [PendingPayment]) -> [Any] {
+        return pendingPaymentList.map { v -> [String: Any?] in dictionaryOf(pendingPayment: v) }
     }
 
     static func asPrepareRedeemOnchainFundsRequest(prepareRedeemOnchainFundsRequest: [String: Any?]) throws -> PrepareRedeemOnchainFundsRequest {
@@ -3214,7 +3277,7 @@ enum BreezSDKMapper {
         guard let paymentTmp = sendPaymentResponse["payment"] as? [String: Any?] else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "SendPaymentResponse"))
         }
-        let payment = try asPayment(payment: paymentTmp)
+        let payment = try asPaymentListItem(paymentListItem: paymentTmp)
 
         return SendPaymentResponse(
             payment: payment)
@@ -3222,7 +3285,7 @@ enum BreezSDKMapper {
 
     static func dictionaryOf(sendPaymentResponse: SendPaymentResponse) -> [String: Any?] {
         return [
-            "payment": dictionaryOf(payment: sendPaymentResponse.payment),
+            "payment": dictionaryOf(paymentListItem: sendPaymentResponse.payment),
         ]
     }
 
@@ -3869,7 +3932,7 @@ enum BreezSDKMapper {
             guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
             }
-            let _details = try asPayment(payment: detailsTmp)
+            let _details = try asPendingPayment(pendingPayment: detailsTmp)
 
             return BreezEvent.paymentSucceed(details: _details)
         }
@@ -3927,7 +3990,7 @@ enum BreezSDKMapper {
         ):
             return [
                 "type": "paymentSucceed",
-                "details": dictionaryOf(payment: details),
+                "details": dictionaryOf(pendingPayment: details),
             ]
 
         case let .paymentFailed(

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -299,7 +299,7 @@ class RNBreezSDK: RCTEventEmitter {
         do {
             let listPaymentsRequest = try BreezSDKMapper.asListPaymentsRequest(listPaymentsRequest: req)
             var res = try getBreezServices().listPayments(req: listPaymentsRequest)
-            resolve(BreezSDKMapper.arrayOf(paymentList: res))
+            resolve(BreezSDKMapper.arrayOf(paymentListItemList: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
@@ -310,7 +310,7 @@ class RNBreezSDK: RCTEventEmitter {
         do {
             var res = try getBreezServices().paymentByHash(hash: hash)
             if res != nil {
-                resolve(BreezSDKMapper.dictionaryOf(payment: res!))
+                resolve(BreezSDKMapper.dictionaryOf(paymentListItem: res!))
             } else {
                 resolve(nil)
             }

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -109,7 +109,7 @@ export type GreenlightNodeConfig = {
 export type InvoicePaidDetails = {
     paymentHash: string
     bolt11: string
-    payment?: Payment
+    payment?: PaymentListItem
 }
 
 export type LnInvoice = {
@@ -296,7 +296,13 @@ export type OpeningFeeParamsMenu = {
     values: OpeningFeeParams[]
 }
 
-export type Payment = {
+export type PaymentFailedData = {
+    error: string
+    nodeId: string
+    invoice?: LnInvoice
+}
+
+export type PaymentListItem = {
     id: string
     paymentType: PaymentType
     paymentTime: number
@@ -309,10 +315,13 @@ export type Payment = {
     metadata?: string
 }
 
-export type PaymentFailedData = {
-    error: string
-    nodeId: string
-    invoice?: LnInvoice
+export type PendingPayment = {
+    id: string
+    paymentTime: number
+    amountMsat: number
+    feeMsat: number
+    description?: string
+    details: PaymentDetails
 }
 
 export type PrepareRedeemOnchainFundsRequest = {
@@ -447,7 +456,7 @@ export type SendPaymentRequest = {
 }
 
 export type SendPaymentResponse = {
-    payment: Payment
+    payment: PaymentListItem
 }
 
 export type SendSpontaneousPaymentRequest = {
@@ -559,7 +568,7 @@ export type BreezEvent = {
     type: BreezEventVariant.SYNCED
 } | {
     type: BreezEventVariant.PAYMENT_SUCCEED,
-    details: Payment
+    details: PendingPayment
 } | {
     type: BreezEventVariant.PAYMENT_FAILED,
     details: PaymentFailedData
@@ -886,12 +895,12 @@ export const backup = async (): Promise<void> => {
     await BreezSDK.backup()
 }
 
-export const listPayments = async (req: ListPaymentsRequest): Promise<Payment[]> => {
+export const listPayments = async (req: ListPaymentsRequest): Promise<PaymentListItem[]> => {
     const response = await BreezSDK.listPayments(req)
     return response
 }
 
-export const paymentByHash = async (hash: string): Promise<Payment | null> => {
+export const paymentByHash = async (hash: string): Promise<PaymentListItem | null> => {
     const response = await BreezSDK.paymentByHash(hash)
     return response
 }


### PR DESCRIPTION
Fixes #563.
_Note:_ I understand that `PendingPayment` could cause some confusion given that a `PaymentListItem` can also have "pending" as status (meaning that the two structs are identical/repetitive), though there are instances in which the distinction between the two is clear enough to allow for this kind of naming. I'm open to suggestions, though.