### PR TITLE
Use TransactionBehavior::Immediate

### DIFF
--- a/libs/sdk-core/src/persist/reverseswap.rs
+++ b/libs/sdk-core/src/persist/reverseswap.rs
@@ -1,11 +1,11 @@
 use super::{db::SqliteStorage, error::PersistResult};
 use crate::{FullReverseSwapInfo, ReverseSwapInfoCached, ReverseSwapStatus};
-use rusqlite::{named_params, OptionalExtension, Params, Row};
+use rusqlite::{named_params, OptionalExtension, Params, Row, TransactionBehavior};
 
 impl SqliteStorage {
     pub(crate) fn insert_reverse_swap(&self, rsi: &FullReverseSwapInfo) -> PersistResult<()> {
         let mut con = self.get_connection()?;
-        let tx = con.transaction()?;
+        let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         tx.execute(
             "INSERT INTO sync.reverse_swaps (id, created_at_block_height, preimage, private_key, claim_pubkey, timeout_block_height, invoice, onchain_amount_sat, sat_per_vbyte, redeem_script)\

--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::OpeningFeeParams;
 use anyhow::anyhow;
-use rusqlite::{named_params, OptionalExtension, Params, Row, Transaction};
+use rusqlite::{named_params, OptionalExtension, Params, Row, Transaction, TransactionBehavior};
 
 pub(crate) struct SwapChainInfo {
     pub(crate) unconfirmed_sats: u64,
@@ -20,7 +20,7 @@ pub(crate) struct SwapChainInfo {
 impl SqliteStorage {
     pub(crate) fn insert_swap(&self, swap_info: SwapInfo) -> PersistResult<()> {
         let mut con = self.get_connection()?;
-        let tx = con.transaction()?;
+        let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         tx.execute("
          INSERT INTO sync.swaps (
@@ -161,7 +161,7 @@ impl SqliteStorage {
         channel_opening_fees: OpeningFeeParams,
     ) -> PersistResult<()> {
         let mut con = self.get_connection()?;
-        let tx = con.transaction()?;
+        let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         Self::insert_swaps_fees(&tx, bitcoin_address, channel_opening_fees)?;
 

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -1,7 +1,7 @@
 use crate::ReverseSwapStatus;
 
 use super::{db::SqliteStorage, error::PersistResult};
-use rusqlite::{named_params, Row, Transaction};
+use rusqlite::{named_params, Row, Transaction, TransactionBehavior};
 use std::path::Path;
 
 #[allow(dead_code)]
@@ -101,7 +101,7 @@ impl SqliteStorage {
         }
 
         let mut con = self.get_connection()?;
-        let tx = con.transaction()?;
+        let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
         tx.execute("ATTACH DATABASE ? AS remote_sync;", [sync_data_file])?;
 
         if to_local {


### PR DESCRIPTION
This is an attempt to acquire write lock right on transaction start and by that prevent deadlock may be caused by two transactions trying to upgrade their lock from shared to write.
I am not sure it solves the deadlock as I couldn't reproduce that with despite my attempt to run many multithreaded transactions.
It seems a better practice anyway.

One more thing we should consider which I want to test before push is to move to WAL (write ahead logging) mode which is  the recommended way for multithreading and may reduce a lot the chances for deadlocks.
I will cover that in a different PR.