### PR TITLE
iOS notification grouping

### DIFF
--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Constants.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Constants.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 struct Constants {
+    // Notification Threads
+    static let NOTIFICATION_THREAD_LNURL_PAY = "LNURL_PAY"
+    static let NOTIFICATION_THREAD_PAYMENT_RECEIVED = "PAYMENT_RECEIVED"
+    static let NOTIFICATION_THREAD_SWAP_TX_CONFIRMED = "SWAP_TX_CONFIRMED"
+
     // Message Data
     static let MESSAGE_DATA_TYPE = "notification_type"
     static let MESSAGE_DATA_PAYLOAD = "notification_payload"

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPay.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPay.swift
@@ -35,12 +35,12 @@ class LnurlPayTask : TaskProtocol {
     func start(breezSDK: BlockingBreezServices) throws {}
     
     func onShutdown() {
-        displayPushNotification(title: self.failNotificationTitle, logger: self.logger)
+        displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
     }
     
     func replyServer(encodable: Encodable, replyURL: String) {
         guard let serverReplyURL = URL(string: replyURL) else {
-            self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger)
+            self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
             return
         }
         var request = URLRequest(url: serverReplyURL)
@@ -50,9 +50,9 @@ class LnurlPayTask : TaskProtocol {
             let statusCode = (response as! HTTPURLResponse).statusCode
             
             if statusCode == 200 {
-                self.displayPushNotification(title: self.successNotifiationTitle, logger: self.logger)
+                self.displayPushNotification(title: self.successNotifiationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
             } else {
-                self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger)
+                self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
                 return
             }
         }
@@ -69,6 +69,6 @@ class LnurlPayTask : TaskProtocol {
             }
             task.resume()
         }
-        self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger)
+        self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
     }
 }

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPayInfo.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPayInfo.swift
@@ -37,7 +37,7 @@ class LnurlPayInfoTask : LnurlPayTask {
             request = try JSONDecoder().decode(LnurlInfoRequest.self, from: self.payload.data(using: .utf8)!)
         } catch let e {
             self.logger.log(tag: TAG, line: "failed to decode payload: \(e)", level: "ERROR")
-            self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger)
+            self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
             throw e
         }
         

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPayInvoice.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPayInvoice.swift
@@ -31,7 +31,7 @@ class LnurlPayInvoiceTask : LnurlPayTask {
             request = try JSONDecoder().decode(LnurlInvoiceRequest.self, from: self.payload.data(using: .utf8)!)
         } catch let e {
             self.logger.log(tag: TAG, line: "failed to decode payload: \(e)", level: "ERROR")
-            self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger)
+            self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
             throw e
         }
         

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/ReceivePayment.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/ReceivePayment.swift
@@ -40,6 +40,6 @@ class ReceivePaymentTask : TaskProtocol {
         let successReceivedPayment = ResourceHelper.shared.getString(key: Constants.PAYMENT_RECEIVED_NOTIFICATION_TITLE, validateContains: "%d", fallback: Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TITLE)
         let failReceivedPayment = ResourceHelper.shared.getString(key: Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE, fallback: Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE)
         let title = self.receivedPayment != nil ? String(format: successReceivedPayment, self.receivedPayment!.amountMsat/1000) : failReceivedPayment
-        self.displayPushNotification(title: title, logger: self.logger)
+        self.displayPushNotification(title: title, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_PAYMENT_RECEIVED)
     }
 }

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/RedeemSwap.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/RedeemSwap.swift
@@ -37,7 +37,7 @@ class RedeemSwapTask : TaskProtocol {
             try breezSDK.redeemSwap(swapAddress: addressTxsConfirmedRequest!.address)
             self.logger.log(tag: TAG, line: "Found swap for \(addressTxsConfirmedRequest!.address)", level: "DEBUG")
             let successRedeemSwap = ResourceHelper.shared.getString(key: Constants.SWAP_TX_CONFIRMED_NOTIFICATION_TITLE, fallback: Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE)
-            self.displayPushNotification(title: successRedeemSwap, logger: self.logger)
+            self.displayPushNotification(title: successRedeemSwap, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_SWAP_TX_CONFIRMED)
         } catch let e {
             self.logger.log(tag: TAG, line: "Failed to process swap notification: \(e)", level: "ERROR")
             self.onShutdown()
@@ -46,6 +46,6 @@ class RedeemSwapTask : TaskProtocol {
 
     func onShutdown() {
         let failRedeemSwap = ResourceHelper.shared.getString(key: Constants.SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE, fallback: Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE)
-        self.displayPushNotification(title: failRedeemSwap, logger: self.logger)
+        self.displayPushNotification(title: failRedeemSwap, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_SWAP_TX_CONFIRMED)
     }
 }

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/TaskProtocol.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/TaskProtocol.swift
@@ -10,13 +10,17 @@ public protocol TaskProtocol : EventListener {
 }
 
 extension TaskProtocol {
-    func displayPushNotification(title: String, logger: ServiceLogger) {
+    func displayPushNotification(title: String, logger: ServiceLogger, threadIdentifier: String? = nil) {
         logger.log(tag: "TaskProtocol", line:"displayPushNotification \(title)", level: "INFO")
         guard
             let contentHandler = contentHandler,
             let bestAttemptContent = bestAttemptContent
         else {
             return
+        }
+        
+        if threadIdentifier != nil {
+            bestAttemptContent.threadIdentifier = threadIdentifier!
         }
         
         bestAttemptContent.title = title


### PR DESCRIPTION
Adds an optional threadIdentifier param to displayPushNotification to allow tasks to group notifications into their own threads