### PR TITLE
Lookup open channel bolt11 before fetching invoice

### DIFF
--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -986,7 +986,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
         .unwrap();
     assert_eq!(open_channel_bolt11, "original_invoice");
 
-    let open_channel_bolt11 = storage.get_open_channel_bolt11_by_hash("non existing hadh")?;
+    let open_channel_bolt11 = storage.get_open_channel_bolt11_by_hash("non existing hash")?;
     assert_eq!(open_channel_bolt11, None);
 
     let retrieve_txs = storage.list_payments(ListPaymentsRequest {


### PR DESCRIPTION
There is a bug in the following scenario:
1. User initiate a swap
2. Swap confirmed, sdk creates invoice that opens a channel, tries to redeem and fails for some reason.
3. User restores, swap redeem always fails, user has to refund.

The reason for the failure in step 3 is because when the sdk tries to create the invoice it fails on preimage already exists.
Recently we added a code that fallbacks to the node invoice but this invoice is the decreased amount in case of opening a channel so the swapper returns error for amount doesn't match.
The fix is to attempt first fetching the increased amount invoice from the persistent storage before falling back to the node.