### PR TITLE
Android SDK notification handling package - Address project errors & LogHelper compatibility

### DIFF
--- a/libs/sdk-bindings/bindings-android/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.2")
+        classpath("com.android.tools.build:gradle:7.4.2")
     }
 }

--- a/libs/sdk-bindings/bindings-android/gradle/wrapper/gradle-wrapper.properties
+++ b/libs/sdk-bindings/bindings-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Feb 29 12:00:20 TRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android") version "1.6.10"
     id("maven-publish")
-    id("kotlinx-serialization")
+    kotlin("plugin.serialization") version "1.6.10"
 }
 
 repositories {
@@ -15,7 +15,6 @@ android {
 
     defaultConfig {
         minSdk = 24
-        targetSdk = 33
         consumerProguardFiles("consumer-rules.pro")
     }
 
@@ -34,13 +33,13 @@ android {
 }
 
 dependencies {
-    implementation("net.java.dev.jna:jna:5.8.0@aar")
+    implementation("net.java.dev.jna:jna:5.14.0@aar")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
-    implementation("androidx.appcompat:appcompat:1.4.0")
-    implementation("androidx.core:core-ktx:1.7.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("org.tinylog:tinylog-api-kotlin:2.6.2")
     implementation("org.tinylog:tinylog-impl:2.6.2")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 }
 
 val libraryVersion: String by project

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
@@ -16,7 +16,9 @@ object Constants {
     const val EXTRA_REMOTE_MESSAGE = "remote_message"
 
     // Message Data
+    @Suppress("unused")
     const val MESSAGE_DATA_TYPE = "notification_type"
+    @Suppress("unused")
     const val MESSAGE_DATA_PAYLOAD = "notification_payload"
 
     const val MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED = "address_txs_confirmed"

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
@@ -2,7 +2,6 @@ package breez_sdk_notification
 
 import android.app.Service
 import android.content.Intent
-import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
@@ -52,9 +51,7 @@ abstract class ForegroundService : SdkForegroundService, Service() {
 
     override fun shutdown() {
         Logger.tag(TAG).debug { "Shutting down foreground service" }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-        }
+        stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
@@ -7,8 +7,14 @@ import android.os.IBinder
 import android.os.Looper
 import breez_sdk.BlockingBreezServices
 import breez_sdk.ConnectRequest
-import breez_sdk_notification.NotificationHelper.Companion.notifyForegroundService
 import breez_sdk_notification.BreezSdkConnector.Companion.connectSDK
+import breez_sdk_notification.Constants.MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED
+import breez_sdk_notification.Constants.MESSAGE_TYPE_LNURL_PAY_INFO
+import breez_sdk_notification.Constants.MESSAGE_TYPE_LNURL_PAY_INVOICE
+import breez_sdk_notification.Constants.MESSAGE_TYPE_PAYMENT_RECEIVED
+import breez_sdk_notification.Constants.NOTIFICATION_ID_FOREGROUND_SERVICE
+import breez_sdk_notification.Constants.SHUTDOWN_DELAY_MS
+import breez_sdk_notification.NotificationHelper.Companion.notifyForegroundService
 import breez_sdk_notification.job.Job
 import breez_sdk_notification.job.LnurlPayInfoJob
 import breez_sdk_notification.job.LnurlPayInvoiceJob
@@ -47,7 +53,7 @@ abstract class ForegroundService : SdkForegroundService, Service() {
 
     override fun pushbackShutdown() {
         shutdownHandler.removeCallbacksAndMessages(null)
-        shutdownHandler.postDelayed(shutdownRunnable, Constants.SHUTDOWN_DELAY_MS)
+        shutdownHandler.postDelayed(shutdownRunnable, SHUTDOWN_DELAY_MS)
     }
 
     override fun shutdown() {
@@ -68,7 +74,7 @@ abstract class ForegroundService : SdkForegroundService, Service() {
 
         // Display foreground service notification
         val notification = notifyForegroundService(applicationContext)
-        startForeground(Constants.NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
+        startForeground(NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
 
         // Connect to SDK if source intent has data message with valid payload
         getConnectRequest()?.let { connectRequest ->
@@ -97,25 +103,25 @@ abstract class ForegroundService : SdkForegroundService, Service() {
         return Message.createFromIntent(intent)?.let { message ->
             message.payload?.let { payload ->
                 when (message.type) {
-                    Constants.MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED -> RedeemSwapJob(
+                    MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED -> RedeemSwapJob(
                         applicationContext,
                         this,
                         payload
                     )
 
-                    Constants.MESSAGE_TYPE_LNURL_PAY_INFO -> LnurlPayInfoJob(
+                    MESSAGE_TYPE_LNURL_PAY_INFO -> LnurlPayInfoJob(
                         applicationContext,
                         this,
                         payload
                     )
 
-                    Constants.MESSAGE_TYPE_LNURL_PAY_INVOICE -> LnurlPayInvoiceJob(
+                    MESSAGE_TYPE_LNURL_PAY_INVOICE -> LnurlPayInvoiceJob(
                         applicationContext,
                         this,
                         payload
                     )
 
-                    Constants.MESSAGE_TYPE_PAYMENT_RECEIVED -> ReceivePaymentJob(
+                    MESSAGE_TYPE_PAYMENT_RECEIVED -> ReceivePaymentJob(
                         applicationContext,
                         this
                     )

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
@@ -23,6 +23,7 @@ import org.tinylog.kotlin.Logger
 
 abstract class ForegroundService : SdkForegroundService, Service() {
     private var breezSDK: BlockingBreezServices? = null
+    @Suppress("MemberVisibilityCanBePrivate")
     val serviceScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
 
     companion object {
@@ -116,8 +117,7 @@ abstract class ForegroundService : SdkForegroundService, Service() {
 
                     Constants.MESSAGE_TYPE_PAYMENT_RECEIVED -> ReceivePaymentJob(
                         applicationContext,
-                        this,
-                        payload
+                        this
                     )
 
                     else -> null

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/LogHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/LogHelper.kt
@@ -5,6 +5,7 @@ import io.flutter.util.PathUtils
 import org.tinylog.kotlin.Logger
 import java.io.File
 
+@Suppress("unused")
 class LogHelper {
     companion object {
         private const val TAG = "LogHelper"

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/LogHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/LogHelper.kt
@@ -1,7 +1,5 @@
 package breez_sdk_notification
 
-import android.content.Context
-import io.flutter.util.PathUtils
 import org.tinylog.kotlin.Logger
 import java.io.File
 
@@ -13,15 +11,9 @@ class LogHelper {
         private var isInit: Boolean? = null
 
         fun configureLogger(
-            applicationContext: Context,
-            relativeLogDirectory: String = "/logs/"
+            loggingDir: File,
         ): Boolean? {
             synchronized(this) {
-                val loggingDir =
-                    File(PathUtils.getDataDirectory(applicationContext), relativeLogDirectory).apply {
-                        mkdirs()
-                    }
-
                 System.setProperty("tinylog.directory", loggingDir.absolutePath)
                 System.setProperty("tinylog.timestamp", System.currentTimeMillis().toString())
 

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Message.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Message.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
+import breez_sdk_notification.Constants.EXTRA_REMOTE_MESSAGE
 
 data class Message(val type: String?, val payload: String?) : Parcelable {
     constructor(parcel: Parcel) : this(parcel.readString(), parcel.readString())
@@ -22,9 +23,9 @@ data class Message(val type: String?, val payload: String?) : Parcelable {
         fun createFromIntent(intent: Intent?): Message? {
             return intent?.let {
                 return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) it.getParcelableExtra(
-                    Constants.EXTRA_REMOTE_MESSAGE,
+                    EXTRA_REMOTE_MESSAGE,
                     Message::class.java
-                ) else it.getParcelableExtra(Constants.EXTRA_REMOTE_MESSAGE)
+                ) else it.getParcelableExtra(EXTRA_REMOTE_MESSAGE)
             }
         }
 

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/MessagingService.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/MessagingService.kt
@@ -4,6 +4,8 @@ import android.app.ActivityManager
 import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
 import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE
 import android.content.Context
+import breez_sdk_notification.Constants.MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED
+import breez_sdk_notification.Constants.MESSAGE_TYPE_PAYMENT_RECEIVED
 import org.tinylog.kotlin.Logger
 
 @Suppress("unused")
@@ -21,8 +23,8 @@ interface MessagingService {
      *  message type and foreground state of the application. */
     fun startServiceIfNeeded(context: Context, message: Message) {
         val isServiceNeeded = when (message.type) {
-            Constants.MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED -> !isAppForeground(context)
-            Constants.MESSAGE_TYPE_PAYMENT_RECEIVED -> !isAppForeground(context)
+            MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED -> !isAppForeground(context)
+            MESSAGE_TYPE_PAYMENT_RECEIVED -> !isAppForeground(context)
             else -> true
         }
         if (isServiceNeeded) startForegroundService(message)

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/MessagingService.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/MessagingService.kt
@@ -6,6 +6,7 @@ import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE
 import android.content.Context
 import org.tinylog.kotlin.Logger
 
+@Suppress("unused")
 interface MessagingService {
     companion object {
         private const val TAG = "MessagingService"

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
@@ -16,6 +16,47 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import breez_sdk_notification.Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_WORKGROUP_NAME
+import breez_sdk_notification.Constants.DEFAULT_NOTIFICATION_COLOR
+import breez_sdk_notification.Constants.DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_NAME
+import breez_sdk_notification.Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_NAME
+import breez_sdk_notification.Constants.FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.FOREGROUND_SERVICE_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.LNURL_PAY_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.LNURL_PAY_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.LNURL_PAY_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.LNURL_PAY_WORKGROUP_ID
+import breez_sdk_notification.Constants.LNURL_PAY_WORKGROUP_NAME
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_FOREGROUND_SERVICE
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_LNURL_PAY
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_PAYMENT_RECEIVED
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED
+import breez_sdk_notification.Constants.NOTIFICATION_COLOR
+import breez_sdk_notification.Constants.NOTIFICATION_ICON
+import breez_sdk_notification.Constants.NOTIFICATION_ID_FOREGROUND_SERVICE
+import breez_sdk_notification.Constants.OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.OFFLINE_PAYMENTS_WORKGROUP_ID
+import breez_sdk_notification.Constants.OFFLINE_PAYMENTS_WORKGROUP_NAME
+import breez_sdk_notification.Constants.PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_WORKGROUP_ID
+import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_WORKGROUP_NAME
 import breez_sdk_notification.ResourceHelper.Companion.getColor
 import breez_sdk_notification.ResourceHelper.Companion.getDrawable
 import breez_sdk_notification.ResourceHelper.Companion.getString
@@ -53,67 +94,67 @@ class NotificationHelper {
         ) {
             val applicationId = context.applicationContext.packageName
             val foregroundServiceNotificationChannel = NotificationChannel(
-                "${applicationId}.${Constants.NOTIFICATION_CHANNEL_FOREGROUND_SERVICE}",
+                "${applicationId}.${NOTIFICATION_CHANNEL_FOREGROUND_SERVICE}",
                 getString(
                     context,
-                    Constants.FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME,
-                    Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME
+                    FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME,
+                    DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME
                 ),
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
                 description = getString(
                     context,
-                    Constants.FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION,
-                    Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION
+                    FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION,
+                    DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION
                 )
             }
             val receivedPaymentsNotificationChannel = NotificationChannel(
-                "${applicationId}.${Constants.NOTIFICATION_CHANNEL_PAYMENT_RECEIVED}",
+                "${applicationId}.${NOTIFICATION_CHANNEL_PAYMENT_RECEIVED}",
                 getString(
                     context,
-                    Constants.PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME,
-                    Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME
+                    PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME,
+                    DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME
                 ),
                 NotificationManager.IMPORTANCE_DEFAULT
             ).apply {
                 description = getString(
                     context,
-                    Constants.PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION,
-                    Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION
+                    PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION,
+                    DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION
                 )
-                group = Constants.OFFLINE_PAYMENTS_WORKGROUP_ID
+                group = OFFLINE_PAYMENTS_WORKGROUP_ID
             }
             val lnurlPayNotificationChannel = NotificationChannel(
-                "${applicationId}.${Constants.NOTIFICATION_CHANNEL_LNURL_PAY}",
+                "${applicationId}.${NOTIFICATION_CHANNEL_LNURL_PAY}",
                 getString(
                     context,
-                    Constants.LNURL_PAY_NOTIFICATION_CHANNEL_NAME,
-                    Constants.DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_NAME
+                    LNURL_PAY_NOTIFICATION_CHANNEL_NAME,
+                    DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_NAME
                 ),
                 NotificationManager.IMPORTANCE_DEFAULT
             ).apply {
                 description = getString(
                     context,
-                    Constants.LNURL_PAY_NOTIFICATION_CHANNEL_DESCRIPTION,
-                    Constants.DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_DESCRIPTION
+                    LNURL_PAY_NOTIFICATION_CHANNEL_DESCRIPTION,
+                    DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_DESCRIPTION
                 )
-                group = Constants.LNURL_PAY_WORKGROUP_ID
+                group = LNURL_PAY_WORKGROUP_ID
             }
             val swapTxConfirmedNotificationChannel = NotificationChannel(
-                "${applicationId}.${Constants.NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED}",
+                "${applicationId}.${NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED}",
                 getString(
                     context,
-                    Constants.SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME,
-                    Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME
+                    SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME,
+                    DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME
                 ),
                 NotificationManager.IMPORTANCE_DEFAULT
             ).apply {
                 description = getString(
                     context,
-                    Constants.SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION,
-                    Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
+                    SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION,
+                    DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
                 )
-                group = Constants.SWAP_TX_CONFIRMED_WORKGROUP_ID
+                group = SWAP_TX_CONFIRMED_WORKGROUP_ID
             }
             notificationManager.createNotificationChannels(
                 listOf(
@@ -131,44 +172,44 @@ class NotificationHelper {
             notificationManager: NotificationManager,
         ) {
             val offlinePaymentsNotificationChannelGroup = NotificationChannelGroup(
-                Constants.OFFLINE_PAYMENTS_WORKGROUP_ID,
+                OFFLINE_PAYMENTS_WORKGROUP_ID,
                 getString(
                     context,
-                    Constants.OFFLINE_PAYMENTS_WORKGROUP_NAME,
-                    Constants.DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_NAME
+                    OFFLINE_PAYMENTS_WORKGROUP_NAME,
+                    DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_NAME
                 ),
             )
             val lnurlPayNotificationChannelGroup = NotificationChannelGroup(
-                Constants.LNURL_PAY_WORKGROUP_ID,
+                LNURL_PAY_WORKGROUP_ID,
                 getString(
                     context,
-                    Constants.LNURL_PAY_WORKGROUP_NAME,
-                    Constants.DEFAULT_LNURL_PAY_WORKGROUP_NAME
+                    LNURL_PAY_WORKGROUP_NAME,
+                    DEFAULT_LNURL_PAY_WORKGROUP_NAME
                 ),
             )
             val swapTxConfirmedNotificationChannelGroup = NotificationChannelGroup(
-                Constants.SWAP_TX_CONFIRMED_WORKGROUP_ID,
+                SWAP_TX_CONFIRMED_WORKGROUP_ID,
                 getString(
                     context,
-                    Constants.SWAP_TX_CONFIRMED_WORKGROUP_NAME,
-                    Constants.DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_NAME
+                    SWAP_TX_CONFIRMED_WORKGROUP_NAME,
+                    DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_NAME
                 ),
             )
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 offlinePaymentsNotificationChannelGroup.description = getString(
                     context,
-                    Constants.OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION,
-                    Constants.DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION
+                    OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION,
+                    DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION
                 )
                 lnurlPayNotificationChannelGroup.description = getString(
                     context,
-                    Constants.LNURL_PAY_WORKGROUP_DESCRIPTION,
-                    Constants.DEFAULT_LNURL_PAY_WORKGROUP_DESCRIPTION
+                    LNURL_PAY_WORKGROUP_DESCRIPTION,
+                    DEFAULT_LNURL_PAY_WORKGROUP_DESCRIPTION
                 )
                 swapTxConfirmedNotificationChannelGroup.description = getString(
                     context,
-                    Constants.SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION,
-                    Constants.DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION
+                    SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION,
+                    DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION
                 )
             }
 
@@ -186,26 +227,26 @@ class NotificationHelper {
             val notificationColor =
                 getColor(
                     context,
-                    Constants.NOTIFICATION_COLOR,
-                    Constants.DEFAULT_NOTIFICATION_COLOR
+                    NOTIFICATION_COLOR,
+                    DEFAULT_NOTIFICATION_COLOR
                 )
 
             return NotificationCompat.Builder(
                 context,
-                "${context.applicationInfo.packageName}.${Constants.NOTIFICATION_CHANNEL_FOREGROUND_SERVICE}"
+                "${context.applicationInfo.packageName}.$NOTIFICATION_CHANNEL_FOREGROUND_SERVICE"
             )
                 .apply {
                     setContentTitle(
                         getString(
                             context,
-                            Constants.FOREGROUND_SERVICE_NOTIFICATION_TITLE,
-                            Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_TITLE
+                            FOREGROUND_SERVICE_NOTIFICATION_TITLE,
+                            DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_TITLE
                         )
                     )
                     setSmallIcon(
                         getDrawable(
                             context,
-                            Constants.NOTIFICATION_ICON,
+                            NOTIFICATION_ICON,
                             android.R.drawable.sym_def_app_icon
                         )
                     )
@@ -219,7 +260,7 @@ class NotificationHelper {
                         ) == PackageManager.PERMISSION_GRANTED
                     ) {
                         NotificationManagerCompat.from(context)
-                            .notify(Constants.NOTIFICATION_ID_FOREGROUND_SERVICE, it)
+                            .notify(NOTIFICATION_ID_FOREGROUND_SERVICE, it)
                     }
                 }
         }
@@ -236,8 +277,8 @@ class NotificationHelper {
             val notificationColor =
                 getColor(
                     context,
-                    Constants.NOTIFICATION_COLOR,
-                    Constants.DEFAULT_NOTIFICATION_COLOR
+                    NOTIFICATION_COLOR,
+                    DEFAULT_NOTIFICATION_COLOR
                 )
 
             val notificationIntent =
@@ -275,7 +316,7 @@ class NotificationHelper {
                     setSmallIcon(
                         getDrawable(
                             context,
-                            Constants.NOTIFICATION_ICON,
+                            NOTIFICATION_ICON,
                             android.R.drawable.sym_def_app_icon
                         )
                     )

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.tinylog.kotlin.Logger
 
+@Suppress("unused")
 class NotificationHelper {
     companion object {
         private const val TAG = "NotificationHelper"

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ResourceHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ResourceHelper.kt
@@ -19,9 +19,19 @@ class ResourceHelper {
 
         private fun getBundle(context: Context): Bundle? {
             return try {
-                context.packageManager.getApplicationInfo(
-                    context.packageName, PackageManager.GET_META_DATA
-                ).metaData
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.packageManager.getApplicationInfo(
+                        context.packageName,
+                        PackageManager.ApplicationInfoFlags.of(0)
+                    ).metaData
+                } else {
+                    @Suppress("DEPRECATION")
+                    context.packageManager
+                        .getApplicationInfo(
+                            context.packageName,
+                            PackageManager.GET_META_DATA
+                        ).metaData
+                }
             } catch (_: NameNotFoundException) {
                 null
             }

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ResourceHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ResourceHelper.kt
@@ -10,6 +10,8 @@ import android.graphics.drawable.AdaptiveIconDrawable
 import android.os.Build
 import android.os.Bundle
 import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
+
 
 class ResourceHelper {
     companion object {
@@ -37,7 +39,7 @@ class ResourceHelper {
             }
 
             return try {
-                val icon = context.resources.getDrawable(resourceId, null)
+                val icon = ResourcesCompat.getDrawable(context.resources, resourceId, context.theme)
 
                 icon !is AdaptiveIconDrawable
             } catch (_: NotFoundException) {

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
@@ -2,8 +2,14 @@ package breez_sdk_notification.job
 
 import android.content.Context
 import breez_sdk.BlockingBreezServices
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_INFO_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+import breez_sdk_notification.Constants.LNURL_PAY_INFO_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.LNURL_PAY_METADATA_PLAIN_TEXT
+import breez_sdk_notification.Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_LNURL_PAY
 import breez_sdk_notification.NotificationHelper.Companion.notifyChannel
-import breez_sdk_notification.Constants
 import breez_sdk_notification.ResourceHelper.Companion.getString
 import breez_sdk_notification.SdkForegroundService
 import kotlinx.serialization.SerialName
@@ -45,8 +51,8 @@ class LnurlPayInfoJob(
             val nodeState = breezSDK.nodeInfo()
             val plainTextMetadata = getString(
                 context,
-                Constants.LNURL_PAY_METADATA_PLAIN_TEXT,
-                Constants.DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
+                LNURL_PAY_METADATA_PLAIN_TEXT,
+                DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
             )
             val response =
                 LnurlPayInfoResponse(
@@ -59,11 +65,11 @@ class LnurlPayInfoJob(
             val success = replyServer(Json.encodeToString(response), request.replyURL)
             notifyChannel(
                 context,
-                Constants.NOTIFICATION_CHANNEL_LNURL_PAY,
+                NOTIFICATION_CHANNEL_LNURL_PAY,
                 getString(
                     context,
-                    if (success) Constants.LNURL_PAY_INFO_NOTIFICATION_TITLE else Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
-                    if (success) Constants.DEFAULT_LNURL_PAY_INFO_NOTIFICATION_TITLE else Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+                    if (success) LNURL_PAY_INFO_NOTIFICATION_TITLE else LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
+                    if (success) DEFAULT_LNURL_PAY_INFO_NOTIFICATION_TITLE else DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
                 ),
             )
         } catch (e: Exception) {
@@ -73,11 +79,11 @@ class LnurlPayInfoJob(
             }
             notifyChannel(
                 context,
-                Constants.NOTIFICATION_CHANNEL_LNURL_PAY,
+                NOTIFICATION_CHANNEL_LNURL_PAY,
                 getString(
                     context,
-                    Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
-                    Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+                    LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
+                    DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
                 ),
             )
         }

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
@@ -41,7 +41,7 @@ class LnurlPayInfoJob(
     override fun start(breezSDK: BlockingBreezServices) {
         var request: LnurlInfoRequest? = null
         try {
-            request = Json.decodeFromString<LnurlInfoRequest>(LnurlInfoRequest.serializer(), payload)
+            request = Json.decodeFromString(LnurlInfoRequest.serializer(), payload)
             val nodeState = breezSDK.nodeInfo()
             val plainTextMetadata = getString(
                 context,

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
@@ -39,7 +39,7 @@ class LnurlPayInvoiceJob(
     override fun start(breezSDK: BlockingBreezServices) {
         var request: LnurlInvoiceRequest? = null
         try {
-            request = Json.decodeFromString<LnurlInvoiceRequest>(LnurlInvoiceRequest.serializer(), payload)
+            request = Json.decodeFromString(LnurlInvoiceRequest.serializer(), payload)
             val nodeState = breezSDK.nodeInfo()
             if (request.amount < 1000UL || request.amount > nodeState.inboundLiquidityMsats) {
                 fail("Invalid amount requested ${request.amount}", request.replyURL)

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
@@ -3,8 +3,15 @@ package breez_sdk_notification.job
 import android.content.Context
 import breez_sdk.BlockingBreezServices
 import breez_sdk.ReceivePaymentRequest
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_INVOICE_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
+import breez_sdk_notification.Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+import breez_sdk_notification.Constants.LNURL_PAY_INVOICE_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.LNURL_PAY_METADATA_PLAIN_TEXT
+import breez_sdk_notification.Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_LNURL_PAY
 import breez_sdk_notification.NotificationHelper.Companion.notifyChannel
-import breez_sdk_notification.Constants
+
 import breez_sdk_notification.ResourceHelper.Companion.getString
 import breez_sdk_notification.SdkForegroundService
 import kotlinx.serialization.SerialName
@@ -45,19 +52,19 @@ class LnurlPayInvoiceJob(
                 fail("Invalid amount requested ${request.amount}", request.replyURL)
                 notifyChannel(
                     context,
-                    Constants.NOTIFICATION_CHANNEL_LNURL_PAY,
+                    NOTIFICATION_CHANNEL_LNURL_PAY,
                     getString(
                         context,
-                        Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
-                        Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+                        LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
+                        DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
                     ),
                 )
                 return
             }
             val plainTextMetadata = getString(
                 context,
-                Constants.LNURL_PAY_METADATA_PLAIN_TEXT,
-                Constants.DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
+                LNURL_PAY_METADATA_PLAIN_TEXT,
+                DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
             )
             val receivePaymentResponse = breezSDK.receivePayment(
                 ReceivePaymentRequest(
@@ -74,11 +81,11 @@ class LnurlPayInvoiceJob(
             val success = replyServer(Json.encodeToString(response), request.replyURL)
             notifyChannel(
                 context,
-                Constants.NOTIFICATION_CHANNEL_LNURL_PAY,
+                NOTIFICATION_CHANNEL_LNURL_PAY,
                 getString(
                     context,
-                    if (success) Constants.LNURL_PAY_INVOICE_NOTIFICATION_TITLE else Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
-                    if (success) Constants.DEFAULT_LNURL_PAY_INVOICE_NOTIFICATION_TITLE else Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+                    if (success) LNURL_PAY_INVOICE_NOTIFICATION_TITLE else LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
+                    if (success) DEFAULT_LNURL_PAY_INVOICE_NOTIFICATION_TITLE else DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
                 ),
             )
         } catch (e: Exception) {
@@ -88,11 +95,11 @@ class LnurlPayInvoiceJob(
             }
             notifyChannel(
                 context,
-                Constants.NOTIFICATION_CHANNEL_LNURL_PAY,
+                NOTIFICATION_CHANNEL_LNURL_PAY,
                 getString(
                     context,
-                    Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
-                    Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
+                    LNURL_PAY_NOTIFICATION_FAILURE_TITLE,
+                    DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE
                 ),
             )
         }

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
@@ -13,7 +13,6 @@ import org.tinylog.kotlin.Logger
 class ReceivePaymentJob(
     private val context: Context,
     private val fgService: SdkForegroundService,
-    private val payload: String,
 ) : Job {
     private var receivedPayment: Payment? = null
 

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
@@ -4,8 +4,12 @@ import android.content.Context
 import breez_sdk.BlockingBreezServices
 import breez_sdk.BreezEvent
 import breez_sdk.Payment
+import breez_sdk_notification.Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TEXT
+import breez_sdk_notification.Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_PAYMENT_RECEIVED
+import breez_sdk_notification.Constants.PAYMENT_RECEIVED_NOTIFICATION_TEXT
+import breez_sdk_notification.Constants.PAYMENT_RECEIVED_NOTIFICATION_TITLE
 import breez_sdk_notification.NotificationHelper.Companion.notifyChannel
-import breez_sdk_notification.Constants
 import breez_sdk_notification.ResourceHelper.Companion.getString
 import breez_sdk_notification.SdkForegroundService
 import org.tinylog.kotlin.Logger
@@ -55,18 +59,18 @@ class ReceivePaymentJob(
         val amountSat = (amountMsat ?: ULong.MIN_VALUE) / 1000u
         notifyChannel(
             context,
-            Constants.NOTIFICATION_CHANNEL_PAYMENT_RECEIVED,
+            NOTIFICATION_CHANNEL_PAYMENT_RECEIVED,
             getString(
                 context,
-                Constants.PAYMENT_RECEIVED_NOTIFICATION_TITLE,
-                Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TITLE
+                PAYMENT_RECEIVED_NOTIFICATION_TITLE,
+                DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TITLE
             ),
             String.format(
                 getString(
                     context,
-                    Constants.PAYMENT_RECEIVED_NOTIFICATION_TEXT,
+                    PAYMENT_RECEIVED_NOTIFICATION_TEXT,
                     "%d",
-                    Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TEXT
+                    DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TEXT
                 ), amountSat.toLong()
             )
         )

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/RedeemSwap.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/RedeemSwap.kt
@@ -3,8 +3,12 @@ package breez_sdk_notification.job
 import android.content.Context
 import breez_sdk.BlockingBreezServices
 import breez_sdk.BreezEvent
+import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE
+import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED
+import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE
+import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_NOTIFICATION_TITLE
 import breez_sdk_notification.NotificationHelper.Companion.notifyChannel
-import breez_sdk_notification.Constants
 import breez_sdk_notification.ResourceHelper.Companion.getString
 import breez_sdk_notification.SdkForegroundService
 import kotlinx.serialization.Serializable
@@ -26,29 +30,28 @@ class RedeemSwapJob(
     }
 
     override fun start(breezSDK: BlockingBreezServices) {
-        var request: AddressTxsConfirmedRequest? = null
         try {
-            val request = Json.decodeFromString<AddressTxsConfirmedRequest>(AddressTxsConfirmedRequest.serializer(), payload)
-            breezSDK.redeemSwap(request!!.address)
+            val request = Json.decodeFromString(AddressTxsConfirmedRequest.serializer(), payload)
+            breezSDK.redeemSwap(request.address)
             Logger.tag(TAG).info { "Found swap for ${request.address}" }
             notifyChannel(
                 context,
-                Constants.NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED,
+                NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED,
                 getString(
                     context,
-                    Constants.SWAP_TX_CONFIRMED_NOTIFICATION_TITLE,
-                    Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE
+                    SWAP_TX_CONFIRMED_NOTIFICATION_TITLE,
+                    DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE
                 ),
             )
         } catch (e: Exception) {
             Logger.tag(TAG).warn { "Failed to process swap notification: ${e.message}" }
             notifyChannel(
                 context,
-                Constants.NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED,
+                NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED,
                 getString(
                     context,
-                    Constants.SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE,
-                    Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE
+                    SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE,
+                    DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE
                 ),
             )
         }


### PR DESCRIPTION
This PR addresses project wide errors on the Android SDK notification handling package and makes one fundamental changes to `LogHelper` so it's compatible with a wide array of applications.

#### Changelogs:
- `LogHelper` now takes logging directory as argument f0dea3ec6b6c9820d9ad0b6cbfd9ebf0ec4ed944
  - Previous implementation would only work on **Flutter** applications and using `applicationContext.dataDir`/`filesDir` wouldn't be applicable to most apps.

#### Addressed these linter errors:
- Removed obsolete SDK check 4b4697ccb7a166445b43680b19be7a9d690e036b
  - `SDK_INT` is always >= 24
- Use `Compat` loading for drawables 7114e87dfa026d7eb03bb8d40ffcf1892b5dcff9
- `getApplicationInfo(String, Int): ApplicationInfo` is deprecated in Android API level 33 3168c806b33c5b18a83a0330bff42abef30236c8
- Upgrade `gradle` & dependencies to latest_(except kotlin.android & plugin.serialization)_ 7e0286ab4f722ea120fa0f20dc33618c5118088c
  - Fixes _serializer_ related error & warnings
  - Removed deprecated `targetSdk` config
  - Removed explicit type arguments
- Suppressed `unused` & `MemberVisibilityCanBePrivate` warnings
- Improved import resolution for `Constants`
- Removed unused variables