### PR TITLE
Fix link to rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For a higher resolution video, click [here](https://youtu.be/PRVWB4K52Es).
 To get started with the Breez SDK, follow [these examples](https://sdk-doc.breez.technology/).
 
 ## API
-API documentation is [here](https://breez.github.io/breez-sdk-rustdoc/doc/breez_sdk_core/). 
+API documentation is [here](https://breez.github.io/breez-sdk/breez_sdk_core/). 
 
 ## Support
 Join [this telegram group](https://t.me/breezsdk).


### PR DESCRIPTION
The link points to [breez-sdk-rustdoc](https://github.com/breez/breez-sdk-rustdoc), which is an old deprecated rustdoc repo. That repo has a redirect to the correct rustdocs link: https://breez.github.io/breez-sdk/breez_sdk_core/

This PR changes the README link to the rustdoc to the target link, so we bypass the redirect in the middle. The next step will be to remove the intermediary deprecated docs repo.