### PR TITLE
Rescan swaps

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -737,6 +737,12 @@ impl BreezServices {
         Ok(None)
     }
 
+    pub async fn rescan_swaps(&self) -> SdkResult<()> {
+        let tip = self.chain_service.current_tip().await?;
+        self.btc_receive_swapper.rescan_swaps(tip).await?;
+        Ok(())
+    }
+
     /// Lookup the reverse swap fees (see [ReverseSwapServiceAPI::fetch_reverse_swap_fees]).
     ///
     /// To get the total estimated fees for a specific amount, specify the amount to be sent in

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1277,10 +1277,7 @@ impl SwapInfo {
     }
 
     pub(crate) fn redeemable(&self) -> bool {
-        self.unconfirmed_sats == 0
-            && self.confirmed_sats > 0
-            && self.paid_sats == 0
-            && self.status != SwapStatus::Expired
+        self.confirmed_sats > 0 && self.paid_sats == 0 && self.status != SwapStatus::Expired
     }
 
     pub(crate) fn refundable(&self) -> bool {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -346,6 +346,10 @@ pub(crate) async fn handle_command(
         Commands::ListRefundables {} => {
             serde_json::to_string_pretty(&sdk()?.list_refundables().await?).map_err(|e| e.into())
         }
+        Commands::RescanSwaps {} => {
+            sdk()?.rescan_swaps().await?;
+            Ok("Rescan completed successfully".to_string())
+        }
         Commands::PrepareRefund {
             swap_address,
             to_address,

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -229,6 +229,9 @@ pub(crate) enum Commands {
     /// List refundable swap addresses
     ListRefundables {},
 
+    /// Rescan all swaps
+    RescanSwaps {},
+
     /// Prepare a refund transaction for an incomplete swap
     PrepareRefund {
         swap_address: String,


### PR DESCRIPTION
Two changes here:
1. We no longer requires redeemable swaps to have no unconfirmed funds associated with swap address. If the swap address as confirmed sats and no lightning payment yet then it is redeemable. It allows users, in case of long waiting unconfirmed transaction, initiate another transaction (if the wallet doesn't support RBF) with higher fees.
2. New API added to rescan all swaps.

fixes https://github.com/breez/breez-sdk/issues/726