### PR TITLE
Fix Android bindings build

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -18,6 +18,10 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildTypes {
         getByName("release") {
             @Suppress("UnstableApiUsage")


### PR DESCRIPTION
Sets the jvm target to 1.8 to prevent:

https://github.com/breez/breez-sdk/actions/runs/8355628604
```
* What went wrong:
Execution failed for task ':lib:compileDebugKotlin'.
19 actionable tasks: 19 executed
> 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.
```