### PR TITLE
Skip missing intervals

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -16,7 +16,7 @@ use log::{LevelFilter, Metadata, Record};
 use reqwest::{header::CONTENT_TYPE, Body};
 use serde_json::json;
 use tokio::sync::{mpsc, watch, Mutex};
-use tokio::time::sleep;
+use tokio::time::{sleep, MissedTickBehavior};
 use tonic::codegen::InterceptedService;
 use tonic::metadata::errors::InvalidMetadataValue;
 use tonic::metadata::{Ascii, MetadataValue};
@@ -1547,6 +1547,7 @@ impl BreezServices {
             let mut current_block: u32 = 0;
             let mut shutdown_receiver = cloned.shutdown_receiver.clone();
             let mut interval = tokio::time::interval(Duration::from_secs(30));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
             loop {
                 tokio::select! {
                  _ = interval.tick() => {


### PR DESCRIPTION
The default interval behavior is `Burst` which means that any interval that wasn't called (delayed) is caught up as fast as possible so for example if mobile went to background and app doesn't get any cpu for several hours, when app is awaken the missed ticks will be called one after another which may cause rate limit on the chain service.
Here we change the behavior to `Skip` which will skip these missing ticks.