### PR TITLE
Fix rustdoc warnings

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1121,9 +1121,9 @@ impl BreezServices {
         }
     }
 
-    /// Get the static backup data from the peristent storage.
+    /// Get the static backup data from the persistent storage.
     /// This data enables the user to recover the node in an external core ligntning node.
-    /// See here for instructions on how to recover using this data: https://docs.corelightning.org/docs/backup-and-recovery#backing-up-using-static-channel-backup
+    /// See here for instructions on how to recover using this data: <https://docs.corelightning.org/docs/backup-and-recovery#backing-up-using-static-channel-backup>
     pub fn static_backup(req: StaticBackupRequest) -> SdkResult<StaticBackupResponse> {
         let storage = SqliteStorage::new(req.working_dir);
         Ok(StaticBackupResponse {

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -10,7 +10,7 @@ use crate::{
 
 pub type SdkResult<T, E = SdkError> = Result<T, E>;
 
-/// Error returned by [BreezServices::lnurl_auth]
+/// Error returned by [crate::breez_services::BreezServices::lnurl_auth]
 #[derive(Debug, Error)]
 pub enum LnUrlAuthError {
     #[error("Generic: {err}")]
@@ -50,7 +50,7 @@ impl From<SdkError> for LnUrlAuthError {
     }
 }
 
-/// Error returned by [BreezServices::lnurl_pay]
+/// Error returned by [crate::breez_services::BreezServices::lnurl_pay]
 #[derive(Debug, Error)]
 pub enum LnUrlPayError {
     #[error("Invoice already paid")]
@@ -175,7 +175,7 @@ impl From<SendPaymentError> for LnUrlPayError {
     }
 }
 
-/// Error returned by [BreezServices::lnurl_withdraw]
+/// Error returned by [crate::breez_services::BreezServices::lnurl_withdraw]
 #[derive(Debug, Error)]
 pub enum LnUrlWithdrawError {
     #[error("Generic: {err}")]
@@ -245,7 +245,8 @@ impl From<SdkError> for LnUrlWithdrawError {
     }
 }
 
-/// Error returned by [BreezServices::receive_onchain] and [BreezServices::buy_bitcoin]
+/// Error returned by [crate::breez_services::BreezServices::receive_onchain] and
+/// [crate::breez_services::BreezServices::buy_bitcoin]
 #[derive(Debug, Error)]
 pub enum ReceiveOnchainError {
     #[error("Generic: {err}")]
@@ -290,7 +291,7 @@ impl From<SwapError> for ReceiveOnchainError {
     }
 }
 
-/// Error returned by [BreezServices::receive_payment]
+/// Error returned by [crate::breez_services::BreezServices::receive_payment]
 #[derive(Debug, Error)]
 pub enum ReceivePaymentError {
     #[error("Generic: {err}")]
@@ -492,7 +493,7 @@ impl From<SendPaymentError> for SdkError {
     }
 }
 
-/// Error returned by [BreezServices::send_onchain]
+/// Error returned by [crate::breez_services::BreezServices::send_onchain]
 #[derive(Debug, Error)]
 pub enum SendOnchainError {
     #[error("Generic: {err}")]
@@ -569,7 +570,7 @@ impl From<ReverseSwapError> for SendOnchainError {
     }
 }
 
-/// Error returned by [BreezServices::send_payment] and [BreezServices::send_spontaneous_payment]
+/// Error returned by [crate::breez_services::BreezServices::send_payment] and [crate::breez_services::BreezServices::send_spontaneous_payment]
 #[derive(Clone, Debug, Error)]
 pub enum SendPaymentError {
     #[error("Invoice already paid")]

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -492,7 +492,7 @@ pub struct LnUrlErrorData {
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
-/// See https://github.com/lnurl/luds/blob/luds/06.md
+/// See <https://github.com/lnurl/luds/blob/luds/06.md>
 #[derive(Clone, Deserialize, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LnUrlPayRequestData {
@@ -507,7 +507,7 @@ pub struct LnUrlPayRequestData {
     pub metadata_str: String,
     /// The comment length accepted by this endpoint
     ///
-    /// See https://github.com/lnurl/luds/blob/luds/12.md
+    /// See <https://github.com/lnurl/luds/blob/luds/12.md>
     #[serde(default)]
     pub comment_allowed: u16,
 
@@ -547,7 +547,7 @@ impl LnUrlPayRequestData {
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
-/// See https://github.com/lnurl/luds/blob/luds/03.md
+/// See <https://github.com/lnurl/luds/blob/luds/03.md>
 #[derive(Deserialize, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LnUrlWithdrawRequestData {
@@ -576,7 +576,7 @@ impl LnUrlWithdrawRequestData {
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
-/// See https://github.com/lnurl/luds/blob/luds/04.md
+/// See <https://github.com/lnurl/luds/blob/luds/04.md>
 #[derive(Deserialize, Debug, Serialize)]
 pub struct LnUrlAuthRequestData {
     /// Hex encoded 32 bytes of challenge

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -620,7 +620,7 @@ pub struct NodeState {
     pub inbound_liquidity_msats: u64,
 }
 
-/// Internal response to a [NodeAPI::pull_changed] call
+/// Internal response to a [crate::node_api::NodeAPI::pull_changed] call
 pub struct SyncResponse {
     pub node_state: NodeState,
     pub payments: Vec<crate::models::Payment>,
@@ -743,7 +743,7 @@ pub struct LnPaymentDetails {
     /// Only set for [PaymentType::Sent] payments that were sent in the context of a reverse swap
     pub reverse_swap_info: Option<ReverseSwapInfo>,
 
-    /// Only set for [PaymentType::Pending] payments that are inflight.
+    /// Only set for [PaymentStatus::Pending] payments that are inflight.
     pub pending_expiration_block: Option<u32>,
 }
 
@@ -803,7 +803,7 @@ pub struct ReceivePaymentRequest {
 ///
 /// Breez SDK may have to open a new channel to receive this payment. In that case, the channel will
 /// be opened automatically when the invoice is paid, and the fees will be described in the
-/// [opening_fee_params] and [opening_fee_msat] fields.
+/// `opening_fee_params` and `opening_fee_msat` fields.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceivePaymentResponse {
     /// The generated invoice, including any necessary routing hints
@@ -1360,7 +1360,7 @@ pub struct LnUrlWithdrawRequest {
 /// Represents a LNURL-pay request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LnUrlPayRequest {
-    /// The [LnUrlPayRequestData] returned by [BreezServices::parse_input]
+    /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
     pub data: LnUrlPayRequestData,
     /// The amount in millisatoshis for this payment
     pub amount_msat: u64,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -112,7 +112,7 @@ pub trait SwapperAPI: Send + Sync {
 
 /// Details about the BTC/BTC reverse swap pair, at this point in time
 ///
-/// Maps the result of https://docs.boltz.exchange/en/latest/api/#getting-pairs for the BTC/BTC pair
+/// Maps the result of <https://docs.boltz.exchange/en/latest/api/#getting-pairs> for the BTC/BTC pair
 #[derive(Clone, PartialEq, Debug, Serialize)]
 pub struct ReverseSwapPairInfo {
     /// Minimum amount of sats a reverse swap is allowed to have on this endpoint

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -723,7 +723,7 @@ class LnPaymentDetails {
   /// Only set for [PaymentType::Sent] payments that were sent in the context of a reverse swap
   final ReverseSwapInfo? reverseSwapInfo;
 
-  /// Only set for [PaymentType::Pending] payments that are inflight.
+  /// Only set for [PaymentStatus::Pending] payments that are inflight.
   final int? pendingExpirationBlock;
 
   const LnPaymentDetails({
@@ -748,7 +748,7 @@ class LnPaymentDetails {
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
-/// See https://github.com/lnurl/luds/blob/luds/04.md
+/// See <https://github.com/lnurl/luds/blob/luds/04.md>
 class LnUrlAuthRequestData {
   /// Hex encoded 32 bytes of challenge
   final String k1;
@@ -804,7 +804,7 @@ class LnUrlPayErrorData {
 
 /// Represents a LNURL-pay request.
 class LnUrlPayRequest {
-  /// The [LnUrlPayRequestData] returned by [BreezServices::parse_input]
+  /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
   final LnUrlPayRequestData data;
 
   /// The amount in millisatoshis for this payment
@@ -824,7 +824,7 @@ class LnUrlPayRequest {
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
-/// See https://github.com/lnurl/luds/blob/luds/06.md
+/// See <https://github.com/lnurl/luds/blob/luds/06.md>
 class LnUrlPayRequestData {
   final String callback;
 
@@ -840,7 +840,7 @@ class LnUrlPayRequestData {
 
   /// The comment length accepted by this endpoint
   ///
-  /// See https://github.com/lnurl/luds/blob/luds/12.md
+  /// See <https://github.com/lnurl/luds/blob/luds/12.md>
   final int commentAllowed;
 
   /// Indicates the domain of the LNURL-pay service, to be shown to the user when asking for
@@ -911,7 +911,7 @@ class LnUrlWithdrawRequest {
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
-/// See https://github.com/lnurl/luds/blob/luds/03.md
+/// See <https://github.com/lnurl/luds/blob/luds/03.md>
 class LnUrlWithdrawRequestData {
   final String callback;
   final String k1;
@@ -1364,7 +1364,7 @@ class ReceivePaymentRequest {
 ///
 /// Breez SDK may have to open a new channel to receive this payment. In that case, the channel will
 /// be opened automatically when the invoice is paid, and the fees will be described in the
-/// [opening_fee_params] and [opening_fee_msat] fields.
+/// `opening_fee_params` and `opening_fee_msat` fields.
 class ReceivePaymentResponse {
   /// The generated invoice, including any necessary routing hints
   final LNInvoice lnInvoice;
@@ -1490,7 +1490,7 @@ class ReverseSwapInfo {
 
 /// Details about the BTC/BTC reverse swap pair, at this point in time
 ///
-/// Maps the result of https://docs.boltz.exchange/en/latest/api/#getting-pairs for the BTC/BTC pair
+/// Maps the result of <https://docs.boltz.exchange/en/latest/api/#getting-pairs> for the BTC/BTC pair
 class ReverseSwapPairInfo {
   /// Minimum amount of sats a reverse swap is allowed to have on this endpoint
   final int min;


### PR DESCRIPTION
Fix warnings that prevent links from being parsed as such.

For example, the rustdoc description of [SendPaymentError](https://breez.github.io/breez-sdk/breez_sdk_core/error/enum.SendPaymentError.html) is

> Error returned by [BreezServices::send_payment] and [BreezServices::send_spontaneous_payment]

where none of these references are clickable links.