### PR TITLE
Use swap event to complete swap in the background

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/RedeemSwap.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/RedeemSwap.kt
@@ -50,7 +50,7 @@ class RedeemSwapJob(
                     logger.log(TAG, "Received swap updated event: ${swapInfo.bitcoinAddress} current address: ${address} status: ${swapInfo.status}", "TRACE")
                     if (swapInfo.bitcoinAddress == address) {
                         if (swapInfo.paidMsat.toLong() > 0) {
-                            notifySuccessAndShutdown()
+                            notifySuccessAndShutdown(address)
                         }
                     }
                 }
@@ -60,8 +60,8 @@ class RedeemSwapJob(
         }
     }
 
-    private  fun notifySuccessAndShutdown() {
-        logger.log(TAG, "Swap address redeemed succesfully", "INFO")
+    private  fun notifySuccessAndShutdown(address: String) {
+        logger.log(TAG, "Swap address ${address} redeemed succesfully", "INFO")
         notifyChannel(
             context,
             NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED,

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/RedeemSwap.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDKNotification/Task/RedeemSwap.swift
@@ -1,6 +1,5 @@
 import UserNotifications
 import Foundation
-import BreezSDK
 
 struct AddressTxsConfirmedRequest: Codable {
     let address: String
@@ -29,6 +28,7 @@ class RedeemSwapTask : TaskProtocol {
                 self.logger.log(tag: TAG, line: "Received swap updated event: \(swapInfo.bitcoinAddress), current address: \(address) status: \(swapInfo.status)\n", level: "INFO")
                 if address == swapInfo.bitcoinAddress {
                     if (swapInfo.paidMsat > 0) {
+                        self.logger.log(tag: TAG, line: "Swap address \(swapInfo.bitcoinAddress) redeemed succesfully", level: "INFO")
                         let successRedeemSwap = ResourceHelper.shared.getString(key: Constants.SWAP_TX_CONFIRMED_NOTIFICATION_TITLE, fallback: Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE)
                         self.displayPushNotification(title: successRedeemSwap, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_SWAP_TX_CONFIRMED)
                     }
@@ -53,6 +53,7 @@ class RedeemSwapTask : TaskProtocol {
         guard let address = swapAddress else {
             self.logger.log(tag: TAG, line: "Failed to process swap notification: swap address not in payload", level: "ERROR")
             self.onShutdown()
+            return
         }
         
         do {


### PR DESCRIPTION
Since both the job and the sdk are racing for redeeming the swap, one of them can fail and if the job fails we show failure to redeem although the redeem succeed.
It is better to rely on the swap event as the source of truth here.