### PR TITLE
Defer signer with 2 seconds

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1372,6 +1372,7 @@ impl BreezServices {
     async fn start_signer(self: &Arc<BreezServices>, shutdown_receiver: mpsc::Receiver<()>) {
         let signer_api = self.clone();
         tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             signer_api.node_api.start_signer(shutdown_receiver).await;
         });
     }


### PR DESCRIPTION
This differs the signer connection in 2 seconds to ensure the node is scheduled before the connection.
This mitigates a slow startup in gl where the signer starts before the schedule which leads to a slow startup on the backend.