### PR TITLE
Re-use `lightning` crate exported by `gl-client`

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -528,7 +528,6 @@ dependencies = [
  "gl-client",
  "hex",
  "lazy_static",
- "lightning",
  "log",
  "miniz_oxide",
  "mockito",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -48,8 +48,6 @@ tonic = { version = "^0.8", features = [
     "tls-webpki-roots",
 ] }
 lazy_static = "^1.4.0"
-# Keep in sync with the version used by gl-client
-lightning = "0.0.116"
 log = "0.4"
 once_cell = "1"
 openssl = { version = "0.10", features = ["vendored"] }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -23,7 +23,6 @@ use gl_client::signer::model::greenlight::{amount, scheduler};
 use gl_client::signer::Signer;
 use gl_client::tls::TlsConfig;
 use gl_client::{node, utils};
-use lightning::util::message_signing::verify;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use tokio::sync::{mpsc, Mutex};
@@ -42,6 +41,7 @@ use crate::bitcoin::{
     Address, OutPoint, Script, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use crate::invoice::{parse_invoice, validate_network, InvoiceError, RouteHintHop};
+use crate::lightning::util::message_signing::verify;
 use crate::lightning_invoice::{RawBolt11Invoice, SignedRawBolt11Invoice};
 use crate::models::*;
 use crate::node_api::{NodeAPI, NodeError, NodeResult};

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -3,12 +3,12 @@ use std::time::{SystemTimeError, UNIX_EPOCH};
 
 use anyhow::anyhow;
 use hex::ToHex;
-use lightning::routing::gossip::RoutingFees;
-use lightning::routing::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::secp256k1::{self, PublicKey};
+use crate::lightning::routing::gossip::RoutingFees;
+use crate::lightning::routing::*;
 use crate::lightning_invoice::*;
 use crate::Network;
 
@@ -179,7 +179,7 @@ pub fn add_routing_hints(
 
     // When merging route hints, only route hints are added that go through different nodes than ones in the invoice route hints.
     // Otherwise when not merging route hints, the invoice route hints are replaced by the provided route hints.
-    let unique_hop_hints: Vec<lightning::routing::router::RouteHint> = match route_hints.len() {
+    let unique_hop_hints: Vec<router::RouteHint> = match route_hints.len() {
         0 => invoice.route_hints(),
         _ => match merge_with_existing {
             true => {

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -192,6 +192,7 @@ mod swap_out;
 
 // Re-use crates from gl_client for consistency
 use gl_client::bitcoin;
+use gl_client::lightning;
 use gl_client::lightning_invoice;
 
 pub use breez_services::{

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -8,7 +8,6 @@ use chrono::{SecondsFormat, Utc};
 use gl_client::signer::model::greenlight::amount::Unit;
 use gl_client::signer::model::greenlight::Amount;
 use gl_client::signer::model::greenlight::PayStatus;
-use lightning::ln::PaymentSecret;
 use rand::distributions::{Alphanumeric, DistString, Standard};
 use rand::rngs::OsRng;
 use rand::{random, Rng};
@@ -31,6 +30,7 @@ use crate::error::{ReceivePaymentError, SdkError, SdkResult};
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{PaymentInformation, RegisterPaymentNotificationResponse, RegisterPaymentReply};
 use crate::invoice::{InvoiceError, InvoiceResult};
+use crate::lightning::ln::PaymentSecret;
 use crate::lightning_invoice::{Currency, InvoiceBuilder, RawBolt11Invoice};
 use crate::lsp::LspInformation;
 use crate::models::{

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -474,7 +474,6 @@ dependencies = [
  "gl-client",
  "hex",
  "lazy_static",
- "lightning",
  "log",
  "miniz_oxide",
  "once_cell",


### PR DESCRIPTION
This PR is the equivalent of #791 for the `lightning` dependency.

It includes:
- bumping GL by one commit, such that it now re-exports its `lightning` dependency
- removing the direct dependency from our `Cargo.toml`
- updating our internal references to re-use the imported one from `gl_client`