### PR TITLE
Consolidate reverse swap service fee calculation

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -825,7 +825,7 @@ impl BreezServices {
                 res.fees_claim = BTCSendSwap::calculate_claim_tx_fee(claim_tx_feerate)?;
             }
 
-            let service_fee_sat = swap_out::calculate_service_fee_sat(amt, res.fees_percentage);
+            let service_fee_sat = swap_out::get_service_fee_sat(amt, res.fees_percentage);
             res.total_fees = Some(service_fee_sat + res.fees_lockup + res.fees_claim);
         }
 
@@ -960,7 +960,7 @@ impl BreezServices {
         let (send_amt, recv_amt) = match req.amount_type {
             SwapAmountType::Send => {
                 let temp_send_amt = req.amount_sat;
-                let service_fees = swap_out::calculate_service_fee_sat(temp_send_amt, p);
+                let service_fees = swap_out::get_service_fee_sat(temp_send_amt, p);
                 let total_fees = service_fees + fees_lockup + fees_claim;
                 ensure_sdk!(
                     temp_send_amt > total_fees,
@@ -974,8 +974,7 @@ impl BreezServices {
             SwapAmountType::Receive => {
                 let temp_recv_amt = req.amount_sat;
                 let send_amt_and_service_fee = temp_recv_amt + fees_lockup + fees_claim;
-                let temp_send_amt =
-                    swap_out::calculate_invoice_amount_sat(send_amt_and_service_fee, p);
+                let temp_send_amt = swap_out::get_invoice_amount_sat(send_amt_and_service_fee, p);
 
                 (temp_send_amt, temp_recv_amt)
             }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -973,8 +973,8 @@ impl BreezServices {
             }
             SwapAmountType::Receive => {
                 let temp_recv_amt = req.amount_sat;
-                let send_amt_and_service_fee = temp_recv_amt + fees_lockup + fees_claim;
-                let temp_send_amt = swap_out::get_invoice_amount_sat(send_amt_and_service_fee, p);
+                let send_amt_minus_service_fee = temp_recv_amt + fees_lockup + fees_claim;
+                let temp_send_amt = swap_out::get_invoice_amount_sat(send_amt_minus_service_fee, p);
 
                 (temp_send_amt, temp_recv_amt)
             }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -960,7 +960,7 @@ impl BreezServices {
         let (send_amt, recv_amt) = match req.amount_type {
             SwapAmountType::Send => {
                 let temp_send_amt = req.amount_sat;
-                let service_fees = ((temp_send_amt as f64) * p / 100.0) as u64;
+                let service_fees = swap_out::calculate_service_fee_sat(temp_send_amt, p);
                 let total_fees = service_fees + fees_lockup + fees_claim;
                 ensure_sdk!(
                     temp_send_amt > total_fees,
@@ -974,9 +974,10 @@ impl BreezServices {
             SwapAmountType::Receive => {
                 let temp_recv_amt = req.amount_sat;
                 let send_amt_and_service_fee = temp_recv_amt + fees_lockup + fees_claim;
-                let temp_send_amt = send_amt_and_service_fee as f64 * 100.0 / (100.0 - p);
+                let temp_send_amt =
+                    swap_out::calculate_invoice_amount_sat(send_amt_and_service_fee, p);
 
-                (temp_send_amt as u64, temp_recv_amt)
+                (temp_send_amt, temp_recv_amt)
             }
         };
 

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -72,8 +72,13 @@ mod tests {
         // - invoice_amount_sat = 50_001, service_fee_sat = 251
         // both lead to an onchain_amount_sat of 49_750 and an identical receive_amount_sat of 46_040.
         //
-        // Trying to find the invoice_amount_sat in reverse can result in more than one valid result.
-        // In that case, the smaller one is preferred (user sends least amount possible for the same result).
-        assert!(calculated_invoice_amount_sat <= invoice_amount_sat);
+        // This is not case anymore for invoice_amount_sat of 50_002, as service_fee_sat stays 251, and
+        // therefore the received amount has to increase by 1 sat.
+        //
+        // Trying to find the invoice_amount_sat in reverse can result in either one or two valid results.
+        assert!(
+            (calculated_invoice_amount_sat == invoice_amount_sat)
+                || (calculated_invoice_amount_sat == invoice_amount_sat - 1)
+        );
     }
 }

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -41,26 +41,26 @@ mod tests {
     #[test]
     fn test_get_invoice_amount_sat() {
         // Round values, so rounding up plays no role
-        test_fee_calculation_in_both_directions(50_000, 0.5);
-        test_fee_calculation_in_both_directions(51_000, 0.5);
-        test_fee_calculation_in_both_directions(52_000, 0.5);
-        test_fee_calculation_in_both_directions(53_000, 0.5);
-        test_fee_calculation_in_both_directions(54_000, 0.5);
-        test_fee_calculation_in_both_directions(60_000, 0.6);
-        test_fee_calculation_in_both_directions(100_000, 0.75);
+        test_invoice_amount_calculation_in_reverse(50_000, 0.5);
+        test_invoice_amount_calculation_in_reverse(51_000, 0.5);
+        test_invoice_amount_calculation_in_reverse(52_000, 0.5);
+        test_invoice_amount_calculation_in_reverse(53_000, 0.5);
+        test_invoice_amount_calculation_in_reverse(54_000, 0.5);
+        test_invoice_amount_calculation_in_reverse(60_000, 0.6);
+        test_invoice_amount_calculation_in_reverse(100_000, 0.75);
 
         // Odd values, where the rounding up in the service fee calculation kicks in
-        test_fee_calculation_in_both_directions(50_001, 0.5);
-        test_fee_calculation_in_both_directions(50_999, 0.5);
-        test_fee_calculation_in_both_directions(51_001, 0.5);
-        test_fee_calculation_in_both_directions(52_001, 0.5);
-        test_fee_calculation_in_both_directions(53_001, 0.5);
-        test_fee_calculation_in_both_directions(54_001, 0.5);
-        test_fee_calculation_in_both_directions(60_001, 0.6);
-        test_fee_calculation_in_both_directions(75_001, 0.75);
+        test_invoice_amount_calculation_in_reverse(50_001, 0.5);
+        test_invoice_amount_calculation_in_reverse(50_999, 0.5);
+        test_invoice_amount_calculation_in_reverse(51_001, 0.5);
+        test_invoice_amount_calculation_in_reverse(52_001, 0.5);
+        test_invoice_amount_calculation_in_reverse(53_001, 0.5);
+        test_invoice_amount_calculation_in_reverse(54_001, 0.5);
+        test_invoice_amount_calculation_in_reverse(60_001, 0.6);
+        test_invoice_amount_calculation_in_reverse(75_001, 0.75);
     }
 
-    fn test_fee_calculation_in_both_directions(invoice_amount_sat: u64, fees_percentage: f64) {
+    fn test_invoice_amount_calculation_in_reverse(invoice_amount_sat: u64, fees_percentage: f64) {
         let service_fee_sat = get_service_fee_sat(invoice_amount_sat, fees_percentage);
         let calculated_invoice_amount_sat =
             get_invoice_amount_sat(invoice_amount_sat - service_fee_sat, fees_percentage);

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -9,14 +9,16 @@ pub(crate) fn get_service_fee_sat(invoice_amount_sat: u64, fees_percentage: f64)
     ((invoice_amount_sat as f64) * fees_percentage / 100.0).ceil() as u64
 }
 
-/// Calculate the `invoice_amount_sat` from `invoice_amount_and_service_fee`.
+/// Calculate the `invoice_amount_sat` from `invoice_amount_minus_service_fee`.
 ///
 /// This calculates the initial amount going in reverse, e.g. from the resulting sum.
 pub(crate) fn get_invoice_amount_sat(
-    invoice_amount_and_service_fee: u64,
+    invoice_amount_minus_service_fee: u64,
     fees_percentage: f64,
 ) -> u64 {
-    (invoice_amount_and_service_fee as f64 * 100.0 / (100.0 + fees_percentage)) as u64
+    // The resulting invoice amount contains the service fee, which is rounded up with ceil()
+    // Therefore, when calculating the invoice amount, we must also round it up with ceil()
+    (invoice_amount_minus_service_fee as f64 * 100.0 / (100.0 - fees_percentage)).ceil() as u64
 }
 
 #[cfg(test)]
@@ -60,9 +62,18 @@ mod tests {
 
     fn test_fee_calculation_in_both_directions(invoice_amount_sat: u64, fees_percentage: f64) {
         let service_fee_sat = get_service_fee_sat(invoice_amount_sat, fees_percentage);
-        assert_eq!(
-            invoice_amount_sat,
-            get_invoice_amount_sat(invoice_amount_sat + service_fee_sat, fees_percentage)
-        );
+        let calculated_invoice_amount_sat =
+            get_invoice_amount_sat(invoice_amount_sat - service_fee_sat, fees_percentage);
+
+        // The rounding up of the service fee means there will be a precision loss when we try to calculate in reverse.
+        //
+        // For example:
+        // - invoice_amount_sat = 50_000, service_fee_sat = 250
+        // - invoice_amount_sat = 50_001, service_fee_sat = 251
+        // both lead to an onchain_amount_sat of 49_750 and an identical receive_amount_sat of 46_040.
+        //
+        // Trying to find the invoice_amount_sat in reverse can result in more than one valid result.
+        // In that case, the smaller one is preferred (user sends least amount possible for the same result).
+        assert!(calculated_invoice_amount_sat <= invoice_amount_sat);
     }
 }

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -5,14 +5,14 @@ pub(crate) mod reverseswap;
 /// Calculate the service fee from the `invoice_amount_sat`.
 ///
 /// The fee is a percentage of the invoice amount, rounded up.
-pub(crate) fn calculate_service_fee_sat(invoice_amount_sat: u64, fees_percentage: f64) -> u64 {
+pub(crate) fn get_service_fee_sat(invoice_amount_sat: u64, fees_percentage: f64) -> u64 {
     ((invoice_amount_sat as f64) * fees_percentage / 100.0).ceil() as u64
 }
 
 /// Calculate the `invoice_amount_sat` from `invoice_amount_and_service_fee`.
 ///
 /// This calculates the initial amount going in reverse, e.g. from the resulting sum.
-pub(crate) fn calculate_invoice_amount_sat(
+pub(crate) fn get_invoice_amount_sat(
     invoice_amount_and_service_fee: u64,
     fees_percentage: f64,
 ) -> u64 {
@@ -21,23 +21,23 @@ pub(crate) fn calculate_invoice_amount_sat(
 
 #[cfg(test)]
 mod tests {
-    use crate::swap_out::{calculate_invoice_amount_sat, calculate_service_fee_sat};
+    use crate::swap_out::{get_invoice_amount_sat, get_service_fee_sat};
 
     #[test]
-    fn test_calculate_service_fee_sat() {
+    fn test_get_service_fee_sat() {
         // Round values, so rounding up plays no role
-        assert_eq!(250, calculate_service_fee_sat(50_000, 0.5));
-        assert_eq!(300, calculate_service_fee_sat(50_000, 0.6));
-        assert_eq!(750, calculate_service_fee_sat(100_000, 0.75));
+        assert_eq!(250, get_service_fee_sat(50_000, 0.5));
+        assert_eq!(300, get_service_fee_sat(50_000, 0.6));
+        assert_eq!(750, get_service_fee_sat(100_000, 0.75));
 
         // Odd values, where rounding up kicks in
-        assert_eq!(251, calculate_service_fee_sat(50_001, 0.5));
-        assert_eq!(301, calculate_service_fee_sat(50_001, 0.6));
-        assert_eq!(751, calculate_service_fee_sat(100_001, 0.75));
+        assert_eq!(251, get_service_fee_sat(50_001, 0.5));
+        assert_eq!(301, get_service_fee_sat(50_001, 0.6));
+        assert_eq!(751, get_service_fee_sat(100_001, 0.75));
     }
 
     #[test]
-    fn test_calculate_invoice_amount_sat() {
+    fn test_get_invoice_amount_sat() {
         // Round values, so rounding up plays no role
         test_fee_calculation_in_both_directions(50_000, 0.5);
         test_fee_calculation_in_both_directions(51_000, 0.5);
@@ -59,10 +59,10 @@ mod tests {
     }
 
     fn test_fee_calculation_in_both_directions(invoice_amount_sat: u64, fees_percentage: f64) {
-        let service_fee_sat = calculate_service_fee_sat(invoice_amount_sat, fees_percentage);
+        let service_fee_sat = get_service_fee_sat(invoice_amount_sat, fees_percentage);
         assert_eq!(
             invoice_amount_sat,
-            calculate_invoice_amount_sat(invoice_amount_sat + service_fee_sat, fees_percentage)
+            get_invoice_amount_sat(invoice_amount_sat + service_fee_sat, fees_percentage)
         );
     }
 }

--- a/libs/sdk-core/src/swap_out/mod.rs
+++ b/libs/sdk-core/src/swap_out/mod.rs
@@ -2,13 +2,26 @@ pub(crate) mod boltzswap;
 pub(crate) mod error;
 pub(crate) mod reverseswap;
 
-pub(crate) fn calculate_service_fee_sat(send_amount_sat: u64, fees_percentage: f64) -> u64 {
-    ((send_amount_sat as f64) * fees_percentage / 100.0).ceil() as u64
+/// Calculate the service fee from the `invoice_amount_sat`.
+///
+/// The fee is a percentage of the invoice amount, rounded up.
+pub(crate) fn calculate_service_fee_sat(invoice_amount_sat: u64, fees_percentage: f64) -> u64 {
+    ((invoice_amount_sat as f64) * fees_percentage / 100.0).ceil() as u64
+}
+
+/// Calculate the `invoice_amount_sat` from `invoice_amount_and_service_fee`.
+///
+/// This calculates the initial amount going in reverse, e.g. from the resulting sum.
+pub(crate) fn calculate_invoice_amount_sat(
+    invoice_amount_and_service_fee: u64,
+    fees_percentage: f64,
+) -> u64 {
+    (invoice_amount_and_service_fee as f64 * 100.0 / (100.0 + fees_percentage)) as u64
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::swap_out::calculate_service_fee_sat;
+    use crate::swap_out::{calculate_invoice_amount_sat, calculate_service_fee_sat};
 
     #[test]
     fn test_calculate_service_fee_sat() {
@@ -21,5 +34,35 @@ mod tests {
         assert_eq!(251, calculate_service_fee_sat(50_001, 0.5));
         assert_eq!(301, calculate_service_fee_sat(50_001, 0.6));
         assert_eq!(751, calculate_service_fee_sat(100_001, 0.75));
+    }
+
+    #[test]
+    fn test_calculate_invoice_amount_sat() {
+        // Round values, so rounding up plays no role
+        test_fee_calculation_in_both_directions(50_000, 0.5);
+        test_fee_calculation_in_both_directions(51_000, 0.5);
+        test_fee_calculation_in_both_directions(52_000, 0.5);
+        test_fee_calculation_in_both_directions(53_000, 0.5);
+        test_fee_calculation_in_both_directions(54_000, 0.5);
+        test_fee_calculation_in_both_directions(60_000, 0.6);
+        test_fee_calculation_in_both_directions(100_000, 0.75);
+
+        // Odd values, where the rounding up in the service fee calculation kicks in
+        test_fee_calculation_in_both_directions(50_001, 0.5);
+        test_fee_calculation_in_both_directions(50_999, 0.5);
+        test_fee_calculation_in_both_directions(51_001, 0.5);
+        test_fee_calculation_in_both_directions(52_001, 0.5);
+        test_fee_calculation_in_both_directions(53_001, 0.5);
+        test_fee_calculation_in_both_directions(54_001, 0.5);
+        test_fee_calculation_in_both_directions(60_001, 0.6);
+        test_fee_calculation_in_both_directions(75_001, 0.75);
+    }
+
+    fn test_fee_calculation_in_both_directions(invoice_amount_sat: u64, fees_percentage: f64) {
+        let service_fee_sat = calculate_service_fee_sat(invoice_amount_sat, fees_percentage);
+        assert_eq!(
+            invoice_amount_sat,
+            calculate_invoice_amount_sat(invoice_amount_sat + service_fee_sat, fees_percentage)
+        );
     }
 }

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -202,7 +202,7 @@ impl BTCSendSwap {
 
             // Validate onchain_amount
             let lockup_fee_sat = req.prepare_res.fees_lockup;
-            let service_fee_sat = super::calculate_service_fee_sat(
+            let service_fee_sat = super::get_service_fee_sat(
                 req.prepare_res.sender_amount_sat,
                 req.prepare_res.fees_percentage,
             );

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -713,6 +713,7 @@ impl BTCSendSwap {
 mod tests {
     use anyhow::Result;
 
+    use crate::swap_out::get_service_fee_sat;
     use crate::test_utils::{MOCK_REVERSE_SWAP_MAX, MOCK_REVERSE_SWAP_MIN};
     use crate::{PrepareOnchainPaymentRequest, PrepareOnchainPaymentResponse, SwapAmountType};
 
@@ -811,7 +812,7 @@ mod tests {
         let total_fees = res.total_fees;
         assert_eq!(send_amount_sat - total_fees, receive_amount_sat);
 
-        let service_fees = ((send_amount_sat as f64) * res.fees_percentage / 100.0) as u64;
+        let service_fees = get_service_fee_sat(send_amount_sat, res.fees_percentage);
         let expected_total_fees = res.fees_lockup + res.fees_claim + service_fees;
         assert_eq!(expected_total_fees, total_fees);
 


### PR DESCRIPTION
There were still a few places that were doing the fee calculation explicitly, instead of (re-)using the dedicated method.

This PR
- re-uses `get_service_fee_sat` (the "forward calculation" of the service fee)
- encapsulates and adds tests for `get_invoice_amount_sat` (the "reverse calculation" of the invoice amount)