### PR TITLE
Use OSLog for lower deployment targets

### DIFF
--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/BreezSDKConnector.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/BreezSDKConnector.swift
@@ -2,12 +2,12 @@ import Foundation
 import os.log
 
 #if DEBUG && true
-fileprivate var log = Logger(
+fileprivate var logger = OSLog(
     subsystem: Bundle.main.bundleIdentifier!,
     category: "BreezSDKConnector"
 )
 #else
-fileprivate var log = Logger(OSLog.disabled)
+fileprivate var logger = OSLog.disabled
 #endif
 
 class BreezSDKConnector {
@@ -33,9 +33,9 @@ class BreezSDKConnector {
     
     static func connectSDK(connectRequest: ConnectRequest) throws -> BlockingBreezServices? {
         // Connect to the Breez SDK make it ready for use
-        log.trace("Connecting to Breez SDK")
+        os_log("Connecting to Breez SDK", log: logger, type: .debug)
         let breezSDK = try connect(req: connectRequest, listener: BreezSDKEventListener())
-        log.trace("Connected to Breez SDK")
+        os_log("Connected to Breez SDK", log: logger, type: .debug)
         return breezSDK
     }
 }

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/ServiceLogger.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/ServiceLogger.swift
@@ -2,12 +2,12 @@ import Foundation
 import os.log
 
 #if DEBUG && true
-fileprivate var os_log = Logger(
+fileprivate var logger = OSLog(
     subsystem: Bundle.main.bundleIdentifier!,
     category: "ServiceLogger"
 )
 #else
-fileprivate var os_log = Logger(OSLog.disabled)
+fileprivate var logger = OSLog.disabled
 #endif
 
 class ServiceLogger {
@@ -23,21 +23,16 @@ class ServiceLogger {
         } else {
             switch(level) {
                 case "ERROR":
-                    os_log.error("[\(tag)] \(line)")
+                    os_log("[%{public}@] %{public}@", log: logger, type: .error, tag, line)
                     break
-                case "WARN":
-                    os_log.warning("[\(tag)] \(line)")
-                    break
-                case "INFO":
-                    os_log.info("[\(tag)] \(line)")
-                    break
-                case "DEBUG":
-                    os_log.debug("[\(tag)] \(line)")
+                case "INFO", "WARN":
+                    os_log("[%{public}@] %{public}@", log: logger, type: .info, tag, line)
                     break
                 case "TRACE":
-                    os_log.trace("[\(tag)] \(line)")
+                    os_log("[%{public}@] %{public}@", log: logger, type: .debug, tag, line)
                     break
                 default:
+                    os_log("[%{public}@] %{public}@", log: logger, type: .default, tag, line)
                     return
             }
         }


### PR DESCRIPTION
Logger is not available to deployment targets lower than 14, but the package supports deployment target 11