### PR TITLE
Fix clippy error "you are using an explicit closure for cloning elements"

### DIFF
--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -170,7 +170,7 @@ impl BTCSendSwap {
                     "No hops found for reverse routing node {reverse_routing_node:?}"
                 ))
             })
-            .map(|r| r.clone())
+            .cloned()
     }
 
     /// Creates and persists a reverse swap. If the initial payment fails, the reverse swap has the new


### PR DESCRIPTION
Fixes new clippy errors detected in new stable rust version.