### PR TITLE
Update `channels_balance_msat` immediately after a payment arrives 

### DIFF
--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -637,7 +637,11 @@ pub struct BackupStatus {
     pub last_backup_time: Option<u64>,
 }
 
-/// The node state of a Greenlight LN node running in the cloud
+/// The node state of a Greenlight LN node running in the cloud.
+///
+/// Note: The implementation attempts to provide the most up-to-date values,
+/// which may result in some short-lived inconsistencies
+/// (e.g., `channels_balance_msat` may be updated before `inbound_liquidity_msats`).
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct NodeState {
     pub id: String,


### PR DESCRIPTION
Hi. Here is an idea how to handle issue with the balance not being up to date when a payment received.
I propose to expose an additional parameter `not_synced_balance_msat` such that different clients can act as they need (ignore or add the value to the balance). I do not feel that changing `node_info()` is the right way to do that, because the method has it is own guarantees. 

Closes #845.