### PR TITLE
ChainService: Fallback to next mempool.space endpoint on error

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -133,7 +133,7 @@ interface NodeConfig {
 dictionary Config {
     string breezserver;
     string chainnotifier_url;
-    string mempoolspace_url;
+    string? mempoolspace_url;
     string working_dir;
     Network network;
     u32 payment_timeout_sec;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -27,6 +27,7 @@ use tonic::{Request, Status};
 use crate::backup::{BackupRequest, BackupTransport, BackupWatcher};
 use crate::chain::{
     ChainService, Outspend, RecommendedFees, RedundantChainService, RedundantChainServiceTrait,
+    DEFAULT_MEMPOOL_SPACE_URL,
 };
 use crate::error::{
     LnUrlAuthError, LnUrlPayError, LnUrlWithdrawError, ReceiveOnchainError, ReceiveOnchainResult,
@@ -2078,7 +2079,10 @@ impl BreezServicesBuilder {
                     0 => {
                         // If we have no cached values, or we cached an empty list, fetch new ones
 
-                        let fresh_urls = breez_server.fetch_mempoolspace_urls().await?;
+                        let fresh_urls = breez_server
+                            .fetch_mempoolspace_urls()
+                            .await
+                            .unwrap_or(vec![DEFAULT_MEMPOOL_SPACE_URL.into()]);
                         persister.set_mempoolspace_base_urls(fresh_urls.clone())?;
                         fresh_urls
                     }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -25,7 +25,9 @@ use tonic::transport::{Channel, Endpoint};
 use tonic::{Request, Status};
 
 use crate::backup::{BackupRequest, BackupTransport, BackupWatcher};
-use crate::chain::{ChainService, MempoolSpace, Outspend, RecommendedFees};
+use crate::chain::{
+    ChainService, Outspend, RecommendedFees, RedundantChainService, RedundantChainServiceTrait,
+};
 use crate::error::{
     LnUrlAuthError, LnUrlPayError, LnUrlWithdrawError, ReceiveOnchainError, ReceiveOnchainResult,
     ReceivePaymentError, SdkError, SdkResult, SendOnchainError, SendPaymentError,
@@ -2105,7 +2107,7 @@ impl BreezServicesBuilder {
             }
             Some(mempoolspace_url_from_config) => vec![mempoolspace_url_from_config],
         };
-        let chain_service = Arc::new(MempoolSpace::from_base_urls(mempoolspace_urls));
+        let chain_service = Arc::new(RedundantChainService::from_base_urls(mempoolspace_urls));
 
         let btc_receive_swapper = Arc::new(BTCReceiveSwap::new(
             self.config.network.into(),

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1994,10 +1994,12 @@ impl BreezServicesBuilder {
             .unwrap_or_else(|| Arc::new(SqliteStorage::new(self.config.working_dir.clone())));
         persister.init()?;
 
+        // TODO Read values from config or from cache
         // mempool space is used to monitor the chain
-        let chain_service = Arc::new(MempoolSpace::from_base_url(
-            self.config.mempoolspace_url.clone(),
-        ));
+        let chain_service = Arc::new(MempoolSpace::from_base_urls(vec![self
+            .config
+            .mempoolspace_url
+            .clone()]));
 
         let mut node_api = self.node_api.clone();
         let mut backup_transport = self.backup_transport.clone();
@@ -2067,7 +2069,7 @@ impl BreezServicesBuilder {
         }
 
         let fresh_mempool_space_endpoints = breez_server.fetch_mempool_space_endpoints().await?;
-        persister.set_mempool_space_endpoints(fresh_mempool_space_endpoints)?;
+        persister.set_mempool_space_base_urls(fresh_mempool_space_endpoints)?;
 
         let payment_receiver = Arc::new(PaymentReceiver {
             config: self.config.clone(),

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1189,7 +1189,7 @@ impl support::IntoDart for Config {
         vec![
             self.breezserver.into_into_dart().into_dart(),
             self.chainnotifier_url.into_into_dart().into_dart(),
-            self.mempoolspace_url.into_into_dart().into_dart(),
+            self.mempoolspace_url.into_dart(),
             self.working_dir.into_into_dart().into_dart(),
             self.network.into_into_dart().into_dart(),
             self.payment_timeout_sec.into_into_dart().into_dart(),

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -5,6 +5,8 @@ use crate::bitcoin::hashes::hex::FromHex;
 use crate::bitcoin::{OutPoint, Txid};
 use crate::input_parser::{get_parse_and_log_response, get_reqwest_client, post_and_log_response};
 
+pub const DEFAULT_MEMPOOL_SPACE_URL: &str = "https://mempool.space/api";
+
 #[tonic::async_trait]
 pub trait ChainService: Send + Sync {
     async fn recommended_fees(&self) -> Result<RecommendedFees>;
@@ -308,7 +310,7 @@ pub struct Outspend {
 impl Default for MempoolSpace {
     fn default() -> Self {
         MempoolSpace {
-            base_url: "https://mempool.space/api".to_string(),
+            base_url: DEFAULT_MEMPOOL_SPACE_URL.into(),
         }
     }
 }

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::hashes::hex::FromHex;
 use crate::bitcoin::{OutPoint, Txid};
-use crate::input_parser::{get_parse_and_log_response, post_and_log_response};
+use crate::input_parser::{get_parse_and_log_response, get_reqwest_client, post_and_log_response};
 
 #[tonic::async_trait]
 pub trait ChainService: Send + Sync {
@@ -19,6 +19,89 @@ pub trait ChainService: Send + Sync {
     async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>>;
     /// If successful, it returns the transaction ID. Otherwise returns an `Err` describing the error.
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String>;
+}
+
+pub trait RedundantChainServiceTrait: ChainService {
+    fn from_base_urls(base_urls: Vec<String>) -> Self;
+}
+
+#[derive(Clone)]
+pub struct RedundantChainService {
+    instances: Vec<MempoolSpace>,
+}
+impl RedundantChainServiceTrait for RedundantChainService {
+    fn from_base_urls(base_urls: Vec<String>) -> Self {
+        Self {
+            instances: base_urls
+                .iter()
+                .map(|url: &String| url.trim_end_matches('/'))
+                .map(MempoolSpace::from_base_url)
+                .collect(),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl ChainService for RedundantChainService {
+    async fn recommended_fees(&self) -> Result<RecommendedFees> {
+        for inst in &self.instances {
+            match inst.recommended_fees().await {
+                Ok(res) => {
+                    return Ok(res);
+                }
+                Err(e) => error!("Call to chain service {} failed: {e}", inst.base_url),
+            }
+        }
+        Err(anyhow!("All chain service instances failed"))
+    }
+
+    async fn address_transactions(&self, address: String) -> Result<Vec<OnchainTx>> {
+        for inst in &self.instances {
+            match inst.address_transactions(address.clone()).await {
+                Ok(res) => {
+                    return Ok(res);
+                }
+                Err(e) => error!("Call to chain service {} failed: {e}", inst.base_url),
+            }
+        }
+        Err(anyhow!("All chain service instances failed"))
+    }
+
+    async fn current_tip(&self) -> Result<u32> {
+        for inst in &self.instances {
+            match inst.current_tip().await {
+                Ok(res) => {
+                    return Ok(res);
+                }
+                Err(e) => error!("Call to chain service {} failed: {e}", inst.base_url),
+            }
+        }
+        Err(anyhow!("All chain service instances failed"))
+    }
+
+    async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>> {
+        for inst in &self.instances {
+            match inst.transaction_outspends(txid.clone()).await {
+                Ok(res) => {
+                    return Ok(res);
+                }
+                Err(e) => error!("Call to chain service {} failed: {e}", inst.base_url),
+            }
+        }
+        Err(anyhow!("All chain service instances failed"))
+    }
+
+    async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String> {
+        for inst in &self.instances {
+            match inst.broadcast_transaction(tx.clone()).await {
+                Ok(res) => {
+                    return Ok(res);
+                }
+                Err(e) => error!("Call to chain service {} failed: {e}", inst.base_url),
+            }
+        }
+        Err(anyhow!("All chain service instances failed"))
+    }
 }
 
 #[derive(Clone)]
@@ -146,7 +229,7 @@ pub(crate) fn get_total_incoming_txs(address: String, transactions: Vec<OnchainT
 
 #[derive(Clone)]
 pub(crate) struct MempoolSpace {
-    pub(crate) base_urls: Vec<String>,
+    pub(crate) base_url: String,
 }
 
 /// Wrapper containing the result of the recommended fees query, in sat/vByte, based on mempool.space data
@@ -225,74 +308,15 @@ pub struct Outspend {
 impl Default for MempoolSpace {
     fn default() -> Self {
         MempoolSpace {
-            base_urls: vec!["https://mempool.space/api".to_string()],
+            base_url: "https://mempool.space/api".to_string(),
         }
     }
 }
 
 impl MempoolSpace {
-    pub fn from_base_urls(base_urls: Vec<String>) -> MempoolSpace {
-        MempoolSpace { base_urls }
-    }
-
-    fn get_base_url_at(&self, i: usize) -> Result<&str> {
-        self.base_urls
-            .get(i)
-            .map(|url: &String| url.trim_end_matches('/'))
-            .ok_or(anyhow!("No mempool.space URL found at index {i}"))
-    }
-
-    async fn call_get_with_fallback<T>(
-        &self,
-        build_api_url_fn: impl Fn(&str) -> String,
-    ) -> Result<T>
-    where
-        for<'a> T: serde::de::Deserialize<'a>,
-    {
-        let get_fn = get_parse_and_log_response;
-
-        let mut i = 0;
-        loop {
-            let base_url = self.get_base_url_at(i)?;
-            let get_call_url = build_api_url_fn(base_url);
-
-            info!("Trying GET request with chain service URL {get_call_url}");
-            let res = get_fn(&get_call_url).await;
-            match res {
-                Ok(_) => {
-                    return res;
-                }
-                Err(e) => {
-                    error!("Chain service GET call failed: {e}");
-                    i += 1;
-                }
-            }
-        }
-    }
-
-    async fn call_post_with_fallback(
-        &self,
-        build_api_url_fn: impl Fn(&str) -> String,
-        body: Option<String>,
-    ) -> Result<String> {
-        let post_fn = post_and_log_response;
-
-        let mut i = 0;
-        loop {
-            let base_url = self.get_base_url_at(i)?;
-            let post_call_url = build_api_url_fn(base_url);
-
-            info!("Trying POST request with chain service URL {post_call_url}");
-            let res = post_fn(&post_call_url, body.clone()).await;
-            match res {
-                Ok(_) => {
-                    return res;
-                }
-                Err(e) => {
-                    error!("Chain service POST call failed: {e}");
-                    i += 1;
-                }
-            }
+    pub fn from_base_url(base_url: &str) -> MempoolSpace {
+        MempoolSpace {
+            base_url: base_url.into(),
         }
     }
 }
@@ -300,30 +324,25 @@ impl MempoolSpace {
 #[tonic::async_trait]
 impl ChainService for MempoolSpace {
     async fn recommended_fees(&self) -> Result<RecommendedFees> {
-        let api_url_from_base_url_fn = |base_url: &str| format!("{base_url}/v1/fees/recommended");
-        self.call_get_with_fallback(api_url_from_base_url_fn).await
+        get_parse_and_log_response(&format!("{}/v1/fees/recommended", self.base_url)).await
     }
 
     async fn address_transactions(&self, address: String) -> Result<Vec<OnchainTx>> {
-        let api_url_from_base_url_fn = |base_url: &str| format!("{base_url}/address/{address}/txs");
-        self.call_get_with_fallback(api_url_from_base_url_fn).await
+        get_parse_and_log_response(&format!("{}/address/{address}/txs", self.base_url)).await
     }
 
     async fn current_tip(&self) -> Result<u32> {
-        let api_url_from_base_url_fn = |base_url: &str| format!("{base_url}/blocks/tip/height");
-        self.call_get_with_fallback(api_url_from_base_url_fn).await
+        get_parse_and_log_response(&format!("{}/blocks/tip/height", self.base_url)).await
     }
 
     async fn transaction_outspends(&self, txid: String) -> Result<Vec<Outspend>> {
-        let api_url_from_base_url_fn = |base_url: &str| format!("{base_url}/tx/{txid}/outspends");
-        self.call_get_with_fallback(api_url_from_base_url_fn).await
+        let url = format!("{}/tx/{txid}/outspends", self.base_url);
+        Ok(get_reqwest_client()?.get(url).send().await?.json().await?)
     }
 
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> Result<String> {
-        let api_url_from_base_url_fn = |base_url: &str| format!("{base_url}/tx");
-        let txid_or_error = self
-            .call_post_with_fallback(api_url_from_base_url_fn, Some(hex::encode(tx)))
-            .await?;
+        let txid_or_error =
+            post_and_log_response(&format!("{}/tx", self.base_url), Some(hex::encode(tx))).await?;
         match txid_or_error.contains("error") {
             true => Err(anyhow!("Error fetching tx: {txid_or_error}")),
             false => Ok(txid_or_error),
@@ -332,7 +351,9 @@ impl ChainService for MempoolSpace {
 }
 #[cfg(test)]
 mod tests {
-    use crate::chain::{MempoolSpace, OnchainTx};
+    use crate::chain::{
+        MempoolSpace, OnchainTx, RedundantChainService, RedundantChainServiceTrait,
+    };
     use anyhow::Result;
     use tokio::test;
 
@@ -353,23 +374,24 @@ mod tests {
 
     #[test]
     async fn test_recommended_fees_with_fallback() -> Result<()> {
-        let ms =
-            MempoolSpace::from_base_urls(vec!["https://mempool-url-unreachable.space/api/".into()]);
+        let ms = RedundantChainService::from_base_urls(vec![
+            "https://mempool-url-unreachable.space/api/".into(),
+        ]);
         assert!(ms.recommended_fees().await.is_err());
 
-        let ms = MempoolSpace::from_base_urls(vec![
+        let ms = RedundantChainService::from_base_urls(vec![
             "https://mempool-url-unreachable.space/api/".into(),
             "https://mempool.emzy.de/api/".into(),
         ]);
         assert!(ms.recommended_fees().await.is_ok());
 
-        let ms = MempoolSpace::from_base_urls(vec![
+        let ms = RedundantChainService::from_base_urls(vec![
             "https://mempool-url-unreachable.space/api/".into(),
             "https://another-mempool-url-unreachable.space/api/".into(),
         ]);
         assert!(ms.recommended_fees().await.is_err());
 
-        let ms = MempoolSpace::from_base_urls(vec![
+        let ms = RedundantChainService::from_base_urls(vec![
             "https://mempool-url-unreachable.space/api/".into(),
             "https://another-mempool-url-unreachable.space/api/".into(),
             "https://mempool.emzy.de/api/".into(),

--- a/libs/sdk-core/src/grpc/proto/breez.proto
+++ b/libs/sdk-core/src/grpc/proto/breez.proto
@@ -26,6 +26,7 @@ service Information {
   rpc BreezAppVersions(BreezAppVersionsRequest)
       returns (BreezAppVersionsReply) {}
   rpc ReceiverInfo(ReceiverInfoRequest) returns (ReceiverInfoReply) {}
+  rpc ChainApiServers(ChainApiServersRequest) returns (ChainApiServersReply) {}
 }
 
 service ChannelOpener {
@@ -427,6 +428,15 @@ message BreezStatusReply {
     SERVICE_DISRUPTION = 2;
   }
   BreezStatus status = 1;
+}
+
+message ChainApiServersRequest {}
+message ChainApiServersReply {
+  message ChainAPIServer {
+    string server_type = 1;
+    string server_base_url = 2;
+  }
+  repeated ChainAPIServer servers = 1;
 }
 
 /////////////////////////////////////////////

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -230,6 +230,19 @@ pub async fn parse(input: &str) -> Result<InputType> {
     Err(anyhow!("Unrecognized input type"))
 }
 
+pub(crate) async fn post_and_log_response(url: &str, body: Option<String>) -> Result<String> {
+    debug!("Making POST request to: {url}");
+
+    let mut req = reqwest::Client::new().post(url);
+    if let Some(body) = body {
+        req = req.body(body);
+    }
+    let raw_body = req.send().await?.text().await?;
+    debug!("Received raw response body: {raw_body}");
+
+    Ok(raw_body)
+}
+
 /// Makes a GET request to the specified `url` and logs on DEBUG:
 /// - the URL
 /// - the raw response body

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -233,7 +233,7 @@ pub async fn parse(input: &str) -> Result<InputType> {
 pub(crate) async fn post_and_log_response(url: &str, body: Option<String>) -> Result<String> {
     debug!("Making POST request to: {url}");
 
-    let mut req = reqwest::Client::new().post(url);
+    let mut req = get_reqwest_client()?.post(url);
     if let Some(body) = body {
         req = req.body(body);
     }

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -467,6 +467,8 @@ pub struct Config {
     ///
     /// If not set, a list of mempool.space URLs will be used to provide fault-tolerance. If calls
     /// to the first URL fail, then the call will be repeated to the next URL, and so on.
+    ///
+    /// Note that, if specified, the URL has to be in the format: `https://mempool.space/api`
     pub mempoolspace_url: Option<String>,
     /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
     /// the folder should exist before starting the SDK.

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -463,7 +463,7 @@ pub struct LogEntry {
 pub struct Config {
     pub breezserver: String,
     pub chainnotifier_url: String,
-    pub mempoolspace_url: String,
+    pub mempoolspace_url: Option<String>,
     /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
     /// the folder should exist before starting the SDK.
     pub working_dir: String,
@@ -486,7 +486,7 @@ impl Config {
         Config {
             breezserver: PRODUCTION_BREEZSERVER_URL.to_string(),
             chainnotifier_url: "https://chainnotifier.breez.technology".to_string(),
-            mempoolspace_url: "https://mempool.space/api/".to_string(),
+            mempoolspace_url: None,
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,
@@ -502,7 +502,7 @@ impl Config {
         Config {
             breezserver: STAGING_BREEZSERVER_URL.to_string(),
             chainnotifier_url: "https://chainnotifier.breez.technology".to_string(),
-            mempoolspace_url: "https://mempool.space/api/".to_string(),
+            mempoolspace_url: None,
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -486,7 +486,7 @@ impl Config {
         Config {
             breezserver: PRODUCTION_BREEZSERVER_URL.to_string(),
             chainnotifier_url: "https://chainnotifier.breez.technology".to_string(),
-            mempoolspace_url: "https://mempool.space".to_string(),
+            mempoolspace_url: "https://mempool.space/api/".to_string(),
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,
@@ -502,7 +502,7 @@ impl Config {
         Config {
             breezserver: STAGING_BREEZSERVER_URL.to_string(),
             chainnotifier_url: "https://chainnotifier.breez.technology".to_string(),
-            mempoolspace_url: "https://mempool.space".to_string(),
+            mempoolspace_url: "https://mempool.space/api/".to_string(),
             working_dir: ".".to_string(),
             network: Bitcoin,
             payment_timeout_sec: 60,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -463,6 +463,10 @@ pub struct LogEntry {
 pub struct Config {
     pub breezserver: String,
     pub chainnotifier_url: String,
+    /// If set, this is the mempool.space URL that will be used.
+    ///
+    /// If not set, a list of mempool.space URLs will be used to provide fault-tolerance. If calls
+    /// to the first URL fail, then the call will be repeated to the next URL, and so on.
     pub mempoolspace_url: Option<String>,
     /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
     /// the folder should exist before starting the SDK.

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -8,7 +8,7 @@ const KEY_LAST_SYNC_TIME: &str = "last_sync_time";
 const KEY_NODE_STATE: &str = "node_state";
 const KEY_STATIC_BACKUP: &str = "static_backup";
 const KEY_WEBHOOK_URL: &str = "webhook_url";
-const KEY_MEMPOOL_SPACE_ENDPOINTS: &str = "mempool_space_endpoints";
+const KEY_MEMPOOL_SPACE_BASE_URLS: &str = "mempool_space_base_urls";
 
 impl SqliteStorage {
     pub fn get_cached_item(&self, key: &str) -> PersistResult<Option<String>> {
@@ -110,16 +110,16 @@ impl SqliteStorage {
         self.get_cached_item(KEY_WEBHOOK_URL)
     }
 
-    pub fn set_mempool_space_endpoints(
+    pub fn set_mempool_space_base_urls(
         &self,
         mempool_space_endpoints: Vec<String>,
     ) -> PersistResult<()> {
         let serialized = serde_json::to_string(&mempool_space_endpoints)?;
-        self.update_cached_item(KEY_MEMPOOL_SPACE_ENDPOINTS, serialized)
+        self.update_cached_item(KEY_MEMPOOL_SPACE_BASE_URLS, serialized)
     }
 
-    pub fn get_mempool_space_endpoints(&self) -> PersistResult<Vec<String>> {
-        let res = match self.get_cached_item(KEY_MEMPOOL_SPACE_ENDPOINTS)? {
+    pub fn get_mempool_space_base_urls(&self) -> PersistResult<Vec<String>> {
+        let res = match self.get_cached_item(KEY_MEMPOOL_SPACE_BASE_URLS)? {
             Some(str) => serde_json::from_str(str.as_str())?,
             None => vec![],
         };

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -8,6 +8,7 @@ const KEY_LAST_SYNC_TIME: &str = "last_sync_time";
 const KEY_NODE_STATE: &str = "node_state";
 const KEY_STATIC_BACKUP: &str = "static_backup";
 const KEY_WEBHOOK_URL: &str = "webhook_url";
+const KEY_MEMPOOL_SPACE_ENDPOINTS: &str = "mempool_space_endpoints";
 
 impl SqliteStorage {
     pub fn get_cached_item(&self, key: &str) -> PersistResult<Option<String>> {
@@ -107,6 +108,23 @@ impl SqliteStorage {
     #[allow(dead_code)]
     pub fn get_webhook_url(&self) -> PersistResult<Option<String>> {
         self.get_cached_item(KEY_WEBHOOK_URL)
+    }
+
+    pub fn set_mempool_space_endpoints(
+        &self,
+        mempool_space_endpoints: Vec<String>,
+    ) -> PersistResult<()> {
+        let serialized = serde_json::to_string(&mempool_space_endpoints)?;
+        self.update_cached_item(KEY_MEMPOOL_SPACE_ENDPOINTS, serialized)
+    }
+
+    pub fn get_mempool_space_endpoints(&self) -> PersistResult<Vec<String>> {
+        let res = match self.get_cached_item(KEY_MEMPOOL_SPACE_ENDPOINTS)? {
+            Some(str) => serde_json::from_str(str.as_str())?,
+            None => vec![],
+        };
+
+        Ok(res)
     }
 }
 

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -8,7 +8,7 @@ const KEY_LAST_SYNC_TIME: &str = "last_sync_time";
 const KEY_NODE_STATE: &str = "node_state";
 const KEY_STATIC_BACKUP: &str = "static_backup";
 const KEY_WEBHOOK_URL: &str = "webhook_url";
-const KEY_MEMPOOL_SPACE_BASE_URLS: &str = "mempool_space_base_urls";
+const KEY_MEMPOOLSPACE_BASE_URLS: &str = "mempoolspace_base_urls";
 
 impl SqliteStorage {
     pub fn get_cached_item(&self, key: &str) -> PersistResult<Option<String>> {
@@ -110,16 +110,16 @@ impl SqliteStorage {
         self.get_cached_item(KEY_WEBHOOK_URL)
     }
 
-    pub fn set_mempool_space_base_urls(
+    pub fn set_mempoolspace_base_urls(
         &self,
         mempool_space_endpoints: Vec<String>,
     ) -> PersistResult<()> {
         let serialized = serde_json::to_string(&mempool_space_endpoints)?;
-        self.update_cached_item(KEY_MEMPOOL_SPACE_BASE_URLS, serialized)
+        self.update_cached_item(KEY_MEMPOOLSPACE_BASE_URLS, serialized)
     }
 
-    pub fn get_mempool_space_base_urls(&self) -> PersistResult<Vec<String>> {
-        let res = match self.get_cached_item(KEY_MEMPOOL_SPACE_BASE_URLS)? {
+    pub fn get_mempoolspace_base_urls(&self) -> PersistResult<Vec<String>> {
+        let res = match self.get_cached_item(KEY_MEMPOOLSPACE_BASE_URLS)? {
             Some(str) => serde_json::from_str(str.as_str())?,
             None => vec![],
         };

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -16,7 +16,7 @@ use crate::bitcoin::util::sighash::SighashCache;
 use crate::bitcoin::{
     Address, AddressType, EcdsaSighashType, Script, Sequence, Transaction, TxIn, TxOut, Witness,
 };
-use crate::chain::{get_utxos, ChainService, MempoolSpace, OnchainTx};
+use crate::chain::{get_utxos, ChainService, OnchainTx};
 use crate::error::SdkResult;
 use crate::models::{ReverseSwapServiceAPI, ReverseSwapperRoutingAPI};
 use crate::node_api::{NodeAPI, NodeError};
@@ -118,7 +118,7 @@ impl BTCSendSwap {
         reverse_swapper_api: Arc<dyn ReverseSwapperRoutingAPI>,
         reverse_swap_service_api: Arc<dyn ReverseSwapServiceAPI>,
         persister: Arc<crate::persist::db::SqliteStorage>,
-        chain_service: Arc<MempoolSpace>,
+        chain_service: Arc<dyn ChainService>,
         node_api: Arc<dyn NodeAPI>,
     ) -> Self {
         Self {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -507,6 +507,8 @@ class Config {
   ///
   /// If not set, a list of mempool.space URLs will be used to provide fault-tolerance. If calls
   /// to the first URL fail, then the call will be repeated to the next URL, and so on.
+  ///
+  /// Note that, if specified, the URL has to be in the format: `https://mempool.space/api`
   final String? mempoolspaceUrl;
 
   /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -502,7 +502,12 @@ class ClosedChannelPaymentDetails {
 class Config {
   final String breezserver;
   final String chainnotifierUrl;
-  final String mempoolspaceUrl;
+
+  /// If set, this is the mempool.space URL that will be used.
+  ///
+  /// If not set, a list of mempool.space URLs will be used to provide fault-tolerance. If calls
+  /// to the first URL fail, then the call will be repeated to the next URL, and so on.
+  final String? mempoolspaceUrl;
 
   /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
   /// the folder should exist before starting the SDK.
@@ -522,7 +527,7 @@ class Config {
   const Config({
     required this.breezserver,
     required this.chainnotifierUrl,
-    required this.mempoolspaceUrl,
+    this.mempoolspaceUrl,
     required this.workingDir,
     required this.network,
     required this.paymentTimeoutSec,
@@ -3317,7 +3322,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     return Config(
       breezserver: _wire2api_String(arr[0]),
       chainnotifierUrl: _wire2api_String(arr[1]),
-      mempoolspaceUrl: _wire2api_String(arr[2]),
+      mempoolspaceUrl: _wire2api_opt_String(arr[2]),
       workingDir: _wire2api_String(arr[3]),
       network: _wire2api_network(arr[4]),
       paymentTimeoutSec: _wire2api_u32(arr[5]),
@@ -4765,7 +4770,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_config(Config apiObj, wire_Config wireObj) {
     wireObj.breezserver = api2wire_String(apiObj.breezserver);
     wireObj.chainnotifier_url = api2wire_String(apiObj.chainnotifierUrl);
-    wireObj.mempoolspace_url = api2wire_String(apiObj.mempoolspaceUrl);
+    wireObj.mempoolspace_url = api2wire_opt_String(apiObj.mempoolspaceUrl);
     wireObj.working_dir = api2wire_String(apiObj.workingDir);
     wireObj.network = api2wire_network(apiObj.network);
     wireObj.payment_timeout_sec = api2wire_u32(apiObj.paymentTimeoutSec);

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -382,7 +382,6 @@ fun asConfig(config: ReadableMap): Config? {
             arrayOf(
                 "breezserver",
                 "chainnotifierUrl",
-                "mempoolspaceUrl",
                 "workingDir",
                 "network",
                 "paymentTimeoutSec",
@@ -396,7 +395,7 @@ fun asConfig(config: ReadableMap): Config? {
     }
     val breezserver = config.getString("breezserver")!!
     val chainnotifierUrl = config.getString("chainnotifierUrl")!!
-    val mempoolspaceUrl = config.getString("mempoolspaceUrl")!!
+    val mempoolspaceUrl = if (hasNonNullKey(config, "mempoolspaceUrl")) config.getString("mempoolspaceUrl") else null
     val workingDir = config.getString("workingDir")!!
     val network = config.getString("network")?.let { asNetwork(it) }!!
     val paymentTimeoutSec = config.getInt("paymentTimeoutSec").toUInt()

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -401,8 +401,12 @@ enum BreezSDKMapper {
         guard let chainnotifierUrl = config["chainnotifierUrl"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "chainnotifierUrl", typeName: "Config"))
         }
-        guard let mempoolspaceUrl = config["mempoolspaceUrl"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "mempoolspaceUrl", typeName: "Config"))
+        var mempoolspaceUrl: String?
+        if hasNonNilKey(data: config, key: "mempoolspaceUrl") {
+            guard let mempoolspaceUrlTmp = config["mempoolspaceUrl"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "mempoolspaceUrl"))
+            }
+            mempoolspaceUrl = mempoolspaceUrlTmp
         }
         guard let workingDir = config["workingDir"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "workingDir", typeName: "Config"))
@@ -459,7 +463,7 @@ enum BreezSDKMapper {
         return [
             "breezserver": config.breezserver,
             "chainnotifierUrl": config.chainnotifierUrl,
-            "mempoolspaceUrl": config.mempoolspaceUrl,
+            "mempoolspaceUrl": config.mempoolspaceUrl == nil ? nil : config.mempoolspaceUrl,
             "workingDir": config.workingDir,
             "network": valueOf(network: config.network),
             "paymentTimeoutSec": config.paymentTimeoutSec,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -71,7 +71,7 @@ export type ClosedChannelPaymentDetails = {
 export type Config = {
     breezserver: string
     chainnotifierUrl: string
-    mempoolspaceUrl: string
+    mempoolspaceUrl?: string
     workingDir: string
     network: Network
     paymentTimeoutSec: number


### PR DESCRIPTION
This PR adds support for fallback chainservice URLs.

This includes:
- fetching a list of mempool.space endpoints from the breez server
- changing `Config::mempoolspace_url` to an optional value. If the callers sets it when initializing the SDK, this value will be used. If no value is set (default), then we use the list.
- changing the chainservice methods to support calls that fallback on to the next URL, for both GET and POST requests