### PR TITLE
Add send_payment validation: liquidity

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -91,6 +91,8 @@ enum SendPaymentError {
     "InvalidInvoice",
     "InvoiceExpired",
     "InvalidNetwork",
+    "NoConnectedPeers",
+    "NotEnoughLiquidity",
     "PaymentFailed",
     "PaymentTimeout",
     "RouteNotFound",

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -91,7 +91,6 @@ enum SendPaymentError {
     "InvalidInvoice",
     "InvoiceExpired",
     "InvalidNetwork",
-    "NoConnectedPeers",
     "NotEnoughLiquidity",
     "PaymentFailed",
     "PaymentTimeout",

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -294,7 +294,6 @@ impl BreezServices {
         {
             Some(_) => Err(SendPaymentError::AlreadyPaid),
             None => {
-                self.validate_peers_connected()?;
                 self.validate_liquidity(amount_msat)?;
 
                 self.persist_pending_payment(&parsed_invoice, amount_msat)?;
@@ -1592,14 +1591,6 @@ impl BreezServices {
             error: None,
             metadata: None,
         })
-    }
-
-    fn validate_peers_connected(&self) -> Result<(), SendPaymentError> {
-        ensure_sdk!(
-            !self.node_info()?.connected_peers.is_empty(),
-            SendPaymentError::NoConnectedPeers
-        );
-        Ok(())
     }
 
     fn validate_liquidity(&self, payment_amount_msat: u64) -> Result<(), SendPaymentError> {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2836,6 +2836,7 @@ pub(crate) mod tests {
         persister.init()?;
         persister.insert_or_update_payments(&known_payments, false)?;
         persister.set_lsp_id(MockBreezServer {}.lsp_id())?;
+        persister.set_node_state(&get_dummy_node_state())?;
 
         let mut builder = BreezServicesBuilder::new(test_config.clone());
         let breez_services = builder
@@ -2854,18 +2855,18 @@ pub(crate) mod tests {
     /// Build dummy NodeState for tests
     pub(crate) fn get_dummy_node_state() -> NodeState {
         NodeState {
-            id: "tx1".to_string(),
+            id: "node_id_1".to_string(),
             block_height: 1,
-            channels_balance_msat: 100,
-            onchain_balance_msat: 1000,
+            channels_balance_msat: 100_000,
+            onchain_balance_msat: 1_000,
             pending_onchain_balance_msat: 100,
             utxos: vec![],
-            max_payable_msat: 95,
-            max_receivable_msat: 1000,
-            max_single_payment_amount_msat: 1000,
+            max_payable_msat: 100_000,
+            max_receivable_msat: 1_000,
+            max_single_payment_amount_msat: 1_000,
             max_chan_reserve_msats: 0,
             connected_peers: vec!["1111".to_string()],
-            inbound_liquidity_msats: 2000,
+            inbound_liquidity_msats: 2_000,
         }
     }
 }

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -666,9 +666,6 @@ pub enum SendPaymentError {
     #[error("Invoice expired: {err}")]
     InvoiceExpired { err: String },
 
-    #[error("No connected peers")]
-    NoConnectedPeers,
-
     #[error(
         "Not enough liquidity to pay {amount_msat} msat: \
         channel balance {channels_balance_msat} msat, \

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -666,6 +666,22 @@ pub enum SendPaymentError {
     #[error("Invoice expired: {err}")]
     InvoiceExpired { err: String },
 
+    #[error("No connected peers at this moment. Please try again later.")]
+    NoConnectedPeers,
+
+    #[error(
+        "Not enough liquidity to pay {amount_msat} msat: \
+        channel balance {channels_balance_msat} msat, \
+        onchain balance {onchain_balance_msat} msat, \
+        pending onchain balance {pending_onchain_balance_msat} msat"
+    )]
+    NotEnoughLiquidity {
+        amount_msat: u64,
+        channels_balance_msat: u64,
+        onchain_balance_msat: u64,
+        pending_onchain_balance_msat: u64,
+    },
+
     #[error("Payment failed: {err}")]
     PaymentFailed { err: String },
 
@@ -680,6 +696,22 @@ pub enum SendPaymentError {
 
     #[error("Service connectivity: {err}")]
     ServiceConnectivity { err: String },
+}
+
+impl SendPaymentError {
+    pub(crate) fn not_enough_liquidity(
+        amount_msat: u64,
+        channels_balance_msat: u64,
+        onchain_balance_msat: u64,
+        pending_onchain_balance_msat: u64,
+    ) -> Self {
+        Self::NotEnoughLiquidity {
+            amount_msat,
+            channels_balance_msat,
+            onchain_balance_msat,
+            pending_onchain_balance_msat,
+        }
+    }
 }
 
 impl From<anyhow::Error> for SendPaymentError {

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -666,7 +666,7 @@ pub enum SendPaymentError {
     #[error("Invoice expired: {err}")]
     InvoiceExpired { err: String },
 
-    #[error("No connected peers at this moment. Please try again later.")]
+    #[error("No connected peers")]
     NoConnectedPeers,
 
     #[error(

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -219,7 +219,7 @@ pub fn add_routing_hints(
 }
 
 // Validate that the LNInvoice network matches the provided network
-pub fn validate_network(invoice: LNInvoice, network: Network) -> InvoiceResult<()> {
+pub(crate) fn validate_network(invoice: LNInvoice, network: Network) -> InvoiceResult<()> {
     match invoice.network == network {
         true => Ok(()),
         false => Err(InvoiceError::InvalidNetwork(anyhow!(


### PR DESCRIPTION
Before attempting to send the payment, check a few node conditions that would obviously result in a failure.

This allows `send_payment` to fail instantly, instead of after about a minute with "ran out of routes".