### PR TITLE
CLI: Group commands by prefix, clarify help output

### DIFF
--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -11,17 +11,17 @@ pub(crate) struct SdkCli {
 #[derive(Parser, Debug, Clone, PartialEq)]
 #[clap(rename_all = "snake")]
 pub(crate) enum Commands {
-    /// Set the API key
+    /// [config] Set the API key
     SetAPIKey {
         /// The API key to use        
         key: String,
     },
-    /// Set the Environment type
+    /// [config] Set the Environment type
     SetEnv {
         /// The environment to use (staging|production)        
         env: EnvironmentType,
     },
-    /// Connect to the sdk services, make it operational
+    /// [init] Connect to the sdk services, make it operational
     Connect {
         /// The optional file location containing the greenlight partner certificate
         #[clap(name = "partner_cert", short = 'c', long = "partner_cert")]
@@ -40,22 +40,22 @@ pub(crate) enum Commands {
         restore_only: bool,
     },
 
-    /// Sync local data with remote node
+    /// [misc] Sync local data with remote node
     Sync {},
 
-    /// Triggers a backup of the local data
+    /// [misc] Triggers a backup of the local data
     Backup {},
 
-    /// Fetch the static backup data
+    /// [misc] Fetch the static backup data
     StaticBackup {},
 
-    /// Parse a generic string to get its type and relevant metadata
+    /// [misc] Parse a generic string to get its type and relevant metadata
     Parse {
         /// Generic input (URL, LNURL, BIP-21 BTC Address, LN invoice, etc)
         input: String,
     },
 
-    /// Generate a bolt11 invoice
+    /// [pay] Generate a bolt11 invoice
     ReceivePayment {
         amount_msat: u64,
         description: String,
@@ -67,22 +67,22 @@ pub(crate) enum Commands {
         cltv: Option<u32>,
     },
 
-    /// Pay using lnurl pay
+    /// [lnurl] Pay using lnurl pay
     LnurlPay {
         lnurl: String,
     },
 
-    /// Withdraw using lnurl withdraw
+    /// [lnurl] Withdraw using lnurl withdraw
     LnurlWithdraw {
         lnurl: String,
     },
 
-    /// Authenticate using lnurl auth
+    /// [lnurl] Authenticate using lnurl auth
     LnurlAuth {
         lnurl: String,
     },
 
-    /// Send on-chain using a reverse swap
+    /// [swap-out] Send on-chain using a reverse swap
     SendOnchain {
         amount_sat: u64,
         onchain_recipient_address: String,
@@ -90,9 +90,10 @@ pub(crate) enum Commands {
         sat_per_vbyte: u32,
     },
 
+    /// [swap-out] The maximum amount that can be sent onchain with a reverse swap
     MaxReverseSwapAmount {},
 
-    /// Get the current fees for a potential new reverse swap
+    /// [swap-out] Get the current fees for a potential new reverse swap
     FetchOnchainFees {
         #[clap(name = "amount", short = 'a', long = "amt")]
         send_amount_sat: Option<u64>,
@@ -101,10 +102,10 @@ pub(crate) enum Commands {
         claim_tx_feerate: Option<u32>,
     },
 
-    /// Get the current blocking in-progress reverse swaps, if any exist
+    /// [swap-out] Get the current blocking in-progress reverse swaps, if any exist
     InProgressReverseSwaps {},
 
-    /// Send a lightning payment
+    /// [pay] Send a lightning payment
     SendPayment {
         bolt11: String,
 
@@ -112,25 +113,25 @@ pub(crate) enum Commands {
         amount_msat: Option<u64>,
     },
 
-    /// Send a spontaneous (keysend) payment
+    /// [pay] Send a spontaneous (keysend) payment
     SendSpontaneousPayment {
         node_id: String,
         amount_msat: u64,
     },
 
-    /// Sign a message with the node's private key
+    /// [sign] Sign a message with the node's private key
     SignMessage {
         message: String,
     },
 
-    /// Verify a message with a node's public key
+    /// [sign] Verify a message with a node's public key
     CheckMessage {
         message: String,
         pubkey: String,
         signature: String,
     },
 
-    /// List all payments
+    /// [node-mgmt] List all payments
     ListPayments {
         /// The optional from unix timestamp
         #[clap(name = "from_timestamp", short = 'f', long = "from")]
@@ -157,18 +158,18 @@ pub(crate) enum Commands {
         metadata_filters: Option<Vec<String>>,
     },
 
-    /// Set the metadata for a given payment
+    /// [node-mgmt] Set the metadata for a given payment
     SetPaymentMetadata {
         payment_hash: String,
         metadata: String,
     },
 
-    /// Retrieve a payment by its hash
+    /// [node-mgmt] Retrieve a payment by its hash
     PaymentByHash {
         hash: String,
     },
 
-    /// Send on-chain funds to an external address
+    /// [redeem] Send on-chain funds to an external address
     RedeemOnchainFunds {
         /// The redeem_onchain_funds destination address
         to_address: String,
@@ -177,7 +178,7 @@ pub(crate) enum Commands {
         sat_per_vbyte: u32,
     },
 
-    /// Calculate the fee (in sats) for a potential transaction
+    /// [redeem] Calculate the fee (in sats) for a potential transaction
     PrepareRedeemOnchainFunds {
         /// The destination address
         to_address: String,
@@ -186,18 +187,19 @@ pub(crate) enum Commands {
         sat_per_vbyte: u32,
     },
 
-    /// The up to date lsp information
+    /// [node-mgmt] The up to date lsp information
     LspInfo {},
 
-    /// List available LSPs
+    /// [node-mgmt] List available LSPs
     ListLsps {},
 
-    /// Connect to an LSP
+    /// [node-mgmt] Connect to an LSP
     ConnectLSP {
         /// The lsp id the sdk should connect to
         lsp_id: String,
     },
 
+    /// [pay] Find the current fees for opening a new channel
     OpenChannelFee {
         /// The received amount
         amount_msat: Option<u64>,
@@ -206,78 +208,80 @@ pub(crate) enum Commands {
         expiry: Option<u32>,
     },
 
-    /// The node credentials
+    /// [node-mgmt] The node credentials
     NodeCredentials {},
 
-    /// The up to date node information
+    /// [node-mgmt] The up to date node information
     NodeInfo {},
 
-    /// Configurate the node
+    /// [node-mgmt] Configure the node
     ConfigureNode {
         // Optional address to send funds to during a mutual channel close
         #[clap(short = 'c', long = "close_to_address")]
         close_to_address: Option<String>,
     },
 
-    /// List fiat currencies
+    /// [fiat] List fiat currencies
     ListFiat {},
 
-    /// Fetch available fiat rates
+    /// [fiat] Fetch available fiat rates
     FetchFiatRates {},
 
-    /// Close all LSP channels
+    /// [node-mgmt] Close all LSP channels
     CloseLSPChannels {},
 
-    /// Stop the node and disconnect from the sdk services
+    /// [node-mgmt] Stop the node and disconnect from the sdk services
     Disconnect {},
 
-    /// List recommended fees based on the mempool
+    /// [pay] List recommended fees based on the mempool
     RecommendedFees {},
 
-    /// Generate address to receive onchain
+    /// [swap-in] Generate address to receive onchain
     ReceiveOnchain {},
 
-    /// Get the current in-progress swap if exists
+    /// [swap-in] Get the current in-progress swap if exists
     InProgressSwap {},
 
-    /// List refundable swap addresses
+    /// [swap-in] List refundable swap addresses
     ListRefundables {},
 
-    /// Rescan all swaps
+    /// [swap-in] Rescan all swaps
     RescanSwaps {},
 
-    /// Prepare a refund transaction for an incomplete swap
+    /// [swap-in] Prepare a refund transaction for an incomplete swap
     PrepareRefund {
         swap_address: String,
         to_address: String,
         sat_per_vbyte: u32,
     },
 
-    /// Broadcast a refund transaction for an incomplete swap
+    /// [swap-in] Broadcast a refund transaction for an incomplete swap
     Refund {
         swap_address: String,
         to_address: String,
         sat_per_vbyte: u32,
     },
 
-    /// Fetches the service health check
+    /// [node-mgmt] Fetches the service health check
     ServiceHealthCheck {},
 
-    /// Send a payment failure report
+    /// [node-mgmt] Send a payment failure report
     ReportPaymentFailure {
         payment_hash: String,
         comment: Option<String>,
     },
 
-    /// Execute a low level node command (used for debugging)
+    /// [dev] Execute a low level node command (used for debugging)
     ExecuteDevCommand {
         command: String,
     },
 
-    /// Generates an URL to buy bitcoin from a 3rd party provider
+    /// [buy] Generates an URL to buy bitcoin from a 3rd party provider
     BuyBitcoin {
         provider: BuyBitcoinProvider,
     },
+
+    /// [node-mgmt] Register a webhook URL, where the SDK will trigger a callback on specific events.
     RegisterWebhook {
         url: String,
     },

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -40,19 +40,18 @@ pub(crate) enum Commands {
         restore_only: bool,
     },
 
-    /// [misc] Sync local data with remote node
-    Sync {},
+    /// [pay] Send a lightning payment
+    SendPayment {
+        bolt11: String,
 
-    /// [misc] Triggers a backup of the local data
-    Backup {},
+        #[clap(name = "amount_msat", short = 'a', long = "amt")]
+        amount_msat: Option<u64>,
+    },
 
-    /// [misc] Fetch the static backup data
-    StaticBackup {},
-
-    /// [misc] Parse a generic string to get its type and relevant metadata
-    Parse {
-        /// Generic input (URL, LNURL, BIP-21 BTC Address, LN invoice, etc)
-        input: String,
+    /// [pay] Send a spontaneous (keysend) payment
+    SendSpontaneousPayment {
+        node_id: String,
+        amount_msat: u64,
     },
 
     /// [pay] Generate a bolt11 invoice
@@ -65,6 +64,18 @@ pub(crate) enum Commands {
         expiry: Option<u32>,
         #[clap(name = "cltv", short = 'c', long = "cltv")]
         cltv: Option<u32>,
+    },
+
+    /// [pay] List recommended fees based on the mempool
+    RecommendedFees {},
+
+    /// [pay] Find the current fees for opening a new channel
+    OpenChannelFee {
+        /// The received amount
+        amount_msat: Option<u64>,
+
+        /// The expiration of the fee returned
+        expiry: Option<u32>,
     },
 
     /// [lnurl] Pay using lnurl pay
@@ -80,6 +91,32 @@ pub(crate) enum Commands {
     /// [lnurl] Authenticate using lnurl auth
     LnurlAuth {
         lnurl: String,
+    },
+
+    /// [swap-in] Generate address to receive onchain
+    ReceiveOnchain {},
+
+    /// [swap-in] Get the current in-progress swap if exists
+    InProgressSwap {},
+
+    /// [swap-in] List refundable swap addresses
+    ListRefundables {},
+
+    /// [swap-in] Rescan all swaps
+    RescanSwaps {},
+
+    /// [swap-in] Prepare a refund transaction for an incomplete swap
+    PrepareRefund {
+        swap_address: String,
+        to_address: String,
+        sat_per_vbyte: u32,
+    },
+
+    /// [swap-in] Broadcast a refund transaction for an incomplete swap
+    Refund {
+        swap_address: String,
+        to_address: String,
+        sat_per_vbyte: u32,
     },
 
     /// [swap-out] Send on-chain using a reverse swap
@@ -105,20 +142,6 @@ pub(crate) enum Commands {
     /// [swap-out] Get the current blocking in-progress reverse swaps, if any exist
     InProgressReverseSwaps {},
 
-    /// [pay] Send a lightning payment
-    SendPayment {
-        bolt11: String,
-
-        #[clap(name = "amount_msat", short = 'a', long = "amt")]
-        amount_msat: Option<u64>,
-    },
-
-    /// [pay] Send a spontaneous (keysend) payment
-    SendSpontaneousPayment {
-        node_id: String,
-        amount_msat: u64,
-    },
-
     /// [sign] Sign a message with the node's private key
     SignMessage {
         message: String,
@@ -129,6 +152,40 @@ pub(crate) enum Commands {
         message: String,
         pubkey: String,
         signature: String,
+    },
+
+
+    /// [redeem] Send on-chain funds to an external address
+    RedeemOnchainFunds {
+        /// The redeem_onchain_funds destination address
+        to_address: String,
+
+        /// The fee rate for the redeem_onchain_funds transaction
+        sat_per_vbyte: u32,
+    },
+
+    /// [redeem] Calculate the fee (in sats) for a potential transaction
+    PrepareRedeemOnchainFunds {
+        /// The destination address
+        to_address: String,
+
+        /// The fee rate for the transaction in vbyte/sats
+        sat_per_vbyte: u32,
+    },
+
+    /// [node-mgmt] Sync local data with remote node
+    Sync {},
+
+    /// [node-mgmt] Triggers a backup of the local data
+    Backup {},
+
+    /// [node-mgmt] Fetch the static backup data
+    StaticBackup {},
+
+    /// [node-mgmt] Parse a generic string to get its type and relevant metadata
+    Parse {
+        /// Generic input (URL, LNURL, BIP-21 BTC Address, LN invoice, etc)
+        input: String,
     },
 
     /// [node-mgmt] List all payments
@@ -169,24 +226,6 @@ pub(crate) enum Commands {
         hash: String,
     },
 
-    /// [redeem] Send on-chain funds to an external address
-    RedeemOnchainFunds {
-        /// The redeem_onchain_funds destination address
-        to_address: String,
-
-        /// The fee rate for the redeem_onchain_funds transaction
-        sat_per_vbyte: u32,
-    },
-
-    /// [redeem] Calculate the fee (in sats) for a potential transaction
-    PrepareRedeemOnchainFunds {
-        /// The destination address
-        to_address: String,
-
-        /// The fee rate for the transaction in vbyte/sats
-        sat_per_vbyte: u32,
-    },
-
     /// [node-mgmt] The up to date lsp information
     LspInfo {},
 
@@ -197,15 +236,6 @@ pub(crate) enum Commands {
     ConnectLSP {
         /// The lsp id the sdk should connect to
         lsp_id: String,
-    },
-
-    /// [pay] Find the current fees for opening a new channel
-    OpenChannelFee {
-        /// The received amount
-        amount_msat: Option<u64>,
-
-        /// The expiration of the fee returned
-        expiry: Option<u32>,
     },
 
     /// [node-mgmt] The node credentials
@@ -221,46 +251,11 @@ pub(crate) enum Commands {
         close_to_address: Option<String>,
     },
 
-    /// [fiat] List fiat currencies
-    ListFiat {},
-
-    /// [fiat] Fetch available fiat rates
-    FetchFiatRates {},
-
     /// [node-mgmt] Close all LSP channels
     CloseLSPChannels {},
 
     /// [node-mgmt] Stop the node and disconnect from the sdk services
     Disconnect {},
-
-    /// [pay] List recommended fees based on the mempool
-    RecommendedFees {},
-
-    /// [swap-in] Generate address to receive onchain
-    ReceiveOnchain {},
-
-    /// [swap-in] Get the current in-progress swap if exists
-    InProgressSwap {},
-
-    /// [swap-in] List refundable swap addresses
-    ListRefundables {},
-
-    /// [swap-in] Rescan all swaps
-    RescanSwaps {},
-
-    /// [swap-in] Prepare a refund transaction for an incomplete swap
-    PrepareRefund {
-        swap_address: String,
-        to_address: String,
-        sat_per_vbyte: u32,
-    },
-
-    /// [swap-in] Broadcast a refund transaction for an incomplete swap
-    Refund {
-        swap_address: String,
-        to_address: String,
-        sat_per_vbyte: u32,
-    },
 
     /// [node-mgmt] Fetches the service health check
     ServiceHealthCheck {},
@@ -271,9 +266,9 @@ pub(crate) enum Commands {
         comment: Option<String>,
     },
 
-    /// [dev] Execute a low level node command (used for debugging)
-    ExecuteDevCommand {
-        command: String,
+    /// [node-mgmt] Register a webhook URL, where the SDK will trigger a callback on specific events.
+    RegisterWebhook {
+        url: String,
     },
 
     /// [buy] Generates an URL to buy bitcoin from a 3rd party provider
@@ -281,8 +276,14 @@ pub(crate) enum Commands {
         provider: BuyBitcoinProvider,
     },
 
-    /// [node-mgmt] Register a webhook URL, where the SDK will trigger a callback on specific events.
-    RegisterWebhook {
-        url: String,
+    /// [fiat] List fiat currencies
+    ListFiat {},
+
+    /// [fiat] Fetch available fiat rates
+    FetchFiatRates {},
+
+    /// [dev] Execute a low level node command (used for debugging)
+    ExecuteDevCommand {
+        command: String,
     },
 }


### PR DESCRIPTION
The `help` output has grown large and it's hard to mentally understand what commands belong together.

This PR adds a short prefix in the command description, making it easier to visually see the different command categories.

Sample output:

```
sdk> help
Usage:  <COMMAND>

Commands:
  set_api_key                   [config] Set the API key
  set_env                       [config] Set the Environment type
  connect                       [init] Connect to the sdk services, make it operational
  send_payment                  [pay] Send a lightning payment
  send_spontaneous_payment      [pay] Send a spontaneous (keysend) payment
  receive_payment               [pay] Generate a bolt11 invoice
  recommended_fees              [pay] List recommended fees based on the mempool
  open_channel_fee              [pay] Find the current fees for opening a new channel
  lnurl_pay                     [lnurl] Pay using lnurl pay
  lnurl_withdraw                [lnurl] Withdraw using lnurl withdraw
  lnurl_auth                    [lnurl] Authenticate using lnurl auth
  receive_onchain               [swap-in] Generate address to receive onchain
  in_progress_swap              [swap-in] Get the current in-progress swap if exists
  list_refundables              [swap-in] List refundable swap addresses
  rescan_swaps                  [swap-in] Rescan all swaps
  prepare_refund                [swap-in] Prepare a refund transaction for an incomplete swap
  refund                        [swap-in] Broadcast a refund transaction for an incomplete swap
  send_onchain                  [swap-out] Send on-chain using a reverse swap
  max_reverse_swap_amount       [swap-out] The maximum amount that can be sent onchain with a reverse swap
  fetch_onchain_fees            [swap-out] Get the current fees for a potential new reverse swap
  in_progress_reverse_swaps     [swap-out] Get the current blocking in-progress reverse swaps, if any exist
  sign_message                  [sign] Sign a message with the node's private key
  check_message                 [sign] Verify a message with a node's public key
  redeem_onchain_funds          [redeem] Send on-chain funds to an external address
  prepare_redeem_onchain_funds  [redeem] Calculate the fee (in sats) for a potential transaction
  sync                          [node-mgmt] Sync local data with remote node
  backup                        [node-mgmt] Triggers a backup of the local data
  static_backup                 [node-mgmt] Fetch the static backup data
  parse                         [node-mgmt] Parse a generic string to get its type and relevant metadata
  list_payments                 [node-mgmt] List all payments
  set_payment_metadata          [node-mgmt] Set the metadata for a given payment
  payment_by_hash               [node-mgmt] Retrieve a payment by its hash
  lsp_info                      [node-mgmt] The up to date lsp information
  list_lsps                     [node-mgmt] List available LSPs
  connect_lsp                   [node-mgmt] Connect to an LSP
  node_credentials              [node-mgmt] The node credentials
  node_info                     [node-mgmt] The up to date node information
  configure_node                [node-mgmt] Configure the node
  close_lsp_channels            [node-mgmt] Close all LSP channels
  disconnect                    [node-mgmt] Stop the node and disconnect from the sdk services
  service_health_check          [node-mgmt] Fetches the service health check
  report_payment_failure        [node-mgmt] Send a payment failure report
  register_webhook              [node-mgmt] Register a webhook URL, where the SDK will trigger a callback on specific events
  buy_bitcoin                   [buy] Generates an URL to buy bitcoin from a 3rd party provider
  list_fiat                     [fiat] List fiat currencies
  fetch_fiat_rates              [fiat] Fetch available fiat rates
  execute_dev_command           [dev] Execute a low level node command (used for debugging)
  help                          Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```