### PR TITLE
Re-use bitcoin crate exported by gl-client

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -518,7 +518,6 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bip21",
- "bitcoin 0.29.2",
  "cbc",
  "chrono",
  "const_format",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -13,9 +13,7 @@ aes = "0.8"
 anyhow = { version = "1.0.79", features = ["backtrace"] }
 cbc = { version = "0.1", features = ["std"] }
 hex = "0.4"
-# v0.3 requires bitcoin 0.30, but gl-client uses bitcoin 0.29.2, so we keep this at v0.2 which also uses bitcoin 0.29
 bip21 = "0.2"
-bitcoin = "0.29.2"
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
 ], rev = "556eedf47a837b71c4277ba6ee84322f5cbd80de" }

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -1,8 +1,9 @@
-use crate::input_parser::{get_parse_and_log_response, get_reqwest_client};
 use anyhow::{anyhow, Result};
-use bitcoin::hashes::hex::FromHex;
-use bitcoin::{OutPoint, Txid};
 use serde::{Deserialize, Serialize};
+
+use crate::bitcoin::hashes::hex::FromHex;
+use crate::bitcoin::{OutPoint, Txid};
+use crate::input_parser::{get_parse_and_log_response, get_reqwest_client};
 
 #[tonic::async_trait]
 pub trait ChainService: Send + Sync {

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -1,10 +1,10 @@
-use anyhow::Result;
-use bitcoin::util::bip32;
 use std::time::SystemTimeError;
+
+use anyhow::Result;
 use thiserror::Error;
 
 use crate::{
-    invoice::InvoiceError, lnurl::error::LnUrlError, node_api::NodeError,
+    bitcoin::util::bip32, invoice::InvoiceError, lnurl::error::LnUrlError, node_api::NodeError,
     persist::error::PersistError, swap_in::error::SwapError, swap_out::error::ReverseSwapError,
 };
 
@@ -98,8 +98,8 @@ impl From<anyhow::Error> for LnUrlPayError {
     }
 }
 
-impl From<bitcoin::hashes::hex::Error> for LnUrlPayError {
-    fn from(err: bitcoin::hashes::hex::Error) -> Self {
+impl From<crate::bitcoin::hashes::hex::Error> for LnUrlPayError {
+    fn from(err: crate::bitcoin::hashes::hex::Error) -> Self {
         Self::Generic {
             err: err.to_string(),
         }
@@ -391,8 +391,8 @@ impl From<anyhow::Error> for SdkError {
     }
 }
 
-impl From<bitcoin::hashes::hex::Error> for SdkError {
-    fn from(err: bitcoin::hashes::hex::Error) -> Self {
+impl From<crate::bitcoin::hashes::hex::Error> for SdkError {
+    fn from(err: crate::bitcoin::hashes::hex::Error) -> Self {
         Self::Generic {
             err: err.to_string(),
         }

--- a/libs/sdk-core/src/greenlight/error.rs
+++ b/libs/sdk-core/src/greenlight/error.rs
@@ -1,11 +1,12 @@
 use std::{num::TryFromIntError, time::SystemTimeError};
 
 use anyhow::{anyhow, Result};
-use bitcoin::secp256k1;
 use regex::Regex;
 use strum_macros::FromRepr;
 
-use crate::{invoice::InvoiceError, node_api::NodeError, persist::error::PersistError};
+use crate::{
+    bitcoin::secp256k1, invoice::InvoiceError, node_api::NodeError, persist::error::PersistError,
+};
 
 #[derive(FromRepr, Debug, PartialEq)]
 #[repr(i16)]
@@ -117,14 +118,14 @@ impl From<anyhow::Error> for NodeError {
     }
 }
 
-impl From<bitcoin::util::address::Error> for NodeError {
-    fn from(err: bitcoin::util::address::Error) -> Self {
+impl From<crate::bitcoin::util::address::Error> for NodeError {
+    fn from(err: crate::bitcoin::util::address::Error) -> Self {
         Self::Generic(anyhow::Error::new(err))
     }
 }
 
-impl From<bitcoin::util::bip32::Error> for NodeError {
-    fn from(err: bitcoin::util::bip32::Error) -> Self {
+impl From<crate::bitcoin::util::bip32::Error> for NodeError {
+    fn from(err: crate::bitcoin::util::bip32::Error) -> Self {
         Self::Generic(anyhow::Error::new(err))
     }
 }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1,31 +1,23 @@
 use std::cmp::{min, Reverse};
+use std::iter::Iterator;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Result};
-use bitcoin::bech32::{u5, ToBase32};
-use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
-use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::secp256k1::Secp256k1;
-use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
-use bitcoin::{Address, OutPoint, Script, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
 use ecies::symmetric::{sym_decrypt, sym_encrypt};
 use futures::Stream;
 use gl_client::node::ClnClient;
 use gl_client::pb::cln::listinvoices_invoices::ListinvoicesInvoicesStatus;
 use gl_client::pb::cln::listpays_pays::ListpaysPaysStatus;
+use gl_client::pb::cln::listpeers_peers_channels::ListpeersPeersChannelsState::*;
 use gl_client::pb::cln::{
     self, Amount, GetrouteRequest, GetrouteRoute, ListchannelsRequest,
     ListclosedchannelsClosedchannels, ListpeersPeersChannels, PreapproveinvoiceRequest,
     SendpayRequest, SendpayRoute, WaitsendpayRequest,
 };
 use gl_client::pb::{OffChainPayment, PayStatus};
-
-use gl_client::pb::cln::listpeers_peers_channels::ListpeersPeersChannelsState::*;
 use gl_client::scheduler::Scheduler;
 use gl_client::signer::model::greenlight::{amount, scheduler};
 use gl_client::signer::Signer;
@@ -40,13 +32,21 @@ use tokio::time::sleep;
 use tokio_stream::StreamExt;
 use tonic::Streaming;
 
+use crate::bitcoin::bech32::{u5, ToBase32};
+use crate::bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
+use crate::bitcoin::hashes::Hash;
+use crate::bitcoin::secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
+use crate::bitcoin::secp256k1::PublicKey;
+use crate::bitcoin::secp256k1::Secp256k1;
+use crate::bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
+use crate::bitcoin::{
+    Address, OutPoint, Script, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+};
 use crate::invoice::{parse_invoice, validate_network, InvoiceError, RouteHintHop};
 use crate::models::*;
 use crate::node_api::{NodeAPI, NodeError, NodeResult};
-
 use crate::persist::db::SqliteStorage;
 use crate::{NodeConfig, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse};
-use std::iter::Iterator;
 
 const MAX_PAYMENT_AMOUNT_MSAT: u64 = 4294967000;
 const MAX_INBOUND_LIQUIDITY_MSAT: u64 = 4000000000;
@@ -1068,7 +1068,7 @@ impl NodeAPI for Greenlight {
         }];
         let mut tx = Transaction {
             version: 2,
-            lock_time: bitcoin::PackedLockTime(0),
+            lock_time: crate::bitcoin::PackedLockTime(0),
             input: txins.clone(),
             output: tx_out,
         };

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -3,16 +3,15 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use bip21::Uri;
-use bitcoin::bech32;
-use bitcoin::bech32::FromBase32;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::bitcoin::bech32;
+use crate::bitcoin::bech32::FromBase32;
 use crate::ensure_sdk;
 use crate::input_parser::InputType::*;
 use crate::input_parser::LnUrlRequestData::*;
 use crate::invoice::{parse_invoice, LNInvoice};
-
 use crate::lnurl::error::LnUrlResult;
 use crate::lnurl::maybe_replace_host_with_mockito_test_host;
 
@@ -174,7 +173,7 @@ pub async fn parse(input: &str) -> Result<InputType> {
     }
 
     // Public key serialized in compressed form (66 hex chars)
-    if let Ok(_node_id) = bitcoin::secp256k1::PublicKey::from_str(input) {
+    if let Ok(_node_id) = crate::bitcoin::secp256k1::PublicKey::from_str(input) {
         return Ok(NodeId {
             node_id: input.into(),
         });
@@ -182,7 +181,7 @@ pub async fn parse(input: &str) -> Result<InputType> {
 
     // Possible Node URI (check for separator symbol, try to parse pubkey, ignore rest)
     if let Some('@') = input.chars().nth(66) {
-        if let Ok(_node_id) = bitcoin::secp256k1::PublicKey::from_str(&input[..66]) {
+        if let Ok(_node_id) = crate::bitcoin::secp256k1::PublicKey::from_str(&input[..66]) {
             return Ok(NodeId {
                 node_id: input.into(),
             });
@@ -631,12 +630,12 @@ pub(crate) mod tests {
 
     use anyhow::anyhow;
     use anyhow::Result;
-    use bitcoin::bech32;
-    use bitcoin::bech32::{ToBase32, Variant};
-    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
     use mockito::{Mock, Server, ServerGuard};
     use once_cell::sync::Lazy;
 
+    use crate::bitcoin::bech32;
+    use crate::bitcoin::bech32::{ToBase32, Variant};
+    use crate::bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
     use crate::input_parser::*;
     use crate::models::Network;
 

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -1,14 +1,15 @@
+use std::str::FromStr;
+use std::time::{SystemTimeError, UNIX_EPOCH};
+
 use anyhow::anyhow;
-use bitcoin::secp256k1::{self, PublicKey};
 use hex::ToHex;
 use lightning::routing::gossip::RoutingFees;
 use lightning::routing::*;
 use lightning_invoice::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
-use std::time::{SystemTimeError, UNIX_EPOCH};
 
+use crate::bitcoin::secp256k1::{self, PublicKey};
 use crate::Network;
 
 pub type InvoiceResult<T, E = InvoiceError> = Result<T, E>;

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -190,6 +190,10 @@ mod support;
 mod swap_in;
 mod swap_out;
 
+// Use the bitcoin crate version from gl_client for consistency
+// Re-export it so that others using the SDK can re-use it
+pub use gl_client::bitcoin;
+
 pub use breez_services::{
     mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, CheckMessageRequest,
     CheckMessageResponse, EventListener, InvoicePaidDetails, LogStream, PaymentFailedData,

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -1,13 +1,15 @@
-use crate::input_parser::get_parse_and_log_response;
-use crate::{node_api::NodeAPI, LnUrlAuthRequestData, LnUrlCallbackStatus};
-use anyhow::anyhow;
-use bitcoin::hashes::{hex::ToHex, sha256, Hash, HashEngine, Hmac, HmacEngine};
-use bitcoin::secp256k1::{Message, Secp256k1};
-use bitcoin::util::bip32::ChildNumber;
-use bitcoin::KeyPair;
-use reqwest::Url;
 use std::str::FromStr;
 use std::sync::Arc;
+
+use anyhow::anyhow;
+use reqwest::Url;
+
+use crate::bitcoin::hashes::{hex::ToHex, sha256, Hash, HashEngine, Hmac, HmacEngine};
+use crate::bitcoin::secp256k1::{Message, Secp256k1};
+use crate::bitcoin::util::bip32::ChildNumber;
+use crate::bitcoin::KeyPair;
+use crate::input_parser::get_parse_and_log_response;
+use crate::{node_api::NodeAPI, LnUrlAuthRequestData, LnUrlCallbackStatus};
 
 use super::error::{LnUrlError, LnUrlResult};
 

--- a/libs/sdk-core/src/lnurl/error.rs
+++ b/libs/sdk-core/src/lnurl/error.rs
@@ -1,8 +1,8 @@
 use std::{array::TryFromSliceError, string::FromUtf8Error};
 
 use anyhow::anyhow;
-use bitcoin::{bech32, secp256k1, util::bip32};
 
+use crate::bitcoin::{bech32, secp256k1, util::bip32};
 use crate::{invoice::InvoiceError, node_api::NodeError};
 
 pub type LnUrlResult<T, E = LnUrlError> = Result<T, E>;

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -357,17 +357,16 @@ pub(crate) mod model {
 mod tests {
     use std::sync::Arc;
 
+    use crate::bitcoin::hashes::hex::ToHex;
+    use crate::bitcoin::hashes::{sha256, Hash};
     use crate::input_parser::tests::MOCK_HTTP_SERVER;
     use crate::lnurl::pay::*;
     use crate::{breez_services::tests::get_dummy_node_state, lnurl::pay::model::*};
+    use crate::{test_utils::*, LnUrlPayRequest};
 
     use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
     use anyhow::{anyhow, Result};
-    use bitcoin::hashes::hex::ToHex;
-    use bitcoin::hashes::{sha256, Hash};
     use gl_client::signer::model::greenlight::PayStatus;
-
-    use crate::{test_utils::*, LnUrlPayRequest};
     use mockito::Mock;
     use rand::random;
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -3,12 +3,6 @@ use std::ops::Add;
 use std::str::FromStr;
 
 use anyhow::{anyhow, ensure, Result};
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::script::Builder;
-use bitcoin::hashes::hex::{FromHex, ToHex};
-use bitcoin::hashes::{sha256, Hash};
-use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-use bitcoin::{Address, Script};
 use chrono::{DateTime, Duration, Utc};
 use ripemd::Digest;
 use ripemd::Ripemd160;
@@ -17,6 +11,12 @@ use rusqlite::ToSql;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
+use crate::bitcoin::blockdata::opcodes;
+use crate::bitcoin::blockdata::script::Builder;
+use crate::bitcoin::hashes::hex::{FromHex, ToHex};
+use crate::bitcoin::hashes::{sha256, Hash};
+use crate::bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use crate::bitcoin::{Address, Script};
 use crate::breez_services::BreezServer;
 use crate::error::SdkResult;
 use crate::fiat::{FiatCurrency, Rate};
@@ -537,24 +537,24 @@ pub enum Network {
     Regtest,
 }
 
-impl From<bitcoin::network::constants::Network> for Network {
-    fn from(network: bitcoin::network::constants::Network) -> Self {
+impl From<crate::bitcoin::network::constants::Network> for Network {
+    fn from(network: crate::bitcoin::network::constants::Network) -> Self {
         match network {
-            bitcoin::network::constants::Network::Bitcoin => Bitcoin,
-            bitcoin::network::constants::Network::Testnet => Testnet,
-            bitcoin::network::constants::Network::Signet => Signet,
-            bitcoin::network::constants::Network::Regtest => Regtest,
+            crate::bitcoin::network::constants::Network::Bitcoin => Bitcoin,
+            crate::bitcoin::network::constants::Network::Testnet => Testnet,
+            crate::bitcoin::network::constants::Network::Signet => Signet,
+            crate::bitcoin::network::constants::Network::Regtest => Regtest,
         }
     }
 }
 
-impl From<Network> for bitcoin::network::constants::Network {
+impl From<Network> for crate::bitcoin::network::constants::Network {
     fn from(network: Network) -> Self {
         match network {
-            Bitcoin => bitcoin::network::constants::Network::Bitcoin,
-            Testnet => bitcoin::network::constants::Network::Testnet,
-            Signet => bitcoin::network::constants::Network::Signet,
-            Regtest => bitcoin::network::constants::Network::Regtest,
+            Bitcoin => crate::bitcoin::network::constants::Network::Bitcoin,
+            Testnet => crate::bitcoin::network::constants::Network::Testnet,
+            Signet => crate::bitcoin::network::constants::Network::Signet,
+            Regtest => crate::bitcoin::network::constants::Network::Regtest,
         }
     }
 }

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,15 +1,17 @@
+use std::pin::Pin;
+
+use anyhow::Result;
+use lightning_invoice::RawBolt11Invoice;
+use tokio::sync::mpsc;
+use tokio_stream::Stream;
+use tonic::Streaming;
+
 use crate::{
+    bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey},
     invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
     NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest,
     PrepareRedeemOnchainFundsResponse, RouteHintHop, SyncResponse, TlvEntry,
 };
-use anyhow::Result;
-use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
-use lightning_invoice::RawBolt11Invoice;
-use std::pin::Pin;
-use tokio::sync::mpsc;
-use tokio_stream::Stream;
-use tonic::Streaming;
 
 pub type NodeResult<T, E = NodeError> = Result<T, E>;
 

--- a/libs/sdk-core/src/swap_out/boltzswap.rs
+++ b/libs/sdk-core/src/swap_out/boltzswap.rs
@@ -4,13 +4,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::to_string_pretty;
 
 use anyhow::{anyhow, Result};
-use bitcoin::Txid;
-use serde_json::json;
-
 use const_format::concatcp;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Body;
+use serde_json::json;
 
+use crate::bitcoin::Txid;
 use crate::input_parser::{get_parse_and_log_response, get_reqwest_client};
 use crate::models::ReverseSwapPairInfo;
 use crate::swap_out::reverseswap::CreateReverseSwapResponse;
@@ -383,9 +382,9 @@ fn build_boltz_reverse_swap_args(
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::Txid;
     use std::str::FromStr;
 
+    use crate::bitcoin::Txid;
     use crate::swap_out::boltzswap::{BoltzApiReverseSwapStatus, LockTxData};
 
     #[test]

--- a/libs/sdk-core/src/swap_out/error.rs
+++ b/libs/sdk-core/src/swap_out/error.rs
@@ -1,7 +1,11 @@
 use anyhow::anyhow;
-use bitcoin::{hashes, secp256k1};
 
-use crate::{error::SdkError, node_api::NodeError, persist::error::PersistError};
+use crate::{
+    bitcoin::{hashes, secp256k1},
+    error::SdkError,
+    node_api::NodeError,
+    persist::error::PersistError,
+};
 
 pub type ReverseSwapResult<T, E = ReverseSwapError> = Result<T, E>;
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -4,12 +4,6 @@ use std::time::{Duration, SystemTime};
 use std::{mem, vec};
 
 use anyhow::{anyhow, Error, Result};
-use bitcoin::hashes::hex::ToHex;
-use bitcoin::hashes::{sha256, Hash};
-use bitcoin::secp256k1::ecdsa::RecoverableSignature;
-use bitcoin::secp256k1::{KeyPair, Message, PublicKey, Secp256k1, SecretKey};
-use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
-use bitcoin::Network;
 use chrono::{SecondsFormat, Utc};
 use gl_client::signer::model::greenlight::amount::Unit;
 use gl_client::signer::model::greenlight::Amount;
@@ -26,6 +20,12 @@ use tokio_stream::StreamExt;
 use tonic::Streaming;
 
 use crate::backup::{BackupState, BackupTransport};
+use crate::bitcoin::hashes::hex::ToHex;
+use crate::bitcoin::hashes::{sha256, Hash};
+use crate::bitcoin::secp256k1::ecdsa::RecoverableSignature;
+use crate::bitcoin::secp256k1::{KeyPair, Message, PublicKey, Secp256k1, SecretKey};
+use crate::bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
+use crate::bitcoin::Network;
 use crate::breez_services::Receiver;
 use crate::chain::{ChainService, OnchainTx, Outspend, RecommendedFees, TxStatus};
 use crate::error::{ReceivePaymentError, SdkError, SdkResult};
@@ -43,10 +43,8 @@ use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
     parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
     PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
-    RouteHint, RouteHintHop,
+    RouteHint, RouteHintHop, OpeningFeeParams, OpeningFeeParamsMenu, ReceivePaymentRequest, SwapInfo
 };
-use crate::{OpeningFeeParams, OpeningFeeParamsMenu};
-use crate::{ReceivePaymentRequest, SwapInfo};
 
 pub struct MockBackupTransport {
     pub num_pushed: std::sync::Mutex<u32>,
@@ -130,7 +128,7 @@ impl SwapperAPI for MockSwapperAPI {
 
         let script =
             create_submarine_swap_script(hash, swapper_pub_key.clone(), payer_pubkey, 144).unwrap();
-        let address = bitcoin::Address::p2wsh(&script, bitcoin::Network::Bitcoin);
+        let address = crate::bitcoin::Address::p2wsh(&script, crate::bitcoin::Network::Bitcoin);
 
         Ok(Swap {
             bitcoin_address: address.to_string(),

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 dependencies = [
  "backtrace",
 ]
@@ -184,7 +184,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -195,7 +195,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -464,7 +464,6 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bip21",
- "bitcoin 0.29.2",
  "cbc",
  "chrono",
  "const_format",
@@ -632,7 +631,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -769,7 +768,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -780,7 +779,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -846,7 +845,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1128,7 +1127,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1973,7 +1972,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2084,7 +2083,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2176,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2251,9 +2250,9 @@ checksum = "9318ead08c799aad12a55a3e78b82e0b6167271ffd1f627b758891282f739187"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2577,7 +2576,7 @@ checksum = "5a32af5427251d2e4be14fc151eabe18abb4a7aad5efee7044da9f096c906a43"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2723,7 +2722,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2790,7 +2789,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2802,7 +2801,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2897,7 +2896,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2919,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2976,22 +2975,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3101,7 +3100,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3262,7 +3261,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3504,7 +3503,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -3538,7 +3537,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3837,5 +3836,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]


### PR DESCRIPTION
This PR removes the explicit dependency on `bitcoin` in our `Cargo.toml`. Instead of it, we use the version re-exported by GL at `gl_client::bitcoin`.

This helps us avoid having to track and re-align the `bitcoin` version with each `gl_client` update.