### PR TITLE
Reverse swap validation: fix service fee rounding

### DIFF
--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1045,7 +1045,7 @@ pub struct PrepareOnchainPaymentResponse {
     pub total_fees: u64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PayOnchainRequest {
     pub recipient_address: String,
     pub prepare_res: PrepareOnchainPaymentResponse,

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -3,5 +3,5 @@ pub(crate) mod error;
 pub(crate) mod reverseswap;
 
 pub(crate) fn calculate_service_fee_sat(send_amount_sat: u64, fees_percentage: f64) -> u64 {
-    ((send_amount_sat as f64) * fees_percentage / 100.0) as u64
+    ((send_amount_sat as f64) * fees_percentage / 100.0).ceil() as u64
 }

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -5,3 +5,21 @@ pub(crate) mod reverseswap;
 pub(crate) fn calculate_service_fee_sat(send_amount_sat: u64, fees_percentage: f64) -> u64 {
     ((send_amount_sat as f64) * fees_percentage / 100.0).ceil() as u64
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::swap_out::calculate_service_fee_sat;
+
+    #[test]
+    fn test_calculate_service_fee_sat() {
+        // Round values, so rounding up plays no role
+        assert_eq!(250, calculate_service_fee_sat(50_000, 0.5));
+        assert_eq!(300, calculate_service_fee_sat(50_000, 0.6));
+        assert_eq!(750, calculate_service_fee_sat(100_000, 0.75));
+
+        // Odd values, where rounding up kicks in
+        assert_eq!(251, calculate_service_fee_sat(50_001, 0.5));
+        assert_eq!(301, calculate_service_fee_sat(50_001, 0.6));
+        assert_eq!(751, calculate_service_fee_sat(100_001, 0.75));
+    }
+}

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -209,7 +209,6 @@ impl BTCSendSwap {
             trace!("create_rev_swap v2 service_fee_sat: {service_fee_sat} sat");
             let expected_onchain_amount =
                 request_send_amount_sat - service_fee_sat - lockup_fee_sat;
-            trace!("create_rev_swap v2 onchain_amount expected: {expected_onchain_amount} sat");
             ensure_sdk!(
                 created_rsi.onchain_amount_sat == expected_onchain_amount,
                 ReverseSwapError::generic("Unexpected onchain amount (lockup fee or service fee)")

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -192,6 +192,9 @@ impl BTCSendSwap {
 
         // For v2 reverse swaps, we perform validation on the created swap
         if let CreateReverseSwapArg::V2(req) = req {
+            trace!("create_rev_swap v2 request: {req:?}");
+            trace!("create_rev_swap v2 created_rsi: {created_rsi:?}");
+
             // Validate send_amount
             let request_send_amount_sat = req.prepare_res.sender_amount_sat;
             let request_send_amount_msat = request_send_amount_sat * 1_000;
@@ -203,8 +206,14 @@ impl BTCSendSwap {
                 req.prepare_res.sender_amount_sat,
                 req.prepare_res.fees_percentage,
             );
+            trace!("create_rev_swap v2 service_fee_sat: {service_fee_sat} sat");
             let expected_onchain_amount =
                 request_send_amount_sat - service_fee_sat - lockup_fee_sat;
+            trace!("create_rev_swap v2 onchain_amount expected: {expected_onchain_amount} sat");
+            trace!(
+                "create_rev_swap v2 onchain_amount actual  : {} sat",
+                created_rsi.onchain_amount_sat
+            );
             ensure_sdk!(
                 created_rsi.onchain_amount_sat == expected_onchain_amount,
                 ReverseSwapError::generic("Unexpected onchain amount (lockup fee or service fee)")

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -210,10 +210,6 @@ impl BTCSendSwap {
             let expected_onchain_amount =
                 request_send_amount_sat - service_fee_sat - lockup_fee_sat;
             trace!("create_rev_swap v2 onchain_amount expected: {expected_onchain_amount} sat");
-            trace!(
-                "create_rev_swap v2 onchain_amount actual  : {} sat",
-                created_rsi.onchain_amount_sat
-            );
             ensure_sdk!(
                 created_rsi.onchain_amount_sat == expected_onchain_amount,
                 ReverseSwapError::generic("Unexpected onchain amount (lockup fee or service fee)")


### PR DESCRIPTION
The service fee formula deals with fractions of a sat.

This value has to be rounded up, not down, to match the actual Boltz service fee.