### PR TITLE
Ensure there is at least one routing hint when creating invoice

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -44,6 +44,7 @@ enum LnUrlWithdrawError {
     "InvalidInvoice",
     "InvalidUri",
     "ServiceConnectivity",
+    "InvoiceNoRoutingHints",
 };
 
 [Error]
@@ -62,6 +63,7 @@ enum ReceivePaymentError {
     "InvoiceNoDescription",
     "InvoicePreimageAlreadyExists",
     "ServiceConnectivity",
+    "InvoiceNoRoutingHints",
 };
 
 [Error]

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2095,7 +2095,8 @@ impl Receiver for PaymentReceiver {
         // check if the lsp hint already exists
         info!("Existing routing hints {:?}", parsed_invoice.routing_hints);
 
-        // We only create a new invoice if we need to add the lsp hint or change the amount
+        // We only create a new invoice if we need to add routing hints because the invoice
+        // has not routing hints or change the amount due to openning a channel request.
         if parsed_invoice.routing_hints.is_empty() || open_channel_needed {
             // create the large amount invoice
             let raw_invoice_with_hint = add_routing_hints(

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2090,7 +2090,7 @@ impl Receiver for PaymentReceiver {
             optional_lsp_hint,
             parsed_invoice.routing_hints.is_empty(),
         ) {
-            // If we need to open a channel we only need to set the decicated lsp hint.
+            // If we need to open a channel we only need to set the dedicated lsp hint.
             (true, _, _) => {
                 let open_channel_hint = RouteHint {
                     hops: vec![RouteHintHop {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2114,14 +2114,19 @@ impl Receiver for PaymentReceiver {
             // In case we don't need to open a channel and we have a channel with our lsp then we only ensure it
             // exists as part of the invoice routing hints (merging).
             (false, Some(h), _) => {
-                // In case we need to open a channel and the invoice has no routing hints we replace them with ours.
-                info!("Adding lsp hint: {:?}", h);
-                Some(add_routing_hints(
-                    invoice.clone(),
-                    true,
-                    &vec![h],
-                    req.amount_msat,
-                )?)
+                match parsed_invoice.contains_hint_for_node(lsp_info.pubkey.as_str()) {
+                    false => {
+                        info!("Adding lsp hint: {:?}", h);
+                        Some(add_routing_hints(
+                            invoice.clone(),
+                            true,
+                            &vec![h],
+                            req.amount_msat,
+                        )?)
+                    }
+                    // Lsp already in routing hints, no need to modify the invoice
+                    true => None,
+                }
             }
             // In case we don't need to open a channel and the invoice has no routing hints we replace them with ours.
             (false, None, true) => {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2095,23 +2095,20 @@ impl Receiver for PaymentReceiver {
         // check if the lsp hint already exists
         info!("Existing routing hints {:?}", parsed_invoice.routing_hints);
 
-        // We only create a new invoice if we need to add routing hints because the invoice
-        // has not routing hints or change the amount due to openning a channel request.
-        if parsed_invoice.routing_hints.is_empty() || open_channel_needed {
-            // create the large amount invoice
-            let raw_invoice_with_hint = add_routing_hints(
-                invoice.clone(),
-                !open_channel_needed,
-                &routing_hints,
-                req.amount_msat,
-            )?;
+        // In the case we have liquidity we only append the routing hints we have to the gl invoice.
+        // In the case we don't have liquidity we set the lsp hint to the gl invoice and change the amount.
+        let raw_invoice_with_hint = add_routing_hints(
+            invoice.clone(),
+            !open_channel_needed,
+            &routing_hints,
+            req.amount_msat,
+        )?;
 
-            info!("Routing hint added");
-            let signed_invoice_with_hint = self.node_api.sign_invoice(raw_invoice_with_hint)?;
-            info!("Signed invoice with hint = {}", signed_invoice_with_hint);
+        info!("Routing hint added");
+        let signed_invoice_with_hint = self.node_api.sign_invoice(raw_invoice_with_hint)?;
+        info!("Signed invoice with hint = {}", signed_invoice_with_hint);
 
-            parsed_invoice = parse_invoice(&signed_invoice_with_hint)?;
-        }
+        parsed_invoice = parse_invoice(&signed_invoice_with_hint)?;
 
         // register the payment at the lsp if needed
         if open_channel_needed {

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -192,6 +192,9 @@ pub enum LnUrlWithdrawError {
 
     #[error("Service connectivity: {err}")]
     ServiceConnectivity { err: String },
+
+    #[error("No routing hints: {err}")]
+    InvoiceNoRoutingHints { err: String },
 }
 
 impl From<LnUrlError> for LnUrlWithdrawError {
@@ -227,6 +230,9 @@ impl From<ReceivePaymentError> for LnUrlWithdrawError {
             ReceivePaymentError::InvalidAmount { err } => Self::InvalidAmount { err },
             ReceivePaymentError::InvalidInvoice { err } => Self::InvalidInvoice { err },
             ReceivePaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            ReceivePaymentError::InvoiceNoRoutingHints { err } => {
+                Self::InvoiceNoRoutingHints { err }
+            }
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -314,6 +320,9 @@ pub enum ReceivePaymentError {
 
     #[error("Service connectivity: {err}")]
     ServiceConnectivity { err: String },
+
+    #[error("No routing hints: {err}")]
+    InvoiceNoRoutingHints { err: String },
 }
 
 impl From<anyhow::Error> for ReceivePaymentError {

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -175,20 +175,19 @@ pub fn add_routing_hints(
         0 => invoice.route_hints(),
         _ => match merge_with_existing {
             true => {
+                let invoice_hints_hop_src_node_ids: Vec<String> = invoice
+                    .route_hints()
+                    .into_iter()
+                    .flat_map(|hint| hint.0)
+                    .map(|hop| hop.src_node_id.serialize().encode_hex::<String>())
+                    .collect();
+
                 let unique_to_add: Vec<&RouteHint> = route_hints
                     .iter()
                     .filter(|hint| {
-                        hint.hops.clone().into_iter().all(|hop| {
-                            invoice.route_hints().into_iter().all(|invoice_hint| {
-                                invoice_hint.clone().0.into_iter().all(|invoice_hop| {
-                                    hop.src_node_id
-                                        != invoice_hop
-                                            .src_node_id
-                                            .serialize()
-                                            .encode_hex::<String>()
-                                })
-                            })
-                        })
+                        hint.hops
+                            .iter()
+                            .all(|hop| !invoice_hints_hop_src_node_ids.contains(&hop.src_node_id))
                     })
                     .collect();
 

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -169,9 +169,8 @@ pub fn add_routing_hints(
         .payment_secret(*invoice.payment_secret())
         .min_final_cltv_expiry_delta(invoice.min_final_cltv_expiry_delta());
 
-    // We make sure the hint we add does not conflict with other hints.
-    // The lsp hint takes priority so in case the lsp hop is already in one of the existing hints
-    // We make sure not to include them in the new hints.
+    // When merging route hints, only route hints are added that go through different nodes than ones in the invoice route hints.
+    // Otherwise when not merging route hints, the invoice route hints are replaced by the provided route hints.
     let unique_hop_hints: Vec<lightning::routing::router::RouteHint> = match route_hints.len() {
         0 => invoice.route_hints(),
         _ => match merge_with_existing {

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -79,6 +79,14 @@ pub struct LNInvoice {
     pub min_final_cltv_expiry_delta: u64,
 }
 
+impl LNInvoice {
+    pub(crate) fn contains_hint_for_node(&self, pubkey: &str) -> bool {
+        self.routing_hints
+            .iter()
+            .any(|hint| hint.hops.iter().any(|hop| hop.src_node_id == pubkey))
+    }
+}
+
 /// Details of a specific hop in a larger route hint
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RouteHintHop {

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -124,6 +124,7 @@ pub trait NodeAPI: Send + Sync {
     fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
     fn legacy_derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
 
-    // Gets the routing hints related to all private channels that the node has
-    async fn get_routing_hints(&self) -> NodeResult<Vec<RouteHint>>;
+    // Gets the routing hints related to all private channels that the node has.
+    // Also returns a boolean indicating if the node has a public channel or not.
+    async fn get_routing_hints(&self) -> NodeResult<(Vec<RouteHint>, bool)>;
 }

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,7 +1,7 @@
 use crate::{
     invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
     NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest,
-    PrepareRedeemOnchainFundsResponse, RouteHintHop, SyncResponse, TlvEntry,
+    PrepareRedeemOnchainFundsResponse, RouteHint, RouteHintHop, SyncResponse, TlvEntry,
 };
 use anyhow::Result;
 use bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
@@ -123,4 +123,7 @@ pub trait NodeAPI: Send + Sync {
     /// Gets the private key at the path specified
     fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
     fn legacy_derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
+
+    // Gets the routing hints related to all private channels that the node has
+    async fn get_routing_hints(&self) -> NodeResult<Vec<RouteHint>>;
 }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -42,8 +42,9 @@ use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{
     parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
-    PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse,
-    RouteHint, RouteHintHop, OpeningFeeParams, OpeningFeeParamsMenu, ReceivePaymentRequest, SwapInfo
+    OpeningFeeParams, OpeningFeeParamsMenu, PaymentResponse, Peer,
+    PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, ReceivePaymentRequest,
+    RouteHint, RouteHintHop, SwapInfo,
 };
 
 pub struct MockBackupTransport {
@@ -440,8 +441,8 @@ impl NodeAPI for MockNodeAPI {
         ))
     }
 
-    async fn get_routing_hints(&self) -> NodeResult<Vec<RouteHint>> {
-        Ok(vec![])
+    async fn get_routing_hints(&self) -> NodeResult<(Vec<RouteHint>, bool)> {
+        Ok((vec![], false))
     }
 }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -441,6 +441,10 @@ impl NodeAPI for MockNodeAPI {
             tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok),
         ))
     }
+
+    async fn get_routing_hints(&self) -> NodeResult<Vec<RouteHint>> {
+        Ok(vec![])
+    }
 }
 
 impl MockNodeAPI {

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 dependencies = [
  "backtrace",
 ]
@@ -184,7 +184,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -195,7 +195,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -632,7 +632,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -769,7 +769,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -780,7 +780,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -846,7 +846,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1128,7 +1128,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1973,7 +1973,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2251,9 +2251,9 @@ checksum = "9318ead08c799aad12a55a3e78b82e0b6167271ffd1f627b758891282f739187"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2577,7 +2577,7 @@ checksum = "5a32af5427251d2e4be14fc151eabe18abb4a7aad5efee7044da9f096c906a43"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2723,7 +2723,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2790,7 +2790,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2802,7 +2802,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2897,7 +2897,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2919,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2976,22 +2976,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3101,7 +3101,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3504,7 +3504,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -3538,7 +3538,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3837,5 +3837,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.48",
 ]


### PR DESCRIPTION
This PR do a bit of refactor of the part adding the routing hints to the invoice.
The motivation for this was a real case when a user had private channels with a node that is not the lsp (same case as changing lsp after some channels were opened).
Creating an invoice for that user resulted without routing hints. The invoice returned from greenlight without routing hints and we didn't add routing hints because our previous logic only added hints for the current lsp and the user still didn't have a channel with the current lsp...

The logic here has been simplified to this:
1. If we need to open a channel the routing hints are only the lsp with the zero channel id
2. If we don't need to open a channel we: 
- use all private channels of the node to create the routing hints array (one channel per peer).
- We add to the invoice only the routing hints for peers that don't exist already in the hints returned from gl.

In addition, before using the node api to create the invoice we check if the user has routing hint candidates (private channels) and if not we return an early error.