### PR TITLE
Fix sync edge case affecting outbound payments

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1691,9 +1691,7 @@ async fn pull_transactions(
     let outbound_transactions: NodeResult<Vec<Payment>> = payments
         .pays
         .into_iter()
-        .filter(|p| {
-            p.created_at > since_timestamp || p.completed_at.unwwrap_or(0) > since_timestamp
-        })
+        .filter(|p| p.created_at > since_timestamp || p.completed_at.unwrap_or(0) > since_timestamp)
         .map(TryInto::try_into)
         .collect();
 

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1691,7 +1691,9 @@ async fn pull_transactions(
     let outbound_transactions: NodeResult<Vec<Payment>> = payments
         .pays
         .into_iter()
-        .filter(|p| p.created_at > since_timestamp)
+        .filter(|p| {
+            p.created_at > since_timestamp || p.completed_at.unwwrap_or(0) > since_timestamp
+        })
         .map(TryInto::try_into)
         .collect();
 

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1691,7 +1691,13 @@ async fn pull_transactions(
     let outbound_transactions: NodeResult<Vec<Payment>> = payments
         .pays
         .into_iter()
-        .filter(|p| p.created_at > since_timestamp || p.completed_at.unwrap_or(0) > since_timestamp)
+        .filter(|p| {
+            p.created_at > since_timestamp
+                || match p.completed_at {
+                    None => true,
+                    Some(completed_at) => completed_at > since_timestamp,
+                }
+        })
         .map(TryInto::try_into)
         .collect();
 


### PR DESCRIPTION
If `since_timestamp` is set due to a newly received payment, but an outbound payment was created shortly before that, then the filter would normally miss this outbound payment.

We therefore extend the filter to also check if `completed_at` happened after `since_timestamp`.