### PR TITLE
Derive Default trait for OpenChannelFeeRequest

### DIFF
--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -910,6 +910,7 @@ pub struct StaticBackupResponse {
     pub backup: Option<Vec<String>>,
 }
 
+#[derive(Default)]
 pub struct OpenChannelFeeRequest {
     pub amount_msat: Option<u64>,
     pub expiry: Option<u32>,


### PR DESCRIPTION
With https://github.com/breez/breez-sdk/pull/737 it is now possible to call `open_channel_fee` without providing an amount:

```rust
let opening_fee_response = sdk
    .open_channel_fee(OpenChannelFeeRequest {
        amount_msat: None,
        expiry: None,
    })
    .await?;
```

This is used for retrieving general fee parameters before knowing the payment amount.

This PR derives the `Default` trait, to simplify the above call:

```rust
let opening_fee_response = sdk
    .open_channel_fee(OpenChannelFeeRequest::default())
    .await?;
```