### PR TITLE
Handle `redeem_swap` error in case the invoice is known

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1804,6 +1804,7 @@ impl BreezServicesBuilder {
 
         let btc_receive_swapper = Arc::new(BTCReceiveSwap::new(
             self.config.network.into(),
+            unwrapped_node_api.clone(),
             self.swapper_api
                 .clone()
                 .unwrap_or_else(|| breez_server.clone()),

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -708,6 +708,25 @@ impl NodeAPI for Greenlight {
         Ok(res.bolt11)
     }
 
+    async fn lookup_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
+        let request = cln::ListinvoicesRequest {
+            payment_hash: Some(payment_hash),
+            ..Default::default()
+        };
+
+        let found_bolt11 = self
+            .get_node_client()
+            .await?
+            .list_invoices(request)
+            .await?
+            .into_inner()
+            .invoices
+            .first()
+            .cloned()
+            .and_then(|res| res.bolt11);
+        Ok(found_bolt11)
+    }
+
     // implement pull changes from greenlight
     async fn pull_changed(
         &self,

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -708,7 +708,7 @@ impl NodeAPI for Greenlight {
         Ok(res.bolt11)
     }
 
-    async fn lookup_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
+    async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
         let request = cln::ListinvoicesRequest {
             payment_hash: Some(payment_hash),
             ..Default::default()

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1243,7 +1243,7 @@ pub struct SwapInfo {
     pub public_key: Vec<u8>,
     /// The public key in binary format from the swapping service. Received from [SwapperAPI::create_swap].
     pub swapper_public_key: Vec<u8>,
-    /// The lockingsscript for the generated bitcoin address. Received from [SwapperAPI::create_swap].
+    /// The locking script for the generated bitcoin address. Received from [SwapperAPI::create_swap].
     pub script: Vec<u8>,
 
     /// bolt11 invoice to claim the sent funds.

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -91,10 +91,12 @@ pub struct Swap {
     pub bitcoin_address: String,
     pub swapper_pubkey: Vec<u8>,
     pub lock_height: i64,
-    pub max_allowed_deposit: i64,
     pub error_message: String,
     pub required_reserve: i64,
+    /// Minimum amount, in sats, that should be sent to `bitcoin_address` for a successful swap
     pub min_allowed_deposit: i64,
+    /// Maximum amount, in sats, that should be sent to `bitcoin_address` for a successful swap
+    pub max_allowed_deposit: i64,
 }
 
 /// Trait covering functionality involving swaps

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -6,12 +6,7 @@ use tokio::sync::mpsc;
 use tokio_stream::Stream;
 use tonic::Streaming;
 
-use crate::{
-    bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey},
-    invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount,
-    NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest,
-    PrepareRedeemOnchainFundsResponse, RouteHintHop, SyncResponse, TlvEntry,
-};
+use crate::{bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey}, invoice::InvoiceError, persist::error::PersistError, CustomMessage, MaxChannelAmount, NodeCredentials, Payment, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHintHop, SyncResponse, TlvEntry};
 
 pub type NodeResult<T, E = NodeError> = Result<T, E>;
 
@@ -65,6 +60,8 @@ pub trait NodeAPI: Send + Sync {
         expiry: Option<u32>,
         cltv: Option<u32>,
     ) -> NodeResult<String>;
+    /// Looks up an existing BOLT11 invoice by payment hash
+    async fn lookup_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>>;
     async fn pull_changed(
         &self,
         since_timestamp: u64,

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -60,8 +60,8 @@ pub trait NodeAPI: Send + Sync {
         expiry: Option<u32>,
         cltv: Option<u32>,
     ) -> NodeResult<String>;
-    /// Looks up an existing BOLT11 invoice by payment hash
-    async fn lookup_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>>;
+    /// Fetches an existing BOLT11 invoice from the node
+    async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>>;
     async fn pull_changed(
         &self,
         since_timestamp: u64,

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -428,8 +428,10 @@ impl BTCReceiveSwap {
                         Ok(bolt11)
                     }
 
-                    // If the swap was created on a different device and the invoice creation failed,
-                    // then the invoice already exists. In this case, lookup the invoice from the node.
+                    // If settling the invoice failed on a different device (for example because the
+                    // swap was initiated there), then the unsettled invoice exists on the GL node.
+                    // Trying to create the invoice here will fail because we're using the same preimage.
+                    // In this case, fetch the invoice from GL instead of creating it.
                     Err(ReceivePaymentError::InvoicePreimageAlreadyExists { .. }) => {
                         match self.node_api.fetch_bolt11(swap_info.payment_hash).await? {
                             Some(bolt11) => Ok(bolt11),

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -431,7 +431,7 @@ impl BTCReceiveSwap {
                     // If the swap was crated on a different device and the invoice payment failed,
                     // the invoice already exists. In this case, lookup the invoice from the node.
                     Err(ReceivePaymentError::InvoicePreimageAlreadyExists { .. }) => {
-                        match self.node_api.lookup_bolt11(swap_info.payment_hash).await? {
+                        match self.node_api.fetch_bolt11(swap_info.payment_hash).await? {
                             Some(bolt11) => Ok(bolt11),
                             None => Err(anyhow!("Preimage already known, but invoice not found")),
                         }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -23,7 +23,10 @@ use crate::grpc::{AddFundInitRequest, GetSwapPaymentRequest};
 use crate::models::{Swap, SwapInfo, SwapStatus, SwapperAPI};
 use crate::node_api::NodeAPI;
 use crate::swap_in::error::SwapError;
-use crate::{ensure_sdk, OpeningFeeParams, PrepareRefundRequest, PrepareRefundResponse, ReceivePaymentRequest, RefundRequest, RefundResponse, SWAP_PAYMENT_FEE_EXPIRY_SECONDS};
+use crate::{
+    ensure_sdk, OpeningFeeParams, PrepareRefundRequest, PrepareRefundResponse,
+    ReceivePaymentRequest, RefundRequest, RefundResponse, SWAP_PAYMENT_FEE_EXPIRY_SECONDS,
+};
 
 use super::error::SwapResult;
 
@@ -59,7 +62,8 @@ impl SwapperAPI for BreezServer {
         let req = GetSwapPaymentRequest {
             payment_request: bolt11,
         };
-        let resp = self.get_fund_manager_client()
+        let resp = self
+            .get_fund_manager_client()
             .await?
             .get_swap_payment(req)
             .await?
@@ -67,7 +71,7 @@ impl SwapperAPI for BreezServer {
 
         match resp.swap_error() {
             crate::grpc::get_swap_payment_reply::SwapError::NoError => Ok(()),
-            err => Err(anyhow!("Failed to complete swap: {}", err.as_str_name()))
+            err => Err(anyhow!("Failed to complete swap: {}", err.as_str_name())),
         }
     }
 }
@@ -423,7 +427,8 @@ impl BTCReceiveSwap {
                             .update_swap_bolt11(bitcoin_address, invoice.bolt11.clone())?;
 
                         // Making sure the created invoice amount matches the on-chain amount minus opening channel opening fees
-                        let expected_invoice_amount_msat = swap_info.confirmed_sats * 1_000 - create_invoice_response.opening_fee_msat.unwrap_or_default();
+                        let expected_invoice_amount_msat = swap_info.confirmed_sats * 1_000
+                            - create_invoice_response.opening_fee_msat.unwrap_or_default();
                         let invoice_amount_msat = invoice.amount_msat.unwrap_or_default();
 
                         ensure_sdk!(

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -428,8 +428,8 @@ impl BTCReceiveSwap {
                         Ok(bolt11)
                     }
 
-                    // If the swap was crated on a different device and the invoice payment failed,
-                    // the invoice already exists. In this case, lookup the invoice from the node.
+                    // If the swap was created on a different device and the invoice creation failed,
+                    // then the invoice already exists. In this case, lookup the invoice from the node.
                     Err(ReceivePaymentError::InvoicePreimageAlreadyExists { .. }) => {
                         match self.node_api.fetch_bolt11(swap_info.payment_hash).await? {
                             Some(bolt11) => Ok(bolt11),

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -439,6 +439,10 @@ impl NodeAPI for MockNodeAPI {
             tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok),
         ))
     }
+
+    async fn lookup_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
+        Ok(None)
+    }
 }
 
 impl MockNodeAPI {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -440,7 +440,7 @@ impl NodeAPI for MockNodeAPI {
         ))
     }
 
-    async fn lookup_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
+    async fn fetch_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
         Ok(None)
     }
 }

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1766,7 +1766,7 @@ class SwapInfo {
   /// The public key in binary format from the swapping service. Received from [SwapperAPI::create_swap].
   final Uint8List swapperPublicKey;
 
-  /// The lockingsscript for the generated bitcoin address. Received from [SwapperAPI::create_swap].
+  /// The locking script for the generated bitcoin address. Received from [SwapperAPI::create_swap].
   final Uint8List script;
 
   /// bolt11 invoice to claim the sent funds.


### PR DESCRIPTION
This PR attempts to fix the issue in the following scenario:

- user starts a swap on device A
- user pays onchain amount and it confirms, but for one reason or another the invoice cannot be paid (for example, the amount was below `min_allowed_deposit`)
- user restores on device B
- there, the ongoing swap sees a confirmed tx and attempts to create an invoice, but fails because GL cannot create another invoice with the same preimage

The main change brought by the PR is in `redeem_swap`:
- if no invoice is known, try to create it on GL
- if invoice creation fails with `InvoicePreimageAlreadyExists`, try to retrieve it from DB

Fixes #710

---

~The issue is this invoice doesn't exist on device B. It exists on GL, but we only `sync()` settled invoices.~

Update: as per @dangeross 's suggestion, I added a `NodeAPI` method to fetch the invoice from GL directly.