### PR TITLE
Update docs for swap channel fees

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -719,14 +719,12 @@ impl BreezServices {
                     in_progress.bitcoin_address
                 )});
         }
-        let channel_opening_fees = match req.opening_fee_params {
-            Some(fee_params) => fee_params,
-            None => self
-                .lsp_info()
+        let channel_opening_fees = req.opening_fee_params.unwrap_or(
+            self.lsp_info()
                 .await?
                 .cheapest_open_channel_fee(SWAP_PAYMENT_FEE_EXPIRY_SECONDS)?
                 .clone(),
-        };
+        );
 
         let swap_info = self
             .btc_receive_swapper

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -75,7 +75,7 @@ impl LspInformation {
         Ok(info)
     }
 
-    /// Returns the cheapeset opening channel fees from LSP that within the expiry range.
+    /// Returns the cheapest opening channel fees from LSP that within the expiry range.
     ///
     /// If the LSP fees are needed, the LSP is expected to have at least one dynamic fee entry in its menu,
     /// otherwise this will result in an error.

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1268,6 +1268,10 @@ pub struct SwapInfo {
     /// Error reason for when swap fails.
     pub last_redeem_error: Option<String>,
     /// The dynamic fees which is set if a channel opening is needed.
+    ///
+    /// This is an optional field for backward compatibility with swaps created before dynamic fees.
+    ///
+    /// Swaps created after dynamic fees were introduced always have this field set.
     pub channel_opening_fees: Option<OpeningFeeParams>,
 }
 

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -133,8 +133,6 @@ impl BTCReceiveSwap {
     }
 
     /// Create a [SwapInfo] that represents the details of an on-going swap.
-    ///
-    /// See [SwapInfo] for details.
     pub(crate) async fn create_swap_address(
         &self,
         channel_opening_fees: OpeningFeeParams,
@@ -206,11 +204,9 @@ impl BTCReceiveSwap {
             channel_opening_fees: Some(channel_opening_fees),
         };
 
-        // persist the address
+        // persist the swap info
         self.persister.insert_swap(swap_info.clone())?;
         Ok(swap_info)
-
-        // return swap.bitcoinAddress;
     }
 
     fn list_unused(&self) -> Result<Vec<SwapInfo>> {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1803,6 +1803,10 @@ class SwapInfo {
   final String? lastRedeemError;
 
   /// The dynamic fees which is set if a channel opening is needed.
+  ///
+  /// This is an optional field for backward compatibility with swaps created before dynamic fees.
+  ///
+  /// Swaps created after dynamic fees were introduced always have this field set.
   final OpeningFeeParams? channelOpeningFees;
 
   const SwapInfo({


### PR DESCRIPTION
Added clarification that `SwapInfo::channel_opening_fees` are always set.