### PR TITLE
remove deprecated fields from lsp info

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -467,8 +467,6 @@ dictionary LspInformation {
     string widget_url;
     string pubkey;
     string host;
-    i64 channel_capacity;
-    i32 target_conf;
     i64 base_fee_msat;
     f64 fee_rate;
     u32 time_lock_delta;

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1534,8 +1534,6 @@ impl support::IntoDart for LspInformation {
             self.widget_url.into_into_dart().into_dart(),
             self.pubkey.into_into_dart().into_dart(),
             self.host.into_into_dart().into_dart(),
-            self.channel_capacity.into_into_dart().into_dart(),
-            self.target_conf.into_into_dart().into_dart(),
             self.base_fee_msat.into_into_dart().into_dart(),
             self.fee_rate.into_into_dart().into_dart(),
             self.time_lock_delta.into_into_dart().into_dart(),

--- a/libs/sdk-core/src/grpc/proto/breez.proto
+++ b/libs/sdk-core/src/grpc/proto/breez.proto
@@ -142,17 +142,14 @@ message LSPInformation {
   string widget_url = 2 [ json_name = "widget_url" ];
   string pubkey = 3 [ json_name = "pubkey" ];
   string host = 4 [ json_name = "host" ];
-  int64 channel_capacity = 5 [ json_name = "channel_capacity" ];
-  int32 target_conf = 6 [ json_name = "target_conf" ];
+
   int64 base_fee_msat = 7 [ json_name = "base_fee_msat" ];
   double fee_rate = 8 [ json_name = "fee_rate" ];
   uint32 time_lock_delta = 9 [ json_name = "time_lock_delta" ];
   int64 min_htlc_msat = 10 [ json_name = "min_htlc_msat" ];
-  int64 channel_fee_permyriad = 11 [deprecated = true];
+
   bytes lsp_pubkey = 12;
-  // The channel can be closed if not used this duration in seconds.
-  int64 max_inactive_duration = 13 [deprecated = true];
-  int64 channel_minimum_fee_msat = 14 [deprecated = true];
+
   repeated OpeningFeeParams opening_fee_params_list = 15;
 }
 

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -30,12 +30,6 @@ pub struct LspInformation {
     /// The network location of the lightning node, e.g. `12.34.56.78:9012` or `localhost:10011`
     pub host: String,
 
-    /// The channel capacity in satoshis
-    pub channel_capacity: i64,
-
-    /// The target number of blocks that the funding transaction should be confirmed by
-    pub target_conf: i32,
-
     /// The base fee charged regardless of the number of milli-satoshis sent
     pub base_fee_msat: i64,
 
@@ -60,8 +54,6 @@ impl LspInformation {
             widget_url: lsp_info.widget_url,
             pubkey: lsp_info.pubkey,
             host: lsp_info.host,
-            channel_capacity: lsp_info.channel_capacity,
-            target_conf: lsp_info.target_conf,
             base_fee_msat: lsp_info.base_fee_msat,
             fee_rate: lsp_info.fee_rate,
             time_lock_delta: lsp_info.time_lock_delta,
@@ -199,8 +191,6 @@ mod tests {
             widget_url: "".to_string(),
             pubkey: "pubkey".to_string(),
             host: "localhost".to_string(),
-            channel_capacity: 1000000,
-            target_conf: 1,
             base_fee_msat: 1,
             fee_rate: 1.0,
             time_lock_delta: 32,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -581,8 +581,6 @@ impl LspAPI for MockBreezServer {
             widget_url: "".to_string(),
             pubkey: self.lsp_pub_key(),
             host: "localhost".to_string(),
-            channel_capacity: 1000000,
-            target_conf: 1,
             base_fee_msat: 1,
             fee_rate: 1.0,
             time_lock_delta: 32,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1017,12 +1017,6 @@ class LspInformation {
   /// The network location of the lightning node, e.g. `12.34.56.78:9012` or `localhost:10011`
   final String host;
 
-  /// The channel capacity in satoshis
-  final int channelCapacity;
-
-  /// The target number of blocks that the funding transaction should be confirmed by
-  final int targetConf;
-
   /// The base fee charged regardless of the number of milli-satoshis sent
   final int baseFeeMsat;
 
@@ -1043,8 +1037,6 @@ class LspInformation {
     required this.widgetUrl,
     required this.pubkey,
     required this.host,
-    required this.channelCapacity,
-    required this.targetConf,
     required this.baseFeeMsat,
     required this.feeRate,
     required this.timeLockDelta,
@@ -3441,21 +3433,19 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LspInformation _wire2api_lsp_information(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 13) throw Exception('unexpected arr length: expect 13 but see ${arr.length}');
+    if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return LspInformation(
       id: _wire2api_String(arr[0]),
       name: _wire2api_String(arr[1]),
       widgetUrl: _wire2api_String(arr[2]),
       pubkey: _wire2api_String(arr[3]),
       host: _wire2api_String(arr[4]),
-      channelCapacity: _wire2api_i64(arr[5]),
-      targetConf: _wire2api_i32(arr[6]),
-      baseFeeMsat: _wire2api_i64(arr[7]),
-      feeRate: _wire2api_f64(arr[8]),
-      timeLockDelta: _wire2api_u32(arr[9]),
-      minHtlcMsat: _wire2api_i64(arr[10]),
-      lspPubkey: _wire2api_uint_8_list(arr[11]),
-      openingFeeParamsList: _wire2api_opening_fee_params_menu(arr[12]),
+      baseFeeMsat: _wire2api_i64(arr[5]),
+      feeRate: _wire2api_f64(arr[6]),
+      timeLockDelta: _wire2api_u32(arr[7]),
+      minHtlcMsat: _wire2api_i64(arr[8]),
+      lspPubkey: _wire2api_uint_8_list(arr[9]),
+      openingFeeParamsList: _wire2api_opening_fee_params_menu(arr[10]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1474,8 +1474,6 @@ fun asLspInformation(lspInformation: ReadableMap): LspInformation? {
                 "widgetUrl",
                 "pubkey",
                 "host",
-                "channelCapacity",
-                "targetConf",
                 "baseFeeMsat",
                 "feeRate",
                 "timeLockDelta",
@@ -1492,8 +1490,6 @@ fun asLspInformation(lspInformation: ReadableMap): LspInformation? {
     val widgetUrl = lspInformation.getString("widgetUrl")!!
     val pubkey = lspInformation.getString("pubkey")!!
     val host = lspInformation.getString("host")!!
-    val channelCapacity = lspInformation.getDouble("channelCapacity").toLong()
-    val targetConf = lspInformation.getInt("targetConf")
     val baseFeeMsat = lspInformation.getDouble("baseFeeMsat").toLong()
     val feeRate = lspInformation.getDouble("feeRate")
     val timeLockDelta = lspInformation.getInt("timeLockDelta").toUInt()
@@ -1506,8 +1502,6 @@ fun asLspInformation(lspInformation: ReadableMap): LspInformation? {
         widgetUrl,
         pubkey,
         host,
-        channelCapacity,
-        targetConf,
         baseFeeMsat,
         feeRate,
         timeLockDelta,
@@ -1524,8 +1518,6 @@ fun readableMapOf(lspInformation: LspInformation): ReadableMap {
         "widgetUrl" to lspInformation.widgetUrl,
         "pubkey" to lspInformation.pubkey,
         "host" to lspInformation.host,
-        "channelCapacity" to lspInformation.channelCapacity,
-        "targetConf" to lspInformation.targetConf,
         "baseFeeMsat" to lspInformation.baseFeeMsat,
         "feeRate" to lspInformation.feeRate,
         "timeLockDelta" to lspInformation.timeLockDelta,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1631,12 +1631,6 @@ enum BreezSDKMapper {
         guard let host = lspInformation["host"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "host", typeName: "LspInformation"))
         }
-        guard let channelCapacity = lspInformation["channelCapacity"] as? Int64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "channelCapacity", typeName: "LspInformation"))
-        }
-        guard let targetConf = lspInformation["targetConf"] as? Int32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "targetConf", typeName: "LspInformation"))
-        }
         guard let baseFeeMsat = lspInformation["baseFeeMsat"] as? Int64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "baseFeeMsat", typeName: "LspInformation"))
         }
@@ -1663,8 +1657,6 @@ enum BreezSDKMapper {
             widgetUrl: widgetUrl,
             pubkey: pubkey,
             host: host,
-            channelCapacity: channelCapacity,
-            targetConf: targetConf,
             baseFeeMsat: baseFeeMsat,
             feeRate: feeRate,
             timeLockDelta: timeLockDelta,
@@ -1681,8 +1673,6 @@ enum BreezSDKMapper {
             "widgetUrl": lspInformation.widgetUrl,
             "pubkey": lspInformation.pubkey,
             "host": lspInformation.host,
-            "channelCapacity": lspInformation.channelCapacity,
-            "targetConf": lspInformation.targetConf,
             "baseFeeMsat": lspInformation.baseFeeMsat,
             "feeRate": lspInformation.feeRate,
             "timeLockDelta": lspInformation.timeLockDelta,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -236,8 +236,6 @@ export type LspInformation = {
     widgetUrl: string
     pubkey: string
     host: string
-    channelCapacity: number
-    targetConf: number
     baseFeeMsat: number
     feeRate: number
     timeLockDelta: number


### PR DESCRIPTION
The channel_capacity and target_conf have no meaning in LspInformation. This PR removes those fields. They will be removed from lspd as well.

Also deprecated/unused fields in LSPInformation are now removed from the breez.proto file.
