### PR TITLE
Minimize the use of mempool.space /tip endpoint

### DIFF
--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -12,6 +12,9 @@ pub trait ChainService: Send + Sync {
     ///
     /// See <https://mempool.space/docs/api/rest#get-address-transactions>
     async fn address_transactions(&self, address: String) -> Result<Vec<OnchainTx>>;
+    /// This should not be called directly, unless absolutely necessary.
+    ///
+    /// Instead, read the blockheight from the [crate::models::NodeState]
     async fn current_tip(&self) -> Result<u32>;
     /// Gets the spending status of all tx outputs for this tx.
     ///

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -1,4 +1,7 @@
 use crate::models::NodeState;
+use crate::persist::error::PersistError;
+
+use anyhow::anyhow;
 
 use super::{db::SqliteStorage, error::PersistResult};
 
@@ -45,6 +48,11 @@ impl SqliteStorage {
             Some(str) => serde_json::from_str(str.as_str())?,
             None => None,
         })
+    }
+
+    pub fn node_info(&self) -> PersistResult<NodeState> {
+        self.get_node_state()?
+            .ok_or(PersistError::Generic(anyhow!("Node info not found")))
     }
 
     pub fn set_last_backup_time(&self, t: u64) -> PersistResult<()> {

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -149,10 +149,7 @@ impl BTCReceiveSwap {
         &self,
         channel_opening_fees: OpeningFeeParams,
     ) -> SwapResult<SwapInfo> {
-        let node_state = self
-            .persister
-            .get_node_state()?
-            .ok_or(anyhow!("Node info not found"))?;
+        let node_state = self.persister.node_info()?;
 
         // check first that we don't have any swap in progress waiting for redeem.
         if let Some(in_progress_swap) = self.list_unused()?.first().cloned() {

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -250,7 +250,7 @@ impl BTCSendSwap {
         match boltz_response {
             BoltzApiCreateReverseSwapResponse::BoltzApiSuccess(response) => {
                 let res = FullReverseSwapInfo {
-                    created_at_block_height: self.chain_service.current_tip().await?,
+                    created_at_block_height: self.persister.node_info()?.block_height,
                     claim_pubkey: req.onchain_recipient_address,
                     invoice: response.invoice,
                     preimage: reverse_swap_keys.preimage,
@@ -494,7 +494,7 @@ impl BTCSendSwap {
             },
             InProgress => match claim_tx_status {
                 TxStatus::Unknown => {
-                    let block_height = self.chain_service.current_tip().await?;
+                    let block_height = self.persister.node_info()?.block_height;
                     match block_height >= rsi.timeout_block_height {
                         true => {
                             warn!("Reverse swap {} crossed the timeout block height", rsi.id);


### PR DESCRIPTION
This is an attempt to minimize the amount of mempool.space calls we make.

It replaces, where possible, the use of `chain_service.current_tip()` with our internal `node_info()?.block_height`.