### PR TITLE
don't redeem on in_progress_swap

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -766,7 +766,7 @@ impl BreezServices {
     /// A [SwapInfo] is in-progress if it is waiting for confirmation to be redeemed and complete the swap.
     pub async fn in_progress_swap(&self) -> SdkResult<Option<SwapInfo>> {
         let tip = self.chain_service.current_tip().await?;
-        self.btc_receive_swapper.execute_pending_swaps(tip).await?;
+        self.btc_receive_swapper.rescan_monitored_swaps(tip).await?;
         let in_progress = self.btc_receive_swapper.list_in_progress()?;
         if !in_progress.is_empty() {
             return Ok(Some(in_progress[0].clone()));

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -310,6 +310,10 @@ impl BTCReceiveSwap {
         self.refresh_swaps(self.persister.list_swaps()?, tip).await
     }
 
+    pub(crate) async fn rescan_monitored_swaps(&self, tip: u32) -> Result<()> {
+        self.refresh_swaps(self.list_monitored()?, tip).await
+    }
+
     pub(crate) async fn execute_pending_swaps(&self, tip: u32) -> Result<()> {
         // first refresh all swaps we monitor
         self.refresh_swaps(self.list_monitored()?, tip).await?;


### PR DESCRIPTION
The `in_progress_swap` function gets the current state of a swap, but doesn't try to execute pending swaps. This is potentially called many times, each request doing a call to the server. If the server is trying to pay out a swap already, the `in_progress_swap` function will error, while everything is fine. This PR lets the background service handle pending swaps, and makes the `in_progress_swap` function only return the current state. It does still check the mempool for potentially new transactions.