### PR TITLE
Link bindings dynamically in iOS Flutter plugin

### DIFF
--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -246,6 +246,7 @@ jobs:
   publish-flutter:
     needs:
       - setup
+      - build-language-bindings
     if: ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -35,7 +35,6 @@ jobs:
           ssh-key: ${{ secrets.REPO_SSH_KEY }}
           fetch-depth: 0
           path: flutter
-          ref: test-ios-dynamic-linking
 
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
@@ -89,11 +88,10 @@ jobs:
         working-directory: flutter
         if: ${{ inputs.publish }}
         run: |
-          [[ $(git branch --show-current) == "test-ios-dynamic-linking" ]] || return 1
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
           git add .
           git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
           git push
-          # git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
-          # git push --tags
+          git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
+          git push --tags

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -35,6 +35,7 @@ jobs:
           ssh-key: ${{ secrets.REPO_SSH_KEY }}
           fetch-depth: 0
           path: flutter
+          ref: test-ios-dynamic-linking
 
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
@@ -88,10 +89,11 @@ jobs:
         working-directory: flutter
         if: ${{ inputs.publish }}
         run: |
+          [[ $(git branch --show-current) == "test-ios-dynamic-linking" ]] || return 1
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
           git add .
           git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
           git push
-          git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
-          git push --tags
+          # git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
+          # git push --tags

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -61,12 +61,17 @@ jobs:
           cp ../breez-sdk/libs/sdk-flutter/pubspec.yaml .
           cp ../breez-sdk/libs/sdk-flutter/pubspec.lock .
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: bindings-swift
+          path: flutter/ios/bindings-swift/Sources/BreezSDK/
+
       - name: Set package version
         working-directory: flutter
         run: |
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
           sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
-          sed -i.bak -e "s/s.version          = .*/s.version          = '${{ inputs.package-version }}'/" ios/breez_sdk.podspec
+          sed -i.bak -e "s/^tag_version = .*/tag_version = '${{ inputs.package-version }}'/" ios/breez_sdk.podspec
           rm pubspec.yaml.bak
           rm android/build.gradle.bak
           rm ios/breez_sdk.podspec.bak

--- a/libs/sdk-flutter/ios/breez_sdk.podspec.production
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec.production
@@ -1,8 +1,23 @@
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint breez_sdk.podspec` to validate before publishing.
+tag_version = '0.2.15'
+framework = 'breez_sdkFFI.xcframework'
+lib_name = "breez-sdkFFI.#{tag_version}"
+url = "https://github.com/breez/breez-sdk-swift/releases/download/#{tag_version}/#{framework}.zip"
+frameworks_dir = 'bindings-swift'
+
+`
+if [ ! -d #{frameworks_dir}/#{framework} ]; then
+    mkdir -p #{frameworks_dir}
+    curl -L #{url} -o #{frameworks_dir}/#{lib_name}.zip
+    cd #{frameworks_dir}
+    unzip #{lib_name}.zip
+    rm -rf __MACOSX
+    rm #{lib_name}.zip
+fi
+`
+
 Pod::Spec.new do |s|
   s.name             = 'breez_sdk'
-  s.version          = '0.2.15'
+  s.version          = "#{tag_version}"
   s.summary          = 'BreezSDK flutter plugin.'
   s.description      = <<-DESC
   BreezSDK flutter plugin.
@@ -12,12 +27,12 @@ Pod::Spec.new do |s|
   s.author           = { 'Breez' => 'contact@breez.technology' }
   s.source           = { :git => "https://github.com/breez/breez-sdk-flutter.git", :tag => "#{s.version}" }
   s.source_files = 'Classes/**/*'
+  s.on_demand_resources = { 'BreezSDK' => 'bindings-swift/Sources/BreezSDK/BreezSDK.swift' }
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
-  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
-  s.dependency "BreezSDK", "#{s.version}"
+  s.vendored_frameworks = "#{frameworks_dir}/#{framework}"
 end

--- a/libs/sdk-flutter/lib/native_toolkit.dart
+++ b/libs/sdk-flutter/lib/native_toolkit.dart
@@ -5,6 +5,7 @@ import 'bridge_generated.dart';
 BreezSdkCore? _breezSDK;
 
 const _libName = "libbreez_sdk_bindings.so";
+const _iosLibName = "breez_sdk";
 
 class UnsupportedPlatform implements Exception {
   UnsupportedPlatform(String s);
@@ -16,8 +17,11 @@ BreezSdkCore getNativeToolkit() {
       // On Linux the lib needs to be in LD_LIBRARY_PATH or working directory
       _breezSDK = BreezSdkCoreImpl(DynamicLibrary.open(_libName));
     } else if (Platform.isIOS || Platform.isMacOS) {
-      // iOS and macOS are statically linked
-      _breezSDK = BreezSdkCoreImpl(DynamicLibrary.process());
+      try {
+        _breezSDK = BreezSdkCoreImpl(DynamicLibrary.open("$_iosLibName.framework/$_iosLibName"));
+      } catch (e) {
+        _breezSDK = BreezSdkCoreImpl(DynamicLibrary.process());
+      }
     } else {
       throw UnsupportedPlatform('${Platform.operatingSystem} is not yet supported!');
     }

--- a/libs/sdk-flutter/pubspec.yaml
+++ b/libs/sdk-flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: breez_sdk
-description: A new flutter plugin project.
+description: Flutter bindings for the Breez SDK
+repository: https://github.com/breez/breez-sdk-flutter
 version: 0.2.15
-publish_to: none
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Due to an [issue with `flutter_rust_bridge`](https://github.com/fzyzcjy/flutter_rust_bridge/issues/1712), we need to link our bindings dynamically in the iOS Flutter plugin. [Inspired by BDK,](https://github.com/LtbLightning/bdk-flutter/blob/main/ios/bdk_flutter.podspec#L24) @roeierez found [a way to make that work](https://github.com/breez/breez-sdk-flutter/compare/main...dloader#diff-2a95d4193310f4a1bc04106bce8d8c6b3e712ce52a0864b10d0e80ee21335bbbR33). This PR adds this change.

The idea is to:

1. Download `breez_sdkFFI.xcframework` on `pod install` (we cannot bundle it due to size constraints with pub.dev).
2. Deliver `BreezSDK.swift` together with the plugin the same way we do it for local development

That way we achieve:

- The ability to link the bindings dynamically and use native Swift code as a Flutter plugin user the same way we do it in c-breez
- Have an easy way to switch between development and production in c-breez

## Testing

I tried to simulate locally what the CI would do and pushed that to: [`breez-sdk-flutter/tree/dynamic-linking-test`](https://github.com/breez/breez-sdk-flutter/tree/dynamic-linking-test). Running c-breez and pulling the breez-sdk from this branch works on my machine.

Would appreciate if anyone could double check this.