### PR TITLE
Allow setting of close_to_addr

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -176,6 +176,10 @@ dictionary NodeState {
     u64 inbound_liquidity_msats;    
 };
 
+dictionary SetNodeConfigRequest {
+    string? close_to_address;
+};
+
 dictionary SignMessageRequest {
     string message;
 };
@@ -741,6 +745,9 @@ interface BlockingBreezServices {
 
    [Throws=SdkError]
    void disconnect();
+
+   [Throws=SdkError]
+   void set_node_config(SetNodeConfigRequest req);
 
    [Throws=SendPaymentError]
    SendPaymentResponse send_payment(SendPaymentRequest req);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -21,9 +21,9 @@ use breez_sdk_core::{
     ReportIssueRequest, ReportPaymentFailureDetails, ReverseSwapFeesRequest, ReverseSwapInfo,
     ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop, SendOnchainRequest,
     SendOnchainResponse, SendPaymentRequest, SendPaymentResponse, SendSpontaneousPaymentRequest,
-    ServiceHealthCheckResponse, SignMessageRequest, SignMessageResponse, StaticBackupRequest,
-    StaticBackupResponse, SuccessActionProcessed, SwapInfo, SwapStatus, Symbol, TlvEntry,
-    UnspentTransactionOutput, UrlSuccessActionData,
+    ServiceHealthCheckResponse, SetNodeConfigRequest, SignMessageRequest, SignMessageResponse,
+    StaticBackupRequest, StaticBackupResponse, SuccessActionProcessed, SwapInfo, SwapStatus,
+    Symbol, TlvEntry, UnspentTransactionOutput, UrlSuccessActionData,
 };
 use log::{Level, LevelFilter, Metadata, Record};
 use once_cell::sync::{Lazy, OnceCell};
@@ -115,6 +115,10 @@ pub struct BlockingBreezServices {
 impl BlockingBreezServices {
     pub fn disconnect(&self) -> SdkResult<()> {
         rt().block_on(self.breez_services.disconnect())
+    }
+
+    pub fn set_node_config(&self, req: SetNodeConfigRequest) -> SdkResult<()> {
+        rt().block_on(self.breez_services.set_node_config(req))
     }
 
     pub fn send_payment(

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -41,8 +41,8 @@ use crate::{
     RedeemOnchainFundsRequest, RedeemOnchainFundsResponse, RefundRequest, RefundResponse,
     ReportIssueRequest, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
     SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
-    SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SignMessageRequest,
-    SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
+    SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SetNodeConfigRequest,
+    SignMessageRequest, SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
 };
 
 /*
@@ -106,6 +106,12 @@ pub fn node_info() -> Result<NodeState> {
             .node_info()
             .map_err(anyhow::Error::new::<SdkError>)
     })
+}
+
+/// See [BreezServices::set_node_config]
+pub fn set_node_config(req: SetNodeConfigRequest) -> Result<()> {
+    block_on(async { get_breez_services().await?.set_node_config(req).await })
+        .map_err(anyhow::Error::new::<SdkError>)
 }
 
 /// Cleanup node resources and stop the signer.

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -238,6 +238,13 @@ impl BreezServices {
         Ok(())
     }
 
+    /// Set the node config
+    ///
+    /// This calls [NodeAPI::set_node_config] to make changes to the active node's configuration.
+    pub async fn set_node_config(&self, req: SetNodeConfigRequest) -> SdkResult<()> {
+        Ok(self.node_api.set_node_config(req.close_to_address).await?)
+    }
+
     /// Pay a bolt11 invoice
     ///
     /// Calling `send_payment` ensures that the payment is not already completed, if so it will result in an error.

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -27,6 +27,11 @@ pub extern "C" fn wire_node_info(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_set_node_config(port_: i64, req: *mut wire_SetNodeConfigRequest) {
+    wire_set_node_config_impl(port_, req)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_disconnect(port_: i64) {
     wire_disconnect_impl(port_)
 }
@@ -419,6 +424,11 @@ pub extern "C" fn new_box_autoadd_send_spontaneous_payment_request_0(
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_set_node_config_request_0() -> *mut wire_SetNodeConfigRequest {
+    support::new_leak_box_ptr(wire_SetNodeConfigRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_sign_message_request_0() -> *mut wire_SignMessageRequest {
     support::new_leak_box_ptr(wire_SignMessageRequest::new_with_null_ptr())
 }
@@ -637,6 +647,12 @@ impl Wire2Api<SendSpontaneousPaymentRequest> for *mut wire_SendSpontaneousPaymen
     fn wire2api(self) -> SendSpontaneousPaymentRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<SendSpontaneousPaymentRequest>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<SetNodeConfigRequest> for *mut wire_SetNodeConfigRequest {
+    fn wire2api(self) -> SetNodeConfigRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<SetNodeConfigRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<SignMessageRequest> for *mut wire_SignMessageRequest {
@@ -959,6 +975,13 @@ impl Wire2Api<SendSpontaneousPaymentRequest> for wire_SendSpontaneousPaymentRequ
         }
     }
 }
+impl Wire2Api<SetNodeConfigRequest> for wire_SetNodeConfigRequest {
+    fn wire2api(self) -> SetNodeConfigRequest {
+        SetNodeConfigRequest {
+            close_to_address: self.close_to_address.wire2api(),
+        }
+    }
+}
 impl Wire2Api<SignMessageRequest> for wire_SignMessageRequest {
     fn wire2api(self) -> SignMessageRequest {
         SignMessageRequest {
@@ -1224,6 +1247,12 @@ pub struct wire_SendSpontaneousPaymentRequest {
     node_id: *mut wire_uint_8_list,
     amount_msat: u64,
     extra_tlvs: *mut wire_list_tlv_entry,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_SetNodeConfigRequest {
+    close_to_address: *mut wire_uint_8_list,
 }
 
 #[repr(C)]
@@ -1756,6 +1785,20 @@ impl NewWithNullPtr for wire_SendSpontaneousPaymentRequest {
 }
 
 impl Default for wire_SendSpontaneousPaymentRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_SetNodeConfigRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            close_to_address: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_SetNodeConfigRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -110,6 +110,7 @@ use crate::models::SendPaymentRequest;
 use crate::models::SendPaymentResponse;
 use crate::models::SendSpontaneousPaymentRequest;
 use crate::models::ServiceHealthCheckResponse;
+use crate::models::SetNodeConfigRequest;
 use crate::models::StaticBackupRequest;
 use crate::models::StaticBackupResponse;
 use crate::models::SwapInfo;
@@ -175,6 +176,22 @@ fn wire_node_info_impl(port_: MessagePort) {
             mode: FfiCallMode::Normal,
         },
         move || move |task_callback| node_info(),
+    )
+}
+fn wire_set_node_config_impl(
+    port_: MessagePort,
+    req: impl Wire2Api<SetNodeConfigRequest> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
+        WrapInfo {
+            debug_name: "set_node_config",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_req = req.wire2api();
+            move |task_callback| set_node_config(api_req)
+        },
     )
 }
 fn wire_disconnect_impl(port_: MessagePort) {

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -651,6 +651,19 @@ impl NodeAPI for Greenlight {
         .map(|credentials| NodeCredentials::Greenlight { credentials }))
     }
 
+    async fn set_node_config(&self, close_to_address: Option<String>) -> NodeResult<()> {
+        let mut client = self.get_client().await?;
+        if let Some(close_to_addr) = close_to_address {
+            client
+                .configure(gl_client::pb::GlConfig { close_to_addr })
+                .await
+                .map_err(|e| {
+                    NodeError::Generic(anyhow!("Unable to set close to address: {}", e))
+                })?;
+        }
+        Ok(())
+    }
+
     async fn create_invoice(
         &self,
         amount_msat: u64,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -556,6 +556,12 @@ impl From<Network> for bitcoin::network::constants::Network {
     }
 }
 
+/// Represents a set node config request.
+#[derive(Default)]
+pub struct SetNodeConfigRequest {
+    pub close_to_address: Option<String>,
+}
+
 /// Different types of supported filters which can be applied when retrieving the transaction list
 #[derive(PartialEq)]
 pub enum PaymentTypeFilter {

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,7 +1,7 @@
 use crate::{
     invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
-    NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
-    RouteHintHop, SyncResponse, TlvEntry,
+    NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest,
+    PrepareRedeemOnchainFundsResponse, RouteHintHop, SyncResponse, TlvEntry,
 };
 use anyhow::Result;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
@@ -53,6 +53,7 @@ pub enum NodeError {
 #[tonic::async_trait]
 pub trait NodeAPI: Send + Sync {
     fn node_credentials(&self) -> NodeResult<Option<NodeCredentials>>;
+    async fn set_node_config(&self, close_to_address: Option<String>) -> NodeResult<()>;
     async fn create_invoice(
         &self,
         amount_msat: u64,
@@ -89,8 +90,15 @@ pub trait NodeAPI: Send + Sync {
         max_hops: u32,
         last_hop: Option<&RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>>;
-    async fn redeem_onchain_funds(&self, to_address: String, sat_per_vbyte: u32) -> NodeResult<Vec<u8>>;
-    async fn prepare_redeem_onchain_funds(&self, req: PrepareRedeemOnchainFundsRequest) -> NodeResult<PrepareRedeemOnchainFundsResponse>;
+    async fn redeem_onchain_funds(
+        &self,
+        to_address: String,
+        sat_per_vbyte: u32,
+    ) -> NodeResult<Vec<u8>>;
+    async fn prepare_redeem_onchain_funds(
+        &self,
+        req: PrepareRedeemOnchainFundsRequest,
+    ) -> NodeResult<PrepareRedeemOnchainFundsResponse>;
     async fn start_signer(&self, shutdown: mpsc::Receiver<()>);
     async fn list_peers(&self) -> NodeResult<Vec<Peer>>;
     async fn connect_peer(&self, node_id: String, addr: String) -> NodeResult<()>;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -33,14 +33,17 @@ use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentNotificationResponse, RegisterPaymentReply};
 use crate::invoice::{InvoiceError, InvoiceResult};
 use crate::lsp::LspInformation;
-use crate::models::{FiatAPI, LspAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse, TlvEntry};
+use crate::models::{
+    FiatAPI, LspAPI, NodeState, Payment, Swap, SwapperAPI, SyncResponse, TlvEntry,
+};
 use crate::moonpay::MoonPayApi;
 use crate::node_api::{NodeAPI, NodeError, NodeResult};
 use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
     parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
-    PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHint, RouteHintHop,
+    PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
+    RouteHint, RouteHintHop, SetNodeConfigRequest,
 };
 use crate::{OpeningFeeParams, OpeningFeeParamsMenu};
 use crate::{ReceivePaymentRequest, SwapInfo};
@@ -282,6 +285,10 @@ impl NodeAPI for MockNodeAPI {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
+    async fn set_node_config(&self, _close_to_address: Option<String>) -> NodeResult<()> {
+        Ok(())
+    }
+
     async fn create_invoice(
         &self,
         amount_sats: u64,
@@ -337,11 +344,18 @@ impl NodeAPI for MockNodeAPI {
         Ok("".to_string())
     }
 
-    async fn redeem_onchain_funds(&self, _to_address: String, _sat_per_vbyte: u32) -> NodeResult<Vec<u8>> {
+    async fn redeem_onchain_funds(
+        &self,
+        _to_address: String,
+        _sat_per_vbyte: u32,
+    ) -> NodeResult<Vec<u8>> {
         Ok(rand_vec_u8(32))
     }
 
-    async fn prepare_redeem_onchain_funds(&self, _req: PrepareRedeemOnchainFundsRequest) -> NodeResult<PrepareRedeemOnchainFundsResponse> {
+    async fn prepare_redeem_onchain_funds(
+        &self,
+        _req: PrepareRedeemOnchainFundsRequest,
+    ) -> NodeResult<PrepareRedeemOnchainFundsResponse> {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -58,6 +58,10 @@ typedef struct wire_Config {
   struct wire_NodeConfig node_config;
 } wire_Config;
 
+typedef struct wire_SetNodeConfigRequest {
+  struct wire_uint_8_list *close_to_address;
+} wire_SetNodeConfigRequest;
+
 typedef struct wire_SignMessageRequest {
   struct wire_uint_8_list *message;
 } wire_SignMessageRequest;
@@ -261,6 +265,8 @@ void wire_node_credentials(int64_t port_);
 
 void wire_node_info(int64_t port_);
 
+void wire_set_node_config(int64_t port_, struct wire_SetNodeConfigRequest *req);
+
 void wire_disconnect(int64_t port_);
 
 void wire_sign_message(int64_t port_, struct wire_SignMessageRequest *req);
@@ -415,6 +421,8 @@ struct wire_SendPaymentRequest *new_box_autoadd_send_payment_request_0(void);
 
 struct wire_SendSpontaneousPaymentRequest *new_box_autoadd_send_spontaneous_payment_request_0(void);
 
+struct wire_SetNodeConfigRequest *new_box_autoadd_set_node_config_request_0(void);
+
 struct wire_SignMessageRequest *new_box_autoadd_sign_message_request_0(void);
 
 struct wire_StaticBackupRequest *new_box_autoadd_static_backup_request_0(void);
@@ -444,6 +452,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_sync);
     dummy_var ^= ((int64_t) (void*) wire_node_credentials);
     dummy_var ^= ((int64_t) (void*) wire_node_info);
+    dummy_var ^= ((int64_t) (void*) wire_set_node_config);
     dummy_var ^= ((int64_t) (void*) wire_disconnect);
     dummy_var ^= ((int64_t) (void*) wire_sign_message);
     dummy_var ^= ((int64_t) (void*) wire_check_message);
@@ -518,6 +527,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_onchain_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_payment_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_spontaneous_payment_request_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_set_node_config_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_sign_message_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_static_backup_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_u32_0);

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -39,6 +39,11 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kNodeInfoConstMeta;
 
+  /// See [BreezServices::set_node_config]
+  Future<void> setNodeConfig({required SetNodeConfigRequest req, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kSetNodeConfigConstMeta;
+
   /// Cleanup node resources and stop the signer.
   Future<void> disconnect({dynamic hint});
 
@@ -1661,6 +1666,15 @@ class ServiceHealthCheckResponse {
   });
 }
 
+/// Represents a set node config request.
+class SetNodeConfigRequest {
+  final String? closeToAddress;
+
+  const SetNodeConfigRequest({
+    this.closeToAddress,
+  });
+}
+
 /// Request to sign a message with the node's private key.
 class SignMessageRequest {
   /// The message to be signed by the node's private key.
@@ -1970,6 +1984,23 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kNodeInfoConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "node_info",
         argNames: [],
+      );
+
+  Future<void> setNodeConfig({required SetNodeConfigRequest req, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_set_node_config_request(req);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_set_node_config(port_, arg0),
+      parseSuccessData: _wire2api_unit,
+      parseErrorData: _wire2api_FrbAnyhowException,
+      constMeta: kSetNodeConfigConstMeta,
+      argValues: [req],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kSetNodeConfigConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "set_node_config",
+        argNames: ["req"],
       );
 
   Future<void> disconnect({dynamic hint}) {
@@ -4152,6 +4183,14 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_SetNodeConfigRequest> api2wire_box_autoadd_set_node_config_request(
+      SetNodeConfigRequest raw) {
+    final ptr = inner.new_box_autoadd_set_node_config_request_0();
+    _api_fill_to_wire_set_node_config_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_SignMessageRequest> api2wire_box_autoadd_sign_message_request(SignMessageRequest raw) {
     final ptr = inner.new_box_autoadd_sign_message_request_0();
     _api_fill_to_wire_sign_message_request(raw, ptr.ref);
@@ -4397,6 +4436,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_send_spontaneous_payment_request(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_set_node_config_request(
+      SetNodeConfigRequest apiObj, ffi.Pointer<wire_SetNodeConfigRequest> wireObj) {
+    _api_fill_to_wire_set_node_config_request(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_sign_message_request(
       SignMessageRequest apiObj, ffi.Pointer<wire_SignMessageRequest> wireObj) {
     _api_fill_to_wire_sign_message_request(apiObj, wireObj.ref);
@@ -4605,6 +4649,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.extra_tlvs = api2wire_opt_list_tlv_entry(apiObj.extraTlvs);
   }
 
+  void _api_fill_to_wire_set_node_config_request(
+      SetNodeConfigRequest apiObj, wire_SetNodeConfigRequest wireObj) {
+    wireObj.close_to_address = api2wire_opt_String(apiObj.closeToAddress);
+  }
+
   void _api_fill_to_wire_sign_message_request(SignMessageRequest apiObj, wire_SignMessageRequest wireObj) {
     wireObj.message = api2wire_String(apiObj.message);
   }
@@ -4767,6 +4816,22 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
 
   late final _wire_node_infoPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_node_info');
   late final _wire_node_info = _wire_node_infoPtr.asFunction<void Function(int)>();
+
+  void wire_set_node_config(
+    int port_,
+    ffi.Pointer<wire_SetNodeConfigRequest> req,
+  ) {
+    return _wire_set_node_config(
+      port_,
+      req,
+    );
+  }
+
+  late final _wire_set_node_configPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SetNodeConfigRequest>)>>(
+          'wire_set_node_config');
+  late final _wire_set_node_config =
+      _wire_set_node_configPtr.asFunction<void Function(int, ffi.Pointer<wire_SetNodeConfigRequest>)>();
 
   void wire_disconnect(
     int port_,
@@ -5739,6 +5804,16 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _new_box_autoadd_send_spontaneous_payment_request_0Ptr
           .asFunction<ffi.Pointer<wire_SendSpontaneousPaymentRequest> Function()>();
 
+  ffi.Pointer<wire_SetNodeConfigRequest> new_box_autoadd_set_node_config_request_0() {
+    return _new_box_autoadd_set_node_config_request_0();
+  }
+
+  late final _new_box_autoadd_set_node_config_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SetNodeConfigRequest> Function()>>(
+          'new_box_autoadd_set_node_config_request_0');
+  late final _new_box_autoadd_set_node_config_request_0 = _new_box_autoadd_set_node_config_request_0Ptr
+      .asFunction<ffi.Pointer<wire_SetNodeConfigRequest> Function()>();
+
   ffi.Pointer<wire_SignMessageRequest> new_box_autoadd_sign_message_request_0() {
     return _new_box_autoadd_sign_message_request_0();
   }
@@ -5932,6 +6007,10 @@ final class wire_Config extends ffi.Struct {
   external int exemptfee_msat;
 
   external wire_NodeConfig node_config;
+}
+
+final class wire_SetNodeConfigRequest extends ffi.Struct {
+  external ffi.Pointer<wire_uint_8_list> close_to_address;
 }
 
 final class wire_SignMessageRequest extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -3063,6 +3063,46 @@ fun asServiceHealthCheckResponseList(arr: ReadableArray): List<ServiceHealthChec
     return list
 }
 
+fun asSetNodeConfigRequest(setNodeConfigRequest: ReadableMap): SetNodeConfigRequest? {
+    if (!validateMandatoryFields(
+            setNodeConfigRequest,
+            arrayOf(),
+        )
+    ) {
+        return null
+    }
+    val closeToAddress =
+        if (hasNonNullKey(
+                setNodeConfigRequest,
+                "closeToAddress",
+            )
+        ) {
+            setNodeConfigRequest.getString("closeToAddress")
+        } else {
+            null
+        }
+    return SetNodeConfigRequest(
+        closeToAddress,
+    )
+}
+
+fun readableMapOf(setNodeConfigRequest: SetNodeConfigRequest): ReadableMap {
+    return readableMapOf(
+        "closeToAddress" to setNodeConfigRequest.closeToAddress,
+    )
+}
+
+fun asSetNodeConfigRequestList(arr: ReadableArray): List<SetNodeConfigRequest> {
+    val list = ArrayList<SetNodeConfigRequest>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asSetNodeConfigRequest(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
 fun asSignMessageRequest(signMessageRequest: ReadableMap): SignMessageRequest? {
     if (!validateMandatoryFields(
             signMessageRequest,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -109,10 +109,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
         executor.execute {
             try {
                 val envTypeTmp = asEnvironmentType(envType)
-                val nodeConfigTmp =
-                    asNodeConfig(
-                        nodeConfig,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("nodeConfig", "NodeConfig")) }
+                val nodeConfigTmp = asNodeConfig(nodeConfig) ?: run { throw SdkException.Generic(errMissingMandatoryField("nodeConfig", "NodeConfig")) }
                 val res = defaultConfig(envTypeTmp, apiKey, nodeConfigTmp)
                 val workingDir = File(reactApplicationContext.filesDir.toString() + "/breezSdk")
 
@@ -195,6 +192,25 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
+    fun setNodeConfig(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
+        executor.execute {
+            try {
+                val setNodeConfigRequest =
+                    asSetNodeConfigRequest(req) ?: run {
+                        throw SdkException.Generic(errMissingMandatoryField("req", "SetNodeConfigRequest"))
+                    }
+                getBreezServices().setNodeConfig(setNodeConfigRequest)
+                promise.resolve(readableMapOf("status" to "ok"))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun sendPayment(
         req: ReadableMap,
         promise: Promise,
@@ -258,10 +274,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val lnUrlPayRequest =
-                    asLnUrlPayRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "LnUrlPayRequest")) }
+                val lnUrlPayRequest = asLnUrlPayRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "LnUrlPayRequest")) }
                 val res = getBreezServices().payLnurl(lnUrlPayRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -315,10 +328,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val reqTmp =
-                    asReportIssueRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ReportIssueRequest")) }
+                val reqTmp = asReportIssueRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ReportIssueRequest")) }
                 getBreezServices().reportIssue(reqTmp)
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
@@ -699,10 +709,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val refundRequest =
-                    asRefundRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "RefundRequest")) }
+                val refundRequest = asRefundRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "RefundRequest")) }
                 val res = getBreezServices().refund(refundRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
@@ -831,10 +838,7 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     ) {
         executor.execute {
             try {
-                val buyBitcoinRequest =
-                    asBuyBitcoinRequest(
-                        req,
-                    ) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "BuyBitcoinRequest")) }
+                val buyBitcoinRequest = asBuyBitcoinRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "BuyBitcoinRequest")) }
                 val res = getBreezServices().buyBitcoin(buyBitcoinRequest)
                 promise.resolve(readableMapOf(res))
             } catch (e: Exception) {

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -3325,6 +3325,42 @@ enum BreezSDKMapper {
         return serviceHealthCheckResponseList.map { v -> [String: Any?] in dictionaryOf(serviceHealthCheckResponse: v) }
     }
 
+    static func asSetNodeConfigRequest(setNodeConfigRequest: [String: Any?]) throws -> SetNodeConfigRequest {
+        var closeToAddress: String?
+        if hasNonNilKey(data: setNodeConfigRequest, key: "closeToAddress") {
+            guard let closeToAddressTmp = setNodeConfigRequest["closeToAddress"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "closeToAddress"))
+            }
+            closeToAddress = closeToAddressTmp
+        }
+
+        return SetNodeConfigRequest(
+            closeToAddress: closeToAddress)
+    }
+
+    static func dictionaryOf(setNodeConfigRequest: SetNodeConfigRequest) -> [String: Any?] {
+        return [
+            "closeToAddress": setNodeConfigRequest.closeToAddress == nil ? nil : setNodeConfigRequest.closeToAddress,
+        ]
+    }
+
+    static func asSetNodeConfigRequestList(arr: [Any]) throws -> [SetNodeConfigRequest] {
+        var list = [SetNodeConfigRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var setNodeConfigRequest = try asSetNodeConfigRequest(setNodeConfigRequest: val)
+                list.append(setNodeConfigRequest)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SetNodeConfigRequest"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(setNodeConfigRequestList: [SetNodeConfigRequest]) -> [Any] {
+        return setNodeConfigRequestList.map { v -> [String: Any?] in dictionaryOf(setNodeConfigRequest: v) }
+    }
+
     static func asSignMessageRequest(signMessageRequest: [String: Any?]) throws -> SignMessageRequest {
         guard let message = signMessageRequest["message"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "SignMessageRequest"))

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -53,6 +53,12 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    setNodeConfig: (NSDictionary*)req
+    resolve: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     sendPayment: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -151,6 +151,17 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
+    @objc(setNodeConfig:resolve:reject:)
+    func setNodeConfig(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            let setNodeConfigRequest = try BreezSDKMapper.asSetNodeConfigRequest(setNodeConfigRequest: req)
+            try getBreezServices().setNodeConfig(req: setNodeConfigRequest)
+            resolve(["status": "ok"])
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(sendPayment:resolve:reject:)
     func sendPayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -461,6 +461,10 @@ export type ServiceHealthCheckResponse = {
     status: HealthCheckStatus
 }
 
+export type SetNodeConfigRequest = {
+    closeToAddress?: string
+}
+
 export type SignMessageRequest = {
     message: string
 }
@@ -822,6 +826,10 @@ export const staticBackup = async (req: StaticBackupRequest): Promise<StaticBack
 
 export const disconnect = async (): Promise<void> => {
     await BreezSDK.disconnect()
+}
+
+export const setNodeConfig = async (req: SetNodeConfigRequest): Promise<void> => {
+    await BreezSDK.setNodeConfig(req)
 }
 
 export const sendPayment = async (req: SendPaymentRequest): Promise<SendPaymentResponse> => {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -316,6 +316,12 @@ pub(crate) async fn handle_command(
         Commands::NodeInfo {} => {
             serde_json::to_string_pretty(&sdk()?.node_info()?).map_err(|e| e.into())
         }
+        Commands::SetNodeConfig { close_to_address } => {
+            sdk()?
+                .set_node_config(breez_sdk_core::SetNodeConfigRequest { close_to_address })
+                .await?;
+            Ok("Node configured successfully".to_string())
+        }
         Commands::ListFiat {} => {
             serde_json::to_string_pretty(&sdk()?.list_fiat_currencies().await?)
                 .map_err(|e| e.into())

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -205,6 +205,13 @@ pub(crate) enum Commands {
     /// The up to date node information
     NodeInfo {},
 
+    /// Set the current node configuration
+    SetNodeConfig {
+        // Optional address to send funds to during a channel close
+        #[clap(short = 'c', long = "close_to_address")]
+        close_to_address: Option<String>,
+    },
+
     /// List fiat currencies
     ListFiat {},
 


### PR DESCRIPTION
This PR adds a `set_node_config` SDK method to allow the `close_to_addr` to be configured in Greenlight. This address is then available Greenlight while the client is not present.

https://github.com/Blockstream/blockstream_breez_issues/issues/16#issuecomment-1878702022

Fixes #711 