### PR TITLE
swap: fix invoice amount mismatch

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2233,6 +2233,12 @@ pub trait Receiver: Send + Sync {
         &self,
         req: ReceivePaymentRequest,
     ) -> Result<ReceivePaymentResponse, ReceivePaymentError>;
+    async fn wrap_open_channel_invoice(
+        &self,
+        invoice: String,
+        amount_msat: u64,
+        opening_fee_params: OpeningFeeParams,
+    ) -> Result<String, ReceivePaymentError>;
 }
 
 pub(crate) struct PaymentReceiver {
@@ -2334,107 +2340,56 @@ impl Receiver for PaymentReceiver {
         // limit the hints to max 3 and extract the lsp one.
         let optional_lsp_hint = Self::limit_and_extract_lsp_hint(&mut routing_hints, &lsp_info);
 
-        // We here check if we need to modify the invoice.
-        let optional_modified_invoice = match (
-            open_channel_needed,
-            optional_lsp_hint,
-            parsed_invoice.routing_hints.is_empty(),
-        ) {
-            // If we need to open a channel we only need to set the dedicated lsp hint.
-            (true, _, _) => {
-                let open_channel_hint = RouteHint {
-                    hops: vec![RouteHintHop {
-                        src_node_id: lsp_info.pubkey.clone(),
-                        short_channel_id: parse_short_channel_id("1x0x0")?,
-                        fees_base_msat: lsp_info.base_fee_msat as u32,
-                        fees_proportional_millionths: (lsp_info.fee_rate * 1000000.0) as u32,
-                        cltv_expiry_delta: lsp_info.time_lock_delta as u64,
-                        htlc_minimum_msat: Some(lsp_info.min_htlc_msat as u64),
-                        htlc_maximum_msat: None,
-                    }],
-                };
-                info!("Adding open channel hint: {:?}", open_channel_hint);
-                Some(add_routing_hints(
+        if open_channel_needed {
+            invoice = self
+                .wrap_open_channel_invoice(
                     invoice.clone(),
-                    false,
-                    &vec![open_channel_hint],
                     req.amount_msat,
-                )?)
-            }
-            // In case we don't need to open a channel and we have a channel with our lsp then we only ensure it
-            // exists as part of the invoice routing hints (merging).
-            (false, Some(h), _) => {
-                match parsed_invoice.contains_hint_for_node(lsp_info.pubkey.as_str()) {
-                    false => {
-                        info!("Adding lsp hint: {:?}", h);
-                        Some(add_routing_hints(
-                            invoice.clone(),
-                            true,
-                            &vec![h],
-                            req.amount_msat,
-                        )?)
+                    channel_opening_fee_params
+                        .clone()
+                        .ok_or(ReceivePaymentError::Generic {
+                            err:
+                                "We need to open a channel, but no channel opening fee params found"
+                                    .into(),
+                        })?,
+                )
+                .await?;
+            parsed_invoice = parse_invoice(&invoice)?;
+        } else if let Some(raw_invoice) =
+            match (optional_lsp_hint, parsed_invoice.routing_hints.is_empty()) {
+                // In case we don't need to open a channel and we have a channel with our lsp then we only ensure it
+                // exists as part of the invoice routing hints (merging).
+                (Some(h), _) => {
+                    match parsed_invoice.contains_hint_for_node(lsp_info.pubkey.as_str()) {
+                        false => {
+                            info!("Adding lsp hint: {:?}", h);
+                            Some(add_routing_hints(
+                                invoice.clone(),
+                                true,
+                                &vec![h],
+                                req.amount_msat,
+                            )?)
+                        }
+                        // Lsp already in routing hints, no need to modify the invoice
+                        true => None,
                     }
-                    // Lsp already in routing hints, no need to modify the invoice
-                    true => None,
                 }
+                // In case we don't need to open a channel and the invoice has no routing hints we replace them with ours.
+                (None, true) => {
+                    info!("Adding custom hints: {:?}", routing_hints);
+                    Some(add_routing_hints(
+                        invoice.clone(),
+                        false,
+                        &routing_hints,
+                        req.amount_msat,
+                    )?)
+                }
+                (_, _) => None,
             }
-            // In case we don't need to open a channel and the invoice has no routing hints we replace them with ours.
-            (false, None, true) => {
-                info!("Adding custom hints: {:?}", routing_hints);
-                Some(add_routing_hints(
-                    invoice.clone(),
-                    false,
-                    &routing_hints,
-                    req.amount_msat,
-                )?)
-            }
-            (_, _, _) => None,
-        };
-
-        if let Some(raw_invoice) = optional_modified_invoice {
+        {
             invoice = self.node_api.sign_invoice(raw_invoice)?;
             info!("Signed invoice with hint = {}", invoice);
             parsed_invoice = parse_invoice(&invoice)?;
-        }
-
-        // register the payment at the lsp if needed
-        if open_channel_needed {
-            info!("Registering payment with LSP");
-
-            if channel_opening_fee_params.is_none() {
-                return Err(ReceivePaymentError::Generic {
-                    err: "We need to open a channel, but no channel opening fee params found"
-                        .into(),
-                });
-            }
-
-            let api_key = self.config.api_key.clone().unwrap_or_default();
-            let api_key_hash = sha256::Hash::hash(api_key.as_bytes()).to_hex();
-
-            self.lsp
-                .register_payment(
-                    lsp_info.id.clone(),
-                    lsp_info.lsp_pubkey.clone(),
-                    PaymentInformation {
-                        payment_hash: hex::decode(parsed_invoice.payment_hash.clone())
-                            .map_err(|e| anyhow!("Failed to decode hex payment hash: {e}"))?,
-                        payment_secret: parsed_invoice.payment_secret.clone(),
-                        destination: hex::decode(parsed_invoice.payee_pubkey.clone())
-                            .map_err(|e| anyhow!("Failed to decode hex payee pubkey: {e}"))?,
-                        incoming_amount_msat: req.amount_msat as i64,
-                        outgoing_amount_msat: destination_invoice_amount_msat as i64,
-                        tag: json!({ "apiKeyHash": api_key_hash }).to_string(),
-                        opening_fee_params: channel_opening_fee_params.clone().map(Into::into),
-                    },
-                )
-                .await?;
-            info!("Payment registered");
-            // Make sure we save the large amount so we can deduce the fees later.
-            self.persister.insert_open_channel_payment_info(
-                &parsed_invoice.payment_hash,
-                req.amount_msat,
-                &invoice,
-            )?;
         }
 
         // return the signed, converted invoice with hints
@@ -2443,6 +2398,70 @@ impl Receiver for PaymentReceiver {
             opening_fee_params: channel_opening_fee_params,
             opening_fee_msat: channel_fees_msat,
         })
+    }
+
+    async fn wrap_open_channel_invoice(
+        &self,
+        invoice: String,
+        amount_msat: u64,
+        opening_fee_params: OpeningFeeParams,
+    ) -> Result<String, ReceivePaymentError> {
+        // TODO: This is called twice now in receive_payment. Optimize.
+        let lsp_info = get_lsp(self.persister.clone(), self.lsp.clone()).await?;
+        let parsed_invoice = parse_invoice(&invoice)?;
+        let open_channel_hint = RouteHint {
+            hops: vec![RouteHintHop {
+                src_node_id: lsp_info.pubkey.clone(),
+                short_channel_id: parse_short_channel_id("1x0x0")?,
+                fees_base_msat: lsp_info.base_fee_msat as u32,
+                fees_proportional_millionths: (lsp_info.fee_rate * 1000000.0) as u32,
+                cltv_expiry_delta: lsp_info.time_lock_delta as u64,
+                htlc_minimum_msat: Some(lsp_info.min_htlc_msat as u64),
+                htlc_maximum_msat: None,
+            }],
+        };
+        info!("Adding open channel hint: {:?}", open_channel_hint);
+        let invoice_with_hint = add_routing_hints(
+            invoice.clone(),
+            false,
+            &vec![open_channel_hint],
+            amount_msat,
+        )?;
+        let signed_invoice = self.node_api.sign_invoice(invoice_with_hint)?;
+
+        info!("Registering payment with LSP");
+        let api_key = self.config.api_key.clone().unwrap_or_default();
+        let api_key_hash = sha256::Hash::hash(api_key.as_bytes()).to_hex();
+
+        self.lsp
+            .register_payment(
+                lsp_info.id.clone(),
+                lsp_info.lsp_pubkey.clone(),
+                PaymentInformation {
+                    payment_hash: hex::decode(parsed_invoice.payment_hash.clone())
+                        .map_err(|e| anyhow!("Failed to decode hex payment hash: {e}"))?,
+                    payment_secret: parsed_invoice.payment_secret.clone(),
+                    destination: hex::decode(parsed_invoice.payee_pubkey.clone())
+                        .map_err(|e| anyhow!("Failed to decode hex payee pubkey: {e}"))?,
+                    incoming_amount_msat: amount_msat as i64,
+                    outgoing_amount_msat: parsed_invoice
+                        .amount_msat
+                        .ok_or(anyhow!("Open channel invoice must have an amount"))?
+                        as i64,
+                    tag: json!({ "apiKeyHash": api_key_hash }).to_string(),
+                    opening_fee_params: Some(opening_fee_params.into()),
+                },
+            )
+            .await?;
+
+        // Make sure we save the large amount so we can deduce the fees later.
+        self.persister.insert_open_channel_payment_info(
+            &parsed_invoice.payment_hash,
+            amount_msat,
+            &invoice,
+        )?;
+
+        Ok(signed_invoice)
     }
 }
 

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -733,16 +733,14 @@ impl NodeAPI for Greenlight {
             .first()
             .cloned()
             .and_then(|invoice| {
-                invoice.bolt11.map(|bolt11| {
-                    serde_json::from_str::<InvoiceLabel>(&invoice.label)
-                        .map(|label| FetchBolt11Result {
-                            bolt11,
-                            payer_amount_msat: label.payer_amount_msat,
-                        })
+                invoice.bolt11.map(|bolt11| FetchBolt11Result {
+                    bolt11,
+                    payer_amount_msat: serde_json::from_str::<InvoiceLabel>(&invoice.label)
+                        .map(|label| label.payer_amount_msat)
                         .ok()
+                        .flatten(),
                 })
-            })
-            .flatten();
+            });
 
         Ok(result)
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -62,6 +62,12 @@ pub(crate) struct Greenlight {
     persister: Arc<SqliteStorage>,
 }
 
+#[derive(Serialize, Deserialize)]
+struct InvoiceLabel {
+    pub unix_milli: u128,
+    pub payer_amount_msat: Option<u64>,
+}
+
 impl Greenlight {
     /// Connects to a live node using the provided seed and config.
     /// If the node is not registered, it will try to recover it using the seed.
@@ -687,25 +693,18 @@ impl NodeAPI for Greenlight {
     }
 
     async fn create_invoice(&self, request: CreateInvoiceRequest) -> NodeResult<String> {
-        // If there is a payer amount, this amount is stored in the label so it can be extracted
-        // later.
-        let label_prefix = match request.payer_amount_msat {
-            Some(payer_amount_msat) => format!("pa-{}-", payer_amount_msat),
-            None => String::from(""),
-        };
-
         let mut client = self.get_node_client().await?;
+        let label = serde_json::to_string(&InvoiceLabel {
+            unix_milli: SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis(),
+            payer_amount_msat: request.payer_amount_msat,
+        })?;
         let cln_request = cln::InvoiceRequest {
             amount_msat: Some(cln::AmountOrAny {
                 value: Some(cln::amount_or_any::Value::Amount(cln::Amount {
                     msat: request.amount_msat,
                 })),
             }),
-            label: format!(
-                "breez-{}{}",
-                label_prefix,
-                SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis()
-            ),
+            label,
             description: request.description,
             preimage: request.preimage,
             deschashonly: request.use_description_hash,
@@ -735,27 +734,17 @@ impl NodeAPI for Greenlight {
             .cloned()
             .and_then(|invoice| {
                 invoice.bolt11.map(|bolt11| {
-                    let split = invoice.label.split('-').collect::<Vec<&str>>();
-                    let payer_amount_msat = match split[1] {
-                        "pa" => Some(split[2].parse::<u64>().map_err(|_| {
-                            NodeError::Generic(anyhow!(
-                                "failed to extract payer amount from invoice label '{}'",
-                                invoice.label
-                            ))
-                        })?),
-                        _ => None,
-                    };
-                    Ok::<FetchBolt11Result, NodeError>(FetchBolt11Result {
-                        bolt11,
-                        payer_amount_msat,
-                    })
+                    serde_json::from_str::<InvoiceLabel>(&invoice.label)
+                        .map(|label| FetchBolt11Result {
+                            bolt11,
+                            payer_amount_msat: label.payer_amount_msat,
+                        })
+                        .ok()
                 })
-            });
+            })
+            .flatten();
 
-        Ok(match result {
-            Some(result) => Some(result?),
-            None => None,
-        })
+        Ok(result)
     }
 
     // implement pull changes from greenlight

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -44,7 +44,7 @@ use crate::invoice::{parse_invoice, validate_network, InvoiceError, RouteHintHop
 use crate::lightning::util::message_signing::verify;
 use crate::lightning_invoice::{RawBolt11Invoice, SignedRawBolt11Invoice};
 use crate::models::*;
-use crate::node_api::{NodeAPI, NodeError, NodeResult};
+use crate::node_api::{CreateInvoiceRequest, FetchBolt11Result, NodeAPI, NodeError, NodeResult};
 use crate::persist::db::SqliteStorage;
 use crate::{
     NodeConfig, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHint,
@@ -686,45 +686,45 @@ impl NodeAPI for Greenlight {
         Ok(())
     }
 
-    async fn create_invoice(
-        &self,
-        amount_msat: u64,
-        description: String,
-        preimage: Option<Vec<u8>>,
-        use_description_hash: Option<bool>,
-        expiry: Option<u32>,
-        cltv: Option<u32>,
-    ) -> NodeResult<String> {
+    async fn create_invoice(&self, request: CreateInvoiceRequest) -> NodeResult<String> {
+        // If there is a payer amount, this amount is stored in the label so it can be extracted
+        // later.
+        let label_prefix = match request.payer_amount_msat {
+            Some(payer_amount_msat) => format!("pa-{}-", payer_amount_msat),
+            None => String::from(""),
+        };
+
         let mut client = self.get_node_client().await?;
-        let request = cln::InvoiceRequest {
+        let cln_request = cln::InvoiceRequest {
             amount_msat: Some(cln::AmountOrAny {
                 value: Some(cln::amount_or_any::Value::Amount(cln::Amount {
-                    msat: amount_msat,
+                    msat: request.amount_msat,
                 })),
             }),
             label: format!(
-                "breez-{}",
+                "breez-{}{}",
+                label_prefix,
                 SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis()
             ),
-            description,
-            preimage,
-            deschashonly: use_description_hash,
-            expiry: expiry.map(|e| e as u64),
+            description: request.description,
+            preimage: request.preimage,
+            deschashonly: request.use_description_hash,
+            expiry: request.expiry.map(|e| e as u64),
             fallbacks: vec![],
-            cltv,
+            cltv: request.cltv,
         };
 
-        let res = client.invoice(request).await?.into_inner();
+        let res = client.invoice(cln_request).await?.into_inner();
         Ok(res.bolt11)
     }
 
-    async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
+    async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>> {
         let request = cln::ListinvoicesRequest {
             payment_hash: Some(payment_hash),
             ..Default::default()
         };
 
-        let found_bolt11 = self
+        let result = self
             .get_node_client()
             .await?
             .list_invoices(request)
@@ -733,8 +733,29 @@ impl NodeAPI for Greenlight {
             .invoices
             .first()
             .cloned()
-            .and_then(|res| res.bolt11);
-        Ok(found_bolt11)
+            .and_then(|invoice| {
+                invoice.bolt11.map(|bolt11| {
+                    let split = invoice.label.split('-').collect::<Vec<&str>>();
+                    let payer_amount_msat = match split[1] {
+                        "pa" => Some(split[2].parse::<u64>().map_err(|_| {
+                            NodeError::Generic(anyhow!(
+                                "failed to extract payer amount from invoice label '{}'",
+                                invoice.label
+                            ))
+                        })?),
+                        _ => None,
+                    };
+                    Ok::<FetchBolt11Result, NodeError>(FetchBolt11Result {
+                        bolt11,
+                        payer_amount_msat,
+                    })
+                })
+            });
+
+        Ok(match result {
+            Some(result) => Some(result?),
+            None => None,
+        })
     }
 
     // implement pull changes from greenlight

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -53,6 +53,21 @@ pub enum NodeError {
     ServiceConnectivity(anyhow::Error),
 }
 
+pub struct CreateInvoiceRequest {
+    pub amount_msat: u64,
+    pub description: String,
+    pub payer_amount_msat: Option<u64>,
+    pub preimage: Option<Vec<u8>>,
+    pub use_description_hash: Option<bool>,
+    pub expiry: Option<u32>,
+    pub cltv: Option<u32>,
+}
+
+pub struct FetchBolt11Result {
+    pub bolt11: String,
+    pub payer_amount_msat: Option<u64>
+}
+
 /// Trait covering functions affecting the LN node
 #[tonic::async_trait]
 pub trait NodeAPI: Send + Sync {
@@ -60,15 +75,10 @@ pub trait NodeAPI: Send + Sync {
     async fn configure_node(&self, close_to_address: Option<String>) -> NodeResult<()>;
     async fn create_invoice(
         &self,
-        amount_msat: u64,
-        description: String,
-        preimage: Option<Vec<u8>>,
-        use_description_hash: Option<bool>,
-        expiry: Option<u32>,
-        cltv: Option<u32>,
+        request: CreateInvoiceRequest,
     ) -> NodeResult<String>;
     /// Fetches an existing BOLT11 invoice from the node
-    async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<String>>;
+    async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>>;
     async fn pull_changed(
         &self,
         since_timestamp: u64,

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -178,7 +178,7 @@ impl SqliteStorage {
         let con = self.get_connection()?;
         let mut prep_statement = con.prepare(
             "
-        INSERT INTO sync.open_channel_payment_info (
+        INSERT OR IGNORE INTO sync.open_channel_payment_info (
           payment_hash,
           payer_amount_msat,
           open_channel_bolt11

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -449,7 +449,7 @@ impl BTCReceiveSwap {
                         amount_msat: swap_info.confirmed_sats * 1_000,
                         description: String::from("Bitcoin Transfer"),
                         preimage: Some(swap_info.preimage),
-                        opening_fee_params: swap_info.channel_opening_fees,
+                        opening_fee_params: swap_info.channel_opening_fees.clone(),
                         use_description_hash: Some(false),
                         expiry: Some(SWAP_PAYMENT_FEE_EXPIRY_SECONDS),
                         cltv: None,
@@ -472,12 +472,29 @@ impl BTCReceiveSwap {
                             .get_open_channel_bolt11_by_hash(payment_hash.as_str())?;
                         match open_channel_bolt11 {
                             Some(bolt11) => Ok(bolt11),
-                            None => self
-                                .node_api
-                                .fetch_bolt11(swap_info.payment_hash)
-                                .await?
-                                .map(|res| res.bolt11)
-                                .ok_or(anyhow!("Preimage already known, but invoice not found")),
+                            None => {
+                                let res = self
+                                    .node_api
+                                    .fetch_bolt11(swap_info.payment_hash)
+                                    .await?
+                                    .ok_or(anyhow!(
+                                        "Preimage already known, but invoice not found"
+                                    ))?;
+                                Ok(match res.payer_amount_msat {
+                                    Some(payer_amount_msat) => {
+                                        self.payment_receiver
+                                            .wrap_open_channel_invoice(
+                                                res.bolt11,
+                                                payer_amount_msat,
+                                                swap_info.channel_opening_fees.ok_or(anyhow!(
+                                                    "Preimage already known, invoice found, missing opening_fee_params"
+                                                ))?,
+                                            )
+                                            .await?
+                                    }
+                                    None => res.bolt11,
+                                })
+                            }
                         }
                     }
 

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -476,6 +476,7 @@ impl BTCReceiveSwap {
                                 .node_api
                                 .fetch_bolt11(swap_info.payment_hash)
                                 .await?
+                                .map(|res| res.bolt11)
                                 .ok_or(anyhow!("Preimage already known, but invoice not found")),
                         }
                     }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -36,7 +36,7 @@ use crate::lightning_invoice::{Currency, InvoiceBuilder, RawBolt11Invoice};
 use crate::lsp::LspInformation;
 use crate::models::{FiatAPI, LspAPI, NodeState, Payment, ReverseSwapServiceAPI, Swap, SwapperAPI, SyncResponse, TlvEntry};
 use crate::moonpay::MoonPayApi;
-use crate::node_api::{NodeAPI, NodeError, NodeResult};
+use crate::node_api::{CreateInvoiceRequest, FetchBolt11Result, NodeAPI, NodeError, NodeResult};
 use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
 use crate::{parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials, OpeningFeeParams, OpeningFeeParamsMenu, PaymentResponse, Peer, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, ReceivePaymentRequest, RouteHint, RouteHintHop, SwapInfo, ReverseSwapPairInfo};
@@ -325,14 +325,9 @@ impl NodeAPI for MockNodeAPI {
 
     async fn create_invoice(
         &self,
-        amount_sats: u64,
-        description: String,
-        preimage: Option<Vec<u8>>,
-        _use_description_hash: Option<bool>,
-        _expiry: Option<u32>,
-        _cltv: Option<u32>,
+        request: CreateInvoiceRequest,
     ) -> NodeResult<String> {
-        let invoice = create_invoice(description, amount_sats * 1000, vec![], preimage);
+        let invoice = create_invoice(request.description, request.amount_msat, vec![], request.preimage);
         Ok(invoice.bolt11)
     }
 
@@ -480,7 +475,7 @@ impl NodeAPI for MockNodeAPI {
         Ok((vec![], false))
     }
 
-    async fn fetch_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<String>> {
+    async fn fetch_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>> {
         Ok(None)
     }
 }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -299,6 +299,14 @@ impl Receiver for MockReceiver {
             opening_fee_msat: None,
         })
     }
+    async fn wrap_open_channel_invoice(
+        &self,
+        invoice: String,
+        _amount_msat: u64,
+        _opening_fee_params: OpeningFeeParams,
+    ) -> Result<String, ReceivePaymentError> {
+        Ok(invoice)
+    }
 }
 
 pub struct MockNodeAPI {


### PR DESCRIPTION
Fixes https://github.com/breez/breez-sdk/issues/859 by doing the following:
- when an invoice is created on the node, 'metadata' is added to the label if the channel is an open channel invoice, containing the payer amount.
- When we fall into the case where the preimage already exists when trying to create an invoice, we take that invoice from the node, and construct the larger invoice from it based on the stored metadata.

When wrapping the invoice in this place, it is unclear which steps had already occurred. Did the payment get registered to the LSP already? Was the larger invoice already stored? These functions, registering and storing, are idempotent, so we can simply re-execute them in this situation. Therefore the newly extracted function to wrap the invoice is able to do the registration at the lsp and persisting the payer invoice.

I _think_ this covers our scenario.
It does not fix existing failing swaps due to the amount mismatch though, these swaps have to be refunded after the timelock. This only works for new swaps that may eventually fall into the same issue.

State: 
- 'normal' swap tested
- swap with invoice on the node: untested