### PR TITLE
Add notification message for the channel fee limit being too low

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
@@ -45,6 +45,8 @@ object Constants {
         "lnurl_pay_notification_channel_name"
     const val LNURL_PAY_NOTIFICATION_FAILURE_TITLE =
         "lnurl_pay_notification_failure_title"
+    const val LNURL_PAY_NOTIFICATION_LIQUIDITY_FAILURE_TITLE =
+        "lnurl_pay_notification_liquidity_failure_title"
     const val LNURL_PAY_WORKGROUP_ID = "lnurl_pay"
     const val LNURL_PAY_WORKGROUP_DESCRIPTION = "lnurl_pay_work_group_description"
     const val LNURL_PAY_WORKGROUP_NAME = "lnurl_pay_work_group_name"
@@ -85,7 +87,7 @@ object Constants {
     const val DEFAULT_LNURL_PAY_INFO_NOTIFICATION_TITLE =
         "Retrieving Payment Information"
     const val DEFAULT_LNURL_PAY_INVOICE_NOTIFICATION_TITLE =
-        "Fetching invoice"
+        "Fetching Invoice"
     const val DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT =
         "Pay with LNURL"
     const val DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_DESCRIPTION =
@@ -93,6 +95,8 @@ object Constants {
     const val DEFAULT_LNURL_PAY_NOTIFICATION_CHANNEL_NAME = "Receiving Payments"
     const val DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE =
         "Receive Payment Failed"
+    const val DEFAULT_LNURL_PAY_NOTIFICATION_LIQUIDITY_FAILURE_TITLE =
+        "Fee Limit Too Low"
     const val DEFAULT_LNURL_PAY_WORKGROUP_DESCRIPTION =
         "Required to handle LNURL pay requests when the application is in the background"
     const val DEFAULT_LNURL_PAY_WORKGROUP_NAME = "LNURL Payments"

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPay.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPay.kt
@@ -54,3 +54,5 @@ interface LnurlPayJob : Job {
         }
     }
 }
+
+class InvalidMinSendableException(message: String) : Exception(message)

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Constants.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Constants.swift
@@ -20,16 +20,20 @@ struct Constants {
     static let LNURL_PAY_INVOICE_NOTIFICATION_TITLE = "lnurl_pay_invoice_notification_title"
     static let LNURL_PAY_METADATA_PLAIN_TEXT = "lnurl_pay_metadata_plain_text"
     static let LNURL_PAY_NOTIFICATION_FAILURE_TITLE = "lnurl_pay_notification_failure_title"
+    static let LNURL_PAY_NOTIFICATION_LIQUIDITY_FAILURE_TITLE = "lnurl_pay_notification_liquidity_failure_title"
     static let PAYMENT_RECEIVED_NOTIFICATION_TITLE = "payment_received_notification_title"
+    static let PAYMENT_RECEIVED_NOTIFICATION_FAILURE_TITLE = "payment_received_notification_failure_title"
     static let SWAP_TX_CONFIRMED_NOTIFICATION_TITLE = "swap_tx_confirmed_notification_title"
     static let SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE = "swap_tx_confirmed_notification_failure_title"
     
     // Resource Identifier Defaults
     static let DEFAULT_LNURL_PAY_INFO_NOTIFICATION_TITLE = "Retrieving Payment Information"
-    static let DEFAULT_LNURL_PAY_INVOICE_NOTIFICATION_TITLE = "Fetching invoice"
+    static let DEFAULT_LNURL_PAY_INVOICE_NOTIFICATION_TITLE = "Fetching Invoice"
     static let DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT = "Pay with LNURL"
     static let DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE = "Receive Payment Failed"
+    static let DEFAULT_LNURL_PAY_NOTIFICATION_LIQUIDITY_FAILURE_TITLE = "Fee Limit Too Low"
     static let DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TITLE = "Received %d sats"
+    static let DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_FAILURE_TITLE = "Receive Payment Failed"
     static let DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE = "Swap Confirmed"
     static let DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE = "Redeem Swap Failed"
 }

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPay.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPay.swift
@@ -17,7 +17,7 @@ class LnurlPayTask : TaskProtocol {
     var bestAttemptContent: UNMutableNotificationContent?
     var logger: ServiceLogger
     var config: ServiceConfig
-    var successNotifiationTitle: String
+    var successNotificationTitle: String
     var failNotificationTitle: String
     
     init(payload: String, logger: ServiceLogger, config: ServiceConfig, contentHandler: ((UNNotificationContent) -> Void)? = nil, bestAttemptContent: UNMutableNotificationContent? = nil, successNotificationTitle: String, failNotificationTitle: String) {
@@ -26,7 +26,7 @@ class LnurlPayTask : TaskProtocol {
         self.bestAttemptContent = bestAttemptContent
         self.logger = logger
         self.config = config
-        self.successNotifiationTitle = successNotificationTitle;
+        self.successNotificationTitle = successNotificationTitle;
         self.failNotificationTitle = failNotificationTitle;
     }
     
@@ -50,7 +50,7 @@ class LnurlPayTask : TaskProtocol {
             let statusCode = (response as! HTTPURLResponse).statusCode
             
             if statusCode == 200 {
-                self.displayPushNotification(title: self.successNotifiationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
+                self.displayPushNotification(title: self.successNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
             } else {
                 self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
                 return
@@ -59,7 +59,7 @@ class LnurlPayTask : TaskProtocol {
         task.resume()
     }
     
-    func fail(withError: String, replyURL: String) {
+    func fail(withError: String, replyURL: String, failNotificationTitle: String? = nil) {
         if let serverReplyURL = URL(string: replyURL) {
             var request = URLRequest(url: serverReplyURL)
             request.httpMethod = "POST"
@@ -69,6 +69,7 @@ class LnurlPayTask : TaskProtocol {
             }
             task.resume()
         }
-        self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
+        var title = failNotificationTitle != nil ? failNotificationTitle! : self.failNotificationTitle
+        self.displayPushNotification(title: title, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_LNURL_PAY)
     }
 }

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/ReceivePayment.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/ReceivePayment.swift
@@ -38,7 +38,7 @@ class ReceivePaymentTask : TaskProtocol {
     
     func onShutdown() {
         let successReceivedPayment = ResourceHelper.shared.getString(key: Constants.PAYMENT_RECEIVED_NOTIFICATION_TITLE, validateContains: "%d", fallback: Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TITLE)
-        let failReceivedPayment = ResourceHelper.shared.getString(key: Constants.LNURL_PAY_NOTIFICATION_FAILURE_TITLE, fallback: Constants.DEFAULT_LNURL_PAY_NOTIFICATION_FAILURE_TITLE)
+        let failReceivedPayment = ResourceHelper.shared.getString(key: Constants.PAYMENT_RECEIVED_NOTIFICATION_FAILURE_TITLE, fallback: Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_FAILURE_TITLE)
         let title = self.receivedPayment != nil ? String(format: successReceivedPayment, self.receivedPayment!.amountMsat/1000) : failReceivedPayment
         self.displayPushNotification(title: title, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_PAYMENT_RECEIVED)
     }


### PR DESCRIPTION
If the configured channel fee limit is set too low it can cause the min sendable to be more than the max sendable (if the calculated max sendable using the fee limit is below the opening fee params min). This PR adds a notification failure message to notify this issue.