### PR TITLE
DRAFT: add min/max payment size to opening fee params

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -426,6 +426,8 @@ dictionary OpeningFeeParams {
     string valid_until;
     u32 max_idle_time;
     u32 max_client_to_self_delay;
+    u64 min_payment_size_msat;
+    u64 max_payment_size_msat;
     string promise;
 };
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2399,6 +2399,8 @@ pub(crate) mod tests {
                 valid_until: "date".to_string(),
                 max_idle_time: 12345,
                 max_client_to_self_delay: 234,
+                min_payment_size_msat: 1000,
+                max_payment_size_msat: 4_000_000_000,
                 promise: "promise".to_string(),
             }),
             confirmed_at: Some(555),

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -882,6 +882,8 @@ impl Wire2Api<OpeningFeeParams> for wire_OpeningFeeParams {
             valid_until: self.valid_until.wire2api(),
             max_idle_time: self.max_idle_time.wire2api(),
             max_client_to_self_delay: self.max_client_to_self_delay.wire2api(),
+            min_payment_size_msat: self.min_payment_size_msat.wire2api(),
+            max_payment_size_msat: self.max_payment_size_msat.wire2api(),
             promise: self.promise.wire2api(),
         }
     }
@@ -1192,6 +1194,8 @@ pub struct wire_OpeningFeeParams {
     valid_until: *mut wire_uint_8_list,
     max_idle_time: u32,
     max_client_to_self_delay: u32,
+    min_payment_size_msat: u64,
+    max_payment_size_msat: u64,
     promise: *mut wire_uint_8_list,
 }
 
@@ -1639,6 +1643,8 @@ impl NewWithNullPtr for wire_OpeningFeeParams {
             valid_until: core::ptr::null_mut(),
             max_idle_time: Default::default(),
             max_client_to_self_delay: Default::default(),
+            min_payment_size_msat: Default::default(),
+            max_payment_size_msat: Default::default(),
             promise: core::ptr::null_mut(),
         }
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1689,6 +1689,8 @@ impl support::IntoDart for OpeningFeeParams {
             self.valid_until.into_into_dart().into_dart(),
             self.max_idle_time.into_into_dart().into_dart(),
             self.max_client_to_self_delay.into_into_dart().into_dart(),
+            self.min_payment_size_msat.into_into_dart().into_dart(),
+            self.max_payment_size_msat.into_into_dart().into_dart(),
             self.promise.into_into_dart().into_dart(),
         ]
         .into_dart()

--- a/libs/sdk-core/src/grpc/proto/breez.proto
+++ b/libs/sdk-core/src/grpc/proto/breez.proto
@@ -161,6 +161,8 @@ message OpeningFeeParams {
   uint32 max_idle_time = 4;
   uint32 max_client_to_self_delay = 5;
   string promise = 6;
+  uint64 min_payment_size_msat = 7;
+  uint64 max_payment_size_msat = 8;
 }
 message LSPListReply {
   map<string, LSPInformation> lsps = 1; // The key is the lsp id

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -181,6 +181,8 @@ mod tests {
                     .to_rfc3339(),
                 max_idle_time: i as u32,
                 max_client_to_self_delay: i as u32,
+                min_payment_size_msat: i,
+                max_payment_size_msat: i,
                 promise: format!("promise {i}"),
             })
         }

--- a/libs/sdk-core/src/lsps2/client.rs
+++ b/libs/sdk-core/src/lsps2/client.rs
@@ -40,6 +40,10 @@ pub struct OpeningFeeParams {
     pub valid_until: String,
     pub min_lifetime: u32,
     pub max_client_to_self_delay: u32,
+    #[serde_as(as = "DisplayFromStr")]
+    pub min_payment_size_msat: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub max_payment_size_msat: u64,
     pub promise: String,
 }
 
@@ -196,6 +200,8 @@ mod tests {
                     "valid_until": "2023-02-23T08:47:30.511Z",
                     "min_lifetime": 1008,
                     "max_client_to_self_delay": 2016,
+                    "min_payment_size_msat": "546000",
+                    "max_payment_size_msat": "4000000000",
                     "promise": "abcdefghijklmnopqrstuvwxyz"
                 },
                 {
@@ -204,11 +210,11 @@ mod tests {
                     "valid_until": "2023-02-27T21:23:57.984Z",
                     "min_lifetime": 1008,
                     "max_client_to_self_delay": 2016,
+                    "min_payment_size_msat": "1092000",
+                    "max_payment_size_msat": "4000000000",
                     "promise": "abcdefghijklmnopqrstuvwxyz"
                 }
-            ],
-            "min_payment_size_msat": "1000",
-            "max_payment_size_msat": "1000000"
+            ]
         }"#;
 
         let result = serde_json::from_str::<GetInfoResponse>(json).unwrap();
@@ -224,6 +230,8 @@ mod tests {
                         valid_until: String::from("2023-02-23T08:47:30.511Z"),
                         min_lifetime: 1008,
                         max_client_to_self_delay: 2016,
+                        min_payment_size_msat: 546000,
+                        max_payment_size_msat: 4_000_000_000,
                         promise: String::from("abcdefghijklmnopqrstuvwxyz")
                     },
                     OpeningFeeParams {
@@ -232,6 +240,8 @@ mod tests {
                         valid_until: String::from("2023-02-27T21:23:57.984Z"),
                         min_lifetime: 1008,
                         max_client_to_self_delay: 2016,
+                        min_payment_size_msat: 1092000,
+                        max_payment_size_msat: 4_000_000_000,
                         promise: String::from("abcdefghijklmnopqrstuvwxyz")
                     },
                 ]
@@ -249,13 +259,15 @@ mod tests {
                 valid_until: String::from("2023-02-23T08:47:30.511Z"),
                 min_lifetime: 1008,
                 max_client_to_self_delay: 2016,
+                min_payment_size_msat: 546000,
+                max_payment_size_msat: 4_000_000_000,
                 promise: String::from("abcdefghijklmnopqrstuvwxyz"),
             },
             payment_size_msat: Some(42000),
         };
         let result = serde_json::to_string(&req).unwrap();
         assert_eq!(
-            r#"{"version":1,"opening_fee_params":{"min_fee_msat":"546000","proportional":1200,"valid_until":"2023-02-23T08:47:30.511Z","min_lifetime":1008,"max_client_to_self_delay":2016,"promise":"abcdefghijklmnopqrstuvwxyz"},"payment_size_msat":"42000"}"#,
+            r#"{"version":1,"opening_fee_params":{"min_fee_msat":"546000","proportional":1200,"valid_until":"2023-02-23T08:47:30.511Z","min_lifetime":1008,"max_client_to_self_delay":2016,"min_payment_size_msat":"546000","max_payment_size_msat":"4000000000","promise":"abcdefghijklmnopqrstuvwxyz"},"payment_size_msat":"42000"}"#,
             result
         )
     }
@@ -270,13 +282,15 @@ mod tests {
                 valid_until: String::from("2023-02-23T08:47:30.511Z"),
                 min_lifetime: 1008,
                 max_client_to_self_delay: 2016,
+                min_payment_size_msat: 546000,
+                max_payment_size_msat: 4_000_000_000,
                 promise: String::from("abcdefghijklmnopqrstuvwxyz"),
             },
             payment_size_msat: None,
         };
         let result = serde_json::to_string(&req).unwrap();
         assert_eq!(
-            r#"{"version":1,"opening_fee_params":{"min_fee_msat":"546000","proportional":1200,"valid_until":"2023-02-23T08:47:30.511Z","min_lifetime":1008,"max_client_to_self_delay":2016,"promise":"abcdefghijklmnopqrstuvwxyz"}}"#,
+            r#"{"version":1,"opening_fee_params":{"min_fee_msat":"546000","proportional":1200,"valid_until":"2023-02-23T08:47:30.511Z","min_lifetime":1008,"max_client_to_self_delay":2016,"min_payment_size_msat":"546000","max_payment_size_msat":"4000000000","promise":"abcdefghijklmnopqrstuvwxyz"}}"#,
             result
         )
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1018,6 +1018,8 @@ pub struct OpeningFeeParams {
     /// The channel can be closed if not used within this duration in blocks
     pub max_idle_time: u32,
     pub max_client_to_self_delay: u32,
+    pub min_payment_size_msat: u64,
+    pub max_payment_size_msat: u64,
     pub promise: String,
 }
 
@@ -1046,6 +1048,8 @@ impl From<OpeningFeeParams> for grpc::OpeningFeeParams {
             valid_until: ofp.valid_until,
             max_idle_time: ofp.max_idle_time,
             max_client_to_self_delay: ofp.max_client_to_self_delay,
+            min_payment_size_msat: ofp.min_payment_size_msat,
+            max_payment_size_msat: ofp.max_payment_size_msat,
             promise: ofp.promise,
         }
     }
@@ -1059,6 +1063,8 @@ impl From<grpc::OpeningFeeParams> for OpeningFeeParams {
             valid_until: gofp.valid_until,
             max_idle_time: gofp.max_idle_time,
             max_client_to_self_delay: gofp.max_client_to_self_delay,
+            min_payment_size_msat: gofp.min_payment_size_msat,
+            max_payment_size_msat: gofp.max_payment_size_msat,
             promise: gofp.promise,
         }
     }

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -561,6 +561,8 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
             valid_until: "date".to_string(),
             max_idle_time: 12345,
             max_client_to_self_delay: 234,
+            min_payment_size_msat: 1000,
+            max_payment_size_msat: 4_000_000_000,
             promise: "promise".to_string(),
         }),
         confirmed_at: Some(555),

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -797,6 +797,8 @@ pub(crate) fn get_test_ofp_generic(
         valid_until: formatted,
         max_idle_time: 0,
         max_client_to_self_delay: 0,
+        min_payment_size_msat: 0,
+        max_payment_size_msat: 0,
         promise: "".to_string(),
     }
     .into()

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -135,6 +135,8 @@ typedef struct wire_OpeningFeeParams {
   struct wire_uint_8_list *valid_until;
   uint32_t max_idle_time;
   uint32_t max_client_to_self_delay;
+  uint64_t min_payment_size_msat;
+  uint64_t max_payment_size_msat;
   struct wire_uint_8_list *promise;
 } wire_OpeningFeeParams;
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1198,6 +1198,8 @@ class OpeningFeeParams {
   /// The channel can be closed if not used within this duration in blocks
   final int maxIdleTime;
   final int maxClientToSelfDelay;
+  final int minPaymentSizeMsat;
+  final int maxPaymentSizeMsat;
   final String promise;
 
   const OpeningFeeParams({
@@ -1206,6 +1208,8 @@ class OpeningFeeParams {
     required this.validUntil,
     required this.maxIdleTime,
     required this.maxClientToSelfDelay,
+    required this.minPaymentSizeMsat,
+    required this.maxPaymentSizeMsat,
     required this.promise,
   });
 }
@@ -3573,14 +3577,16 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   OpeningFeeParams _wire2api_opening_fee_params(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return OpeningFeeParams(
       minMsat: _wire2api_u64(arr[0]),
       proportional: _wire2api_u32(arr[1]),
       validUntil: _wire2api_String(arr[2]),
       maxIdleTime: _wire2api_u32(arr[3]),
       maxClientToSelfDelay: _wire2api_u32(arr[4]),
-      promise: _wire2api_String(arr[5]),
+      minPaymentSizeMsat: _wire2api_u64(arr[5]),
+      maxPaymentSizeMsat: _wire2api_u64(arr[6]),
+      promise: _wire2api_String(arr[7]),
     );
   }
 
@@ -4628,6 +4634,8 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.valid_until = api2wire_String(apiObj.validUntil);
     wireObj.max_idle_time = api2wire_u32(apiObj.maxIdleTime);
     wireObj.max_client_to_self_delay = api2wire_u32(apiObj.maxClientToSelfDelay);
+    wireObj.min_payment_size_msat = api2wire_u64(apiObj.minPaymentSizeMsat);
+    wireObj.max_payment_size_msat = api2wire_u64(apiObj.maxPaymentSizeMsat);
     wireObj.promise = api2wire_String(apiObj.promise);
   }
 
@@ -6191,6 +6199,12 @@ final class wire_OpeningFeeParams extends ffi.Struct {
 
   @ffi.Uint32()
   external int max_client_to_self_delay;
+
+  @ffi.Uint64()
+  external int min_payment_size_msat;
+
+  @ffi.Uint64()
+  external int max_payment_size_msat;
 
   external ffi.Pointer<wire_uint_8_list> promise;
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1895,6 +1895,8 @@ fun asOpeningFeeParams(openingFeeParams: ReadableMap): OpeningFeeParams? {
                 "validUntil",
                 "maxIdleTime",
                 "maxClientToSelfDelay",
+                "minPaymentSizeMsat",
+                "maxPaymentSizeMsat",
                 "promise",
             ),
         )
@@ -1906,6 +1908,8 @@ fun asOpeningFeeParams(openingFeeParams: ReadableMap): OpeningFeeParams? {
     val validUntil = openingFeeParams.getString("validUntil")!!
     val maxIdleTime = openingFeeParams.getInt("maxIdleTime").toUInt()
     val maxClientToSelfDelay = openingFeeParams.getInt("maxClientToSelfDelay").toUInt()
+    val minPaymentSizeMsat = openingFeeParams.getDouble("minPaymentSizeMsat").toULong()
+    val maxPaymentSizeMsat = openingFeeParams.getDouble("maxPaymentSizeMsat").toULong()
     val promise = openingFeeParams.getString("promise")!!
     return OpeningFeeParams(
         minMsat,
@@ -1913,6 +1917,8 @@ fun asOpeningFeeParams(openingFeeParams: ReadableMap): OpeningFeeParams? {
         validUntil,
         maxIdleTime,
         maxClientToSelfDelay,
+        minPaymentSizeMsat,
+        maxPaymentSizeMsat,
         promise,
     )
 }
@@ -1924,6 +1930,8 @@ fun readableMapOf(openingFeeParams: OpeningFeeParams): ReadableMap {
         "validUntil" to openingFeeParams.validUntil,
         "maxIdleTime" to openingFeeParams.maxIdleTime,
         "maxClientToSelfDelay" to openingFeeParams.maxClientToSelfDelay,
+        "minPaymentSizeMsat" to openingFeeParams.minPaymentSizeMsat,
+        "maxPaymentSizeMsat" to openingFeeParams.maxPaymentSizeMsat,
         "promise" to openingFeeParams.promise,
     )
 }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2092,6 +2092,12 @@ enum BreezSDKMapper {
         guard let maxClientToSelfDelay = openingFeeParams["maxClientToSelfDelay"] as? UInt32 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxClientToSelfDelay", typeName: "OpeningFeeParams"))
         }
+        guard let minPaymentSizeMsat = openingFeeParams["minPaymentSizeMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minPaymentSizeMsat", typeName: "OpeningFeeParams"))
+        }
+        guard let maxPaymentSizeMsat = openingFeeParams["maxPaymentSizeMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxPaymentSizeMsat", typeName: "OpeningFeeParams"))
+        }
         guard let promise = openingFeeParams["promise"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "promise", typeName: "OpeningFeeParams"))
         }
@@ -2102,6 +2108,8 @@ enum BreezSDKMapper {
             validUntil: validUntil,
             maxIdleTime: maxIdleTime,
             maxClientToSelfDelay: maxClientToSelfDelay,
+            minPaymentSizeMsat: minPaymentSizeMsat,
+            maxPaymentSizeMsat: maxPaymentSizeMsat,
             promise: promise
         )
     }
@@ -2113,6 +2121,8 @@ enum BreezSDKMapper {
             "validUntil": openingFeeParams.validUntil,
             "maxIdleTime": openingFeeParams.maxIdleTime,
             "maxClientToSelfDelay": openingFeeParams.maxClientToSelfDelay,
+            "minPaymentSizeMsat": openingFeeParams.minPaymentSizeMsat,
+            "maxPaymentSizeMsat": openingFeeParams.maxPaymentSizeMsat,
             "promise": openingFeeParams.promise,
         ]
     }

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -300,6 +300,8 @@ export type OpeningFeeParams = {
     validUntil: string
     maxIdleTime: number
     maxClientToSelfDelay: number
+    minPaymentSizeMsat: number
+    maxPaymentSizeMsat: number
     promise: string
 }
 


### PR DESCRIPTION
The fields `min_payment_size_msat` and `max_payment_size_msat` will be added to lspd in https://github.com/breez/lspd/pull/193

Currently, the only purpose to add these in the SDK is to allow LSPD to create a `promise` in the opening_fee_params that includes these fields. Later, these fields can actually be used to enforce the min and max payment size.