### PR TITLE
0.3.9: Add debugging to signer loop start

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -208,8 +208,8 @@ impl Greenlight {
             break;
         }
 
-        info!("Entering the signer loop");
         loop {
+            debug!("Start of the signer loop, getting node_info from scheduler");
             let get_node = scheduler.get_node_info(NodeInfoRequest {
                 node_id: self.signer.node_id(),
                 // Purposely not using the `wait` parameter


### PR DESCRIPTION
Add a debug statement to mark the start of the signer loop