### PR TITLE
Update sdk.redeem_swap: first refresh, then redeem

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -775,6 +775,10 @@ impl BreezServices {
     ///
     /// This is taken care of automatically in the context of typical SDK usage.
     pub async fn redeem_swap(&self, swap_address: String) -> SdkResult<()> {
+        let tip = self.chain_service.current_tip().await?;
+        self.btc_receive_swapper
+            .refresh_swap_on_chain_status(swap_address.clone(), tip)
+            .await?;
         self.btc_receive_swapper.redeem_swap(swap_address).await?;
         Ok(())
     }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -311,12 +311,8 @@ impl BTCReceiveSwap {
             let result = self
                 .refresh_swap_on_chain_status(address.clone(), tip)
                 .await;
-            if result.is_err() {
-                error!(
-                    "failed to refresh swap status for address {} {}",
-                    address.clone(),
-                    result.err().unwrap()
-                )
+            if let Err(err) = result {
+                error!("failed to refresh swap status for address {address}: {err}")
             }
         }
         Ok(())


### PR DESCRIPTION
Since this is used in mobile notifications, remote data is only fetched on demand.

The first step in redeeming a swap becomes refreshing it to make sure redeem works on the latest state.