### PR TITLE
Update sdk-flutter plugin changelogs

### DIFF
--- a/libs/sdk-flutter/CHANGELOG.md
+++ b/libs/sdk-flutter/CHANGELOG.md
@@ -1,16 +1,68 @@
 SDK release notes can be found at [breez-sdk/releases](https://github.com/breez/breez-sdk/releases/)
+## 0.3.2 (pre-release notes)
+* Updates minimum supported SDK version to Flutter 3.3/Dart 2.19.
 
-## 0.2.8
+## 0.3.1 (pre-release notes)
+- Support notifications via a webhook after a swap transaction confirms.
+
+## 0.3.0
+* Fixes compatibility issues ith `bdk-flutter` plugin.
+* Introduce `rescanSwap` API to rescan swap addresses.
+* Introduce `configureNode` API to configure an address to send funds to during a mutual channel close.
+* Introduce `setPaymentMetadata` API to set the external metadata of a payment as a valid JSON string.
+* Add optional `chainnotifierUrl` to `Config`.
+* Include `openChannelBolt11`, `lnurlPayDomain`, `reverseSwapInfo` in `LnPaymentDetails`.  
+  `openChannelBolt11` for received payments which required to open a channel.  
+  `lnurlPayDomain` for sent payments that are not to a Lightning Address.  
+  `reverseSwapInfo` for payments that were sent in the context of a reverse swap.
+
+## 0.2.15
+* This is a hotfix release that fixes a critical issue from previous release.
+
+## 0.2.14 (Please use >=0.2.15)
+* **Breaking** Rename `sweep` to `redeemOnchainFunds`.
+* * Updates `flutter_rust_bridge` to `v1.82.6`.
+* Introduce `registerWebhook` API to receive payments via mobile notifications. More information [here](https://sdk-doc.breez.technology/guide/payment_notification.html).
+* Allow `RegisterWebhook` command to be executed through `executeCommand` API.
+* Add expiry time to pending payments.  
+  Add optional `pendingExpirationBlock` to `LnPaymentDetails`.
+* Add extra TLVs to send spontaneous payment.  
+  Add optional `extraTlvs` to `SendSpontaneousPaymentRequest`.
+* Support custom payment metadata.  
+  Add optional `metadataFilters` to `ListPaymentsRequest`.
+
+## 0.2.12
+* Allow native access to SDK from flutter (Kotlin & Swift).
+* Updates `flutter_rust_bridge` to `v1.82.4`.
+
+## 0.2.10
+* **Breaking** Replace parameters of `prepareSweep` with `PrepareSweepRequest`.
+* Amount is now populated in failed payments.
+* Introduce `reportIssue` API to report payment failures.
+* Introduce `serviceHealthCheck` API to get service health status.
+* Include `Payment` information on `InvoicePaid` event.
+
+## 0.2.9
 * Requires Dart 3.0 or later.
 * Migrate to null safety.
-* Introduce `prepareRefund` API
 * **Breaking** `filter` field of `ListPaymentsRequest` is deprecated and must be replaced with the optional `filters` field.
-* **Breaking** `PaymentTypeFilter.All` is removed. Unfiltered payment list will be retrieved if `filters` fields of `ListPaymentsRequest` is left empty(_or is a list that contains all PaymentTypeFilter types_).
+* **Breaking** `PaymentTypeFilter.All` is removed. Unfiltered payment list will be retrieved if `filters` fields of `ListPaymentsRequest` is left empty(_or is a list that contains all `PaymentTypeFilter` types_).
+* Introduce `prepareRefund` API to estimate the refund transaction fee.
+* Introduce `prepareSweep` API to estimate the sweep transaction fee.
+* Introduce `maxReverseSwapAmount` API to allow draining all channels when sending on-chain.
 * `ClosedChannel` transactions can now be filtered by adding `PaymentTypeFilter.ClosedChannels` to the `filters` list.
+* Include `swapInfo` in `Payment`.
+* Include `paymentHash` in `LnUrlPayResult`.
 
 ## 0.2.7
 * **Breaking** All APIs which previously allowed multiple parameters to be
-  passed now require their corresponding `Request` object.
-  These API's include: `sendOnchain`, `sendPayment`, `sendSpontaneousPayment`, `refund`, `lnurlPay`, `lnurlWithdraw`
-* **Breaking** All `request` params is renamed to `req`
-* **Breaking** All `reqData` params that belong to a `req` object(_lnurlPay,lnurlWithdraw except lnurlAuth_) is renamed to `data`
+  passed now require their corresponding `Request` object.  
+  These API's include: `sendOnchain`, `sendPayment`, `sendSpontaneousPayment`, `refund`, `lnurlPay`, `lnurlWithdraw`.
+* **Breaking** All `request` params is renamed to `req`.
+* **Breaking** All `reqData` params that belong to a `req` object(_lnurlPay, lnurlWithdraw except lnurlAuth_) is renamed to `data`.
+* **Breaking** Use millisatoshi instead of satoshi for lightning amounts.  
+  `ReceivePaymentRequest`, `SendPaymentRequest`, `SendSpontaneousPaymentRequest` now use `amount_msat` instead of `amount_sat`.
+* Support pagination in `listPayments`.
+* Add optional `claimTxid` and `lockTxid` to `ReverseSwapInfo`.
+* Add `closingTxid` to closed channels received in payments list.
+* Allow `GetInfo` command to be executed through `executeCommand` API.

--- a/libs/sdk-flutter/CHANGELOG.md
+++ b/libs/sdk-flutter/CHANGELOG.md
@@ -1,9 +1,10 @@
 SDK release notes can be found at [breez-sdk/releases](https://github.com/breez/breez-sdk/releases/)
-## 0.3.2 (pre-release notes)
-* Updates minimum supported SDK version to Flutter 3.3/Dart 2.19.
+## 0.3.2
+* Fixed a signer crash
 
-## 0.3.1 (pre-release notes)
-- Support notifications via a webhook after a swap transaction confirms.
+## 0.3.1
+* Support notifications via a webhook after a swap transaction confirms.
+* Reduced package size by not bundling pre-built binaries
 
 ## 0.3.0
 * Fixes compatibility issues ith `bdk-flutter` plugin.

--- a/libs/sdk-flutter/README.md
+++ b/libs/sdk-flutter/README.md
@@ -6,7 +6,7 @@ The [flutter_rust_bridge](https://github.com/fzyzcjy/flutter_rust_bridge) is use
 ## Build
 
 ### Prerequisites:
-* Flutter version `3.13.8`
+* Flutter version `3.19.0`
 * set the ANDROID_NDK_HOME env variable to your sdk home folder
 ```
 export ANDROID_NDK_HOME=<your android ndk directory>
@@ -26,7 +26,7 @@ cargo install cargo-ndk
 ```
 * Install [flutter_rust_bridge](https://github.com/fzyzcjy/flutter_rust_bridge): 
 ```
-cargo install flutter_rust_bridge_codegen --version 1.80.1
+cargo install flutter_rust_bridge_codegen --version 1.82.6
 ```
 
 ## Building the plugin

--- a/libs/sdk-flutter/README.pub.md
+++ b/libs/sdk-flutter/README.pub.md
@@ -1,0 +1,58 @@
+# Breez SDK plugin
+
+[![pub package](https://img.shields.io/pub/v/breez_sdk.svg)](https://pub.dev/packages/breez_sdk)
+
+## Table of contents
+- [Description](#description)
+- [Overview](#overview)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Documentation](#documentation)
+
+## Description
+
+This is a Flutter package that wraps the Dart bindings of [Breez SDK](https://github.com/breez/breez-sdk?tab=readme-ov-file#readme).
+
+|             | Android | iOS   |
+|-------------|---------|-------|
+| **Support** | SDK 21+ | 12.0+ |
+
+## Overview
+
+Breez SDK enables developers to integrate Lightning and bitcoin payments into their apps with a very shallow learning curve. The use cases are endless – from social apps that want to integrate tipping between users to content-creation apps interested in adding bitcoin monetization. Crucially, this SDK is an end-to-end, non-custodial, drop-in solution powered by Greenlight, a built-in LSP, on-chain interoperability, third-party fiat on-ramps, and other services users and operators need. Breez SDK is free for developers.
+
+Breez SDK provides the following services:
+
+ - Sending payments (via various protocols such as: bolt11, keysend, lnurl-pay, lightning address, etc.)
+ - Receiving payments (via various protocols such as: bolt11, lnurl-withdraw, etc.)
+ - Fetching node status (e.g. balance, max allow to pay, max allow to receive, on-chain balance, etc.)
+ - Connecting to a new or existing node.
+
+and many more! See [Documentation](#documentation).
+
+## Installation
+To use this plugin, add `breez_sdk` as a [dependency in your pubspec.yaml file](https://flutter.dev/docs/development/platform-integration/platform-channels).
+
+## Usage
+
+To start using this package first import it in your Dart file.
+
+```dart
+import 'package:breez_sdk/breez_sdk.dart';
+```
+
+It's recommended to use a single instance of `BreezSDK()` throughout your app. Assuming `breezSDK` variable in the example points to this instance: 
+
+Check whether Breez node services are initialized first by calling `isInitialized()` and then call `initialize()` to initialize Breez SDK's event & log streams, preferably on `main.dart`:
+
+```dart
+if (!await breezSDK.isInitialized()) {
+  breezSDK.initialize();
+}
+```
+
+Please refer to Dart examples on Breez SDK documentation for more information on features & capabilities of the Breez SDK.
+
+## Documentation
+
+- [Official Breez SDK documentation](https://sdk-doc.breez.technology/)

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -1,5 +1,5 @@
 group 'com.breez.breez_sdk'
-version '0.3.1'
+version '0.3.2'
 
 buildscript {
     ext.kotlin_version = '1.7.10'

--- a/libs/sdk-flutter/ios/breez_sdk.podspec
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec
@@ -2,7 +2,7 @@
 # Run `pod lib lint breez_sdk.podspec` to validate before publishing.
 Pod::Spec.new do |s|
   s.name             = 'breez_sdk'
-  s.version          = '0.3.1'
+  s.version          = '0.3.2'
   s.summary          = 'BreezSDK flutter plugin.'
   s.description      = <<-DESC
   BreezSDK flutter plugin.

--- a/libs/sdk-flutter/ios/breez_sdk.podspec.production
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec.production
@@ -1,4 +1,4 @@
-tag_version = '0.3.1'
+tag_version = '0.3.2'
 framework = 'breez_sdkFFI.xcframework'
 lib_name = "breez-sdkFFI.#{tag_version}"
 url = "https://github.com/breez/breez-sdk-swift/releases/download/#{tag_version}/#{framework}.zip"

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -382,6 +382,10 @@ class BreezSDK {
     return await _lnToolkit.prepareRefund(req: req);
   }
 
+  /// Iterate all historical swap addresses and fetch their current status from the blockchain.
+  /// The status is then updated in the persistent storage.
+  Future<void> rescanSwaps() async => await _lnToolkit.rescanSwaps();
+
   /* In Progress Swap API's */
 
   /// Returns an optional in-progress [SwapInfo].

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -128,6 +128,13 @@ class BreezSDK {
     return nodeState;
   }
 
+  /// Configure an optional address to send funds to during a mutual channel close
+  Future<void> configureNode({
+    required ConfigureNodeRequest req,
+  }) async {
+    return await _lnToolkit.configureNode(req: req);
+  }
+
   /// Cleanup node resources and stop the signer.
   Future<void> disconnect() async => await _lnToolkit.disconnect();
 

--- a/libs/sdk-flutter/pubspec.yaml
+++ b/libs/sdk-flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: breez_sdk
 description: Flutter bindings for the Breez SDK
 repository: https://github.com/breez/breez-sdk-flutter
-version: 0.3.1
+version: 0.3.2
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
Updated CHANGELOGs of our Flutter plugin as we're releasing on pub.dev.

Noticed `configureNode` & `rescanSwaps` API's weren't exposed through plugin as I went through the SDK changelogs. These API's need to be exposed through the plugin and cherry-picked to their respective release branches.

---

1. One other thing, if `0.3.0` is going to be a standalone version `0.3.1` release notes should be updated to reflect changes between `0.3.0...0.3.1`, rather than `0.2.15...0.3.1`.

2. It's updated on `0.3.1` branch but it looks like version `0.3.1` should be applied to plugin versions on pubspec/podspec files etc. on `main` branch as they currently are set to `0.3.0`. 

@roeierez Any clarification on these two points?