### PR TITLE
Add in_progress_onchain_payments() wrapper

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -920,6 +920,9 @@ interface BlockingBreezServices {
    PrepareOnchainPaymentResponse prepare_onchain_payment(PrepareOnchainPaymentRequest req);
 
    [Throws=SdkError]
+   sequence<ReverseSwapInfo> in_progress_onchain_payments();
+
+   [Throws=SdkError]
    sequence<ReverseSwapInfo> in_progress_reverse_swaps();
    
    [Throws=SdkError]

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -316,6 +316,10 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.prepare_onchain_payment(req))
     }
 
+    pub fn in_progress_onchain_payments(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
+        rt().block_on(self.breez_services.in_progress_onchain_payments())
+    }
+
     pub fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
         rt().block_on(self.breez_services.in_progress_reverse_swaps())
     }

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -493,6 +493,17 @@ pub fn prepare_onchain_payment(
     })
 }
 
+/// See [BreezServices::in_progress_onchain_payments]
+pub fn in_progress_onchain_payments() -> Result<Vec<ReverseSwapInfo>> {
+    block_on(async {
+        get_breez_services()
+            .await?
+            .in_progress_onchain_payments()
+            .await
+    })
+    .map_err(anyhow::Error::new::<SdkError>)
+}
+
 /// See [BreezServices::recommended_fees]
 pub fn recommended_fees() -> Result<RecommendedFees> {
     block_on(async { get_breez_services().await?.recommended_fees().await })

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -879,6 +879,8 @@ impl BreezServices {
     }
 
     /// Returns the blocking [ReverseSwapInfo]s that are in progress
+    ///
+    /// Deprecated. Please use [BreezServices::in_progress_onchain_payments] instead.
     pub async fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
         let full_rsis = self.btc_send_swapper.list_blocking().await?;
 
@@ -1025,6 +1027,13 @@ impl BreezServices {
         self.do_sync(true).await?;
 
         Ok(reverse_swap_info)
+    }
+
+    /// Returns the blocking [ReverseSwapInfo]s that are in progress.
+    ///
+    /// Supersedes [BreezServices::in_progress_reverse_swaps]
+    pub async fn in_progress_onchain_payments(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
+        self.in_progress_reverse_swaps().await
     }
 
     /// Execute a command directly on the NodeAPI interface.

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -300,6 +300,11 @@ pub extern "C" fn wire_prepare_onchain_payment(
 }
 
 #[no_mangle]
+pub extern "C" fn wire_in_progress_onchain_payments(port_: i64) {
+    wire_in_progress_onchain_payments_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_recommended_fees(port_: i64) {
     wire_recommended_fees_impl(port_)
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -853,6 +853,16 @@ fn wire_prepare_onchain_payment_impl(
         },
     )
 }
+fn wire_in_progress_onchain_payments_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<ReverseSwapInfo>, _>(
+        WrapInfo {
+            debug_name: "in_progress_onchain_payments",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| in_progress_onchain_payments(),
+    )
+}
 fn wire_recommended_fees_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, RecommendedFees, _>(
         WrapInfo {

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -402,6 +402,8 @@ void wire_onchain_payment_limits(int64_t port_);
 
 void wire_prepare_onchain_payment(int64_t port_, struct wire_PrepareOnchainPaymentRequest *req);
 
+void wire_in_progress_onchain_payments(int64_t port_);
+
 void wire_recommended_fees(int64_t port_);
 
 void wire_execute_command(int64_t port_, struct wire_uint_8_list *command);
@@ -544,6 +546,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_fetch_reverse_swap_fees);
     dummy_var ^= ((int64_t) (void*) wire_onchain_payment_limits);
     dummy_var ^= ((int64_t) (void*) wire_prepare_onchain_payment);
+    dummy_var ^= ((int64_t) (void*) wire_in_progress_onchain_payments);
     dummy_var ^= ((int64_t) (void*) wire_recommended_fees);
     dummy_var ^= ((int64_t) (void*) wire_execute_command);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_bool_0);

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -427,6 +427,10 @@ class BreezSDK {
   }
 
   /// Returns the blocking [ReverseSwapInfo]s that are in progress
+  @Deprecated(
+    'Use inProgressOnchainPayments instead. '
+    'This method was deprecated after v0.3.6',
+  )
   Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async => _lnToolkit.inProgressReverseSwaps();
 
   /* Swap Fee API's */
@@ -455,6 +459,9 @@ class BreezSDK {
   }) async {
     return await _lnToolkit.prepareOnchainPayment(req: req);
   }
+
+  /// Returns the blocking [ReverseSwapInfo]s that are in progress
+  Future<List<ReverseSwapInfo>> inProgressOnchainPayments() async => _lnToolkit.inProgressOnchainPayments();
 
   /// Fetches the current recommended fees
   Future<RecommendedFees> recommendedFees() async => await _lnToolkit.recommendedFees();

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -299,6 +299,11 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kPrepareOnchainPaymentConstMeta;
 
+  /// See [BreezServices::in_progress_onchain_payments]
+  Future<List<ReverseSwapInfo>> inProgressOnchainPayments({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kInProgressOnchainPaymentsConstMeta;
+
   /// See [BreezServices::recommended_fees]
   Future<RecommendedFees> recommendedFees({dynamic hint});
 
@@ -2983,6 +2988,23 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kPrepareOnchainPaymentConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "prepare_onchain_payment",
         argNames: ["req"],
+      );
+
+  Future<List<ReverseSwapInfo>> inProgressOnchainPayments({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_in_progress_onchain_payments(port_),
+      parseSuccessData: _wire2api_list_reverse_swap_info,
+      parseErrorData: _wire2api_FrbAnyhowException,
+      constMeta: kInProgressOnchainPaymentsConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kInProgressOnchainPaymentsConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "in_progress_onchain_payments",
+        argNames: [],
       );
 
   Future<RecommendedFees> recommendedFees({dynamic hint}) {
@@ -5872,6 +5894,19 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       'wire_prepare_onchain_payment');
   late final _wire_prepare_onchain_payment = _wire_prepare_onchain_paymentPtr
       .asFunction<void Function(int, ffi.Pointer<wire_PrepareOnchainPaymentRequest>)>();
+
+  void wire_in_progress_onchain_payments(
+    int port_,
+  ) {
+    return _wire_in_progress_onchain_payments(
+      port_,
+    );
+  }
+
+  late final _wire_in_progress_onchain_paymentsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_onchain_payments');
+  late final _wire_in_progress_onchain_payments =
+      _wire_in_progress_onchain_paymentsPtr.asFunction<void Function(int)>();
 
   void wire_recommended_fees(
     int port_,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -817,6 +817,18 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
+    fun inProgressOnchainPayments(promise: Promise) {
+        executor.execute {
+            try {
+                val res = getBreezServices().inProgressOnchainPayments()
+                promise.resolve(readableArrayOf(res))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun inProgressReverseSwaps(promise: Promise) {
         executor.execute {
             try {

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -273,6 +273,11 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    inProgressOnchainPayments: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     inProgressReverseSwaps: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -587,6 +587,16 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
+    @objc(inProgressOnchainPayments:reject:)
+    func inProgressOnchainPayments(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            var res = try getBreezServices().inProgressOnchainPayments()
+            resolve(BreezSDKMapper.arrayOf(reverseSwapInfoList: res))
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(inProgressReverseSwaps:reject:)
     func inProgressReverseSwaps(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -1068,6 +1068,11 @@ export const prepareOnchainPayment = async (req: PrepareOnchainPaymentRequest): 
     return response
 }
 
+export const inProgressOnchainPayments = async (): Promise<ReverseSwapInfo[]> => {
+    const response = await BreezSDK.inProgressOnchainPayments()
+    return response
+}
+
 export const inProgressReverseSwaps = async (): Promise<ReverseSwapInfo[]> => {
     const response = await BreezSDK.inProgressReverseSwaps()
     return response


### PR DESCRIPTION
Add a method to check in progress onchain payments, that matches the reverse swap v2 naming.

The new `in_progress_onchain_payments` is a wrapper around the existing (v1) `in_progress_reverse_swaps`, which is now marked as deprecated.