### PR TITLE
use swapper client instead of fund manager client for swap in

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2994,7 +2994,7 @@ pub(crate) mod tests {
             pending_onchain_balance_msat: 100,
             utxos: vec![],
             max_payable_msat: 95,
-            max_receivable_msat: 1000,
+            max_receivable_msat: 4000000000,
             max_single_payment_amount_msat: 1000,
             max_chan_reserve_msats: 0,
             connected_peers: vec!["1111".to_string()],

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -33,7 +33,6 @@ use crate::error::{
 use crate::fiat::{FiatCurrency, Rate};
 use crate::greenlight::{GLBackupTransport, Greenlight};
 use crate::grpc::channel_opener_client::ChannelOpenerClient;
-use crate::grpc::fund_manager_client::FundManagerClient;
 use crate::grpc::information_client::InformationClient;
 use crate::grpc::payment_notifier_client::PaymentNotifierClient;
 use crate::grpc::signer_client::SignerClient;
@@ -2169,13 +2168,6 @@ impl BreezServer {
             err: format!("(Breez: {}) {e}", self.server_url),
         })?;
         Ok(InformationClient::connect(url).await?)
-    }
-
-    pub(crate) async fn get_fund_manager_client(&self) -> SdkResult<FundManagerClient<Channel>> {
-        let url = Uri::from_str(&self.server_url).map_err(|e| SdkError::ServiceConnectivity {
-            err: format!("(Breez: {}) {e}", self.server_url),
-        })?;
-        Ok(FundManagerClient::connect(url).await?)
     }
 
     pub(crate) async fn get_signer_client(&self) -> SdkResult<SignerClient<Channel>> {

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -221,6 +221,9 @@ impl BTCReceiveSwap {
             node_state.max_receivable_msat as i64,
             swap_reply.max_allowed_deposit,
         );
+        if max_allowed_deposit < swap_reply.min_allowed_deposit {
+            return Err(SwapError::Generic(anyhow!("No allowed deposit amounts")));
+        }
         let swap_info = SwapInfo {
             bitcoin_address: swap_reply.bitcoin_address,
             created_at: SystemTime::now()

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -42,7 +42,7 @@ impl SwapperAPI for BreezServer {
         payer_pubkey: Vec<u8>,
         node_id: String,
     ) -> SwapResult<Swap> {
-        let mut fund_client = self.get_fund_manager_client().await?;
+        let mut fund_client = self.get_swapper_client().await?;
         let req = AddFundInitRequest {
             hash: hash.clone(),
             pubkey: payer_pubkey.clone(),
@@ -67,7 +67,7 @@ impl SwapperAPI for BreezServer {
             payment_request: bolt11,
         };
         let resp = self
-            .get_fund_manager_client()
+            .get_swapper_client()
             .await?
             .get_swap_payment(req)
             .await?

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -217,6 +217,10 @@ impl BTCReceiveSwap {
             return Err(SwapError::Generic(anyhow!("Wrong address: {address_str}")));
         }
 
+        let max_allowed_deposit = std::cmp::min(
+            node_state.max_receivable_msat as i64,
+            swap_reply.max_allowed_deposit,
+        );
         let swap_info = SwapInfo {
             bitcoin_address: swap_reply.bitcoin_address,
             created_at: SystemTime::now()
@@ -240,7 +244,7 @@ impl BTCReceiveSwap {
             unconfirmed_tx_ids: Vec::new(),
             status: SwapStatus::Initial,
             min_allowed_deposit: swap_reply.min_allowed_deposit,
-            max_allowed_deposit: swap_reply.max_allowed_deposit,
+            max_allowed_deposit,
             last_redeem_error: None,
             channel_opening_fees: Some(channel_opening_fees),
             confirmed_at: None,

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -218,7 +218,7 @@ impl BTCReceiveSwap {
         }
 
         let max_allowed_deposit = std::cmp::min(
-            node_state.max_receivable_msat as i64,
+            (node_state.max_receivable_msat / 1000) as i64,
             swap_reply.max_allowed_deposit,
         );
         if max_allowed_deposit < swap_reply.min_allowed_deposit {


### PR DESCRIPTION
The fund manager client maps to `AddFundInitLegacy` on the server. The legacy swapper has lower maximum amounts for swaps, namely 900k instead of 4M sat. The swapper client maps to `AddFundInit` on the server, with a 4M sat limit.

Also, this PR caps the `max_allowed_deposit` for `receive_onchain` to `max_receivable_msat`