### PR TITLE
Add freezed annotation on SDK structs used through Dart bindings

### DIFF
--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -9,7 +9,7 @@
 //!
 //! The first option loses the `SdkError` type. The second option keeps the type, which we can retrieve
 //! with `anyhow::Error::downcast_ref` (or equivalent Dart method). We therefore use the second approach.
-
+#![allow(unused_imports)]
 use std::future::Future;
 use std::sync::Arc;
 
@@ -30,7 +30,7 @@ use crate::input_parser::{self, InputType, LnUrlAuthRequestData};
 use crate::invoice::{self, LNInvoice};
 use crate::lnurl::pay::model::LnUrlPayResult;
 use crate::lsp::LspInformation;
-use crate::models::{Config, LogEntry, NodeState, Payment, SwapInfo};
+use crate::models::{Config, GreenlightCredentials, LogEntry, NodeState, Payment, SwapInfo};
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     ConfigureNodeRequest, ConnectRequest, EnvironmentType, ListPaymentsRequest,

--- a/libs/sdk-core/src/fiat.rs
+++ b/libs/sdk-core/src/fiat.rs
@@ -4,11 +4,13 @@ use crate::error::SdkResult;
 use crate::grpc::RatesRequest;
 use crate::models::FiatAPI;
 use crate::{breez_services::BreezServer, error::SdkError};
+use flutter_rust_bridge::frb;
 use serde::{Deserialize, Serialize};
 use tonic::Request;
 
 /// Settings for the symbol representation of a currency
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[frb(dart_metadata=("freezed"))]
 pub struct Symbol {
     pub grapheme: Option<String>,
     pub template: Option<String>,
@@ -18,6 +20,7 @@ pub struct Symbol {
 
 /// Locale-specific settings for the representation of a currency
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LocaleOverrides {
     pub locale: String,
     pub spacing: Option<u32>,
@@ -26,6 +29,7 @@ pub struct LocaleOverrides {
 
 /// Localized name of a currency
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LocalizedName {
     pub locale: String,
     pub name: String,
@@ -34,6 +38,7 @@ pub struct LocalizedName {
 /// Details about a supported currency in the fiat rate feed
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[frb(dart_metadata=("freezed"))]
 pub struct CurrencyInfo {
     pub name: String,
     pub fraction_size: u32,
@@ -46,6 +51,7 @@ pub struct CurrencyInfo {
 
 /// Wrapper around the [CurrencyInfo] of a fiat currency
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct FiatCurrency {
     pub id: String,
     pub info: CurrencyInfo,

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use bip21::Uri;
+use flutter_rust_bridge::frb;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -501,6 +502,7 @@ impl From<LnUrlRequestData> for InputType {
 
 /// Wrapped in a [LnUrlError], this represents a LNURL-endpoint error.
 #[derive(Deserialize, Debug, Serialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LnUrlErrorData {
     pub reason: String,
 }
@@ -512,6 +514,7 @@ pub struct LnUrlErrorData {
 /// See <https://github.com/lnurl/luds/blob/luds/06.md>
 #[derive(Clone, Deserialize, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[frb(dart_metadata=("freezed"))]
 pub struct LnUrlPayRequestData {
     pub callback: String,
     /// The minimum amount, in millisats, that this LNURL-pay endpoint accepts
@@ -567,6 +570,7 @@ impl LnUrlPayRequestData {
 /// See <https://github.com/lnurl/luds/blob/luds/03.md>
 #[derive(Deserialize, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[frb(dart_metadata=("freezed"))]
 pub struct LnUrlWithdrawRequestData {
     pub callback: String,
     pub k1: String,
@@ -595,6 +599,7 @@ impl LnUrlWithdrawRequestData {
 ///
 /// See <https://github.com/lnurl/luds/blob/luds/04.md>
 #[derive(Deserialize, Debug, Serialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LnUrlAuthRequestData {
     /// Hex encoded 32 bytes of challenge
     pub k1: String,
@@ -622,6 +627,7 @@ pub struct MetadataItem {
 
 /// Wrapped in a [BitcoinAddress], this is the result of [parse] when given a plain or BIP-21 BTC address.
 #[derive(Debug, Serialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct BitcoinAddressData {
     pub address: String,
     pub network: crate::models::Network,

--- a/libs/sdk-core/src/invoice.rs
+++ b/libs/sdk-core/src/invoice.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use std::time::{SystemTimeError, UNIX_EPOCH};
 
 use anyhow::anyhow;
+use flutter_rust_bridge::frb;
 use hex::ToHex;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -64,6 +65,7 @@ impl From<SystemTimeError> for InvoiceError {
 
 /// Wrapper for a BOLT11 LN invoice
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LNInvoice {
     pub bolt11: String,
     pub network: Network,
@@ -89,6 +91,7 @@ impl LNInvoice {
 
 /// Details of a specific hop in a larger route hint
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct RouteHintHop {
     /// The node_id of the non-target end of the route
     pub src_node_id: String,
@@ -108,6 +111,7 @@ pub struct RouteHintHop {
 
 /// A route hint for a LN payment
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct RouteHint {
     pub hops: Vec<RouteHintHop>,
 }

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -9,12 +9,14 @@ use crate::grpc::{
 use crate::models::{LspAPI, OpeningFeeParams, OpeningFeeParamsMenu};
 
 use anyhow::{anyhow, Result};
+use flutter_rust_bridge::frb;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use tonic::Request;
 
 /// Details of supported LSP
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LspInformation {
     pub id: String,
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, ensure, Result};
 use chrono::{DateTime, Duration, Utc};
+use flutter_rust_bridge::frb;
 use ripemd::Digest;
 use ripemd::Ripemd160;
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef};
@@ -329,6 +330,7 @@ impl FullReverseSwapInfo {
 
 /// Simplified version of [FullReverseSwapInfo], containing only the user-relevant fields
 #[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+#[frb(dart_metadata=("freezed"))]
 pub struct ReverseSwapInfo {
     pub id: String,
     pub claim_pubkey: String,
@@ -460,6 +462,7 @@ pub struct LogEntry {
 /// Use [Config::production] or [Config::staging] for default configs of the different supported
 /// environments.
 #[derive(Clone)]
+#[frb(dart_metadata=("freezed"))]
 pub struct Config {
     pub breezserver: String,
     pub chainnotifier_url: String,
@@ -532,6 +535,7 @@ pub enum NodeCredentials {
 }
 
 #[derive(Clone)]
+#[frb(dart_metadata=("freezed"))]
 pub struct GreenlightNodeConfig {
     pub partner_credentials: Option<GreenlightCredentials>,
     pub invite_code: Option<String>,
@@ -649,6 +653,7 @@ pub struct BackupStatus {
 /// which may result in some short-lived inconsistencies
 /// (e.g., `channels_balance_msat` may be updated before `inbound_liquidity_msats`).
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[frb(dart_metadata=("freezed"))]
 pub struct NodeState {
     pub id: String,
     pub block_height: u32,
@@ -684,6 +689,7 @@ pub enum PaymentStatus {
 
 /// Represents a payment, including its [PaymentType] and [PaymentDetails]
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct Payment {
     pub id: String,
     pub payment_type: PaymentType,
@@ -712,6 +718,7 @@ pub struct PaymentExternalInfo {
 
 /// Represents a list payments request.
 #[derive(Default)]
+#[frb(dart_metadata=("freezed"))]
 pub struct ListPaymentsRequest {
     pub filters: Option<Vec<PaymentTypeFilter>>,
     pub metadata_filters: Option<Vec<MetadataFilter>>,
@@ -760,6 +767,7 @@ impl PaymentDetails {
 
 /// Details of a LN payment, as included in a [Payment]
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LnPaymentDetails {
     pub payment_hash: String,
     pub label: String,
@@ -800,6 +808,7 @@ pub struct LnPaymentDetails {
 
 /// Represents the funds that were on the user side of the channel at the time it was closed.
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct ClosedChannelPaymentDetails {
     pub state: ChannelState,
     pub funding_txid: String,
@@ -834,6 +843,7 @@ pub struct MaxChannelAmount {
 
 /// Represents a receive payment request.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct ReceivePaymentRequest {
     /// The amount in satoshis for this payment request
     pub amount_msat: u64,
@@ -859,6 +869,7 @@ pub struct ReceivePaymentRequest {
 /// be opened automatically when the invoice is paid, and the fees will be described in the
 /// `opening_fee_params` and `opening_fee_msat` fields.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct ReceivePaymentResponse {
     /// The generated invoice, including any necessary routing hints
     pub ln_invoice: LNInvoice,
@@ -888,6 +899,7 @@ pub struct TlvEntry {
 
 /// Represents a send spontaneous payment request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct SendSpontaneousPaymentRequest {
     /// The node id to send this payment is
     pub node_id: String,
@@ -899,6 +911,7 @@ pub struct SendSpontaneousPaymentRequest {
 
 /// Represents a send payment response.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct SendPaymentResponse {
     pub payment: Payment,
 }
@@ -927,6 +940,7 @@ pub enum HealthCheckStatus {
 
 /// Represents a service health check response.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct ServiceHealthCheckResponse {
     pub status: HealthCheckStatus,
 }
@@ -971,17 +985,20 @@ pub struct OpenChannelFeeResponse {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct ReceiveOnchainRequest {
     pub opening_fee_params: Option<OpeningFeeParams>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct BuyBitcoinRequest {
     pub provider: BuyBitcoinProvider,
     pub opening_fee_params: Option<OpeningFeeParams>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct BuyBitcoinResponse {
     pub url: String,
     pub opening_fee_params: Option<OpeningFeeParams>,
@@ -1006,6 +1023,7 @@ pub struct SendOnchainRequest {
     pub sat_per_vbyte: u32,
 }
 
+#[frb(dart_metadata=("freezed"))]
 pub struct SendOnchainResponse {
     pub reverse_swap_info: ReverseSwapInfo,
 }
@@ -1088,6 +1106,7 @@ pub struct RefundResponse {
 /// After they are received, the client shouldn't change them when calling LSP methods,
 /// otherwise the LSP may reject the call.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[frb(dart_metadata=("freezed"))]
 pub struct OpeningFeeParams {
     /// The minimum value in millisatoshi we will require for incoming HTLCs on the channel
     pub min_msat: u64,
@@ -1165,6 +1184,7 @@ pub enum DynamicFeeType {
 
 /// See [OpeningFeeParamsMenu::try_from]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct OpeningFeeParamsMenu {
     pub values: Vec<OpeningFeeParams>,
 }
@@ -1336,6 +1356,7 @@ impl TryFrom<i32> for SwapStatus {
 ///
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct SwapInfo {
     /// Bitcoin address for this swap. Sats sent to this address will be swapped.
     pub bitcoin_address: String,
@@ -1498,6 +1519,7 @@ pub(crate) fn format_short_channel_id(id: u64) -> String {
 
 /// UTXO known to the LN node
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[frb(dart_metadata=("freezed"))]
 pub struct UnspentTransactionOutput {
     pub txid: Vec<u8>,
     pub outnum: u32,
@@ -1530,6 +1552,7 @@ pub enum LnUrlCallbackStatus {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LnUrlWithdrawRequest {
     /// Request data containing information on how to call the lnurl withdraw
     /// endpoint. Typically retrieved by calling `parse()` on a lnurl withdraw
@@ -1547,6 +1570,7 @@ pub struct LnUrlWithdrawRequest {
 
 /// Represents a LNURL-pay request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[frb(dart_metadata=("freezed"))]
 pub struct LnUrlPayRequest {
     /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
     pub data: LnUrlPayRequestData,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -365,20 +365,15 @@ class BackupStatus {
 }
 
 /// Wrapped in a [BitcoinAddress], this is the result of [parse] when given a plain or BIP-21 BTC address.
-class BitcoinAddressData {
-  final String address;
-  final Network network;
-  final int? amountSat;
-  final String? label;
-  final String? message;
-
-  const BitcoinAddressData({
-    required this.address,
-    required this.network,
-    this.amountSat,
-    this.label,
-    this.message,
-  });
+@freezed
+class BitcoinAddressData with _$BitcoinAddressData {
+  const factory BitcoinAddressData({
+    required String address,
+    required Network network,
+    int? amountSat,
+    String? label,
+    String? message,
+  }) = _BitcoinAddressData;
 }
 
 @freezed
@@ -426,24 +421,20 @@ enum BuyBitcoinProvider {
   Moonpay,
 }
 
-class BuyBitcoinRequest {
-  final BuyBitcoinProvider provider;
-  final OpeningFeeParams? openingFeeParams;
-
-  const BuyBitcoinRequest({
-    required this.provider,
-    this.openingFeeParams,
-  });
+@freezed
+class BuyBitcoinRequest with _$BuyBitcoinRequest {
+  const factory BuyBitcoinRequest({
+    required BuyBitcoinProvider provider,
+    OpeningFeeParams? openingFeeParams,
+  }) = _BuyBitcoinRequest;
 }
 
-class BuyBitcoinResponse {
-  final String url;
-  final OpeningFeeParams? openingFeeParams;
-
-  const BuyBitcoinResponse({
-    required this.url,
-    this.openingFeeParams,
-  });
+@freezed
+class BuyBitcoinResponse with _$BuyBitcoinResponse {
+  const factory BuyBitcoinResponse({
+    required String url,
+    OpeningFeeParams? openingFeeParams,
+  }) = _BuyBitcoinResponse;
 }
 
 /// State of a Lightning channel
@@ -484,66 +475,35 @@ class CheckMessageResponse {
 }
 
 /// Represents the funds that were on the user side of the channel at the time it was closed.
-class ClosedChannelPaymentDetails {
-  final ChannelState state;
-  final String fundingTxid;
-  final String? shortChannelId;
-
-  /// Can be empty for older closed channels.
-  final String? closingTxid;
-
-  const ClosedChannelPaymentDetails({
-    required this.state,
-    required this.fundingTxid,
-    this.shortChannelId,
-    this.closingTxid,
-  });
+@freezed
+class ClosedChannelPaymentDetails with _$ClosedChannelPaymentDetails {
+  const factory ClosedChannelPaymentDetails({
+    required ChannelState state,
+    required String fundingTxid,
+    String? shortChannelId,
+    String? closingTxid,
+  }) = _ClosedChannelPaymentDetails;
 }
 
 /// Configuration for the Breez Services
 ///
 /// Use [Config::production] or [Config::staging] for default configs of the different supported
 /// environments.
-class Config {
-  final String breezserver;
-  final String chainnotifierUrl;
-
-  /// If set, this is the mempool.space URL that will be used.
-  ///
-  /// If not set, a list of mempool.space URLs will be used to provide fault-tolerance. If calls
-  /// to the first URL fail, then the call will be repeated to the next URL, and so on.
-  ///
-  /// Note that, if specified, the URL has to be in the format: `https://mempool.space/api`
-  final String? mempoolspaceUrl;
-
-  /// Directory in which all SDK files (DB, log) are stored. Defaults to ".", otherwise if it's customized,
-  /// the folder should exist before starting the SDK.
-  final String workingDir;
-  final Network network;
-  final int paymentTimeoutSec;
-  final String? defaultLspId;
-  final String? apiKey;
-
-  /// Maps to the CLN `maxfeepercent` config when paying invoices (`lightning-pay`)
-  final double maxfeePercent;
-
-  /// Maps to the CLN `exemptfee` config when paying invoices (`lightning-pay`)
-  final int exemptfeeMsat;
-  final NodeConfig nodeConfig;
-
-  const Config({
-    required this.breezserver,
-    required this.chainnotifierUrl,
-    this.mempoolspaceUrl,
-    required this.workingDir,
-    required this.network,
-    required this.paymentTimeoutSec,
-    this.defaultLspId,
-    this.apiKey,
-    required this.maxfeePercent,
-    required this.exemptfeeMsat,
-    required this.nodeConfig,
-  });
+@freezed
+class Config with _$Config {
+  const factory Config({
+    required String breezserver,
+    required String chainnotifierUrl,
+    String? mempoolspaceUrl,
+    required String workingDir,
+    required Network network,
+    required int paymentTimeoutSec,
+    String? defaultLspId,
+    String? apiKey,
+    required double maxfeePercent,
+    required int exemptfeeMsat,
+    required NodeConfig nodeConfig,
+  }) = _Config;
 }
 
 /// Represents a configure node request.
@@ -571,24 +531,17 @@ class ConnectRequest {
 }
 
 /// Details about a supported currency in the fiat rate feed
-class CurrencyInfo {
-  final String name;
-  final int fractionSize;
-  final int? spacing;
-  final Symbol? symbol;
-  final Symbol? uniqSymbol;
-  final List<LocalizedName>? localizedName;
-  final List<LocaleOverrides>? localeOverrides;
-
-  const CurrencyInfo({
-    required this.name,
-    required this.fractionSize,
-    this.spacing,
-    this.symbol,
-    this.uniqSymbol,
-    this.localizedName,
-    this.localeOverrides,
-  });
+@freezed
+class CurrencyInfo with _$CurrencyInfo {
+  const factory CurrencyInfo({
+    required String name,
+    required int fractionSize,
+    int? spacing,
+    Symbol? symbol,
+    Symbol? uniqSymbol,
+    List<LocalizedName>? localizedName,
+    List<LocaleOverrides>? localeOverrides,
+  }) = _CurrencyInfo;
 }
 
 /// Indicates the different kinds of supported environments for [crate::BreezServices].
@@ -598,14 +551,12 @@ enum EnvironmentType {
 }
 
 /// Wrapper around the [CurrencyInfo] of a fiat currency
-class FiatCurrency {
-  final String id;
-  final CurrencyInfo info;
-
-  const FiatCurrency({
-    required this.id,
-    required this.info,
-  });
+@freezed
+class FiatCurrency with _$FiatCurrency {
+  const factory FiatCurrency({
+    required String id,
+    required CurrencyInfo info,
+  }) = _FiatCurrency;
 }
 
 /// Client-specific credentials to connect to and manage a Greenlight node in the cloud
@@ -619,14 +570,12 @@ class GreenlightCredentials {
   });
 }
 
-class GreenlightNodeConfig {
-  final GreenlightCredentials? partnerCredentials;
-  final String? inviteCode;
-
-  const GreenlightNodeConfig({
-    this.partnerCredentials,
-    this.inviteCode,
-  });
+@freezed
+class GreenlightNodeConfig with _$GreenlightNodeConfig {
+  const factory GreenlightNodeConfig({
+    GreenlightCredentials? partnerCredentials,
+    String? inviteCode,
+  }) = _GreenlightNodeConfig;
 }
 
 /// Indicates the different service health check statuses.
@@ -709,116 +658,58 @@ class InvoicePaidDetails {
 }
 
 /// Represents a list payments request.
-class ListPaymentsRequest {
-  final List<PaymentTypeFilter>? filters;
-  final List<MetadataFilter>? metadataFilters;
-
-  /// Epoch time, in seconds
-  final int? fromTimestamp;
-
-  /// Epoch time, in seconds
-  final int? toTimestamp;
-  final bool? includeFailures;
-  final int? offset;
-  final int? limit;
-
-  const ListPaymentsRequest({
-    this.filters,
-    this.metadataFilters,
-    this.fromTimestamp,
-    this.toTimestamp,
-    this.includeFailures,
-    this.offset,
-    this.limit,
-  });
+@freezed
+class ListPaymentsRequest with _$ListPaymentsRequest {
+  const factory ListPaymentsRequest({
+    List<PaymentTypeFilter>? filters,
+    List<MetadataFilter>? metadataFilters,
+    int? fromTimestamp,
+    int? toTimestamp,
+    bool? includeFailures,
+    int? offset,
+    int? limit,
+  }) = _ListPaymentsRequest;
 }
 
 /// Wrapper for a BOLT11 LN invoice
-class LNInvoice {
-  final String bolt11;
-  final Network network;
-  final String payeePubkey;
-  final String paymentHash;
-  final String? description;
-  final String? descriptionHash;
-  final int? amountMsat;
-  final int timestamp;
-  final int expiry;
-  final List<RouteHint> routingHints;
-  final Uint8List paymentSecret;
-  final int minFinalCltvExpiryDelta;
-
-  const LNInvoice({
-    required this.bolt11,
-    required this.network,
-    required this.payeePubkey,
-    required this.paymentHash,
-    this.description,
-    this.descriptionHash,
-    this.amountMsat,
-    required this.timestamp,
-    required this.expiry,
-    required this.routingHints,
-    required this.paymentSecret,
-    required this.minFinalCltvExpiryDelta,
-  });
+@freezed
+class LNInvoice with _$LNInvoice {
+  const factory LNInvoice({
+    required String bolt11,
+    required Network network,
+    required String payeePubkey,
+    required String paymentHash,
+    String? description,
+    String? descriptionHash,
+    int? amountMsat,
+    required int timestamp,
+    required int expiry,
+    required List<RouteHint> routingHints,
+    required Uint8List paymentSecret,
+    required int minFinalCltvExpiryDelta,
+  }) = _LNInvoice;
 }
 
 /// Details of a LN payment, as included in a [Payment]
-class LnPaymentDetails {
-  final String paymentHash;
-  final String label;
-  final String destinationPubkey;
-  final String paymentPreimage;
-  final bool keysend;
-  final String bolt11;
-
-  /// Only set for [PaymentType::Received], payments which require to open a channel.
-  /// Represents the actual invoice paid by the sender
-  final String? openChannelBolt11;
-
-  /// Only set for [PaymentType::Sent] payments that are part of a LNURL-pay workflow where
-  /// the endpoint returns a success action
-  final SuccessActionProcessed? lnurlSuccessAction;
-
-  /// Only set for [PaymentType::Sent] payments if it is not a payment to a Lightning Address
-  final String? lnurlPayDomain;
-
-  /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address
-  final String? lnAddress;
-
-  /// Only set for [PaymentType::Sent] payments where the receiver endpoint returned LNURL metadata
-  final String? lnurlMetadata;
-
-  /// Only set for [PaymentType::Received] payments that were received as part of LNURL-withdraw
-  final String? lnurlWithdrawEndpoint;
-
-  /// Only set for [PaymentType::Received] payments that were received in the context of a swap
-  final SwapInfo? swapInfo;
-
-  /// Only set for [PaymentType::Sent] payments that were sent in the context of a reverse swap
-  final ReverseSwapInfo? reverseSwapInfo;
-
-  /// Only set for [PaymentStatus::Pending] payments that are inflight.
-  final int? pendingExpirationBlock;
-
-  const LnPaymentDetails({
-    required this.paymentHash,
-    required this.label,
-    required this.destinationPubkey,
-    required this.paymentPreimage,
-    required this.keysend,
-    required this.bolt11,
-    this.openChannelBolt11,
-    this.lnurlSuccessAction,
-    this.lnurlPayDomain,
-    this.lnAddress,
-    this.lnurlMetadata,
-    this.lnurlWithdrawEndpoint,
-    this.swapInfo,
-    this.reverseSwapInfo,
-    this.pendingExpirationBlock,
-  });
+@freezed
+class LnPaymentDetails with _$LnPaymentDetails {
+  const factory LnPaymentDetails({
+    required String paymentHash,
+    required String label,
+    required String destinationPubkey,
+    required String paymentPreimage,
+    required bool keysend,
+    required String bolt11,
+    String? openChannelBolt11,
+    SuccessActionProcessed? lnurlSuccessAction,
+    String? lnurlPayDomain,
+    String? lnAddress,
+    String? lnurlMetadata,
+    String? lnurlWithdrawEndpoint,
+    SwapInfo? swapInfo,
+    ReverseSwapInfo? reverseSwapInfo,
+    int? pendingExpirationBlock,
+  }) = _LnPaymentDetails;
 }
 
 /// Wrapped in a [LnUrlAuth], this is the result of [parse] when given a LNURL-auth endpoint.
@@ -826,27 +717,14 @@ class LnPaymentDetails {
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
 /// See <https://github.com/lnurl/luds/blob/luds/04.md>
-class LnUrlAuthRequestData {
-  /// Hex encoded 32 bytes of challenge
-  final String k1;
-
-  /// When available, one of: register, login, link, auth
-  final String? action;
-
-  /// Indicates the domain of the LNURL-auth service, to be shown to the user when asking for
-  /// auth confirmation, as per LUD-04 spec.
-  final String domain;
-
-  /// Indicates the URL of the LNURL-auth service, including the query arguments. This will be
-  /// extended with the signed challenge and the linking key, then called in the second step of the workflow.
-  final String url;
-
-  const LnUrlAuthRequestData({
-    required this.k1,
-    this.action,
-    required this.domain,
-    required this.url,
-  });
+@freezed
+class LnUrlAuthRequestData with _$LnUrlAuthRequestData {
+  const factory LnUrlAuthRequestData({
+    required String k1,
+    String? action,
+    required String domain,
+    required String url,
+  }) = _LnUrlAuthRequestData;
 }
 
 @freezed
@@ -861,12 +739,11 @@ sealed class LnUrlCallbackStatus with _$LnUrlCallbackStatus {
 }
 
 /// Wrapped in a [LnUrlError], this represents a LNURL-endpoint error.
-class LnUrlErrorData {
-  final String reason;
-
-  const LnUrlErrorData({
-    required this.reason,
-  });
+@freezed
+class LnUrlErrorData with _$LnUrlErrorData {
+  const factory LnUrlErrorData({
+    required String reason,
+  }) = _LnUrlErrorData;
 }
 
 class LnUrlPayErrorData {
@@ -880,21 +757,13 @@ class LnUrlPayErrorData {
 }
 
 /// Represents a LNURL-pay request.
-class LnUrlPayRequest {
-  /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
-  final LnUrlPayRequestData data;
-
-  /// The amount in millisatoshis for this payment
-  final int amountMsat;
-
-  /// An optional comment for this payment
-  final String? comment;
-
-  const LnUrlPayRequest({
-    required this.data,
-    required this.amountMsat,
-    this.comment,
-  });
+@freezed
+class LnUrlPayRequest with _$LnUrlPayRequest {
+  const factory LnUrlPayRequest({
+    required LnUrlPayRequestData data,
+    required int amountMsat,
+    String? comment,
+  }) = _LnUrlPayRequest;
 }
 
 /// Wrapped in a [LnUrlPay], this is the result of [parse] when given a LNURL-pay endpoint.
@@ -902,42 +771,17 @@ class LnUrlPayRequest {
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
 /// See <https://github.com/lnurl/luds/blob/luds/06.md>
-class LnUrlPayRequestData {
-  final String callback;
-
-  /// The minimum amount, in millisats, that this LNURL-pay endpoint accepts
-  final int minSendable;
-
-  /// The maximum amount, in millisats, that this LNURL-pay endpoint accepts
-  final int maxSendable;
-
-  /// As per LUD-06, `metadata` is a raw string (e.g. a json representation of the inner map).
-  /// Use `metadata_vec()` to get the parsed items.
-  final String metadataStr;
-
-  /// The comment length accepted by this endpoint
-  ///
-  /// See <https://github.com/lnurl/luds/blob/luds/12.md>
-  final int commentAllowed;
-
-  /// Indicates the domain of the LNURL-pay service, to be shown to the user when asking for
-  /// payment input, as per LUD-06 spec.
-  ///
-  /// Note: this is not the domain of the callback, but the domain of the LNURL-pay endpoint.
-  final String domain;
-
-  /// If sending to a LN Address, this will be filled.
-  final String? lnAddress;
-
-  const LnUrlPayRequestData({
-    required this.callback,
-    required this.minSendable,
-    required this.maxSendable,
-    required this.metadataStr,
-    required this.commentAllowed,
-    required this.domain,
-    this.lnAddress,
-  });
+@freezed
+class LnUrlPayRequestData with _$LnUrlPayRequestData {
+  const factory LnUrlPayRequestData({
+    required String callback,
+    required int minSendable,
+    required int maxSendable,
+    required String metadataStr,
+    required int commentAllowed,
+    required String domain,
+    String? lnAddress,
+  }) = _LnUrlPayRequestData;
 }
 
 @freezed
@@ -963,25 +807,13 @@ class LnUrlPaySuccessData {
   });
 }
 
-class LnUrlWithdrawRequest {
-  /// Request data containing information on how to call the lnurl withdraw
-  /// endpoint. Typically retrieved by calling `parse()` on a lnurl withdraw
-  /// input.
-  final LnUrlWithdrawRequestData data;
-
-  /// The amount to withdraw from the lnurl withdraw endpoint. Must be between
-  /// `min_withdrawable` and `max_withdrawable`.
-  final int amountMsat;
-
-  /// Optional description that will be put in the payment request for the
-  /// lnurl withdraw endpoint.
-  final String? description;
-
-  const LnUrlWithdrawRequest({
-    required this.data,
-    required this.amountMsat,
-    this.description,
-  });
+@freezed
+class LnUrlWithdrawRequest with _$LnUrlWithdrawRequest {
+  const factory LnUrlWithdrawRequest({
+    required LnUrlWithdrawRequestData data,
+    required int amountMsat,
+    String? description,
+  }) = _LnUrlWithdrawRequest;
 }
 
 /// Wrapped in a [LnUrlWithdraw], this is the result of [parse] when given a LNURL-withdraw endpoint.
@@ -989,24 +821,15 @@ class LnUrlWithdrawRequest {
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///
 /// See <https://github.com/lnurl/luds/blob/luds/03.md>
-class LnUrlWithdrawRequestData {
-  final String callback;
-  final String k1;
-  final String defaultDescription;
-
-  /// The minimum amount, in millisats, that this LNURL-withdraw endpoint accepts
-  final int minWithdrawable;
-
-  /// The maximum amount, in millisats, that this LNURL-withdraw endpoint accepts
-  final int maxWithdrawable;
-
-  const LnUrlWithdrawRequestData({
-    required this.callback,
-    required this.k1,
-    required this.defaultDescription,
-    required this.minWithdrawable,
-    required this.maxWithdrawable,
-  });
+@freezed
+class LnUrlWithdrawRequestData with _$LnUrlWithdrawRequestData {
+  const factory LnUrlWithdrawRequestData({
+    required String callback,
+    required String k1,
+    required String defaultDescription,
+    required int minWithdrawable,
+    required int maxWithdrawable,
+  }) = _LnUrlWithdrawRequestData;
 }
 
 @freezed
@@ -1028,27 +851,22 @@ class LnUrlWithdrawSuccessData {
 }
 
 /// Locale-specific settings for the representation of a currency
-class LocaleOverrides {
-  final String locale;
-  final int? spacing;
-  final Symbol symbol;
-
-  const LocaleOverrides({
-    required this.locale,
-    this.spacing,
-    required this.symbol,
-  });
+@freezed
+class LocaleOverrides with _$LocaleOverrides {
+  const factory LocaleOverrides({
+    required String locale,
+    int? spacing,
+    required Symbol symbol,
+  }) = _LocaleOverrides;
 }
 
 /// Localized name of a currency
-class LocalizedName {
-  final String locale;
-  final String name;
-
-  const LocalizedName({
-    required this.locale,
-    required this.name,
-  });
+@freezed
+class LocalizedName with _$LocalizedName {
+  const factory LocalizedName({
+    required String locale,
+    required String name,
+  }) = _LocalizedName;
 }
 
 /// Internal SDK log entry
@@ -1063,48 +881,21 @@ class LogEntry {
 }
 
 /// Details of supported LSP
-class LspInformation {
-  final String id;
-
-  /// The name of of LSP
-  final String name;
-
-  /// The URL of the LSP
-  final String widgetUrl;
-
-  /// The identity pubkey of the Lightning node
-  final String pubkey;
-
-  /// The network location of the lightning node, e.g. `12.34.56.78:9012` or `localhost:10011`
-  final String host;
-
-  /// The base fee charged regardless of the number of milli-satoshis sent
-  final int baseFeeMsat;
-
-  /// The effective fee rate in milli-satoshis. The precision of this value goes up to 6 decimal places, so 1e-6.
-  final double feeRate;
-
-  /// The required timelock delta for HTLCs forwarded over the channel
-  final int timeLockDelta;
-
-  /// The minimum value in millisatoshi we will require for incoming HTLCs on the channel
-  final int minHtlcMsat;
-  final Uint8List lspPubkey;
-  final OpeningFeeParamsMenu openingFeeParamsList;
-
-  const LspInformation({
-    required this.id,
-    required this.name,
-    required this.widgetUrl,
-    required this.pubkey,
-    required this.host,
-    required this.baseFeeMsat,
-    required this.feeRate,
-    required this.timeLockDelta,
-    required this.minHtlcMsat,
-    required this.lspPubkey,
-    required this.openingFeeParamsList,
-  });
+@freezed
+class LspInformation with _$LspInformation {
+  const factory LspInformation({
+    required String id,
+    required String name,
+    required String widgetUrl,
+    required String pubkey,
+    required String host,
+    required int baseFeeMsat,
+    required double feeRate,
+    required int timeLockDelta,
+    required int minHtlcMsat,
+    required Uint8List lspPubkey,
+    required OpeningFeeParamsMenu openingFeeParamsList,
+  }) = _LspInformation;
 }
 
 class MaxReverseSwapAmountResponse {
@@ -1167,34 +958,22 @@ sealed class NodeCredentials with _$NodeCredentials {
 /// Note: The implementation attempts to provide the most up-to-date values,
 /// which may result in some short-lived inconsistencies
 /// (e.g., `channels_balance_msat` may be updated before `inbound_liquidity_msats`).
-class NodeState {
-  final String id;
-  final int blockHeight;
-  final int channelsBalanceMsat;
-  final int onchainBalanceMsat;
-  final int pendingOnchainBalanceMsat;
-  final List<UnspentTransactionOutput> utxos;
-  final int maxPayableMsat;
-  final int maxReceivableMsat;
-  final int maxSinglePaymentAmountMsat;
-  final int maxChanReserveMsats;
-  final List<String> connectedPeers;
-  final int inboundLiquidityMsats;
-
-  const NodeState({
-    required this.id,
-    required this.blockHeight,
-    required this.channelsBalanceMsat,
-    required this.onchainBalanceMsat,
-    required this.pendingOnchainBalanceMsat,
-    required this.utxos,
-    required this.maxPayableMsat,
-    required this.maxReceivableMsat,
-    required this.maxSinglePaymentAmountMsat,
-    required this.maxChanReserveMsats,
-    required this.connectedPeers,
-    required this.inboundLiquidityMsats,
-  });
+@freezed
+class NodeState with _$NodeState {
+  const factory NodeState({
+    required String id,
+    required int blockHeight,
+    required int channelsBalanceMsat,
+    required int onchainBalanceMsat,
+    required int pendingOnchainBalanceMsat,
+    required List<UnspentTransactionOutput> utxos,
+    required int maxPayableMsat,
+    required int maxReceivableMsat,
+    required int maxSinglePaymentAmountMsat,
+    required int maxChanReserveMsats,
+    required List<String> connectedPeers,
+    required int inboundLiquidityMsats,
+  }) = _NodeState;
 }
 
 class OnchainPaymentLimitsResponse {
@@ -1242,38 +1021,24 @@ class OpenChannelFeeResponse {
 ///
 /// After they are received, the client shouldn't change them when calling LSP methods,
 /// otherwise the LSP may reject the call.
-class OpeningFeeParams {
-  /// The minimum value in millisatoshi we will require for incoming HTLCs on the channel
-  final int minMsat;
-
-  /// The fee in ppm charged over liquidity when buying a channel
-  final int proportional;
-
-  /// The date and time this opening fee params promise expires, in RFC 3339 / ISO 8601 format
-  final String validUntil;
-
-  /// The channel can be closed if not used within this duration in blocks
-  final int maxIdleTime;
-  final int maxClientToSelfDelay;
-  final String promise;
-
-  const OpeningFeeParams({
-    required this.minMsat,
-    required this.proportional,
-    required this.validUntil,
-    required this.maxIdleTime,
-    required this.maxClientToSelfDelay,
-    required this.promise,
-  });
+@freezed
+class OpeningFeeParams with _$OpeningFeeParams {
+  const factory OpeningFeeParams({
+    required int minMsat,
+    required int proportional,
+    required String validUntil,
+    required int maxIdleTime,
+    required int maxClientToSelfDelay,
+    required String promise,
+  }) = _OpeningFeeParams;
 }
 
 /// See [OpeningFeeParamsMenu::try_from]
-class OpeningFeeParamsMenu {
-  final List<OpeningFeeParams> values;
-
-  const OpeningFeeParamsMenu({
-    required this.values,
-  });
+@freezed
+class OpeningFeeParamsMenu with _$OpeningFeeParamsMenu {
+  const factory OpeningFeeParamsMenu({
+    required List<OpeningFeeParams> values,
+  }) = _OpeningFeeParamsMenu;
 }
 
 class PayOnchainRequest {
@@ -1295,32 +1060,20 @@ class PayOnchainResponse {
 }
 
 /// Represents a payment, including its [PaymentType] and [PaymentDetails]
-class Payment {
-  final String id;
-  final PaymentType paymentType;
-
-  /// Epoch time, in seconds
-  final int paymentTime;
-  final int amountMsat;
-  final int feeMsat;
-  final PaymentStatus status;
-  final String? error;
-  final String? description;
-  final PaymentDetails details;
-  final String? metadata;
-
-  const Payment({
-    required this.id,
-    required this.paymentType,
-    required this.paymentTime,
-    required this.amountMsat,
-    required this.feeMsat,
-    required this.status,
-    this.error,
-    this.description,
-    required this.details,
-    this.metadata,
-  });
+@freezed
+class Payment with _$Payment {
+  const factory Payment({
+    required String id,
+    required PaymentType paymentType,
+    required int paymentTime,
+    required int amountMsat,
+    required int feeMsat,
+    required PaymentStatus status,
+    String? error,
+    String? description,
+    required PaymentDetails details,
+    String? metadata,
+  }) = _Payment;
 }
 
 @freezed
@@ -1462,48 +1215,25 @@ class Rate {
   });
 }
 
-class ReceiveOnchainRequest {
-  final OpeningFeeParams? openingFeeParams;
-
-  const ReceiveOnchainRequest({
-    this.openingFeeParams,
-  });
+@freezed
+class ReceiveOnchainRequest with _$ReceiveOnchainRequest {
+  const factory ReceiveOnchainRequest({
+    OpeningFeeParams? openingFeeParams,
+  }) = _ReceiveOnchainRequest;
 }
 
 /// Represents a receive payment request.
-class ReceivePaymentRequest {
-  /// The amount in satoshis for this payment request
-  final int amountMsat;
-
-  /// The description for this payment request.
-  final String description;
-
-  /// Optional preimage for this payment request.
-  /// If specified, it will be used instead of generating a new one.
-  final Uint8List? preimage;
-
-  /// If set and valid, these fess options are used when a new channels is needed.
-  /// Otherwise the default fee options will be used.
-  final OpeningFeeParams? openingFeeParams;
-
-  /// If set to true, then the bolt11 invoice returned includes the description hash.
-  final bool? useDescriptionHash;
-
-  /// if specified, set the time the invoice is valid for, in seconds.
-  final int? expiry;
-
-  /// if specified, sets the min_final_cltv_expiry for the invoice
-  final int? cltv;
-
-  const ReceivePaymentRequest({
-    required this.amountMsat,
-    required this.description,
-    this.preimage,
-    this.openingFeeParams,
-    this.useDescriptionHash,
-    this.expiry,
-    this.cltv,
-  });
+@freezed
+class ReceivePaymentRequest with _$ReceivePaymentRequest {
+  const factory ReceivePaymentRequest({
+    required int amountMsat,
+    required String description,
+    Uint8List? preimage,
+    OpeningFeeParams? openingFeeParams,
+    bool? useDescriptionHash,
+    int? expiry,
+    int? cltv,
+  }) = _ReceivePaymentRequest;
 }
 
 /// Represents a receive payment response.
@@ -1511,21 +1241,13 @@ class ReceivePaymentRequest {
 /// Breez SDK may have to open a new channel to receive this payment. In that case, the channel will
 /// be opened automatically when the invoice is paid, and the fees will be described in the
 /// `opening_fee_params` and `opening_fee_msat` fields.
-class ReceivePaymentResponse {
-  /// The generated invoice, including any necessary routing hints
-  final LNInvoice lnInvoice;
-
-  /// If set, these are the [OpeningFeeParams] used to calculate the channel opening fees.
-  final OpeningFeeParams? openingFeeParams;
-
-  /// If set, this is the channel opening fee that will be deduced from the invoice amount.
-  final int? openingFeeMsat;
-
-  const ReceivePaymentResponse({
-    required this.lnInvoice,
-    this.openingFeeParams,
-    this.openingFeeMsat,
-  });
+@freezed
+class ReceivePaymentResponse with _$ReceivePaymentResponse {
+  const factory ReceivePaymentResponse({
+    required LNInvoice lnInvoice,
+    OpeningFeeParams? openingFeeParams,
+    int? openingFeeMsat,
+  }) = _ReceivePaymentResponse;
 }
 
 /// Wrapper containing the result of the recommended fees query, in sat/vByte, based on mempool.space data
@@ -1617,26 +1339,16 @@ class ReverseSwapFeesRequest {
 }
 
 /// Simplified version of [FullReverseSwapInfo], containing only the user-relevant fields
-class ReverseSwapInfo {
-  final String id;
-  final String claimPubkey;
-
-  /// The lockup tx id, available from the moment the lockup tx is seen in the mempool by the SDK
-  final String? lockupTxid;
-
-  /// The claim tx id, available from the moment the claim tx is broadcast by the SDK
-  final String? claimTxid;
-  final int onchainAmountSat;
-  final ReverseSwapStatus status;
-
-  const ReverseSwapInfo({
-    required this.id,
-    required this.claimPubkey,
-    this.lockupTxid,
-    this.claimTxid,
-    required this.onchainAmountSat,
-    required this.status,
-  });
+@freezed
+class ReverseSwapInfo with _$ReverseSwapInfo {
+  const factory ReverseSwapInfo({
+    required String id,
+    required String claimPubkey,
+    String? lockupTxid,
+    String? claimTxid,
+    required int onchainAmountSat,
+    required ReverseSwapStatus status,
+  }) = _ReverseSwapInfo;
 }
 
 /// Details about the reverse swap fees and parameters, at this point in time
@@ -1703,44 +1415,25 @@ enum ReverseSwapStatus {
 }
 
 /// A route hint for a LN payment
-class RouteHint {
-  final List<RouteHintHop> hops;
-
-  const RouteHint({
-    required this.hops,
-  });
+@freezed
+class RouteHint with _$RouteHint {
+  const factory RouteHint({
+    required List<RouteHintHop> hops,
+  }) = _RouteHint;
 }
 
 /// Details of a specific hop in a larger route hint
-class RouteHintHop {
-  /// The node_id of the non-target end of the route
-  final String srcNodeId;
-
-  /// The short_channel_id of this channel
-  final int shortChannelId;
-
-  /// The fees which must be paid to use this channel
-  final int feesBaseMsat;
-  final int feesProportionalMillionths;
-
-  /// The difference in CLTV values between this node and the next node.
-  final int cltvExpiryDelta;
-
-  /// The minimum value, in msat, which must be relayed to the next hop.
-  final int? htlcMinimumMsat;
-
-  /// The maximum value in msat available for routing with a single HTLC.
-  final int? htlcMaximumMsat;
-
-  const RouteHintHop({
-    required this.srcNodeId,
-    required this.shortChannelId,
-    required this.feesBaseMsat,
-    required this.feesProportionalMillionths,
-    required this.cltvExpiryDelta,
-    this.htlcMinimumMsat,
-    this.htlcMaximumMsat,
-  });
+@freezed
+class RouteHintHop with _$RouteHintHop {
+  const factory RouteHintHop({
+    required String srcNodeId,
+    required int shortChannelId,
+    required int feesBaseMsat,
+    required int feesProportionalMillionths,
+    required int cltvExpiryDelta,
+    int? htlcMinimumMsat,
+    int? htlcMaximumMsat,
+  }) = _RouteHintHop;
 }
 
 class SendOnchainRequest {
@@ -1757,12 +1450,11 @@ class SendOnchainRequest {
   });
 }
 
-class SendOnchainResponse {
-  final ReverseSwapInfo reverseSwapInfo;
-
-  const SendOnchainResponse({
-    required this.reverseSwapInfo,
-  });
+@freezed
+class SendOnchainResponse with _$SendOnchainResponse {
+  const factory SendOnchainResponse({
+    required ReverseSwapInfo reverseSwapInfo,
+  }) = _SendOnchainResponse;
 }
 
 /// Represents a send payment request.
@@ -1780,37 +1472,29 @@ class SendPaymentRequest {
 }
 
 /// Represents a send payment response.
-class SendPaymentResponse {
-  final Payment payment;
-
-  const SendPaymentResponse({
-    required this.payment,
-  });
+@freezed
+class SendPaymentResponse with _$SendPaymentResponse {
+  const factory SendPaymentResponse({
+    required Payment payment,
+  }) = _SendPaymentResponse;
 }
 
 /// Represents a send spontaneous payment request.
-class SendSpontaneousPaymentRequest {
-  /// The node id to send this payment is
-  final String nodeId;
-
-  /// The amount in millisatoshis for this payment
-  final int amountMsat;
-  final List<TlvEntry>? extraTlvs;
-
-  const SendSpontaneousPaymentRequest({
-    required this.nodeId,
-    required this.amountMsat,
-    this.extraTlvs,
-  });
+@freezed
+class SendSpontaneousPaymentRequest with _$SendSpontaneousPaymentRequest {
+  const factory SendSpontaneousPaymentRequest({
+    required String nodeId,
+    required int amountMsat,
+    List<TlvEntry>? extraTlvs,
+  }) = _SendSpontaneousPaymentRequest;
 }
 
 /// Represents a service health check response.
-class ServiceHealthCheckResponse {
-  final HealthCheckStatus status;
-
-  const ServiceHealthCheckResponse({
-    required this.status,
-  });
+@freezed
+class ServiceHealthCheckResponse with _$ServiceHealthCheckResponse {
+  const factory ServiceHealthCheckResponse({
+    required HealthCheckStatus status,
+  }) = _ServiceHealthCheckResponse;
 }
 
 /// Request to sign a message with the node's private key.
@@ -1882,105 +1566,33 @@ enum SwapAmountType {
 ///
 /// The SwapInfo has a status which changes accordingly, documented in [SwapStatus].
 ///
-class SwapInfo {
-  /// Bitcoin address for this swap. Sats sent to this address will be swapped.
-  final String bitcoinAddress;
-
-  /// Relative time lock start, received from [SwapperAPI::create_swap].
-  final int createdAt;
-
-  /// Relative time lock for the timeout for the script to be redeemed before swap fails.
-  final int lockHeight;
-
-  /// sha256 hash of preimage to used in the claim sript.
-  final Uint8List paymentHash;
-
-  /// Secret to claim the swap.
-  final Uint8List preimage;
-
-  /// Secret claim key for the bitcoin address.
-  final Uint8List privateKey;
-
-  /// Public key in binary format of the private claim private key.
-  final Uint8List publicKey;
-
-  /// The public key in binary format from the swapping service. Received from [SwapperAPI::create_swap].
-  final Uint8List swapperPublicKey;
-
-  /// The locking script for the generated bitcoin address. Received from [SwapperAPI::create_swap].
-  final Uint8List script;
-
-  /// bolt11 invoice to claim the sent funds.
-  final String? bolt11;
-
-  /// Amount of millisatoshis claimed from sent funds and paid for via bolt11 invoice.
-  final int paidMsat;
-
-  /// Total amount of transactions sent to the swap address.
-  final int totalIncomingTxs;
-
-  /// Confirmed onchain sats to be claim with an bolt11 invoice or refunded if swap fails.
-  final int confirmedSats;
-
-  /// Unconfirmed sats waiting to be confirmed onchain.
-  final int unconfirmedSats;
-
-  /// Shows the current status of the swap, either `Initial` or `Expired`.
-  final SwapStatus status;
-
-  /// Transaction IDs for failed swap attempts.
-  final List<String> refundTxIds;
-
-  /// Refund transaction IDs for ongoing swap awaiting confirmation.
-  final List<String> unconfirmedTxIds;
-
-  /// Transaction IDs that have been confirmed on-chain.
-  final List<String> confirmedTxIds;
-
-  /// The minimum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
-  final int minAllowedDeposit;
-
-  /// The maximum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
-  final int maxAllowedDeposit;
-
-  /// Error reason for when swap fails.
-  final String? lastRedeemError;
-
-  /// The dynamic fees which is set if a channel opening is needed.
-  ///
-  /// This is an optional field for backward compatibility with swaps created before dynamic fees.
-  ///
-  /// Swaps created after dynamic fees were introduced always have this field set.
-  final OpeningFeeParams? channelOpeningFees;
-
-  /// The block height when the swap was confirmed.
-  final int? confirmedAt;
-
-  const SwapInfo({
-    required this.bitcoinAddress,
-    required this.createdAt,
-    required this.lockHeight,
-    required this.paymentHash,
-    required this.preimage,
-    required this.privateKey,
-    required this.publicKey,
-    required this.swapperPublicKey,
-    required this.script,
-    this.bolt11,
-    required this.paidMsat,
-    required this.totalIncomingTxs,
-    required this.confirmedSats,
-    required this.unconfirmedSats,
-    required this.status,
-    required this.refundTxIds,
-    required this.unconfirmedTxIds,
-    required this.confirmedTxIds,
-    required this.minAllowedDeposit,
-    required this.maxAllowedDeposit,
-    this.lastRedeemError,
-    this.channelOpeningFees,
-    this.confirmedAt,
-  });
+@freezed
+class SwapInfo with _$SwapInfo {
+  const factory SwapInfo({
+    required String bitcoinAddress,
+    required int createdAt,
+    required int lockHeight,
+    required Uint8List paymentHash,
+    required Uint8List preimage,
+    required Uint8List privateKey,
+    required Uint8List publicKey,
+    required Uint8List swapperPublicKey,
+    required Uint8List script,
+    String? bolt11,
+    required int paidMsat,
+    required int totalIncomingTxs,
+    required int confirmedSats,
+    required int unconfirmedSats,
+    required SwapStatus status,
+    required List<String> refundTxIds,
+    required List<String> unconfirmedTxIds,
+    required List<String> confirmedTxIds,
+    required int minAllowedDeposit,
+    required int maxAllowedDeposit,
+    String? lastRedeemError,
+    OpeningFeeParams? channelOpeningFees,
+    int? confirmedAt,
+  }) = _SwapInfo;
 }
 
 /// The status of a swap
@@ -2001,18 +1613,14 @@ enum SwapStatus {
 }
 
 /// Settings for the symbol representation of a currency
-class Symbol {
-  final String? grapheme;
-  final String? template;
-  final bool? rtl;
-  final int? position;
-
-  const Symbol({
-    this.grapheme,
-    this.template,
-    this.rtl,
-    this.position,
-  });
+@freezed
+class Symbol with _$Symbol {
+  const factory Symbol({
+    String? grapheme,
+    String? template,
+    bool? rtl,
+    int? position,
+  }) = _Symbol;
 }
 
 /// Represents a TLV entry for a keysend payment.
@@ -2030,20 +1638,15 @@ class TlvEntry {
 }
 
 /// UTXO known to the LN node
-class UnspentTransactionOutput {
-  final Uint8List txid;
-  final int outnum;
-  final int amountMillisatoshi;
-  final String address;
-  final bool reserved;
-
-  const UnspentTransactionOutput({
-    required this.txid,
-    required this.outnum,
-    required this.amountMillisatoshi,
-    required this.address,
-    required this.reserved,
-  });
+@freezed
+class UnspentTransactionOutput with _$UnspentTransactionOutput {
+  const factory UnspentTransactionOutput({
+    required Uint8List txid,
+    required int outnum,
+    required int amountMillisatoshi,
+    required String address,
+    required bool reserved,
+  }) = _UnspentTransactionOutput;
 }
 
 class UrlSuccessActionData {

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -348,6 +348,190 @@ abstract class AesSuccessActionDataResult_ErrorStatus implements AesSuccessActio
 }
 
 /// @nodoc
+mixin _$BitcoinAddressData {
+  String get address => throw _privateConstructorUsedError;
+  Network get network => throw _privateConstructorUsedError;
+  int? get amountSat => throw _privateConstructorUsedError;
+  String? get label => throw _privateConstructorUsedError;
+  String? get message => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $BitcoinAddressDataCopyWith<BitcoinAddressData> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BitcoinAddressDataCopyWith<$Res> {
+  factory $BitcoinAddressDataCopyWith(BitcoinAddressData value, $Res Function(BitcoinAddressData) then) =
+      _$BitcoinAddressDataCopyWithImpl<$Res, BitcoinAddressData>;
+  @useResult
+  $Res call({String address, Network network, int? amountSat, String? label, String? message});
+}
+
+/// @nodoc
+class _$BitcoinAddressDataCopyWithImpl<$Res, $Val extends BitcoinAddressData>
+    implements $BitcoinAddressDataCopyWith<$Res> {
+  _$BitcoinAddressDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? address = null,
+    Object? network = null,
+    Object? amountSat = freezed,
+    Object? label = freezed,
+    Object? message = freezed,
+  }) {
+    return _then(_value.copyWith(
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as Network,
+      amountSat: freezed == amountSat
+          ? _value.amountSat
+          : amountSat // ignore: cast_nullable_to_non_nullable
+              as int?,
+      label: freezed == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String?,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$BitcoinAddressDataImplCopyWith<$Res> implements $BitcoinAddressDataCopyWith<$Res> {
+  factory _$$BitcoinAddressDataImplCopyWith(
+          _$BitcoinAddressDataImpl value, $Res Function(_$BitcoinAddressDataImpl) then) =
+      __$$BitcoinAddressDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String address, Network network, int? amountSat, String? label, String? message});
+}
+
+/// @nodoc
+class __$$BitcoinAddressDataImplCopyWithImpl<$Res>
+    extends _$BitcoinAddressDataCopyWithImpl<$Res, _$BitcoinAddressDataImpl>
+    implements _$$BitcoinAddressDataImplCopyWith<$Res> {
+  __$$BitcoinAddressDataImplCopyWithImpl(
+      _$BitcoinAddressDataImpl _value, $Res Function(_$BitcoinAddressDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? address = null,
+    Object? network = null,
+    Object? amountSat = freezed,
+    Object? label = freezed,
+    Object? message = freezed,
+  }) {
+    return _then(_$BitcoinAddressDataImpl(
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as Network,
+      amountSat: freezed == amountSat
+          ? _value.amountSat
+          : amountSat // ignore: cast_nullable_to_non_nullable
+              as int?,
+      label: freezed == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String?,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BitcoinAddressDataImpl implements _BitcoinAddressData {
+  const _$BitcoinAddressDataImpl(
+      {required this.address, required this.network, this.amountSat, this.label, this.message});
+
+  @override
+  final String address;
+  @override
+  final Network network;
+  @override
+  final int? amountSat;
+  @override
+  final String? label;
+  @override
+  final String? message;
+
+  @override
+  String toString() {
+    return 'BitcoinAddressData(address: $address, network: $network, amountSat: $amountSat, label: $label, message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BitcoinAddressDataImpl &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.network, network) || other.network == network) &&
+            (identical(other.amountSat, amountSat) || other.amountSat == amountSat) &&
+            (identical(other.label, label) || other.label == label) &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, address, network, amountSat, label, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BitcoinAddressDataImplCopyWith<_$BitcoinAddressDataImpl> get copyWith =>
+      __$$BitcoinAddressDataImplCopyWithImpl<_$BitcoinAddressDataImpl>(this, _$identity);
+}
+
+abstract class _BitcoinAddressData implements BitcoinAddressData {
+  const factory _BitcoinAddressData(
+      {required final String address,
+      required final Network network,
+      final int? amountSat,
+      final String? label,
+      final String? message}) = _$BitcoinAddressDataImpl;
+
+  @override
+  String get address;
+  @override
+  Network get network;
+  @override
+  int? get amountSat;
+  @override
+  String? get label;
+  @override
+  String? get message;
+  @override
+  @JsonKey(ignore: true)
+  _$$BitcoinAddressDataImplCopyWith<_$BitcoinAddressDataImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$BreezEvent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
@@ -948,6 +1132,8 @@ abstract class _$$BreezEvent_PaymentSucceedImplCopyWith<$Res> {
       __$$BreezEvent_PaymentSucceedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({Payment details});
+
+  $PaymentCopyWith<$Res> get details;
 }
 
 /// @nodoc
@@ -969,6 +1155,14 @@ class __$$BreezEvent_PaymentSucceedImplCopyWithImpl<$Res>
           : details // ignore: cast_nullable_to_non_nullable
               as Payment,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PaymentCopyWith<$Res> get details {
+    return $PaymentCopyWith<$Res>(_value.details, (value) {
+      return _then(_value.copyWith(details: value));
+    });
   }
 }
 
@@ -1763,6 +1957,8 @@ abstract class _$$BreezEvent_SwapUpdatedImplCopyWith<$Res> {
       __$$BreezEvent_SwapUpdatedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({SwapInfo details});
+
+  $SwapInfoCopyWith<$Res> get details;
 }
 
 /// @nodoc
@@ -1784,6 +1980,14 @@ class __$$BreezEvent_SwapUpdatedImplCopyWithImpl<$Res>
           : details // ignore: cast_nullable_to_non_nullable
               as SwapInfo,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SwapInfoCopyWith<$Res> get details {
+    return $SwapInfoCopyWith<$Res>(_value.details, (value) {
+      return _then(_value.copyWith(details: value));
+    });
   }
 }
 
@@ -1932,6 +2136,1365 @@ abstract class BreezEvent_SwapUpdated implements BreezEvent {
 }
 
 /// @nodoc
+mixin _$BuyBitcoinRequest {
+  BuyBitcoinProvider get provider => throw _privateConstructorUsedError;
+  OpeningFeeParams? get openingFeeParams => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $BuyBitcoinRequestCopyWith<BuyBitcoinRequest> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BuyBitcoinRequestCopyWith<$Res> {
+  factory $BuyBitcoinRequestCopyWith(BuyBitcoinRequest value, $Res Function(BuyBitcoinRequest) then) =
+      _$BuyBitcoinRequestCopyWithImpl<$Res, BuyBitcoinRequest>;
+  @useResult
+  $Res call({BuyBitcoinProvider provider, OpeningFeeParams? openingFeeParams});
+
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class _$BuyBitcoinRequestCopyWithImpl<$Res, $Val extends BuyBitcoinRequest>
+    implements $BuyBitcoinRequestCopyWith<$Res> {
+  _$BuyBitcoinRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? provider = null,
+    Object? openingFeeParams = freezed,
+  }) {
+    return _then(_value.copyWith(
+      provider: null == provider
+          ? _value.provider
+          : provider // ignore: cast_nullable_to_non_nullable
+              as BuyBitcoinProvider,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams {
+    if (_value.openingFeeParams == null) {
+      return null;
+    }
+
+    return $OpeningFeeParamsCopyWith<$Res>(_value.openingFeeParams!, (value) {
+      return _then(_value.copyWith(openingFeeParams: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$BuyBitcoinRequestImplCopyWith<$Res> implements $BuyBitcoinRequestCopyWith<$Res> {
+  factory _$$BuyBitcoinRequestImplCopyWith(
+          _$BuyBitcoinRequestImpl value, $Res Function(_$BuyBitcoinRequestImpl) then) =
+      __$$BuyBitcoinRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({BuyBitcoinProvider provider, OpeningFeeParams? openingFeeParams});
+
+  @override
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class __$$BuyBitcoinRequestImplCopyWithImpl<$Res>
+    extends _$BuyBitcoinRequestCopyWithImpl<$Res, _$BuyBitcoinRequestImpl>
+    implements _$$BuyBitcoinRequestImplCopyWith<$Res> {
+  __$$BuyBitcoinRequestImplCopyWithImpl(
+      _$BuyBitcoinRequestImpl _value, $Res Function(_$BuyBitcoinRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? provider = null,
+    Object? openingFeeParams = freezed,
+  }) {
+    return _then(_$BuyBitcoinRequestImpl(
+      provider: null == provider
+          ? _value.provider
+          : provider // ignore: cast_nullable_to_non_nullable
+              as BuyBitcoinProvider,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BuyBitcoinRequestImpl implements _BuyBitcoinRequest {
+  const _$BuyBitcoinRequestImpl({required this.provider, this.openingFeeParams});
+
+  @override
+  final BuyBitcoinProvider provider;
+  @override
+  final OpeningFeeParams? openingFeeParams;
+
+  @override
+  String toString() {
+    return 'BuyBitcoinRequest(provider: $provider, openingFeeParams: $openingFeeParams)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BuyBitcoinRequestImpl &&
+            (identical(other.provider, provider) || other.provider == provider) &&
+            (identical(other.openingFeeParams, openingFeeParams) ||
+                other.openingFeeParams == openingFeeParams));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, provider, openingFeeParams);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BuyBitcoinRequestImplCopyWith<_$BuyBitcoinRequestImpl> get copyWith =>
+      __$$BuyBitcoinRequestImplCopyWithImpl<_$BuyBitcoinRequestImpl>(this, _$identity);
+}
+
+abstract class _BuyBitcoinRequest implements BuyBitcoinRequest {
+  const factory _BuyBitcoinRequest(
+      {required final BuyBitcoinProvider provider,
+      final OpeningFeeParams? openingFeeParams}) = _$BuyBitcoinRequestImpl;
+
+  @override
+  BuyBitcoinProvider get provider;
+  @override
+  OpeningFeeParams? get openingFeeParams;
+  @override
+  @JsonKey(ignore: true)
+  _$$BuyBitcoinRequestImplCopyWith<_$BuyBitcoinRequestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$BuyBitcoinResponse {
+  String get url => throw _privateConstructorUsedError;
+  OpeningFeeParams? get openingFeeParams => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $BuyBitcoinResponseCopyWith<BuyBitcoinResponse> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BuyBitcoinResponseCopyWith<$Res> {
+  factory $BuyBitcoinResponseCopyWith(BuyBitcoinResponse value, $Res Function(BuyBitcoinResponse) then) =
+      _$BuyBitcoinResponseCopyWithImpl<$Res, BuyBitcoinResponse>;
+  @useResult
+  $Res call({String url, OpeningFeeParams? openingFeeParams});
+
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class _$BuyBitcoinResponseCopyWithImpl<$Res, $Val extends BuyBitcoinResponse>
+    implements $BuyBitcoinResponseCopyWith<$Res> {
+  _$BuyBitcoinResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? url = null,
+    Object? openingFeeParams = freezed,
+  }) {
+    return _then(_value.copyWith(
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams {
+    if (_value.openingFeeParams == null) {
+      return null;
+    }
+
+    return $OpeningFeeParamsCopyWith<$Res>(_value.openingFeeParams!, (value) {
+      return _then(_value.copyWith(openingFeeParams: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$BuyBitcoinResponseImplCopyWith<$Res> implements $BuyBitcoinResponseCopyWith<$Res> {
+  factory _$$BuyBitcoinResponseImplCopyWith(
+          _$BuyBitcoinResponseImpl value, $Res Function(_$BuyBitcoinResponseImpl) then) =
+      __$$BuyBitcoinResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String url, OpeningFeeParams? openingFeeParams});
+
+  @override
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class __$$BuyBitcoinResponseImplCopyWithImpl<$Res>
+    extends _$BuyBitcoinResponseCopyWithImpl<$Res, _$BuyBitcoinResponseImpl>
+    implements _$$BuyBitcoinResponseImplCopyWith<$Res> {
+  __$$BuyBitcoinResponseImplCopyWithImpl(
+      _$BuyBitcoinResponseImpl _value, $Res Function(_$BuyBitcoinResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? url = null,
+    Object? openingFeeParams = freezed,
+  }) {
+    return _then(_$BuyBitcoinResponseImpl(
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BuyBitcoinResponseImpl implements _BuyBitcoinResponse {
+  const _$BuyBitcoinResponseImpl({required this.url, this.openingFeeParams});
+
+  @override
+  final String url;
+  @override
+  final OpeningFeeParams? openingFeeParams;
+
+  @override
+  String toString() {
+    return 'BuyBitcoinResponse(url: $url, openingFeeParams: $openingFeeParams)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BuyBitcoinResponseImpl &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.openingFeeParams, openingFeeParams) ||
+                other.openingFeeParams == openingFeeParams));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, url, openingFeeParams);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BuyBitcoinResponseImplCopyWith<_$BuyBitcoinResponseImpl> get copyWith =>
+      __$$BuyBitcoinResponseImplCopyWithImpl<_$BuyBitcoinResponseImpl>(this, _$identity);
+}
+
+abstract class _BuyBitcoinResponse implements BuyBitcoinResponse {
+  const factory _BuyBitcoinResponse({required final String url, final OpeningFeeParams? openingFeeParams}) =
+      _$BuyBitcoinResponseImpl;
+
+  @override
+  String get url;
+  @override
+  OpeningFeeParams? get openingFeeParams;
+  @override
+  @JsonKey(ignore: true)
+  _$$BuyBitcoinResponseImplCopyWith<_$BuyBitcoinResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ClosedChannelPaymentDetails {
+  ChannelState get state => throw _privateConstructorUsedError;
+  String get fundingTxid => throw _privateConstructorUsedError;
+  String? get shortChannelId => throw _privateConstructorUsedError;
+  String? get closingTxid => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ClosedChannelPaymentDetailsCopyWith<ClosedChannelPaymentDetails> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ClosedChannelPaymentDetailsCopyWith<$Res> {
+  factory $ClosedChannelPaymentDetailsCopyWith(
+          ClosedChannelPaymentDetails value, $Res Function(ClosedChannelPaymentDetails) then) =
+      _$ClosedChannelPaymentDetailsCopyWithImpl<$Res, ClosedChannelPaymentDetails>;
+  @useResult
+  $Res call({ChannelState state, String fundingTxid, String? shortChannelId, String? closingTxid});
+}
+
+/// @nodoc
+class _$ClosedChannelPaymentDetailsCopyWithImpl<$Res, $Val extends ClosedChannelPaymentDetails>
+    implements $ClosedChannelPaymentDetailsCopyWith<$Res> {
+  _$ClosedChannelPaymentDetailsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? state = null,
+    Object? fundingTxid = null,
+    Object? shortChannelId = freezed,
+    Object? closingTxid = freezed,
+  }) {
+    return _then(_value.copyWith(
+      state: null == state
+          ? _value.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as ChannelState,
+      fundingTxid: null == fundingTxid
+          ? _value.fundingTxid
+          : fundingTxid // ignore: cast_nullable_to_non_nullable
+              as String,
+      shortChannelId: freezed == shortChannelId
+          ? _value.shortChannelId
+          : shortChannelId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      closingTxid: freezed == closingTxid
+          ? _value.closingTxid
+          : closingTxid // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ClosedChannelPaymentDetailsImplCopyWith<$Res>
+    implements $ClosedChannelPaymentDetailsCopyWith<$Res> {
+  factory _$$ClosedChannelPaymentDetailsImplCopyWith(
+          _$ClosedChannelPaymentDetailsImpl value, $Res Function(_$ClosedChannelPaymentDetailsImpl) then) =
+      __$$ClosedChannelPaymentDetailsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({ChannelState state, String fundingTxid, String? shortChannelId, String? closingTxid});
+}
+
+/// @nodoc
+class __$$ClosedChannelPaymentDetailsImplCopyWithImpl<$Res>
+    extends _$ClosedChannelPaymentDetailsCopyWithImpl<$Res, _$ClosedChannelPaymentDetailsImpl>
+    implements _$$ClosedChannelPaymentDetailsImplCopyWith<$Res> {
+  __$$ClosedChannelPaymentDetailsImplCopyWithImpl(
+      _$ClosedChannelPaymentDetailsImpl _value, $Res Function(_$ClosedChannelPaymentDetailsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? state = null,
+    Object? fundingTxid = null,
+    Object? shortChannelId = freezed,
+    Object? closingTxid = freezed,
+  }) {
+    return _then(_$ClosedChannelPaymentDetailsImpl(
+      state: null == state
+          ? _value.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as ChannelState,
+      fundingTxid: null == fundingTxid
+          ? _value.fundingTxid
+          : fundingTxid // ignore: cast_nullable_to_non_nullable
+              as String,
+      shortChannelId: freezed == shortChannelId
+          ? _value.shortChannelId
+          : shortChannelId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      closingTxid: freezed == closingTxid
+          ? _value.closingTxid
+          : closingTxid // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ClosedChannelPaymentDetailsImpl implements _ClosedChannelPaymentDetails {
+  const _$ClosedChannelPaymentDetailsImpl(
+      {required this.state, required this.fundingTxid, this.shortChannelId, this.closingTxid});
+
+  @override
+  final ChannelState state;
+  @override
+  final String fundingTxid;
+  @override
+  final String? shortChannelId;
+  @override
+  final String? closingTxid;
+
+  @override
+  String toString() {
+    return 'ClosedChannelPaymentDetails(state: $state, fundingTxid: $fundingTxid, shortChannelId: $shortChannelId, closingTxid: $closingTxid)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ClosedChannelPaymentDetailsImpl &&
+            (identical(other.state, state) || other.state == state) &&
+            (identical(other.fundingTxid, fundingTxid) || other.fundingTxid == fundingTxid) &&
+            (identical(other.shortChannelId, shortChannelId) || other.shortChannelId == shortChannelId) &&
+            (identical(other.closingTxid, closingTxid) || other.closingTxid == closingTxid));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, state, fundingTxid, shortChannelId, closingTxid);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ClosedChannelPaymentDetailsImplCopyWith<_$ClosedChannelPaymentDetailsImpl> get copyWith =>
+      __$$ClosedChannelPaymentDetailsImplCopyWithImpl<_$ClosedChannelPaymentDetailsImpl>(this, _$identity);
+}
+
+abstract class _ClosedChannelPaymentDetails implements ClosedChannelPaymentDetails {
+  const factory _ClosedChannelPaymentDetails(
+      {required final ChannelState state,
+      required final String fundingTxid,
+      final String? shortChannelId,
+      final String? closingTxid}) = _$ClosedChannelPaymentDetailsImpl;
+
+  @override
+  ChannelState get state;
+  @override
+  String get fundingTxid;
+  @override
+  String? get shortChannelId;
+  @override
+  String? get closingTxid;
+  @override
+  @JsonKey(ignore: true)
+  _$$ClosedChannelPaymentDetailsImplCopyWith<_$ClosedChannelPaymentDetailsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$Config {
+  String get breezserver => throw _privateConstructorUsedError;
+  String get chainnotifierUrl => throw _privateConstructorUsedError;
+  String? get mempoolspaceUrl => throw _privateConstructorUsedError;
+  String get workingDir => throw _privateConstructorUsedError;
+  Network get network => throw _privateConstructorUsedError;
+  int get paymentTimeoutSec => throw _privateConstructorUsedError;
+  String? get defaultLspId => throw _privateConstructorUsedError;
+  String? get apiKey => throw _privateConstructorUsedError;
+  double get maxfeePercent => throw _privateConstructorUsedError;
+  int get exemptfeeMsat => throw _privateConstructorUsedError;
+  NodeConfig get nodeConfig => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ConfigCopyWith<Config> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ConfigCopyWith<$Res> {
+  factory $ConfigCopyWith(Config value, $Res Function(Config) then) = _$ConfigCopyWithImpl<$Res, Config>;
+  @useResult
+  $Res call(
+      {String breezserver,
+      String chainnotifierUrl,
+      String? mempoolspaceUrl,
+      String workingDir,
+      Network network,
+      int paymentTimeoutSec,
+      String? defaultLspId,
+      String? apiKey,
+      double maxfeePercent,
+      int exemptfeeMsat,
+      NodeConfig nodeConfig});
+
+  $NodeConfigCopyWith<$Res> get nodeConfig;
+}
+
+/// @nodoc
+class _$ConfigCopyWithImpl<$Res, $Val extends Config> implements $ConfigCopyWith<$Res> {
+  _$ConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? breezserver = null,
+    Object? chainnotifierUrl = null,
+    Object? mempoolspaceUrl = freezed,
+    Object? workingDir = null,
+    Object? network = null,
+    Object? paymentTimeoutSec = null,
+    Object? defaultLspId = freezed,
+    Object? apiKey = freezed,
+    Object? maxfeePercent = null,
+    Object? exemptfeeMsat = null,
+    Object? nodeConfig = null,
+  }) {
+    return _then(_value.copyWith(
+      breezserver: null == breezserver
+          ? _value.breezserver
+          : breezserver // ignore: cast_nullable_to_non_nullable
+              as String,
+      chainnotifierUrl: null == chainnotifierUrl
+          ? _value.chainnotifierUrl
+          : chainnotifierUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      mempoolspaceUrl: freezed == mempoolspaceUrl
+          ? _value.mempoolspaceUrl
+          : mempoolspaceUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workingDir: null == workingDir
+          ? _value.workingDir
+          : workingDir // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as Network,
+      paymentTimeoutSec: null == paymentTimeoutSec
+          ? _value.paymentTimeoutSec
+          : paymentTimeoutSec // ignore: cast_nullable_to_non_nullable
+              as int,
+      defaultLspId: freezed == defaultLspId
+          ? _value.defaultLspId
+          : defaultLspId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      apiKey: freezed == apiKey
+          ? _value.apiKey
+          : apiKey // ignore: cast_nullable_to_non_nullable
+              as String?,
+      maxfeePercent: null == maxfeePercent
+          ? _value.maxfeePercent
+          : maxfeePercent // ignore: cast_nullable_to_non_nullable
+              as double,
+      exemptfeeMsat: null == exemptfeeMsat
+          ? _value.exemptfeeMsat
+          : exemptfeeMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      nodeConfig: null == nodeConfig
+          ? _value.nodeConfig
+          : nodeConfig // ignore: cast_nullable_to_non_nullable
+              as NodeConfig,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $NodeConfigCopyWith<$Res> get nodeConfig {
+    return $NodeConfigCopyWith<$Res>(_value.nodeConfig, (value) {
+      return _then(_value.copyWith(nodeConfig: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ConfigImplCopyWith<$Res> implements $ConfigCopyWith<$Res> {
+  factory _$$ConfigImplCopyWith(_$ConfigImpl value, $Res Function(_$ConfigImpl) then) =
+      __$$ConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String breezserver,
+      String chainnotifierUrl,
+      String? mempoolspaceUrl,
+      String workingDir,
+      Network network,
+      int paymentTimeoutSec,
+      String? defaultLspId,
+      String? apiKey,
+      double maxfeePercent,
+      int exemptfeeMsat,
+      NodeConfig nodeConfig});
+
+  @override
+  $NodeConfigCopyWith<$Res> get nodeConfig;
+}
+
+/// @nodoc
+class __$$ConfigImplCopyWithImpl<$Res> extends _$ConfigCopyWithImpl<$Res, _$ConfigImpl>
+    implements _$$ConfigImplCopyWith<$Res> {
+  __$$ConfigImplCopyWithImpl(_$ConfigImpl _value, $Res Function(_$ConfigImpl) _then) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? breezserver = null,
+    Object? chainnotifierUrl = null,
+    Object? mempoolspaceUrl = freezed,
+    Object? workingDir = null,
+    Object? network = null,
+    Object? paymentTimeoutSec = null,
+    Object? defaultLspId = freezed,
+    Object? apiKey = freezed,
+    Object? maxfeePercent = null,
+    Object? exemptfeeMsat = null,
+    Object? nodeConfig = null,
+  }) {
+    return _then(_$ConfigImpl(
+      breezserver: null == breezserver
+          ? _value.breezserver
+          : breezserver // ignore: cast_nullable_to_non_nullable
+              as String,
+      chainnotifierUrl: null == chainnotifierUrl
+          ? _value.chainnotifierUrl
+          : chainnotifierUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      mempoolspaceUrl: freezed == mempoolspaceUrl
+          ? _value.mempoolspaceUrl
+          : mempoolspaceUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workingDir: null == workingDir
+          ? _value.workingDir
+          : workingDir // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as Network,
+      paymentTimeoutSec: null == paymentTimeoutSec
+          ? _value.paymentTimeoutSec
+          : paymentTimeoutSec // ignore: cast_nullable_to_non_nullable
+              as int,
+      defaultLspId: freezed == defaultLspId
+          ? _value.defaultLspId
+          : defaultLspId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      apiKey: freezed == apiKey
+          ? _value.apiKey
+          : apiKey // ignore: cast_nullable_to_non_nullable
+              as String?,
+      maxfeePercent: null == maxfeePercent
+          ? _value.maxfeePercent
+          : maxfeePercent // ignore: cast_nullable_to_non_nullable
+              as double,
+      exemptfeeMsat: null == exemptfeeMsat
+          ? _value.exemptfeeMsat
+          : exemptfeeMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      nodeConfig: null == nodeConfig
+          ? _value.nodeConfig
+          : nodeConfig // ignore: cast_nullable_to_non_nullable
+              as NodeConfig,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ConfigImpl implements _Config {
+  const _$ConfigImpl(
+      {required this.breezserver,
+      required this.chainnotifierUrl,
+      this.mempoolspaceUrl,
+      required this.workingDir,
+      required this.network,
+      required this.paymentTimeoutSec,
+      this.defaultLspId,
+      this.apiKey,
+      required this.maxfeePercent,
+      required this.exemptfeeMsat,
+      required this.nodeConfig});
+
+  @override
+  final String breezserver;
+  @override
+  final String chainnotifierUrl;
+  @override
+  final String? mempoolspaceUrl;
+  @override
+  final String workingDir;
+  @override
+  final Network network;
+  @override
+  final int paymentTimeoutSec;
+  @override
+  final String? defaultLspId;
+  @override
+  final String? apiKey;
+  @override
+  final double maxfeePercent;
+  @override
+  final int exemptfeeMsat;
+  @override
+  final NodeConfig nodeConfig;
+
+  @override
+  String toString() {
+    return 'Config(breezserver: $breezserver, chainnotifierUrl: $chainnotifierUrl, mempoolspaceUrl: $mempoolspaceUrl, workingDir: $workingDir, network: $network, paymentTimeoutSec: $paymentTimeoutSec, defaultLspId: $defaultLspId, apiKey: $apiKey, maxfeePercent: $maxfeePercent, exemptfeeMsat: $exemptfeeMsat, nodeConfig: $nodeConfig)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ConfigImpl &&
+            (identical(other.breezserver, breezserver) || other.breezserver == breezserver) &&
+            (identical(other.chainnotifierUrl, chainnotifierUrl) ||
+                other.chainnotifierUrl == chainnotifierUrl) &&
+            (identical(other.mempoolspaceUrl, mempoolspaceUrl) || other.mempoolspaceUrl == mempoolspaceUrl) &&
+            (identical(other.workingDir, workingDir) || other.workingDir == workingDir) &&
+            (identical(other.network, network) || other.network == network) &&
+            (identical(other.paymentTimeoutSec, paymentTimeoutSec) ||
+                other.paymentTimeoutSec == paymentTimeoutSec) &&
+            (identical(other.defaultLspId, defaultLspId) || other.defaultLspId == defaultLspId) &&
+            (identical(other.apiKey, apiKey) || other.apiKey == apiKey) &&
+            (identical(other.maxfeePercent, maxfeePercent) || other.maxfeePercent == maxfeePercent) &&
+            (identical(other.exemptfeeMsat, exemptfeeMsat) || other.exemptfeeMsat == exemptfeeMsat) &&
+            (identical(other.nodeConfig, nodeConfig) || other.nodeConfig == nodeConfig));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, breezserver, chainnotifierUrl, mempoolspaceUrl, workingDir,
+      network, paymentTimeoutSec, defaultLspId, apiKey, maxfeePercent, exemptfeeMsat, nodeConfig);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ConfigImplCopyWith<_$ConfigImpl> get copyWith =>
+      __$$ConfigImplCopyWithImpl<_$ConfigImpl>(this, _$identity);
+}
+
+abstract class _Config implements Config {
+  const factory _Config(
+      {required final String breezserver,
+      required final String chainnotifierUrl,
+      final String? mempoolspaceUrl,
+      required final String workingDir,
+      required final Network network,
+      required final int paymentTimeoutSec,
+      final String? defaultLspId,
+      final String? apiKey,
+      required final double maxfeePercent,
+      required final int exemptfeeMsat,
+      required final NodeConfig nodeConfig}) = _$ConfigImpl;
+
+  @override
+  String get breezserver;
+  @override
+  String get chainnotifierUrl;
+  @override
+  String? get mempoolspaceUrl;
+  @override
+  String get workingDir;
+  @override
+  Network get network;
+  @override
+  int get paymentTimeoutSec;
+  @override
+  String? get defaultLspId;
+  @override
+  String? get apiKey;
+  @override
+  double get maxfeePercent;
+  @override
+  int get exemptfeeMsat;
+  @override
+  NodeConfig get nodeConfig;
+  @override
+  @JsonKey(ignore: true)
+  _$$ConfigImplCopyWith<_$ConfigImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$CurrencyInfo {
+  String get name => throw _privateConstructorUsedError;
+  int get fractionSize => throw _privateConstructorUsedError;
+  int? get spacing => throw _privateConstructorUsedError;
+  Symbol? get symbol => throw _privateConstructorUsedError;
+  Symbol? get uniqSymbol => throw _privateConstructorUsedError;
+  List<LocalizedName>? get localizedName => throw _privateConstructorUsedError;
+  List<LocaleOverrides>? get localeOverrides => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $CurrencyInfoCopyWith<CurrencyInfo> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CurrencyInfoCopyWith<$Res> {
+  factory $CurrencyInfoCopyWith(CurrencyInfo value, $Res Function(CurrencyInfo) then) =
+      _$CurrencyInfoCopyWithImpl<$Res, CurrencyInfo>;
+  @useResult
+  $Res call(
+      {String name,
+      int fractionSize,
+      int? spacing,
+      Symbol? symbol,
+      Symbol? uniqSymbol,
+      List<LocalizedName>? localizedName,
+      List<LocaleOverrides>? localeOverrides});
+
+  $SymbolCopyWith<$Res>? get symbol;
+  $SymbolCopyWith<$Res>? get uniqSymbol;
+}
+
+/// @nodoc
+class _$CurrencyInfoCopyWithImpl<$Res, $Val extends CurrencyInfo> implements $CurrencyInfoCopyWith<$Res> {
+  _$CurrencyInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? fractionSize = null,
+    Object? spacing = freezed,
+    Object? symbol = freezed,
+    Object? uniqSymbol = freezed,
+    Object? localizedName = freezed,
+    Object? localeOverrides = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      fractionSize: null == fractionSize
+          ? _value.fractionSize
+          : fractionSize // ignore: cast_nullable_to_non_nullable
+              as int,
+      spacing: freezed == spacing
+          ? _value.spacing
+          : spacing // ignore: cast_nullable_to_non_nullable
+              as int?,
+      symbol: freezed == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as Symbol?,
+      uniqSymbol: freezed == uniqSymbol
+          ? _value.uniqSymbol
+          : uniqSymbol // ignore: cast_nullable_to_non_nullable
+              as Symbol?,
+      localizedName: freezed == localizedName
+          ? _value.localizedName
+          : localizedName // ignore: cast_nullable_to_non_nullable
+              as List<LocalizedName>?,
+      localeOverrides: freezed == localeOverrides
+          ? _value.localeOverrides
+          : localeOverrides // ignore: cast_nullable_to_non_nullable
+              as List<LocaleOverrides>?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SymbolCopyWith<$Res>? get symbol {
+    if (_value.symbol == null) {
+      return null;
+    }
+
+    return $SymbolCopyWith<$Res>(_value.symbol!, (value) {
+      return _then(_value.copyWith(symbol: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SymbolCopyWith<$Res>? get uniqSymbol {
+    if (_value.uniqSymbol == null) {
+      return null;
+    }
+
+    return $SymbolCopyWith<$Res>(_value.uniqSymbol!, (value) {
+      return _then(_value.copyWith(uniqSymbol: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$CurrencyInfoImplCopyWith<$Res> implements $CurrencyInfoCopyWith<$Res> {
+  factory _$$CurrencyInfoImplCopyWith(_$CurrencyInfoImpl value, $Res Function(_$CurrencyInfoImpl) then) =
+      __$$CurrencyInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String name,
+      int fractionSize,
+      int? spacing,
+      Symbol? symbol,
+      Symbol? uniqSymbol,
+      List<LocalizedName>? localizedName,
+      List<LocaleOverrides>? localeOverrides});
+
+  @override
+  $SymbolCopyWith<$Res>? get symbol;
+  @override
+  $SymbolCopyWith<$Res>? get uniqSymbol;
+}
+
+/// @nodoc
+class __$$CurrencyInfoImplCopyWithImpl<$Res> extends _$CurrencyInfoCopyWithImpl<$Res, _$CurrencyInfoImpl>
+    implements _$$CurrencyInfoImplCopyWith<$Res> {
+  __$$CurrencyInfoImplCopyWithImpl(_$CurrencyInfoImpl _value, $Res Function(_$CurrencyInfoImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? fractionSize = null,
+    Object? spacing = freezed,
+    Object? symbol = freezed,
+    Object? uniqSymbol = freezed,
+    Object? localizedName = freezed,
+    Object? localeOverrides = freezed,
+  }) {
+    return _then(_$CurrencyInfoImpl(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      fractionSize: null == fractionSize
+          ? _value.fractionSize
+          : fractionSize // ignore: cast_nullable_to_non_nullable
+              as int,
+      spacing: freezed == spacing
+          ? _value.spacing
+          : spacing // ignore: cast_nullable_to_non_nullable
+              as int?,
+      symbol: freezed == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as Symbol?,
+      uniqSymbol: freezed == uniqSymbol
+          ? _value.uniqSymbol
+          : uniqSymbol // ignore: cast_nullable_to_non_nullable
+              as Symbol?,
+      localizedName: freezed == localizedName
+          ? _value._localizedName
+          : localizedName // ignore: cast_nullable_to_non_nullable
+              as List<LocalizedName>?,
+      localeOverrides: freezed == localeOverrides
+          ? _value._localeOverrides
+          : localeOverrides // ignore: cast_nullable_to_non_nullable
+              as List<LocaleOverrides>?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$CurrencyInfoImpl implements _CurrencyInfo {
+  const _$CurrencyInfoImpl(
+      {required this.name,
+      required this.fractionSize,
+      this.spacing,
+      this.symbol,
+      this.uniqSymbol,
+      final List<LocalizedName>? localizedName,
+      final List<LocaleOverrides>? localeOverrides})
+      : _localizedName = localizedName,
+        _localeOverrides = localeOverrides;
+
+  @override
+  final String name;
+  @override
+  final int fractionSize;
+  @override
+  final int? spacing;
+  @override
+  final Symbol? symbol;
+  @override
+  final Symbol? uniqSymbol;
+  final List<LocalizedName>? _localizedName;
+  @override
+  List<LocalizedName>? get localizedName {
+    final value = _localizedName;
+    if (value == null) return null;
+    if (_localizedName is EqualUnmodifiableListView) return _localizedName;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  final List<LocaleOverrides>? _localeOverrides;
+  @override
+  List<LocaleOverrides>? get localeOverrides {
+    final value = _localeOverrides;
+    if (value == null) return null;
+    if (_localeOverrides is EqualUnmodifiableListView) return _localeOverrides;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'CurrencyInfo(name: $name, fractionSize: $fractionSize, spacing: $spacing, symbol: $symbol, uniqSymbol: $uniqSymbol, localizedName: $localizedName, localeOverrides: $localeOverrides)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CurrencyInfoImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.fractionSize, fractionSize) || other.fractionSize == fractionSize) &&
+            (identical(other.spacing, spacing) || other.spacing == spacing) &&
+            (identical(other.symbol, symbol) || other.symbol == symbol) &&
+            (identical(other.uniqSymbol, uniqSymbol) || other.uniqSymbol == uniqSymbol) &&
+            const DeepCollectionEquality().equals(other._localizedName, _localizedName) &&
+            const DeepCollectionEquality().equals(other._localeOverrides, _localeOverrides));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      fractionSize,
+      spacing,
+      symbol,
+      uniqSymbol,
+      const DeepCollectionEquality().hash(_localizedName),
+      const DeepCollectionEquality().hash(_localeOverrides));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CurrencyInfoImplCopyWith<_$CurrencyInfoImpl> get copyWith =>
+      __$$CurrencyInfoImplCopyWithImpl<_$CurrencyInfoImpl>(this, _$identity);
+}
+
+abstract class _CurrencyInfo implements CurrencyInfo {
+  const factory _CurrencyInfo(
+      {required final String name,
+      required final int fractionSize,
+      final int? spacing,
+      final Symbol? symbol,
+      final Symbol? uniqSymbol,
+      final List<LocalizedName>? localizedName,
+      final List<LocaleOverrides>? localeOverrides}) = _$CurrencyInfoImpl;
+
+  @override
+  String get name;
+  @override
+  int get fractionSize;
+  @override
+  int? get spacing;
+  @override
+  Symbol? get symbol;
+  @override
+  Symbol? get uniqSymbol;
+  @override
+  List<LocalizedName>? get localizedName;
+  @override
+  List<LocaleOverrides>? get localeOverrides;
+  @override
+  @JsonKey(ignore: true)
+  _$$CurrencyInfoImplCopyWith<_$CurrencyInfoImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$FiatCurrency {
+  String get id => throw _privateConstructorUsedError;
+  CurrencyInfo get info => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $FiatCurrencyCopyWith<FiatCurrency> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FiatCurrencyCopyWith<$Res> {
+  factory $FiatCurrencyCopyWith(FiatCurrency value, $Res Function(FiatCurrency) then) =
+      _$FiatCurrencyCopyWithImpl<$Res, FiatCurrency>;
+  @useResult
+  $Res call({String id, CurrencyInfo info});
+
+  $CurrencyInfoCopyWith<$Res> get info;
+}
+
+/// @nodoc
+class _$FiatCurrencyCopyWithImpl<$Res, $Val extends FiatCurrency> implements $FiatCurrencyCopyWith<$Res> {
+  _$FiatCurrencyCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? info = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      info: null == info
+          ? _value.info
+          : info // ignore: cast_nullable_to_non_nullable
+              as CurrencyInfo,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $CurrencyInfoCopyWith<$Res> get info {
+    return $CurrencyInfoCopyWith<$Res>(_value.info, (value) {
+      return _then(_value.copyWith(info: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$FiatCurrencyImplCopyWith<$Res> implements $FiatCurrencyCopyWith<$Res> {
+  factory _$$FiatCurrencyImplCopyWith(_$FiatCurrencyImpl value, $Res Function(_$FiatCurrencyImpl) then) =
+      __$$FiatCurrencyImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, CurrencyInfo info});
+
+  @override
+  $CurrencyInfoCopyWith<$Res> get info;
+}
+
+/// @nodoc
+class __$$FiatCurrencyImplCopyWithImpl<$Res> extends _$FiatCurrencyCopyWithImpl<$Res, _$FiatCurrencyImpl>
+    implements _$$FiatCurrencyImplCopyWith<$Res> {
+  __$$FiatCurrencyImplCopyWithImpl(_$FiatCurrencyImpl _value, $Res Function(_$FiatCurrencyImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? info = null,
+  }) {
+    return _then(_$FiatCurrencyImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      info: null == info
+          ? _value.info
+          : info // ignore: cast_nullable_to_non_nullable
+              as CurrencyInfo,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$FiatCurrencyImpl implements _FiatCurrency {
+  const _$FiatCurrencyImpl({required this.id, required this.info});
+
+  @override
+  final String id;
+  @override
+  final CurrencyInfo info;
+
+  @override
+  String toString() {
+    return 'FiatCurrency(id: $id, info: $info)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FiatCurrencyImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.info, info) || other.info == info));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, info);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FiatCurrencyImplCopyWith<_$FiatCurrencyImpl> get copyWith =>
+      __$$FiatCurrencyImplCopyWithImpl<_$FiatCurrencyImpl>(this, _$identity);
+}
+
+abstract class _FiatCurrency implements FiatCurrency {
+  const factory _FiatCurrency({required final String id, required final CurrencyInfo info}) =
+      _$FiatCurrencyImpl;
+
+  @override
+  String get id;
+  @override
+  CurrencyInfo get info;
+  @override
+  @JsonKey(ignore: true)
+  _$$FiatCurrencyImplCopyWith<_$FiatCurrencyImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$GreenlightNodeConfig {
+  GreenlightCredentials? get partnerCredentials => throw _privateConstructorUsedError;
+  String? get inviteCode => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $GreenlightNodeConfigCopyWith<GreenlightNodeConfig> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GreenlightNodeConfigCopyWith<$Res> {
+  factory $GreenlightNodeConfigCopyWith(
+          GreenlightNodeConfig value, $Res Function(GreenlightNodeConfig) then) =
+      _$GreenlightNodeConfigCopyWithImpl<$Res, GreenlightNodeConfig>;
+  @useResult
+  $Res call({GreenlightCredentials? partnerCredentials, String? inviteCode});
+}
+
+/// @nodoc
+class _$GreenlightNodeConfigCopyWithImpl<$Res, $Val extends GreenlightNodeConfig>
+    implements $GreenlightNodeConfigCopyWith<$Res> {
+  _$GreenlightNodeConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? partnerCredentials = freezed,
+    Object? inviteCode = freezed,
+  }) {
+    return _then(_value.copyWith(
+      partnerCredentials: freezed == partnerCredentials
+          ? _value.partnerCredentials
+          : partnerCredentials // ignore: cast_nullable_to_non_nullable
+              as GreenlightCredentials?,
+      inviteCode: freezed == inviteCode
+          ? _value.inviteCode
+          : inviteCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$GreenlightNodeConfigImplCopyWith<$Res> implements $GreenlightNodeConfigCopyWith<$Res> {
+  factory _$$GreenlightNodeConfigImplCopyWith(
+          _$GreenlightNodeConfigImpl value, $Res Function(_$GreenlightNodeConfigImpl) then) =
+      __$$GreenlightNodeConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({GreenlightCredentials? partnerCredentials, String? inviteCode});
+}
+
+/// @nodoc
+class __$$GreenlightNodeConfigImplCopyWithImpl<$Res>
+    extends _$GreenlightNodeConfigCopyWithImpl<$Res, _$GreenlightNodeConfigImpl>
+    implements _$$GreenlightNodeConfigImplCopyWith<$Res> {
+  __$$GreenlightNodeConfigImplCopyWithImpl(
+      _$GreenlightNodeConfigImpl _value, $Res Function(_$GreenlightNodeConfigImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? partnerCredentials = freezed,
+    Object? inviteCode = freezed,
+  }) {
+    return _then(_$GreenlightNodeConfigImpl(
+      partnerCredentials: freezed == partnerCredentials
+          ? _value.partnerCredentials
+          : partnerCredentials // ignore: cast_nullable_to_non_nullable
+              as GreenlightCredentials?,
+      inviteCode: freezed == inviteCode
+          ? _value.inviteCode
+          : inviteCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$GreenlightNodeConfigImpl implements _GreenlightNodeConfig {
+  const _$GreenlightNodeConfigImpl({this.partnerCredentials, this.inviteCode});
+
+  @override
+  final GreenlightCredentials? partnerCredentials;
+  @override
+  final String? inviteCode;
+
+  @override
+  String toString() {
+    return 'GreenlightNodeConfig(partnerCredentials: $partnerCredentials, inviteCode: $inviteCode)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GreenlightNodeConfigImpl &&
+            (identical(other.partnerCredentials, partnerCredentials) ||
+                other.partnerCredentials == partnerCredentials) &&
+            (identical(other.inviteCode, inviteCode) || other.inviteCode == inviteCode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, partnerCredentials, inviteCode);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GreenlightNodeConfigImplCopyWith<_$GreenlightNodeConfigImpl> get copyWith =>
+      __$$GreenlightNodeConfigImplCopyWithImpl<_$GreenlightNodeConfigImpl>(this, _$identity);
+}
+
+abstract class _GreenlightNodeConfig implements GreenlightNodeConfig {
+  const factory _GreenlightNodeConfig(
+      {final GreenlightCredentials? partnerCredentials,
+      final String? inviteCode}) = _$GreenlightNodeConfigImpl;
+
+  @override
+  GreenlightCredentials? get partnerCredentials;
+  @override
+  String? get inviteCode;
+  @override
+  @JsonKey(ignore: true)
+  _$$GreenlightNodeConfigImplCopyWith<_$GreenlightNodeConfigImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$InputType {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
@@ -2032,6 +3595,8 @@ abstract class _$$InputType_BitcoinAddressImplCopyWith<$Res> {
       __$$InputType_BitcoinAddressImplCopyWithImpl<$Res>;
   @useResult
   $Res call({BitcoinAddressData address});
+
+  $BitcoinAddressDataCopyWith<$Res> get address;
 }
 
 /// @nodoc
@@ -2053,6 +3618,14 @@ class __$$InputType_BitcoinAddressImplCopyWithImpl<$Res>
           : address // ignore: cast_nullable_to_non_nullable
               as BitcoinAddressData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $BitcoinAddressDataCopyWith<$Res> get address {
+    return $BitcoinAddressDataCopyWith<$Res>(_value.address, (value) {
+      return _then(_value.copyWith(address: value));
+    });
   }
 }
 
@@ -2202,6 +3775,8 @@ abstract class _$$InputType_Bolt11ImplCopyWith<$Res> {
       __$$InputType_Bolt11ImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LNInvoice invoice});
+
+  $LNInvoiceCopyWith<$Res> get invoice;
 }
 
 /// @nodoc
@@ -2222,6 +3797,14 @@ class __$$InputType_Bolt11ImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl
           : invoice // ignore: cast_nullable_to_non_nullable
               as LNInvoice,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LNInvoiceCopyWith<$Res> get invoice {
+    return $LNInvoiceCopyWith<$Res>(_value.invoice, (value) {
+      return _then(_value.copyWith(invoice: value));
+    });
   }
 }
 
@@ -2701,6 +4284,8 @@ abstract class _$$InputType_LnUrlPayImplCopyWith<$Res> {
       __$$InputType_LnUrlPayImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnUrlPayRequestData data});
+
+  $LnUrlPayRequestDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -2722,6 +4307,14 @@ class __$$InputType_LnUrlPayImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlPayRequestData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlPayRequestDataCopyWith<$Res> get data {
+    return $LnUrlPayRequestDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -2870,6 +4463,8 @@ abstract class _$$InputType_LnUrlWithdrawImplCopyWith<$Res> {
       __$$InputType_LnUrlWithdrawImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnUrlWithdrawRequestData data});
+
+  $LnUrlWithdrawRequestDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -2891,6 +4486,14 @@ class __$$InputType_LnUrlWithdrawImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlWithdrawRequestData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlWithdrawRequestDataCopyWith<$Res> get data {
+    return $LnUrlWithdrawRequestDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -3040,6 +4643,8 @@ abstract class _$$InputType_LnUrlAuthImplCopyWith<$Res> {
       __$$InputType_LnUrlAuthImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnUrlAuthRequestData data});
+
+  $LnUrlAuthRequestDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -3061,6 +4666,14 @@ class __$$InputType_LnUrlAuthImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlAuthRequestData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlAuthRequestDataCopyWith<$Res> get data {
+    return $LnUrlAuthRequestDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -3209,6 +4822,8 @@ abstract class _$$InputType_LnUrlErrorImplCopyWith<$Res> {
       __$$InputType_LnUrlErrorImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnUrlErrorData data});
+
+  $LnUrlErrorDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -3230,6 +4845,14 @@ class __$$InputType_LnUrlErrorImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlErrorData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlErrorDataCopyWith<$Res> get data {
+    return $LnUrlErrorDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -3368,6 +4991,1256 @@ abstract class InputType_LnUrlError implements InputType {
   LnUrlErrorData get data;
   @JsonKey(ignore: true)
   _$$InputType_LnUrlErrorImplCopyWith<_$InputType_LnUrlErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ListPaymentsRequest {
+  List<PaymentTypeFilter>? get filters => throw _privateConstructorUsedError;
+  List<MetadataFilter>? get metadataFilters => throw _privateConstructorUsedError;
+  int? get fromTimestamp => throw _privateConstructorUsedError;
+  int? get toTimestamp => throw _privateConstructorUsedError;
+  bool? get includeFailures => throw _privateConstructorUsedError;
+  int? get offset => throw _privateConstructorUsedError;
+  int? get limit => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ListPaymentsRequestCopyWith<ListPaymentsRequest> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ListPaymentsRequestCopyWith<$Res> {
+  factory $ListPaymentsRequestCopyWith(ListPaymentsRequest value, $Res Function(ListPaymentsRequest) then) =
+      _$ListPaymentsRequestCopyWithImpl<$Res, ListPaymentsRequest>;
+  @useResult
+  $Res call(
+      {List<PaymentTypeFilter>? filters,
+      List<MetadataFilter>? metadataFilters,
+      int? fromTimestamp,
+      int? toTimestamp,
+      bool? includeFailures,
+      int? offset,
+      int? limit});
+}
+
+/// @nodoc
+class _$ListPaymentsRequestCopyWithImpl<$Res, $Val extends ListPaymentsRequest>
+    implements $ListPaymentsRequestCopyWith<$Res> {
+  _$ListPaymentsRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? filters = freezed,
+    Object? metadataFilters = freezed,
+    Object? fromTimestamp = freezed,
+    Object? toTimestamp = freezed,
+    Object? includeFailures = freezed,
+    Object? offset = freezed,
+    Object? limit = freezed,
+  }) {
+    return _then(_value.copyWith(
+      filters: freezed == filters
+          ? _value.filters
+          : filters // ignore: cast_nullable_to_non_nullable
+              as List<PaymentTypeFilter>?,
+      metadataFilters: freezed == metadataFilters
+          ? _value.metadataFilters
+          : metadataFilters // ignore: cast_nullable_to_non_nullable
+              as List<MetadataFilter>?,
+      fromTimestamp: freezed == fromTimestamp
+          ? _value.fromTimestamp
+          : fromTimestamp // ignore: cast_nullable_to_non_nullable
+              as int?,
+      toTimestamp: freezed == toTimestamp
+          ? _value.toTimestamp
+          : toTimestamp // ignore: cast_nullable_to_non_nullable
+              as int?,
+      includeFailures: freezed == includeFailures
+          ? _value.includeFailures
+          : includeFailures // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      offset: freezed == offset
+          ? _value.offset
+          : offset // ignore: cast_nullable_to_non_nullable
+              as int?,
+      limit: freezed == limit
+          ? _value.limit
+          : limit // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ListPaymentsRequestImplCopyWith<$Res> implements $ListPaymentsRequestCopyWith<$Res> {
+  factory _$$ListPaymentsRequestImplCopyWith(
+          _$ListPaymentsRequestImpl value, $Res Function(_$ListPaymentsRequestImpl) then) =
+      __$$ListPaymentsRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<PaymentTypeFilter>? filters,
+      List<MetadataFilter>? metadataFilters,
+      int? fromTimestamp,
+      int? toTimestamp,
+      bool? includeFailures,
+      int? offset,
+      int? limit});
+}
+
+/// @nodoc
+class __$$ListPaymentsRequestImplCopyWithImpl<$Res>
+    extends _$ListPaymentsRequestCopyWithImpl<$Res, _$ListPaymentsRequestImpl>
+    implements _$$ListPaymentsRequestImplCopyWith<$Res> {
+  __$$ListPaymentsRequestImplCopyWithImpl(
+      _$ListPaymentsRequestImpl _value, $Res Function(_$ListPaymentsRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? filters = freezed,
+    Object? metadataFilters = freezed,
+    Object? fromTimestamp = freezed,
+    Object? toTimestamp = freezed,
+    Object? includeFailures = freezed,
+    Object? offset = freezed,
+    Object? limit = freezed,
+  }) {
+    return _then(_$ListPaymentsRequestImpl(
+      filters: freezed == filters
+          ? _value._filters
+          : filters // ignore: cast_nullable_to_non_nullable
+              as List<PaymentTypeFilter>?,
+      metadataFilters: freezed == metadataFilters
+          ? _value._metadataFilters
+          : metadataFilters // ignore: cast_nullable_to_non_nullable
+              as List<MetadataFilter>?,
+      fromTimestamp: freezed == fromTimestamp
+          ? _value.fromTimestamp
+          : fromTimestamp // ignore: cast_nullable_to_non_nullable
+              as int?,
+      toTimestamp: freezed == toTimestamp
+          ? _value.toTimestamp
+          : toTimestamp // ignore: cast_nullable_to_non_nullable
+              as int?,
+      includeFailures: freezed == includeFailures
+          ? _value.includeFailures
+          : includeFailures // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      offset: freezed == offset
+          ? _value.offset
+          : offset // ignore: cast_nullable_to_non_nullable
+              as int?,
+      limit: freezed == limit
+          ? _value.limit
+          : limit // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ListPaymentsRequestImpl implements _ListPaymentsRequest {
+  const _$ListPaymentsRequestImpl(
+      {final List<PaymentTypeFilter>? filters,
+      final List<MetadataFilter>? metadataFilters,
+      this.fromTimestamp,
+      this.toTimestamp,
+      this.includeFailures,
+      this.offset,
+      this.limit})
+      : _filters = filters,
+        _metadataFilters = metadataFilters;
+
+  final List<PaymentTypeFilter>? _filters;
+  @override
+  List<PaymentTypeFilter>? get filters {
+    final value = _filters;
+    if (value == null) return null;
+    if (_filters is EqualUnmodifiableListView) return _filters;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  final List<MetadataFilter>? _metadataFilters;
+  @override
+  List<MetadataFilter>? get metadataFilters {
+    final value = _metadataFilters;
+    if (value == null) return null;
+    if (_metadataFilters is EqualUnmodifiableListView) return _metadataFilters;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final int? fromTimestamp;
+  @override
+  final int? toTimestamp;
+  @override
+  final bool? includeFailures;
+  @override
+  final int? offset;
+  @override
+  final int? limit;
+
+  @override
+  String toString() {
+    return 'ListPaymentsRequest(filters: $filters, metadataFilters: $metadataFilters, fromTimestamp: $fromTimestamp, toTimestamp: $toTimestamp, includeFailures: $includeFailures, offset: $offset, limit: $limit)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ListPaymentsRequestImpl &&
+            const DeepCollectionEquality().equals(other._filters, _filters) &&
+            const DeepCollectionEquality().equals(other._metadataFilters, _metadataFilters) &&
+            (identical(other.fromTimestamp, fromTimestamp) || other.fromTimestamp == fromTimestamp) &&
+            (identical(other.toTimestamp, toTimestamp) || other.toTimestamp == toTimestamp) &&
+            (identical(other.includeFailures, includeFailures) || other.includeFailures == includeFailures) &&
+            (identical(other.offset, offset) || other.offset == offset) &&
+            (identical(other.limit, limit) || other.limit == limit));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_filters),
+      const DeepCollectionEquality().hash(_metadataFilters),
+      fromTimestamp,
+      toTimestamp,
+      includeFailures,
+      offset,
+      limit);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ListPaymentsRequestImplCopyWith<_$ListPaymentsRequestImpl> get copyWith =>
+      __$$ListPaymentsRequestImplCopyWithImpl<_$ListPaymentsRequestImpl>(this, _$identity);
+}
+
+abstract class _ListPaymentsRequest implements ListPaymentsRequest {
+  const factory _ListPaymentsRequest(
+      {final List<PaymentTypeFilter>? filters,
+      final List<MetadataFilter>? metadataFilters,
+      final int? fromTimestamp,
+      final int? toTimestamp,
+      final bool? includeFailures,
+      final int? offset,
+      final int? limit}) = _$ListPaymentsRequestImpl;
+
+  @override
+  List<PaymentTypeFilter>? get filters;
+  @override
+  List<MetadataFilter>? get metadataFilters;
+  @override
+  int? get fromTimestamp;
+  @override
+  int? get toTimestamp;
+  @override
+  bool? get includeFailures;
+  @override
+  int? get offset;
+  @override
+  int? get limit;
+  @override
+  @JsonKey(ignore: true)
+  _$$ListPaymentsRequestImplCopyWith<_$ListPaymentsRequestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LNInvoice {
+  String get bolt11 => throw _privateConstructorUsedError;
+  Network get network => throw _privateConstructorUsedError;
+  String get payeePubkey => throw _privateConstructorUsedError;
+  String get paymentHash => throw _privateConstructorUsedError;
+  String? get description => throw _privateConstructorUsedError;
+  String? get descriptionHash => throw _privateConstructorUsedError;
+  int? get amountMsat => throw _privateConstructorUsedError;
+  int get timestamp => throw _privateConstructorUsedError;
+  int get expiry => throw _privateConstructorUsedError;
+  List<RouteHint> get routingHints => throw _privateConstructorUsedError;
+  Uint8List get paymentSecret => throw _privateConstructorUsedError;
+  int get minFinalCltvExpiryDelta => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LNInvoiceCopyWith<LNInvoice> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LNInvoiceCopyWith<$Res> {
+  factory $LNInvoiceCopyWith(LNInvoice value, $Res Function(LNInvoice) then) =
+      _$LNInvoiceCopyWithImpl<$Res, LNInvoice>;
+  @useResult
+  $Res call(
+      {String bolt11,
+      Network network,
+      String payeePubkey,
+      String paymentHash,
+      String? description,
+      String? descriptionHash,
+      int? amountMsat,
+      int timestamp,
+      int expiry,
+      List<RouteHint> routingHints,
+      Uint8List paymentSecret,
+      int minFinalCltvExpiryDelta});
+}
+
+/// @nodoc
+class _$LNInvoiceCopyWithImpl<$Res, $Val extends LNInvoice> implements $LNInvoiceCopyWith<$Res> {
+  _$LNInvoiceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? bolt11 = null,
+    Object? network = null,
+    Object? payeePubkey = null,
+    Object? paymentHash = null,
+    Object? description = freezed,
+    Object? descriptionHash = freezed,
+    Object? amountMsat = freezed,
+    Object? timestamp = null,
+    Object? expiry = null,
+    Object? routingHints = null,
+    Object? paymentSecret = null,
+    Object? minFinalCltvExpiryDelta = null,
+  }) {
+    return _then(_value.copyWith(
+      bolt11: null == bolt11
+          ? _value.bolt11
+          : bolt11 // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as Network,
+      payeePubkey: null == payeePubkey
+          ? _value.payeePubkey
+          : payeePubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      paymentHash: null == paymentHash
+          ? _value.paymentHash
+          : paymentHash // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      descriptionHash: freezed == descriptionHash
+          ? _value.descriptionHash
+          : descriptionHash // ignore: cast_nullable_to_non_nullable
+              as String?,
+      amountMsat: freezed == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+      timestamp: null == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as int,
+      expiry: null == expiry
+          ? _value.expiry
+          : expiry // ignore: cast_nullable_to_non_nullable
+              as int,
+      routingHints: null == routingHints
+          ? _value.routingHints
+          : routingHints // ignore: cast_nullable_to_non_nullable
+              as List<RouteHint>,
+      paymentSecret: null == paymentSecret
+          ? _value.paymentSecret
+          : paymentSecret // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      minFinalCltvExpiryDelta: null == minFinalCltvExpiryDelta
+          ? _value.minFinalCltvExpiryDelta
+          : minFinalCltvExpiryDelta // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$LNInvoiceImplCopyWith<$Res> implements $LNInvoiceCopyWith<$Res> {
+  factory _$$LNInvoiceImplCopyWith(_$LNInvoiceImpl value, $Res Function(_$LNInvoiceImpl) then) =
+      __$$LNInvoiceImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String bolt11,
+      Network network,
+      String payeePubkey,
+      String paymentHash,
+      String? description,
+      String? descriptionHash,
+      int? amountMsat,
+      int timestamp,
+      int expiry,
+      List<RouteHint> routingHints,
+      Uint8List paymentSecret,
+      int minFinalCltvExpiryDelta});
+}
+
+/// @nodoc
+class __$$LNInvoiceImplCopyWithImpl<$Res> extends _$LNInvoiceCopyWithImpl<$Res, _$LNInvoiceImpl>
+    implements _$$LNInvoiceImplCopyWith<$Res> {
+  __$$LNInvoiceImplCopyWithImpl(_$LNInvoiceImpl _value, $Res Function(_$LNInvoiceImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? bolt11 = null,
+    Object? network = null,
+    Object? payeePubkey = null,
+    Object? paymentHash = null,
+    Object? description = freezed,
+    Object? descriptionHash = freezed,
+    Object? amountMsat = freezed,
+    Object? timestamp = null,
+    Object? expiry = null,
+    Object? routingHints = null,
+    Object? paymentSecret = null,
+    Object? minFinalCltvExpiryDelta = null,
+  }) {
+    return _then(_$LNInvoiceImpl(
+      bolt11: null == bolt11
+          ? _value.bolt11
+          : bolt11 // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as Network,
+      payeePubkey: null == payeePubkey
+          ? _value.payeePubkey
+          : payeePubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      paymentHash: null == paymentHash
+          ? _value.paymentHash
+          : paymentHash // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      descriptionHash: freezed == descriptionHash
+          ? _value.descriptionHash
+          : descriptionHash // ignore: cast_nullable_to_non_nullable
+              as String?,
+      amountMsat: freezed == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+      timestamp: null == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as int,
+      expiry: null == expiry
+          ? _value.expiry
+          : expiry // ignore: cast_nullable_to_non_nullable
+              as int,
+      routingHints: null == routingHints
+          ? _value._routingHints
+          : routingHints // ignore: cast_nullable_to_non_nullable
+              as List<RouteHint>,
+      paymentSecret: null == paymentSecret
+          ? _value.paymentSecret
+          : paymentSecret // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      minFinalCltvExpiryDelta: null == minFinalCltvExpiryDelta
+          ? _value.minFinalCltvExpiryDelta
+          : minFinalCltvExpiryDelta // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LNInvoiceImpl implements _LNInvoice {
+  const _$LNInvoiceImpl(
+      {required this.bolt11,
+      required this.network,
+      required this.payeePubkey,
+      required this.paymentHash,
+      this.description,
+      this.descriptionHash,
+      this.amountMsat,
+      required this.timestamp,
+      required this.expiry,
+      required final List<RouteHint> routingHints,
+      required this.paymentSecret,
+      required this.minFinalCltvExpiryDelta})
+      : _routingHints = routingHints;
+
+  @override
+  final String bolt11;
+  @override
+  final Network network;
+  @override
+  final String payeePubkey;
+  @override
+  final String paymentHash;
+  @override
+  final String? description;
+  @override
+  final String? descriptionHash;
+  @override
+  final int? amountMsat;
+  @override
+  final int timestamp;
+  @override
+  final int expiry;
+  final List<RouteHint> _routingHints;
+  @override
+  List<RouteHint> get routingHints {
+    if (_routingHints is EqualUnmodifiableListView) return _routingHints;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_routingHints);
+  }
+
+  @override
+  final Uint8List paymentSecret;
+  @override
+  final int minFinalCltvExpiryDelta;
+
+  @override
+  String toString() {
+    return 'LNInvoice(bolt11: $bolt11, network: $network, payeePubkey: $payeePubkey, paymentHash: $paymentHash, description: $description, descriptionHash: $descriptionHash, amountMsat: $amountMsat, timestamp: $timestamp, expiry: $expiry, routingHints: $routingHints, paymentSecret: $paymentSecret, minFinalCltvExpiryDelta: $minFinalCltvExpiryDelta)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LNInvoiceImpl &&
+            (identical(other.bolt11, bolt11) || other.bolt11 == bolt11) &&
+            (identical(other.network, network) || other.network == network) &&
+            (identical(other.payeePubkey, payeePubkey) || other.payeePubkey == payeePubkey) &&
+            (identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash) &&
+            (identical(other.description, description) || other.description == description) &&
+            (identical(other.descriptionHash, descriptionHash) || other.descriptionHash == descriptionHash) &&
+            (identical(other.amountMsat, amountMsat) || other.amountMsat == amountMsat) &&
+            (identical(other.timestamp, timestamp) || other.timestamp == timestamp) &&
+            (identical(other.expiry, expiry) || other.expiry == expiry) &&
+            const DeepCollectionEquality().equals(other._routingHints, _routingHints) &&
+            const DeepCollectionEquality().equals(other.paymentSecret, paymentSecret) &&
+            (identical(other.minFinalCltvExpiryDelta, minFinalCltvExpiryDelta) ||
+                other.minFinalCltvExpiryDelta == minFinalCltvExpiryDelta));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      bolt11,
+      network,
+      payeePubkey,
+      paymentHash,
+      description,
+      descriptionHash,
+      amountMsat,
+      timestamp,
+      expiry,
+      const DeepCollectionEquality().hash(_routingHints),
+      const DeepCollectionEquality().hash(paymentSecret),
+      minFinalCltvExpiryDelta);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LNInvoiceImplCopyWith<_$LNInvoiceImpl> get copyWith =>
+      __$$LNInvoiceImplCopyWithImpl<_$LNInvoiceImpl>(this, _$identity);
+}
+
+abstract class _LNInvoice implements LNInvoice {
+  const factory _LNInvoice(
+      {required final String bolt11,
+      required final Network network,
+      required final String payeePubkey,
+      required final String paymentHash,
+      final String? description,
+      final String? descriptionHash,
+      final int? amountMsat,
+      required final int timestamp,
+      required final int expiry,
+      required final List<RouteHint> routingHints,
+      required final Uint8List paymentSecret,
+      required final int minFinalCltvExpiryDelta}) = _$LNInvoiceImpl;
+
+  @override
+  String get bolt11;
+  @override
+  Network get network;
+  @override
+  String get payeePubkey;
+  @override
+  String get paymentHash;
+  @override
+  String? get description;
+  @override
+  String? get descriptionHash;
+  @override
+  int? get amountMsat;
+  @override
+  int get timestamp;
+  @override
+  int get expiry;
+  @override
+  List<RouteHint> get routingHints;
+  @override
+  Uint8List get paymentSecret;
+  @override
+  int get minFinalCltvExpiryDelta;
+  @override
+  @JsonKey(ignore: true)
+  _$$LNInvoiceImplCopyWith<_$LNInvoiceImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LnPaymentDetails {
+  String get paymentHash => throw _privateConstructorUsedError;
+  String get label => throw _privateConstructorUsedError;
+  String get destinationPubkey => throw _privateConstructorUsedError;
+  String get paymentPreimage => throw _privateConstructorUsedError;
+  bool get keysend => throw _privateConstructorUsedError;
+  String get bolt11 => throw _privateConstructorUsedError;
+  String? get openChannelBolt11 => throw _privateConstructorUsedError;
+  SuccessActionProcessed? get lnurlSuccessAction => throw _privateConstructorUsedError;
+  String? get lnurlPayDomain => throw _privateConstructorUsedError;
+  String? get lnAddress => throw _privateConstructorUsedError;
+  String? get lnurlMetadata => throw _privateConstructorUsedError;
+  String? get lnurlWithdrawEndpoint => throw _privateConstructorUsedError;
+  SwapInfo? get swapInfo => throw _privateConstructorUsedError;
+  ReverseSwapInfo? get reverseSwapInfo => throw _privateConstructorUsedError;
+  int? get pendingExpirationBlock => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LnPaymentDetailsCopyWith<LnPaymentDetails> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LnPaymentDetailsCopyWith<$Res> {
+  factory $LnPaymentDetailsCopyWith(LnPaymentDetails value, $Res Function(LnPaymentDetails) then) =
+      _$LnPaymentDetailsCopyWithImpl<$Res, LnPaymentDetails>;
+  @useResult
+  $Res call(
+      {String paymentHash,
+      String label,
+      String destinationPubkey,
+      String paymentPreimage,
+      bool keysend,
+      String bolt11,
+      String? openChannelBolt11,
+      SuccessActionProcessed? lnurlSuccessAction,
+      String? lnurlPayDomain,
+      String? lnAddress,
+      String? lnurlMetadata,
+      String? lnurlWithdrawEndpoint,
+      SwapInfo? swapInfo,
+      ReverseSwapInfo? reverseSwapInfo,
+      int? pendingExpirationBlock});
+
+  $SuccessActionProcessedCopyWith<$Res>? get lnurlSuccessAction;
+  $SwapInfoCopyWith<$Res>? get swapInfo;
+  $ReverseSwapInfoCopyWith<$Res>? get reverseSwapInfo;
+}
+
+/// @nodoc
+class _$LnPaymentDetailsCopyWithImpl<$Res, $Val extends LnPaymentDetails>
+    implements $LnPaymentDetailsCopyWith<$Res> {
+  _$LnPaymentDetailsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? paymentHash = null,
+    Object? label = null,
+    Object? destinationPubkey = null,
+    Object? paymentPreimage = null,
+    Object? keysend = null,
+    Object? bolt11 = null,
+    Object? openChannelBolt11 = freezed,
+    Object? lnurlSuccessAction = freezed,
+    Object? lnurlPayDomain = freezed,
+    Object? lnAddress = freezed,
+    Object? lnurlMetadata = freezed,
+    Object? lnurlWithdrawEndpoint = freezed,
+    Object? swapInfo = freezed,
+    Object? reverseSwapInfo = freezed,
+    Object? pendingExpirationBlock = freezed,
+  }) {
+    return _then(_value.copyWith(
+      paymentHash: null == paymentHash
+          ? _value.paymentHash
+          : paymentHash // ignore: cast_nullable_to_non_nullable
+              as String,
+      label: null == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String,
+      destinationPubkey: null == destinationPubkey
+          ? _value.destinationPubkey
+          : destinationPubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      paymentPreimage: null == paymentPreimage
+          ? _value.paymentPreimage
+          : paymentPreimage // ignore: cast_nullable_to_non_nullable
+              as String,
+      keysend: null == keysend
+          ? _value.keysend
+          : keysend // ignore: cast_nullable_to_non_nullable
+              as bool,
+      bolt11: null == bolt11
+          ? _value.bolt11
+          : bolt11 // ignore: cast_nullable_to_non_nullable
+              as String,
+      openChannelBolt11: freezed == openChannelBolt11
+          ? _value.openChannelBolt11
+          : openChannelBolt11 // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnurlSuccessAction: freezed == lnurlSuccessAction
+          ? _value.lnurlSuccessAction
+          : lnurlSuccessAction // ignore: cast_nullable_to_non_nullable
+              as SuccessActionProcessed?,
+      lnurlPayDomain: freezed == lnurlPayDomain
+          ? _value.lnurlPayDomain
+          : lnurlPayDomain // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnAddress: freezed == lnAddress
+          ? _value.lnAddress
+          : lnAddress // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnurlMetadata: freezed == lnurlMetadata
+          ? _value.lnurlMetadata
+          : lnurlMetadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnurlWithdrawEndpoint: freezed == lnurlWithdrawEndpoint
+          ? _value.lnurlWithdrawEndpoint
+          : lnurlWithdrawEndpoint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      swapInfo: freezed == swapInfo
+          ? _value.swapInfo
+          : swapInfo // ignore: cast_nullable_to_non_nullable
+              as SwapInfo?,
+      reverseSwapInfo: freezed == reverseSwapInfo
+          ? _value.reverseSwapInfo
+          : reverseSwapInfo // ignore: cast_nullable_to_non_nullable
+              as ReverseSwapInfo?,
+      pendingExpirationBlock: freezed == pendingExpirationBlock
+          ? _value.pendingExpirationBlock
+          : pendingExpirationBlock // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SuccessActionProcessedCopyWith<$Res>? get lnurlSuccessAction {
+    if (_value.lnurlSuccessAction == null) {
+      return null;
+    }
+
+    return $SuccessActionProcessedCopyWith<$Res>(_value.lnurlSuccessAction!, (value) {
+      return _then(_value.copyWith(lnurlSuccessAction: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SwapInfoCopyWith<$Res>? get swapInfo {
+    if (_value.swapInfo == null) {
+      return null;
+    }
+
+    return $SwapInfoCopyWith<$Res>(_value.swapInfo!, (value) {
+      return _then(_value.copyWith(swapInfo: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ReverseSwapInfoCopyWith<$Res>? get reverseSwapInfo {
+    if (_value.reverseSwapInfo == null) {
+      return null;
+    }
+
+    return $ReverseSwapInfoCopyWith<$Res>(_value.reverseSwapInfo!, (value) {
+      return _then(_value.copyWith(reverseSwapInfo: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$LnPaymentDetailsImplCopyWith<$Res> implements $LnPaymentDetailsCopyWith<$Res> {
+  factory _$$LnPaymentDetailsImplCopyWith(
+          _$LnPaymentDetailsImpl value, $Res Function(_$LnPaymentDetailsImpl) then) =
+      __$$LnPaymentDetailsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String paymentHash,
+      String label,
+      String destinationPubkey,
+      String paymentPreimage,
+      bool keysend,
+      String bolt11,
+      String? openChannelBolt11,
+      SuccessActionProcessed? lnurlSuccessAction,
+      String? lnurlPayDomain,
+      String? lnAddress,
+      String? lnurlMetadata,
+      String? lnurlWithdrawEndpoint,
+      SwapInfo? swapInfo,
+      ReverseSwapInfo? reverseSwapInfo,
+      int? pendingExpirationBlock});
+
+  @override
+  $SuccessActionProcessedCopyWith<$Res>? get lnurlSuccessAction;
+  @override
+  $SwapInfoCopyWith<$Res>? get swapInfo;
+  @override
+  $ReverseSwapInfoCopyWith<$Res>? get reverseSwapInfo;
+}
+
+/// @nodoc
+class __$$LnPaymentDetailsImplCopyWithImpl<$Res>
+    extends _$LnPaymentDetailsCopyWithImpl<$Res, _$LnPaymentDetailsImpl>
+    implements _$$LnPaymentDetailsImplCopyWith<$Res> {
+  __$$LnPaymentDetailsImplCopyWithImpl(
+      _$LnPaymentDetailsImpl _value, $Res Function(_$LnPaymentDetailsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? paymentHash = null,
+    Object? label = null,
+    Object? destinationPubkey = null,
+    Object? paymentPreimage = null,
+    Object? keysend = null,
+    Object? bolt11 = null,
+    Object? openChannelBolt11 = freezed,
+    Object? lnurlSuccessAction = freezed,
+    Object? lnurlPayDomain = freezed,
+    Object? lnAddress = freezed,
+    Object? lnurlMetadata = freezed,
+    Object? lnurlWithdrawEndpoint = freezed,
+    Object? swapInfo = freezed,
+    Object? reverseSwapInfo = freezed,
+    Object? pendingExpirationBlock = freezed,
+  }) {
+    return _then(_$LnPaymentDetailsImpl(
+      paymentHash: null == paymentHash
+          ? _value.paymentHash
+          : paymentHash // ignore: cast_nullable_to_non_nullable
+              as String,
+      label: null == label
+          ? _value.label
+          : label // ignore: cast_nullable_to_non_nullable
+              as String,
+      destinationPubkey: null == destinationPubkey
+          ? _value.destinationPubkey
+          : destinationPubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      paymentPreimage: null == paymentPreimage
+          ? _value.paymentPreimage
+          : paymentPreimage // ignore: cast_nullable_to_non_nullable
+              as String,
+      keysend: null == keysend
+          ? _value.keysend
+          : keysend // ignore: cast_nullable_to_non_nullable
+              as bool,
+      bolt11: null == bolt11
+          ? _value.bolt11
+          : bolt11 // ignore: cast_nullable_to_non_nullable
+              as String,
+      openChannelBolt11: freezed == openChannelBolt11
+          ? _value.openChannelBolt11
+          : openChannelBolt11 // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnurlSuccessAction: freezed == lnurlSuccessAction
+          ? _value.lnurlSuccessAction
+          : lnurlSuccessAction // ignore: cast_nullable_to_non_nullable
+              as SuccessActionProcessed?,
+      lnurlPayDomain: freezed == lnurlPayDomain
+          ? _value.lnurlPayDomain
+          : lnurlPayDomain // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnAddress: freezed == lnAddress
+          ? _value.lnAddress
+          : lnAddress // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnurlMetadata: freezed == lnurlMetadata
+          ? _value.lnurlMetadata
+          : lnurlMetadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lnurlWithdrawEndpoint: freezed == lnurlWithdrawEndpoint
+          ? _value.lnurlWithdrawEndpoint
+          : lnurlWithdrawEndpoint // ignore: cast_nullable_to_non_nullable
+              as String?,
+      swapInfo: freezed == swapInfo
+          ? _value.swapInfo
+          : swapInfo // ignore: cast_nullable_to_non_nullable
+              as SwapInfo?,
+      reverseSwapInfo: freezed == reverseSwapInfo
+          ? _value.reverseSwapInfo
+          : reverseSwapInfo // ignore: cast_nullable_to_non_nullable
+              as ReverseSwapInfo?,
+      pendingExpirationBlock: freezed == pendingExpirationBlock
+          ? _value.pendingExpirationBlock
+          : pendingExpirationBlock // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LnPaymentDetailsImpl implements _LnPaymentDetails {
+  const _$LnPaymentDetailsImpl(
+      {required this.paymentHash,
+      required this.label,
+      required this.destinationPubkey,
+      required this.paymentPreimage,
+      required this.keysend,
+      required this.bolt11,
+      this.openChannelBolt11,
+      this.lnurlSuccessAction,
+      this.lnurlPayDomain,
+      this.lnAddress,
+      this.lnurlMetadata,
+      this.lnurlWithdrawEndpoint,
+      this.swapInfo,
+      this.reverseSwapInfo,
+      this.pendingExpirationBlock});
+
+  @override
+  final String paymentHash;
+  @override
+  final String label;
+  @override
+  final String destinationPubkey;
+  @override
+  final String paymentPreimage;
+  @override
+  final bool keysend;
+  @override
+  final String bolt11;
+  @override
+  final String? openChannelBolt11;
+  @override
+  final SuccessActionProcessed? lnurlSuccessAction;
+  @override
+  final String? lnurlPayDomain;
+  @override
+  final String? lnAddress;
+  @override
+  final String? lnurlMetadata;
+  @override
+  final String? lnurlWithdrawEndpoint;
+  @override
+  final SwapInfo? swapInfo;
+  @override
+  final ReverseSwapInfo? reverseSwapInfo;
+  @override
+  final int? pendingExpirationBlock;
+
+  @override
+  String toString() {
+    return 'LnPaymentDetails(paymentHash: $paymentHash, label: $label, destinationPubkey: $destinationPubkey, paymentPreimage: $paymentPreimage, keysend: $keysend, bolt11: $bolt11, openChannelBolt11: $openChannelBolt11, lnurlSuccessAction: $lnurlSuccessAction, lnurlPayDomain: $lnurlPayDomain, lnAddress: $lnAddress, lnurlMetadata: $lnurlMetadata, lnurlWithdrawEndpoint: $lnurlWithdrawEndpoint, swapInfo: $swapInfo, reverseSwapInfo: $reverseSwapInfo, pendingExpirationBlock: $pendingExpirationBlock)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LnPaymentDetailsImpl &&
+            (identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash) &&
+            (identical(other.label, label) || other.label == label) &&
+            (identical(other.destinationPubkey, destinationPubkey) ||
+                other.destinationPubkey == destinationPubkey) &&
+            (identical(other.paymentPreimage, paymentPreimage) || other.paymentPreimage == paymentPreimage) &&
+            (identical(other.keysend, keysend) || other.keysend == keysend) &&
+            (identical(other.bolt11, bolt11) || other.bolt11 == bolt11) &&
+            (identical(other.openChannelBolt11, openChannelBolt11) ||
+                other.openChannelBolt11 == openChannelBolt11) &&
+            (identical(other.lnurlSuccessAction, lnurlSuccessAction) ||
+                other.lnurlSuccessAction == lnurlSuccessAction) &&
+            (identical(other.lnurlPayDomain, lnurlPayDomain) || other.lnurlPayDomain == lnurlPayDomain) &&
+            (identical(other.lnAddress, lnAddress) || other.lnAddress == lnAddress) &&
+            (identical(other.lnurlMetadata, lnurlMetadata) || other.lnurlMetadata == lnurlMetadata) &&
+            (identical(other.lnurlWithdrawEndpoint, lnurlWithdrawEndpoint) ||
+                other.lnurlWithdrawEndpoint == lnurlWithdrawEndpoint) &&
+            (identical(other.swapInfo, swapInfo) || other.swapInfo == swapInfo) &&
+            (identical(other.reverseSwapInfo, reverseSwapInfo) || other.reverseSwapInfo == reverseSwapInfo) &&
+            (identical(other.pendingExpirationBlock, pendingExpirationBlock) ||
+                other.pendingExpirationBlock == pendingExpirationBlock));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      paymentHash,
+      label,
+      destinationPubkey,
+      paymentPreimage,
+      keysend,
+      bolt11,
+      openChannelBolt11,
+      lnurlSuccessAction,
+      lnurlPayDomain,
+      lnAddress,
+      lnurlMetadata,
+      lnurlWithdrawEndpoint,
+      swapInfo,
+      reverseSwapInfo,
+      pendingExpirationBlock);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LnPaymentDetailsImplCopyWith<_$LnPaymentDetailsImpl> get copyWith =>
+      __$$LnPaymentDetailsImplCopyWithImpl<_$LnPaymentDetailsImpl>(this, _$identity);
+}
+
+abstract class _LnPaymentDetails implements LnPaymentDetails {
+  const factory _LnPaymentDetails(
+      {required final String paymentHash,
+      required final String label,
+      required final String destinationPubkey,
+      required final String paymentPreimage,
+      required final bool keysend,
+      required final String bolt11,
+      final String? openChannelBolt11,
+      final SuccessActionProcessed? lnurlSuccessAction,
+      final String? lnurlPayDomain,
+      final String? lnAddress,
+      final String? lnurlMetadata,
+      final String? lnurlWithdrawEndpoint,
+      final SwapInfo? swapInfo,
+      final ReverseSwapInfo? reverseSwapInfo,
+      final int? pendingExpirationBlock}) = _$LnPaymentDetailsImpl;
+
+  @override
+  String get paymentHash;
+  @override
+  String get label;
+  @override
+  String get destinationPubkey;
+  @override
+  String get paymentPreimage;
+  @override
+  bool get keysend;
+  @override
+  String get bolt11;
+  @override
+  String? get openChannelBolt11;
+  @override
+  SuccessActionProcessed? get lnurlSuccessAction;
+  @override
+  String? get lnurlPayDomain;
+  @override
+  String? get lnAddress;
+  @override
+  String? get lnurlMetadata;
+  @override
+  String? get lnurlWithdrawEndpoint;
+  @override
+  SwapInfo? get swapInfo;
+  @override
+  ReverseSwapInfo? get reverseSwapInfo;
+  @override
+  int? get pendingExpirationBlock;
+  @override
+  @JsonKey(ignore: true)
+  _$$LnPaymentDetailsImplCopyWith<_$LnPaymentDetailsImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LnUrlAuthRequestData {
+  String get k1 => throw _privateConstructorUsedError;
+  String? get action => throw _privateConstructorUsedError;
+  String get domain => throw _privateConstructorUsedError;
+  String get url => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LnUrlAuthRequestDataCopyWith<LnUrlAuthRequestData> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LnUrlAuthRequestDataCopyWith<$Res> {
+  factory $LnUrlAuthRequestDataCopyWith(
+          LnUrlAuthRequestData value, $Res Function(LnUrlAuthRequestData) then) =
+      _$LnUrlAuthRequestDataCopyWithImpl<$Res, LnUrlAuthRequestData>;
+  @useResult
+  $Res call({String k1, String? action, String domain, String url});
+}
+
+/// @nodoc
+class _$LnUrlAuthRequestDataCopyWithImpl<$Res, $Val extends LnUrlAuthRequestData>
+    implements $LnUrlAuthRequestDataCopyWith<$Res> {
+  _$LnUrlAuthRequestDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? k1 = null,
+    Object? action = freezed,
+    Object? domain = null,
+    Object? url = null,
+  }) {
+    return _then(_value.copyWith(
+      k1: null == k1
+          ? _value.k1
+          : k1 // ignore: cast_nullable_to_non_nullable
+              as String,
+      action: freezed == action
+          ? _value.action
+          : action // ignore: cast_nullable_to_non_nullable
+              as String?,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$LnUrlAuthRequestDataImplCopyWith<$Res> implements $LnUrlAuthRequestDataCopyWith<$Res> {
+  factory _$$LnUrlAuthRequestDataImplCopyWith(
+          _$LnUrlAuthRequestDataImpl value, $Res Function(_$LnUrlAuthRequestDataImpl) then) =
+      __$$LnUrlAuthRequestDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String k1, String? action, String domain, String url});
+}
+
+/// @nodoc
+class __$$LnUrlAuthRequestDataImplCopyWithImpl<$Res>
+    extends _$LnUrlAuthRequestDataCopyWithImpl<$Res, _$LnUrlAuthRequestDataImpl>
+    implements _$$LnUrlAuthRequestDataImplCopyWith<$Res> {
+  __$$LnUrlAuthRequestDataImplCopyWithImpl(
+      _$LnUrlAuthRequestDataImpl _value, $Res Function(_$LnUrlAuthRequestDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? k1 = null,
+    Object? action = freezed,
+    Object? domain = null,
+    Object? url = null,
+  }) {
+    return _then(_$LnUrlAuthRequestDataImpl(
+      k1: null == k1
+          ? _value.k1
+          : k1 // ignore: cast_nullable_to_non_nullable
+              as String,
+      action: freezed == action
+          ? _value.action
+          : action // ignore: cast_nullable_to_non_nullable
+              as String?,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LnUrlAuthRequestDataImpl implements _LnUrlAuthRequestData {
+  const _$LnUrlAuthRequestDataImpl({required this.k1, this.action, required this.domain, required this.url});
+
+  @override
+  final String k1;
+  @override
+  final String? action;
+  @override
+  final String domain;
+  @override
+  final String url;
+
+  @override
+  String toString() {
+    return 'LnUrlAuthRequestData(k1: $k1, action: $action, domain: $domain, url: $url)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LnUrlAuthRequestDataImpl &&
+            (identical(other.k1, k1) || other.k1 == k1) &&
+            (identical(other.action, action) || other.action == action) &&
+            (identical(other.domain, domain) || other.domain == domain) &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, k1, action, domain, url);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LnUrlAuthRequestDataImplCopyWith<_$LnUrlAuthRequestDataImpl> get copyWith =>
+      __$$LnUrlAuthRequestDataImplCopyWithImpl<_$LnUrlAuthRequestDataImpl>(this, _$identity);
+}
+
+abstract class _LnUrlAuthRequestData implements LnUrlAuthRequestData {
+  const factory _LnUrlAuthRequestData(
+      {required final String k1,
+      final String? action,
+      required final String domain,
+      required final String url}) = _$LnUrlAuthRequestDataImpl;
+
+  @override
+  String get k1;
+  @override
+  String? get action;
+  @override
+  String get domain;
+  @override
+  String get url;
+  @override
+  @JsonKey(ignore: true)
+  _$$LnUrlAuthRequestDataImplCopyWith<_$LnUrlAuthRequestDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3539,6 +6412,8 @@ abstract class _$$LnUrlCallbackStatus_ErrorStatusImplCopyWith<$Res> {
       __$$LnUrlCallbackStatus_ErrorStatusImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnUrlErrorData data});
+
+  $LnUrlErrorDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -3560,6 +6435,14 @@ class __$$LnUrlCallbackStatus_ErrorStatusImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlErrorData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlErrorDataCopyWith<$Res> get data {
+    return $LnUrlErrorDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -3664,6 +6547,518 @@ abstract class LnUrlCallbackStatus_ErrorStatus implements LnUrlCallbackStatus {
   LnUrlErrorData get data;
   @JsonKey(ignore: true)
   _$$LnUrlCallbackStatus_ErrorStatusImplCopyWith<_$LnUrlCallbackStatus_ErrorStatusImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LnUrlErrorData {
+  String get reason => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LnUrlErrorDataCopyWith<LnUrlErrorData> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LnUrlErrorDataCopyWith<$Res> {
+  factory $LnUrlErrorDataCopyWith(LnUrlErrorData value, $Res Function(LnUrlErrorData) then) =
+      _$LnUrlErrorDataCopyWithImpl<$Res, LnUrlErrorData>;
+  @useResult
+  $Res call({String reason});
+}
+
+/// @nodoc
+class _$LnUrlErrorDataCopyWithImpl<$Res, $Val extends LnUrlErrorData>
+    implements $LnUrlErrorDataCopyWith<$Res> {
+  _$LnUrlErrorDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reason = null,
+  }) {
+    return _then(_value.copyWith(
+      reason: null == reason
+          ? _value.reason
+          : reason // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$LnUrlErrorDataImplCopyWith<$Res> implements $LnUrlErrorDataCopyWith<$Res> {
+  factory _$$LnUrlErrorDataImplCopyWith(
+          _$LnUrlErrorDataImpl value, $Res Function(_$LnUrlErrorDataImpl) then) =
+      __$$LnUrlErrorDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String reason});
+}
+
+/// @nodoc
+class __$$LnUrlErrorDataImplCopyWithImpl<$Res>
+    extends _$LnUrlErrorDataCopyWithImpl<$Res, _$LnUrlErrorDataImpl>
+    implements _$$LnUrlErrorDataImplCopyWith<$Res> {
+  __$$LnUrlErrorDataImplCopyWithImpl(_$LnUrlErrorDataImpl _value, $Res Function(_$LnUrlErrorDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reason = null,
+  }) {
+    return _then(_$LnUrlErrorDataImpl(
+      reason: null == reason
+          ? _value.reason
+          : reason // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LnUrlErrorDataImpl implements _LnUrlErrorData {
+  const _$LnUrlErrorDataImpl({required this.reason});
+
+  @override
+  final String reason;
+
+  @override
+  String toString() {
+    return 'LnUrlErrorData(reason: $reason)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LnUrlErrorDataImpl &&
+            (identical(other.reason, reason) || other.reason == reason));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, reason);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LnUrlErrorDataImplCopyWith<_$LnUrlErrorDataImpl> get copyWith =>
+      __$$LnUrlErrorDataImplCopyWithImpl<_$LnUrlErrorDataImpl>(this, _$identity);
+}
+
+abstract class _LnUrlErrorData implements LnUrlErrorData {
+  const factory _LnUrlErrorData({required final String reason}) = _$LnUrlErrorDataImpl;
+
+  @override
+  String get reason;
+  @override
+  @JsonKey(ignore: true)
+  _$$LnUrlErrorDataImplCopyWith<_$LnUrlErrorDataImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LnUrlPayRequest {
+  LnUrlPayRequestData get data => throw _privateConstructorUsedError;
+  int get amountMsat => throw _privateConstructorUsedError;
+  String? get comment => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LnUrlPayRequestCopyWith<LnUrlPayRequest> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LnUrlPayRequestCopyWith<$Res> {
+  factory $LnUrlPayRequestCopyWith(LnUrlPayRequest value, $Res Function(LnUrlPayRequest) then) =
+      _$LnUrlPayRequestCopyWithImpl<$Res, LnUrlPayRequest>;
+  @useResult
+  $Res call({LnUrlPayRequestData data, int amountMsat, String? comment});
+
+  $LnUrlPayRequestDataCopyWith<$Res> get data;
+}
+
+/// @nodoc
+class _$LnUrlPayRequestCopyWithImpl<$Res, $Val extends LnUrlPayRequest>
+    implements $LnUrlPayRequestCopyWith<$Res> {
+  _$LnUrlPayRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+    Object? amountMsat = null,
+    Object? comment = freezed,
+  }) {
+    return _then(_value.copyWith(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as LnUrlPayRequestData,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      comment: freezed == comment
+          ? _value.comment
+          : comment // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlPayRequestDataCopyWith<$Res> get data {
+    return $LnUrlPayRequestDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$LnUrlPayRequestImplCopyWith<$Res> implements $LnUrlPayRequestCopyWith<$Res> {
+  factory _$$LnUrlPayRequestImplCopyWith(
+          _$LnUrlPayRequestImpl value, $Res Function(_$LnUrlPayRequestImpl) then) =
+      __$$LnUrlPayRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({LnUrlPayRequestData data, int amountMsat, String? comment});
+
+  @override
+  $LnUrlPayRequestDataCopyWith<$Res> get data;
+}
+
+/// @nodoc
+class __$$LnUrlPayRequestImplCopyWithImpl<$Res>
+    extends _$LnUrlPayRequestCopyWithImpl<$Res, _$LnUrlPayRequestImpl>
+    implements _$$LnUrlPayRequestImplCopyWith<$Res> {
+  __$$LnUrlPayRequestImplCopyWithImpl(
+      _$LnUrlPayRequestImpl _value, $Res Function(_$LnUrlPayRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+    Object? amountMsat = null,
+    Object? comment = freezed,
+  }) {
+    return _then(_$LnUrlPayRequestImpl(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as LnUrlPayRequestData,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      comment: freezed == comment
+          ? _value.comment
+          : comment // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LnUrlPayRequestImpl implements _LnUrlPayRequest {
+  const _$LnUrlPayRequestImpl({required this.data, required this.amountMsat, this.comment});
+
+  @override
+  final LnUrlPayRequestData data;
+  @override
+  final int amountMsat;
+  @override
+  final String? comment;
+
+  @override
+  String toString() {
+    return 'LnUrlPayRequest(data: $data, amountMsat: $amountMsat, comment: $comment)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LnUrlPayRequestImpl &&
+            (identical(other.data, data) || other.data == data) &&
+            (identical(other.amountMsat, amountMsat) || other.amountMsat == amountMsat) &&
+            (identical(other.comment, comment) || other.comment == comment));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, data, amountMsat, comment);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LnUrlPayRequestImplCopyWith<_$LnUrlPayRequestImpl> get copyWith =>
+      __$$LnUrlPayRequestImplCopyWithImpl<_$LnUrlPayRequestImpl>(this, _$identity);
+}
+
+abstract class _LnUrlPayRequest implements LnUrlPayRequest {
+  const factory _LnUrlPayRequest(
+      {required final LnUrlPayRequestData data,
+      required final int amountMsat,
+      final String? comment}) = _$LnUrlPayRequestImpl;
+
+  @override
+  LnUrlPayRequestData get data;
+  @override
+  int get amountMsat;
+  @override
+  String? get comment;
+  @override
+  @JsonKey(ignore: true)
+  _$$LnUrlPayRequestImplCopyWith<_$LnUrlPayRequestImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LnUrlPayRequestData {
+  String get callback => throw _privateConstructorUsedError;
+  int get minSendable => throw _privateConstructorUsedError;
+  int get maxSendable => throw _privateConstructorUsedError;
+  String get metadataStr => throw _privateConstructorUsedError;
+  int get commentAllowed => throw _privateConstructorUsedError;
+  String get domain => throw _privateConstructorUsedError;
+  String? get lnAddress => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LnUrlPayRequestDataCopyWith<LnUrlPayRequestData> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LnUrlPayRequestDataCopyWith<$Res> {
+  factory $LnUrlPayRequestDataCopyWith(LnUrlPayRequestData value, $Res Function(LnUrlPayRequestData) then) =
+      _$LnUrlPayRequestDataCopyWithImpl<$Res, LnUrlPayRequestData>;
+  @useResult
+  $Res call(
+      {String callback,
+      int minSendable,
+      int maxSendable,
+      String metadataStr,
+      int commentAllowed,
+      String domain,
+      String? lnAddress});
+}
+
+/// @nodoc
+class _$LnUrlPayRequestDataCopyWithImpl<$Res, $Val extends LnUrlPayRequestData>
+    implements $LnUrlPayRequestDataCopyWith<$Res> {
+  _$LnUrlPayRequestDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? callback = null,
+    Object? minSendable = null,
+    Object? maxSendable = null,
+    Object? metadataStr = null,
+    Object? commentAllowed = null,
+    Object? domain = null,
+    Object? lnAddress = freezed,
+  }) {
+    return _then(_value.copyWith(
+      callback: null == callback
+          ? _value.callback
+          : callback // ignore: cast_nullable_to_non_nullable
+              as String,
+      minSendable: null == minSendable
+          ? _value.minSendable
+          : minSendable // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxSendable: null == maxSendable
+          ? _value.maxSendable
+          : maxSendable // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadataStr: null == metadataStr
+          ? _value.metadataStr
+          : metadataStr // ignore: cast_nullable_to_non_nullable
+              as String,
+      commentAllowed: null == commentAllowed
+          ? _value.commentAllowed
+          : commentAllowed // ignore: cast_nullable_to_non_nullable
+              as int,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as String,
+      lnAddress: freezed == lnAddress
+          ? _value.lnAddress
+          : lnAddress // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$LnUrlPayRequestDataImplCopyWith<$Res> implements $LnUrlPayRequestDataCopyWith<$Res> {
+  factory _$$LnUrlPayRequestDataImplCopyWith(
+          _$LnUrlPayRequestDataImpl value, $Res Function(_$LnUrlPayRequestDataImpl) then) =
+      __$$LnUrlPayRequestDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String callback,
+      int minSendable,
+      int maxSendable,
+      String metadataStr,
+      int commentAllowed,
+      String domain,
+      String? lnAddress});
+}
+
+/// @nodoc
+class __$$LnUrlPayRequestDataImplCopyWithImpl<$Res>
+    extends _$LnUrlPayRequestDataCopyWithImpl<$Res, _$LnUrlPayRequestDataImpl>
+    implements _$$LnUrlPayRequestDataImplCopyWith<$Res> {
+  __$$LnUrlPayRequestDataImplCopyWithImpl(
+      _$LnUrlPayRequestDataImpl _value, $Res Function(_$LnUrlPayRequestDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? callback = null,
+    Object? minSendable = null,
+    Object? maxSendable = null,
+    Object? metadataStr = null,
+    Object? commentAllowed = null,
+    Object? domain = null,
+    Object? lnAddress = freezed,
+  }) {
+    return _then(_$LnUrlPayRequestDataImpl(
+      callback: null == callback
+          ? _value.callback
+          : callback // ignore: cast_nullable_to_non_nullable
+              as String,
+      minSendable: null == minSendable
+          ? _value.minSendable
+          : minSendable // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxSendable: null == maxSendable
+          ? _value.maxSendable
+          : maxSendable // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadataStr: null == metadataStr
+          ? _value.metadataStr
+          : metadataStr // ignore: cast_nullable_to_non_nullable
+              as String,
+      commentAllowed: null == commentAllowed
+          ? _value.commentAllowed
+          : commentAllowed // ignore: cast_nullable_to_non_nullable
+              as int,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as String,
+      lnAddress: freezed == lnAddress
+          ? _value.lnAddress
+          : lnAddress // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LnUrlPayRequestDataImpl implements _LnUrlPayRequestData {
+  const _$LnUrlPayRequestDataImpl(
+      {required this.callback,
+      required this.minSendable,
+      required this.maxSendable,
+      required this.metadataStr,
+      required this.commentAllowed,
+      required this.domain,
+      this.lnAddress});
+
+  @override
+  final String callback;
+  @override
+  final int minSendable;
+  @override
+  final int maxSendable;
+  @override
+  final String metadataStr;
+  @override
+  final int commentAllowed;
+  @override
+  final String domain;
+  @override
+  final String? lnAddress;
+
+  @override
+  String toString() {
+    return 'LnUrlPayRequestData(callback: $callback, minSendable: $minSendable, maxSendable: $maxSendable, metadataStr: $metadataStr, commentAllowed: $commentAllowed, domain: $domain, lnAddress: $lnAddress)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LnUrlPayRequestDataImpl &&
+            (identical(other.callback, callback) || other.callback == callback) &&
+            (identical(other.minSendable, minSendable) || other.minSendable == minSendable) &&
+            (identical(other.maxSendable, maxSendable) || other.maxSendable == maxSendable) &&
+            (identical(other.metadataStr, metadataStr) || other.metadataStr == metadataStr) &&
+            (identical(other.commentAllowed, commentAllowed) || other.commentAllowed == commentAllowed) &&
+            (identical(other.domain, domain) || other.domain == domain) &&
+            (identical(other.lnAddress, lnAddress) || other.lnAddress == lnAddress));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, callback, minSendable, maxSendable, metadataStr, commentAllowed, domain, lnAddress);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LnUrlPayRequestDataImplCopyWith<_$LnUrlPayRequestDataImpl> get copyWith =>
+      __$$LnUrlPayRequestDataImplCopyWithImpl<_$LnUrlPayRequestDataImpl>(this, _$identity);
+}
+
+abstract class _LnUrlPayRequestData implements LnUrlPayRequestData {
+  const factory _LnUrlPayRequestData(
+      {required final String callback,
+      required final int minSendable,
+      required final int maxSendable,
+      required final String metadataStr,
+      required final int commentAllowed,
+      required final String domain,
+      final String? lnAddress}) = _$LnUrlPayRequestDataImpl;
+
+  @override
+  String get callback;
+  @override
+  int get minSendable;
+  @override
+  int get maxSendable;
+  @override
+  String get metadataStr;
+  @override
+  int get commentAllowed;
+  @override
+  String get domain;
+  @override
+  String? get lnAddress;
+  @override
+  @JsonKey(ignore: true)
+  _$$LnUrlPayRequestDataImplCopyWith<_$LnUrlPayRequestDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3882,6 +7277,8 @@ abstract class _$$LnUrlPayResult_EndpointErrorImplCopyWith<$Res> {
       __$$LnUrlPayResult_EndpointErrorImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnUrlErrorData data});
+
+  $LnUrlErrorDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -3903,6 +7300,14 @@ class __$$LnUrlPayResult_EndpointErrorImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlErrorData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlErrorDataCopyWith<$Res> get data {
+    return $LnUrlErrorDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -4158,6 +7563,364 @@ abstract class LnUrlPayResult_PayError implements LnUrlPayResult {
 }
 
 /// @nodoc
+mixin _$LnUrlWithdrawRequest {
+  LnUrlWithdrawRequestData get data => throw _privateConstructorUsedError;
+  int get amountMsat => throw _privateConstructorUsedError;
+  String? get description => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LnUrlWithdrawRequestCopyWith<LnUrlWithdrawRequest> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LnUrlWithdrawRequestCopyWith<$Res> {
+  factory $LnUrlWithdrawRequestCopyWith(
+          LnUrlWithdrawRequest value, $Res Function(LnUrlWithdrawRequest) then) =
+      _$LnUrlWithdrawRequestCopyWithImpl<$Res, LnUrlWithdrawRequest>;
+  @useResult
+  $Res call({LnUrlWithdrawRequestData data, int amountMsat, String? description});
+
+  $LnUrlWithdrawRequestDataCopyWith<$Res> get data;
+}
+
+/// @nodoc
+class _$LnUrlWithdrawRequestCopyWithImpl<$Res, $Val extends LnUrlWithdrawRequest>
+    implements $LnUrlWithdrawRequestCopyWith<$Res> {
+  _$LnUrlWithdrawRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+    Object? amountMsat = null,
+    Object? description = freezed,
+  }) {
+    return _then(_value.copyWith(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as LnUrlWithdrawRequestData,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlWithdrawRequestDataCopyWith<$Res> get data {
+    return $LnUrlWithdrawRequestDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$LnUrlWithdrawRequestImplCopyWith<$Res> implements $LnUrlWithdrawRequestCopyWith<$Res> {
+  factory _$$LnUrlWithdrawRequestImplCopyWith(
+          _$LnUrlWithdrawRequestImpl value, $Res Function(_$LnUrlWithdrawRequestImpl) then) =
+      __$$LnUrlWithdrawRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({LnUrlWithdrawRequestData data, int amountMsat, String? description});
+
+  @override
+  $LnUrlWithdrawRequestDataCopyWith<$Res> get data;
+}
+
+/// @nodoc
+class __$$LnUrlWithdrawRequestImplCopyWithImpl<$Res>
+    extends _$LnUrlWithdrawRequestCopyWithImpl<$Res, _$LnUrlWithdrawRequestImpl>
+    implements _$$LnUrlWithdrawRequestImplCopyWith<$Res> {
+  __$$LnUrlWithdrawRequestImplCopyWithImpl(
+      _$LnUrlWithdrawRequestImpl _value, $Res Function(_$LnUrlWithdrawRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+    Object? amountMsat = null,
+    Object? description = freezed,
+  }) {
+    return _then(_$LnUrlWithdrawRequestImpl(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as LnUrlWithdrawRequestData,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LnUrlWithdrawRequestImpl implements _LnUrlWithdrawRequest {
+  const _$LnUrlWithdrawRequestImpl({required this.data, required this.amountMsat, this.description});
+
+  @override
+  final LnUrlWithdrawRequestData data;
+  @override
+  final int amountMsat;
+  @override
+  final String? description;
+
+  @override
+  String toString() {
+    return 'LnUrlWithdrawRequest(data: $data, amountMsat: $amountMsat, description: $description)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LnUrlWithdrawRequestImpl &&
+            (identical(other.data, data) || other.data == data) &&
+            (identical(other.amountMsat, amountMsat) || other.amountMsat == amountMsat) &&
+            (identical(other.description, description) || other.description == description));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, data, amountMsat, description);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LnUrlWithdrawRequestImplCopyWith<_$LnUrlWithdrawRequestImpl> get copyWith =>
+      __$$LnUrlWithdrawRequestImplCopyWithImpl<_$LnUrlWithdrawRequestImpl>(this, _$identity);
+}
+
+abstract class _LnUrlWithdrawRequest implements LnUrlWithdrawRequest {
+  const factory _LnUrlWithdrawRequest(
+      {required final LnUrlWithdrawRequestData data,
+      required final int amountMsat,
+      final String? description}) = _$LnUrlWithdrawRequestImpl;
+
+  @override
+  LnUrlWithdrawRequestData get data;
+  @override
+  int get amountMsat;
+  @override
+  String? get description;
+  @override
+  @JsonKey(ignore: true)
+  _$$LnUrlWithdrawRequestImplCopyWith<_$LnUrlWithdrawRequestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LnUrlWithdrawRequestData {
+  String get callback => throw _privateConstructorUsedError;
+  String get k1 => throw _privateConstructorUsedError;
+  String get defaultDescription => throw _privateConstructorUsedError;
+  int get minWithdrawable => throw _privateConstructorUsedError;
+  int get maxWithdrawable => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LnUrlWithdrawRequestDataCopyWith<LnUrlWithdrawRequestData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LnUrlWithdrawRequestDataCopyWith<$Res> {
+  factory $LnUrlWithdrawRequestDataCopyWith(
+          LnUrlWithdrawRequestData value, $Res Function(LnUrlWithdrawRequestData) then) =
+      _$LnUrlWithdrawRequestDataCopyWithImpl<$Res, LnUrlWithdrawRequestData>;
+  @useResult
+  $Res call(
+      {String callback, String k1, String defaultDescription, int minWithdrawable, int maxWithdrawable});
+}
+
+/// @nodoc
+class _$LnUrlWithdrawRequestDataCopyWithImpl<$Res, $Val extends LnUrlWithdrawRequestData>
+    implements $LnUrlWithdrawRequestDataCopyWith<$Res> {
+  _$LnUrlWithdrawRequestDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? callback = null,
+    Object? k1 = null,
+    Object? defaultDescription = null,
+    Object? minWithdrawable = null,
+    Object? maxWithdrawable = null,
+  }) {
+    return _then(_value.copyWith(
+      callback: null == callback
+          ? _value.callback
+          : callback // ignore: cast_nullable_to_non_nullable
+              as String,
+      k1: null == k1
+          ? _value.k1
+          : k1 // ignore: cast_nullable_to_non_nullable
+              as String,
+      defaultDescription: null == defaultDescription
+          ? _value.defaultDescription
+          : defaultDescription // ignore: cast_nullable_to_non_nullable
+              as String,
+      minWithdrawable: null == minWithdrawable
+          ? _value.minWithdrawable
+          : minWithdrawable // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxWithdrawable: null == maxWithdrawable
+          ? _value.maxWithdrawable
+          : maxWithdrawable // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$LnUrlWithdrawRequestDataImplCopyWith<$Res>
+    implements $LnUrlWithdrawRequestDataCopyWith<$Res> {
+  factory _$$LnUrlWithdrawRequestDataImplCopyWith(
+          _$LnUrlWithdrawRequestDataImpl value, $Res Function(_$LnUrlWithdrawRequestDataImpl) then) =
+      __$$LnUrlWithdrawRequestDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String callback, String k1, String defaultDescription, int minWithdrawable, int maxWithdrawable});
+}
+
+/// @nodoc
+class __$$LnUrlWithdrawRequestDataImplCopyWithImpl<$Res>
+    extends _$LnUrlWithdrawRequestDataCopyWithImpl<$Res, _$LnUrlWithdrawRequestDataImpl>
+    implements _$$LnUrlWithdrawRequestDataImplCopyWith<$Res> {
+  __$$LnUrlWithdrawRequestDataImplCopyWithImpl(
+      _$LnUrlWithdrawRequestDataImpl _value, $Res Function(_$LnUrlWithdrawRequestDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? callback = null,
+    Object? k1 = null,
+    Object? defaultDescription = null,
+    Object? minWithdrawable = null,
+    Object? maxWithdrawable = null,
+  }) {
+    return _then(_$LnUrlWithdrawRequestDataImpl(
+      callback: null == callback
+          ? _value.callback
+          : callback // ignore: cast_nullable_to_non_nullable
+              as String,
+      k1: null == k1
+          ? _value.k1
+          : k1 // ignore: cast_nullable_to_non_nullable
+              as String,
+      defaultDescription: null == defaultDescription
+          ? _value.defaultDescription
+          : defaultDescription // ignore: cast_nullable_to_non_nullable
+              as String,
+      minWithdrawable: null == minWithdrawable
+          ? _value.minWithdrawable
+          : minWithdrawable // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxWithdrawable: null == maxWithdrawable
+          ? _value.maxWithdrawable
+          : maxWithdrawable // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LnUrlWithdrawRequestDataImpl implements _LnUrlWithdrawRequestData {
+  const _$LnUrlWithdrawRequestDataImpl(
+      {required this.callback,
+      required this.k1,
+      required this.defaultDescription,
+      required this.minWithdrawable,
+      required this.maxWithdrawable});
+
+  @override
+  final String callback;
+  @override
+  final String k1;
+  @override
+  final String defaultDescription;
+  @override
+  final int minWithdrawable;
+  @override
+  final int maxWithdrawable;
+
+  @override
+  String toString() {
+    return 'LnUrlWithdrawRequestData(callback: $callback, k1: $k1, defaultDescription: $defaultDescription, minWithdrawable: $minWithdrawable, maxWithdrawable: $maxWithdrawable)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LnUrlWithdrawRequestDataImpl &&
+            (identical(other.callback, callback) || other.callback == callback) &&
+            (identical(other.k1, k1) || other.k1 == k1) &&
+            (identical(other.defaultDescription, defaultDescription) ||
+                other.defaultDescription == defaultDescription) &&
+            (identical(other.minWithdrawable, minWithdrawable) || other.minWithdrawable == minWithdrawable) &&
+            (identical(other.maxWithdrawable, maxWithdrawable) || other.maxWithdrawable == maxWithdrawable));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, callback, k1, defaultDescription, minWithdrawable, maxWithdrawable);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LnUrlWithdrawRequestDataImplCopyWith<_$LnUrlWithdrawRequestDataImpl> get copyWith =>
+      __$$LnUrlWithdrawRequestDataImplCopyWithImpl<_$LnUrlWithdrawRequestDataImpl>(this, _$identity);
+}
+
+abstract class _LnUrlWithdrawRequestData implements LnUrlWithdrawRequestData {
+  const factory _LnUrlWithdrawRequestData(
+      {required final String callback,
+      required final String k1,
+      required final String defaultDescription,
+      required final int minWithdrawable,
+      required final int maxWithdrawable}) = _$LnUrlWithdrawRequestDataImpl;
+
+  @override
+  String get callback;
+  @override
+  String get k1;
+  @override
+  String get defaultDescription;
+  @override
+  int get minWithdrawable;
+  @override
+  int get maxWithdrawable;
+  @override
+  @JsonKey(ignore: true)
+  _$$LnUrlWithdrawRequestDataImplCopyWith<_$LnUrlWithdrawRequestDataImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$LnUrlWithdrawResult {
   Object get data => throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -4359,6 +8122,8 @@ abstract class _$$LnUrlWithdrawResult_ErrorStatusImplCopyWith<$Res> {
       __$$LnUrlWithdrawResult_ErrorStatusImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnUrlErrorData data});
+
+  $LnUrlErrorDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -4380,6 +8145,14 @@ class __$$LnUrlWithdrawResult_ErrorStatusImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlErrorData,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnUrlErrorDataCopyWith<$Res> get data {
+    return $LnUrlErrorDataCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -4489,6 +8262,624 @@ abstract class LnUrlWithdrawResult_ErrorStatus implements LnUrlWithdrawResult {
 }
 
 /// @nodoc
+mixin _$LocaleOverrides {
+  String get locale => throw _privateConstructorUsedError;
+  int? get spacing => throw _privateConstructorUsedError;
+  Symbol get symbol => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LocaleOverridesCopyWith<LocaleOverrides> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LocaleOverridesCopyWith<$Res> {
+  factory $LocaleOverridesCopyWith(LocaleOverrides value, $Res Function(LocaleOverrides) then) =
+      _$LocaleOverridesCopyWithImpl<$Res, LocaleOverrides>;
+  @useResult
+  $Res call({String locale, int? spacing, Symbol symbol});
+
+  $SymbolCopyWith<$Res> get symbol;
+}
+
+/// @nodoc
+class _$LocaleOverridesCopyWithImpl<$Res, $Val extends LocaleOverrides>
+    implements $LocaleOverridesCopyWith<$Res> {
+  _$LocaleOverridesCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? locale = null,
+    Object? spacing = freezed,
+    Object? symbol = null,
+  }) {
+    return _then(_value.copyWith(
+      locale: null == locale
+          ? _value.locale
+          : locale // ignore: cast_nullable_to_non_nullable
+              as String,
+      spacing: freezed == spacing
+          ? _value.spacing
+          : spacing // ignore: cast_nullable_to_non_nullable
+              as int?,
+      symbol: null == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as Symbol,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $SymbolCopyWith<$Res> get symbol {
+    return $SymbolCopyWith<$Res>(_value.symbol, (value) {
+      return _then(_value.copyWith(symbol: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$LocaleOverridesImplCopyWith<$Res> implements $LocaleOverridesCopyWith<$Res> {
+  factory _$$LocaleOverridesImplCopyWith(
+          _$LocaleOverridesImpl value, $Res Function(_$LocaleOverridesImpl) then) =
+      __$$LocaleOverridesImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String locale, int? spacing, Symbol symbol});
+
+  @override
+  $SymbolCopyWith<$Res> get symbol;
+}
+
+/// @nodoc
+class __$$LocaleOverridesImplCopyWithImpl<$Res>
+    extends _$LocaleOverridesCopyWithImpl<$Res, _$LocaleOverridesImpl>
+    implements _$$LocaleOverridesImplCopyWith<$Res> {
+  __$$LocaleOverridesImplCopyWithImpl(
+      _$LocaleOverridesImpl _value, $Res Function(_$LocaleOverridesImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? locale = null,
+    Object? spacing = freezed,
+    Object? symbol = null,
+  }) {
+    return _then(_$LocaleOverridesImpl(
+      locale: null == locale
+          ? _value.locale
+          : locale // ignore: cast_nullable_to_non_nullable
+              as String,
+      spacing: freezed == spacing
+          ? _value.spacing
+          : spacing // ignore: cast_nullable_to_non_nullable
+              as int?,
+      symbol: null == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as Symbol,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LocaleOverridesImpl implements _LocaleOverrides {
+  const _$LocaleOverridesImpl({required this.locale, this.spacing, required this.symbol});
+
+  @override
+  final String locale;
+  @override
+  final int? spacing;
+  @override
+  final Symbol symbol;
+
+  @override
+  String toString() {
+    return 'LocaleOverrides(locale: $locale, spacing: $spacing, symbol: $symbol)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LocaleOverridesImpl &&
+            (identical(other.locale, locale) || other.locale == locale) &&
+            (identical(other.spacing, spacing) || other.spacing == spacing) &&
+            (identical(other.symbol, symbol) || other.symbol == symbol));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, locale, spacing, symbol);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LocaleOverridesImplCopyWith<_$LocaleOverridesImpl> get copyWith =>
+      __$$LocaleOverridesImplCopyWithImpl<_$LocaleOverridesImpl>(this, _$identity);
+}
+
+abstract class _LocaleOverrides implements LocaleOverrides {
+  const factory _LocaleOverrides(
+      {required final String locale,
+      final int? spacing,
+      required final Symbol symbol}) = _$LocaleOverridesImpl;
+
+  @override
+  String get locale;
+  @override
+  int? get spacing;
+  @override
+  Symbol get symbol;
+  @override
+  @JsonKey(ignore: true)
+  _$$LocaleOverridesImplCopyWith<_$LocaleOverridesImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LocalizedName {
+  String get locale => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LocalizedNameCopyWith<LocalizedName> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LocalizedNameCopyWith<$Res> {
+  factory $LocalizedNameCopyWith(LocalizedName value, $Res Function(LocalizedName) then) =
+      _$LocalizedNameCopyWithImpl<$Res, LocalizedName>;
+  @useResult
+  $Res call({String locale, String name});
+}
+
+/// @nodoc
+class _$LocalizedNameCopyWithImpl<$Res, $Val extends LocalizedName> implements $LocalizedNameCopyWith<$Res> {
+  _$LocalizedNameCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? locale = null,
+    Object? name = null,
+  }) {
+    return _then(_value.copyWith(
+      locale: null == locale
+          ? _value.locale
+          : locale // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$LocalizedNameImplCopyWith<$Res> implements $LocalizedNameCopyWith<$Res> {
+  factory _$$LocalizedNameImplCopyWith(_$LocalizedNameImpl value, $Res Function(_$LocalizedNameImpl) then) =
+      __$$LocalizedNameImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String locale, String name});
+}
+
+/// @nodoc
+class __$$LocalizedNameImplCopyWithImpl<$Res> extends _$LocalizedNameCopyWithImpl<$Res, _$LocalizedNameImpl>
+    implements _$$LocalizedNameImplCopyWith<$Res> {
+  __$$LocalizedNameImplCopyWithImpl(_$LocalizedNameImpl _value, $Res Function(_$LocalizedNameImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? locale = null,
+    Object? name = null,
+  }) {
+    return _then(_$LocalizedNameImpl(
+      locale: null == locale
+          ? _value.locale
+          : locale // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LocalizedNameImpl implements _LocalizedName {
+  const _$LocalizedNameImpl({required this.locale, required this.name});
+
+  @override
+  final String locale;
+  @override
+  final String name;
+
+  @override
+  String toString() {
+    return 'LocalizedName(locale: $locale, name: $name)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LocalizedNameImpl &&
+            (identical(other.locale, locale) || other.locale == locale) &&
+            (identical(other.name, name) || other.name == name));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, locale, name);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LocalizedNameImplCopyWith<_$LocalizedNameImpl> get copyWith =>
+      __$$LocalizedNameImplCopyWithImpl<_$LocalizedNameImpl>(this, _$identity);
+}
+
+abstract class _LocalizedName implements LocalizedName {
+  const factory _LocalizedName({required final String locale, required final String name}) =
+      _$LocalizedNameImpl;
+
+  @override
+  String get locale;
+  @override
+  String get name;
+  @override
+  @JsonKey(ignore: true)
+  _$$LocalizedNameImplCopyWith<_$LocalizedNameImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$LspInformation {
+  String get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get widgetUrl => throw _privateConstructorUsedError;
+  String get pubkey => throw _privateConstructorUsedError;
+  String get host => throw _privateConstructorUsedError;
+  int get baseFeeMsat => throw _privateConstructorUsedError;
+  double get feeRate => throw _privateConstructorUsedError;
+  int get timeLockDelta => throw _privateConstructorUsedError;
+  int get minHtlcMsat => throw _privateConstructorUsedError;
+  Uint8List get lspPubkey => throw _privateConstructorUsedError;
+  OpeningFeeParamsMenu get openingFeeParamsList => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LspInformationCopyWith<LspInformation> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LspInformationCopyWith<$Res> {
+  factory $LspInformationCopyWith(LspInformation value, $Res Function(LspInformation) then) =
+      _$LspInformationCopyWithImpl<$Res, LspInformation>;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      String widgetUrl,
+      String pubkey,
+      String host,
+      int baseFeeMsat,
+      double feeRate,
+      int timeLockDelta,
+      int minHtlcMsat,
+      Uint8List lspPubkey,
+      OpeningFeeParamsMenu openingFeeParamsList});
+
+  $OpeningFeeParamsMenuCopyWith<$Res> get openingFeeParamsList;
+}
+
+/// @nodoc
+class _$LspInformationCopyWithImpl<$Res, $Val extends LspInformation>
+    implements $LspInformationCopyWith<$Res> {
+  _$LspInformationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? widgetUrl = null,
+    Object? pubkey = null,
+    Object? host = null,
+    Object? baseFeeMsat = null,
+    Object? feeRate = null,
+    Object? timeLockDelta = null,
+    Object? minHtlcMsat = null,
+    Object? lspPubkey = null,
+    Object? openingFeeParamsList = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      widgetUrl: null == widgetUrl
+          ? _value.widgetUrl
+          : widgetUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      pubkey: null == pubkey
+          ? _value.pubkey
+          : pubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      host: null == host
+          ? _value.host
+          : host // ignore: cast_nullable_to_non_nullable
+              as String,
+      baseFeeMsat: null == baseFeeMsat
+          ? _value.baseFeeMsat
+          : baseFeeMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      feeRate: null == feeRate
+          ? _value.feeRate
+          : feeRate // ignore: cast_nullable_to_non_nullable
+              as double,
+      timeLockDelta: null == timeLockDelta
+          ? _value.timeLockDelta
+          : timeLockDelta // ignore: cast_nullable_to_non_nullable
+              as int,
+      minHtlcMsat: null == minHtlcMsat
+          ? _value.minHtlcMsat
+          : minHtlcMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      lspPubkey: null == lspPubkey
+          ? _value.lspPubkey
+          : lspPubkey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      openingFeeParamsList: null == openingFeeParamsList
+          ? _value.openingFeeParamsList
+          : openingFeeParamsList // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParamsMenu,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OpeningFeeParamsMenuCopyWith<$Res> get openingFeeParamsList {
+    return $OpeningFeeParamsMenuCopyWith<$Res>(_value.openingFeeParamsList, (value) {
+      return _then(_value.copyWith(openingFeeParamsList: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$LspInformationImplCopyWith<$Res> implements $LspInformationCopyWith<$Res> {
+  factory _$$LspInformationImplCopyWith(
+          _$LspInformationImpl value, $Res Function(_$LspInformationImpl) then) =
+      __$$LspInformationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      String widgetUrl,
+      String pubkey,
+      String host,
+      int baseFeeMsat,
+      double feeRate,
+      int timeLockDelta,
+      int minHtlcMsat,
+      Uint8List lspPubkey,
+      OpeningFeeParamsMenu openingFeeParamsList});
+
+  @override
+  $OpeningFeeParamsMenuCopyWith<$Res> get openingFeeParamsList;
+}
+
+/// @nodoc
+class __$$LspInformationImplCopyWithImpl<$Res>
+    extends _$LspInformationCopyWithImpl<$Res, _$LspInformationImpl>
+    implements _$$LspInformationImplCopyWith<$Res> {
+  __$$LspInformationImplCopyWithImpl(_$LspInformationImpl _value, $Res Function(_$LspInformationImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? widgetUrl = null,
+    Object? pubkey = null,
+    Object? host = null,
+    Object? baseFeeMsat = null,
+    Object? feeRate = null,
+    Object? timeLockDelta = null,
+    Object? minHtlcMsat = null,
+    Object? lspPubkey = null,
+    Object? openingFeeParamsList = null,
+  }) {
+    return _then(_$LspInformationImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      widgetUrl: null == widgetUrl
+          ? _value.widgetUrl
+          : widgetUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      pubkey: null == pubkey
+          ? _value.pubkey
+          : pubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      host: null == host
+          ? _value.host
+          : host // ignore: cast_nullable_to_non_nullable
+              as String,
+      baseFeeMsat: null == baseFeeMsat
+          ? _value.baseFeeMsat
+          : baseFeeMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      feeRate: null == feeRate
+          ? _value.feeRate
+          : feeRate // ignore: cast_nullable_to_non_nullable
+              as double,
+      timeLockDelta: null == timeLockDelta
+          ? _value.timeLockDelta
+          : timeLockDelta // ignore: cast_nullable_to_non_nullable
+              as int,
+      minHtlcMsat: null == minHtlcMsat
+          ? _value.minHtlcMsat
+          : minHtlcMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      lspPubkey: null == lspPubkey
+          ? _value.lspPubkey
+          : lspPubkey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      openingFeeParamsList: null == openingFeeParamsList
+          ? _value.openingFeeParamsList
+          : openingFeeParamsList // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParamsMenu,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LspInformationImpl implements _LspInformation {
+  const _$LspInformationImpl(
+      {required this.id,
+      required this.name,
+      required this.widgetUrl,
+      required this.pubkey,
+      required this.host,
+      required this.baseFeeMsat,
+      required this.feeRate,
+      required this.timeLockDelta,
+      required this.minHtlcMsat,
+      required this.lspPubkey,
+      required this.openingFeeParamsList});
+
+  @override
+  final String id;
+  @override
+  final String name;
+  @override
+  final String widgetUrl;
+  @override
+  final String pubkey;
+  @override
+  final String host;
+  @override
+  final int baseFeeMsat;
+  @override
+  final double feeRate;
+  @override
+  final int timeLockDelta;
+  @override
+  final int minHtlcMsat;
+  @override
+  final Uint8List lspPubkey;
+  @override
+  final OpeningFeeParamsMenu openingFeeParamsList;
+
+  @override
+  String toString() {
+    return 'LspInformation(id: $id, name: $name, widgetUrl: $widgetUrl, pubkey: $pubkey, host: $host, baseFeeMsat: $baseFeeMsat, feeRate: $feeRate, timeLockDelta: $timeLockDelta, minHtlcMsat: $minHtlcMsat, lspPubkey: $lspPubkey, openingFeeParamsList: $openingFeeParamsList)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LspInformationImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.widgetUrl, widgetUrl) || other.widgetUrl == widgetUrl) &&
+            (identical(other.pubkey, pubkey) || other.pubkey == pubkey) &&
+            (identical(other.host, host) || other.host == host) &&
+            (identical(other.baseFeeMsat, baseFeeMsat) || other.baseFeeMsat == baseFeeMsat) &&
+            (identical(other.feeRate, feeRate) || other.feeRate == feeRate) &&
+            (identical(other.timeLockDelta, timeLockDelta) || other.timeLockDelta == timeLockDelta) &&
+            (identical(other.minHtlcMsat, minHtlcMsat) || other.minHtlcMsat == minHtlcMsat) &&
+            const DeepCollectionEquality().equals(other.lspPubkey, lspPubkey) &&
+            (identical(other.openingFeeParamsList, openingFeeParamsList) ||
+                other.openingFeeParamsList == openingFeeParamsList));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, widgetUrl, pubkey, host, baseFeeMsat, feeRate,
+      timeLockDelta, minHtlcMsat, const DeepCollectionEquality().hash(lspPubkey), openingFeeParamsList);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LspInformationImplCopyWith<_$LspInformationImpl> get copyWith =>
+      __$$LspInformationImplCopyWithImpl<_$LspInformationImpl>(this, _$identity);
+}
+
+abstract class _LspInformation implements LspInformation {
+  const factory _LspInformation(
+      {required final String id,
+      required final String name,
+      required final String widgetUrl,
+      required final String pubkey,
+      required final String host,
+      required final int baseFeeMsat,
+      required final double feeRate,
+      required final int timeLockDelta,
+      required final int minHtlcMsat,
+      required final Uint8List lspPubkey,
+      required final OpeningFeeParamsMenu openingFeeParamsList}) = _$LspInformationImpl;
+
+  @override
+  String get id;
+  @override
+  String get name;
+  @override
+  String get widgetUrl;
+  @override
+  String get pubkey;
+  @override
+  String get host;
+  @override
+  int get baseFeeMsat;
+  @override
+  double get feeRate;
+  @override
+  int get timeLockDelta;
+  @override
+  int get minHtlcMsat;
+  @override
+  Uint8List get lspPubkey;
+  @override
+  OpeningFeeParamsMenu get openingFeeParamsList;
+  @override
+  @JsonKey(ignore: true)
+  _$$LspInformationImplCopyWith<_$LspInformationImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$NodeConfig {
   GreenlightNodeConfig get config => throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -4534,6 +8925,8 @@ abstract class $NodeConfigCopyWith<$Res> {
       _$NodeConfigCopyWithImpl<$Res, NodeConfig>;
   @useResult
   $Res call({GreenlightNodeConfig config});
+
+  $GreenlightNodeConfigCopyWith<$Res> get config;
 }
 
 /// @nodoc
@@ -4557,6 +8950,14 @@ class _$NodeConfigCopyWithImpl<$Res, $Val extends NodeConfig> implements $NodeCo
               as GreenlightNodeConfig,
     ) as $Val);
   }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $GreenlightNodeConfigCopyWith<$Res> get config {
+    return $GreenlightNodeConfigCopyWith<$Res>(_value.config, (value) {
+      return _then(_value.copyWith(config: value) as $Val);
+    });
+  }
 }
 
 /// @nodoc
@@ -4567,6 +8968,9 @@ abstract class _$$NodeConfig_GreenlightImplCopyWith<$Res> implements $NodeConfig
   @override
   @useResult
   $Res call({GreenlightNodeConfig config});
+
+  @override
+  $GreenlightNodeConfigCopyWith<$Res> get config;
 }
 
 /// @nodoc
@@ -4894,6 +9298,1019 @@ abstract class NodeCredentials_Greenlight implements NodeCredentials {
 }
 
 /// @nodoc
+mixin _$NodeState {
+  String get id => throw _privateConstructorUsedError;
+  int get blockHeight => throw _privateConstructorUsedError;
+  int get channelsBalanceMsat => throw _privateConstructorUsedError;
+  int get onchainBalanceMsat => throw _privateConstructorUsedError;
+  int get pendingOnchainBalanceMsat => throw _privateConstructorUsedError;
+  List<UnspentTransactionOutput> get utxos => throw _privateConstructorUsedError;
+  int get maxPayableMsat => throw _privateConstructorUsedError;
+  int get maxReceivableMsat => throw _privateConstructorUsedError;
+  int get maxSinglePaymentAmountMsat => throw _privateConstructorUsedError;
+  int get maxChanReserveMsats => throw _privateConstructorUsedError;
+  List<String> get connectedPeers => throw _privateConstructorUsedError;
+  int get inboundLiquidityMsats => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $NodeStateCopyWith<NodeState> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NodeStateCopyWith<$Res> {
+  factory $NodeStateCopyWith(NodeState value, $Res Function(NodeState) then) =
+      _$NodeStateCopyWithImpl<$Res, NodeState>;
+  @useResult
+  $Res call(
+      {String id,
+      int blockHeight,
+      int channelsBalanceMsat,
+      int onchainBalanceMsat,
+      int pendingOnchainBalanceMsat,
+      List<UnspentTransactionOutput> utxos,
+      int maxPayableMsat,
+      int maxReceivableMsat,
+      int maxSinglePaymentAmountMsat,
+      int maxChanReserveMsats,
+      List<String> connectedPeers,
+      int inboundLiquidityMsats});
+}
+
+/// @nodoc
+class _$NodeStateCopyWithImpl<$Res, $Val extends NodeState> implements $NodeStateCopyWith<$Res> {
+  _$NodeStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? blockHeight = null,
+    Object? channelsBalanceMsat = null,
+    Object? onchainBalanceMsat = null,
+    Object? pendingOnchainBalanceMsat = null,
+    Object? utxos = null,
+    Object? maxPayableMsat = null,
+    Object? maxReceivableMsat = null,
+    Object? maxSinglePaymentAmountMsat = null,
+    Object? maxChanReserveMsats = null,
+    Object? connectedPeers = null,
+    Object? inboundLiquidityMsats = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      blockHeight: null == blockHeight
+          ? _value.blockHeight
+          : blockHeight // ignore: cast_nullable_to_non_nullable
+              as int,
+      channelsBalanceMsat: null == channelsBalanceMsat
+          ? _value.channelsBalanceMsat
+          : channelsBalanceMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      onchainBalanceMsat: null == onchainBalanceMsat
+          ? _value.onchainBalanceMsat
+          : onchainBalanceMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      pendingOnchainBalanceMsat: null == pendingOnchainBalanceMsat
+          ? _value.pendingOnchainBalanceMsat
+          : pendingOnchainBalanceMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      utxos: null == utxos
+          ? _value.utxos
+          : utxos // ignore: cast_nullable_to_non_nullable
+              as List<UnspentTransactionOutput>,
+      maxPayableMsat: null == maxPayableMsat
+          ? _value.maxPayableMsat
+          : maxPayableMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxReceivableMsat: null == maxReceivableMsat
+          ? _value.maxReceivableMsat
+          : maxReceivableMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxSinglePaymentAmountMsat: null == maxSinglePaymentAmountMsat
+          ? _value.maxSinglePaymentAmountMsat
+          : maxSinglePaymentAmountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxChanReserveMsats: null == maxChanReserveMsats
+          ? _value.maxChanReserveMsats
+          : maxChanReserveMsats // ignore: cast_nullable_to_non_nullable
+              as int,
+      connectedPeers: null == connectedPeers
+          ? _value.connectedPeers
+          : connectedPeers // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      inboundLiquidityMsats: null == inboundLiquidityMsats
+          ? _value.inboundLiquidityMsats
+          : inboundLiquidityMsats // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$NodeStateImplCopyWith<$Res> implements $NodeStateCopyWith<$Res> {
+  factory _$$NodeStateImplCopyWith(_$NodeStateImpl value, $Res Function(_$NodeStateImpl) then) =
+      __$$NodeStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      int blockHeight,
+      int channelsBalanceMsat,
+      int onchainBalanceMsat,
+      int pendingOnchainBalanceMsat,
+      List<UnspentTransactionOutput> utxos,
+      int maxPayableMsat,
+      int maxReceivableMsat,
+      int maxSinglePaymentAmountMsat,
+      int maxChanReserveMsats,
+      List<String> connectedPeers,
+      int inboundLiquidityMsats});
+}
+
+/// @nodoc
+class __$$NodeStateImplCopyWithImpl<$Res> extends _$NodeStateCopyWithImpl<$Res, _$NodeStateImpl>
+    implements _$$NodeStateImplCopyWith<$Res> {
+  __$$NodeStateImplCopyWithImpl(_$NodeStateImpl _value, $Res Function(_$NodeStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? blockHeight = null,
+    Object? channelsBalanceMsat = null,
+    Object? onchainBalanceMsat = null,
+    Object? pendingOnchainBalanceMsat = null,
+    Object? utxos = null,
+    Object? maxPayableMsat = null,
+    Object? maxReceivableMsat = null,
+    Object? maxSinglePaymentAmountMsat = null,
+    Object? maxChanReserveMsats = null,
+    Object? connectedPeers = null,
+    Object? inboundLiquidityMsats = null,
+  }) {
+    return _then(_$NodeStateImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      blockHeight: null == blockHeight
+          ? _value.blockHeight
+          : blockHeight // ignore: cast_nullable_to_non_nullable
+              as int,
+      channelsBalanceMsat: null == channelsBalanceMsat
+          ? _value.channelsBalanceMsat
+          : channelsBalanceMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      onchainBalanceMsat: null == onchainBalanceMsat
+          ? _value.onchainBalanceMsat
+          : onchainBalanceMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      pendingOnchainBalanceMsat: null == pendingOnchainBalanceMsat
+          ? _value.pendingOnchainBalanceMsat
+          : pendingOnchainBalanceMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      utxos: null == utxos
+          ? _value._utxos
+          : utxos // ignore: cast_nullable_to_non_nullable
+              as List<UnspentTransactionOutput>,
+      maxPayableMsat: null == maxPayableMsat
+          ? _value.maxPayableMsat
+          : maxPayableMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxReceivableMsat: null == maxReceivableMsat
+          ? _value.maxReceivableMsat
+          : maxReceivableMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxSinglePaymentAmountMsat: null == maxSinglePaymentAmountMsat
+          ? _value.maxSinglePaymentAmountMsat
+          : maxSinglePaymentAmountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxChanReserveMsats: null == maxChanReserveMsats
+          ? _value.maxChanReserveMsats
+          : maxChanReserveMsats // ignore: cast_nullable_to_non_nullable
+              as int,
+      connectedPeers: null == connectedPeers
+          ? _value._connectedPeers
+          : connectedPeers // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      inboundLiquidityMsats: null == inboundLiquidityMsats
+          ? _value.inboundLiquidityMsats
+          : inboundLiquidityMsats // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$NodeStateImpl implements _NodeState {
+  const _$NodeStateImpl(
+      {required this.id,
+      required this.blockHeight,
+      required this.channelsBalanceMsat,
+      required this.onchainBalanceMsat,
+      required this.pendingOnchainBalanceMsat,
+      required final List<UnspentTransactionOutput> utxos,
+      required this.maxPayableMsat,
+      required this.maxReceivableMsat,
+      required this.maxSinglePaymentAmountMsat,
+      required this.maxChanReserveMsats,
+      required final List<String> connectedPeers,
+      required this.inboundLiquidityMsats})
+      : _utxos = utxos,
+        _connectedPeers = connectedPeers;
+
+  @override
+  final String id;
+  @override
+  final int blockHeight;
+  @override
+  final int channelsBalanceMsat;
+  @override
+  final int onchainBalanceMsat;
+  @override
+  final int pendingOnchainBalanceMsat;
+  final List<UnspentTransactionOutput> _utxos;
+  @override
+  List<UnspentTransactionOutput> get utxos {
+    if (_utxos is EqualUnmodifiableListView) return _utxos;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_utxos);
+  }
+
+  @override
+  final int maxPayableMsat;
+  @override
+  final int maxReceivableMsat;
+  @override
+  final int maxSinglePaymentAmountMsat;
+  @override
+  final int maxChanReserveMsats;
+  final List<String> _connectedPeers;
+  @override
+  List<String> get connectedPeers {
+    if (_connectedPeers is EqualUnmodifiableListView) return _connectedPeers;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_connectedPeers);
+  }
+
+  @override
+  final int inboundLiquidityMsats;
+
+  @override
+  String toString() {
+    return 'NodeState(id: $id, blockHeight: $blockHeight, channelsBalanceMsat: $channelsBalanceMsat, onchainBalanceMsat: $onchainBalanceMsat, pendingOnchainBalanceMsat: $pendingOnchainBalanceMsat, utxos: $utxos, maxPayableMsat: $maxPayableMsat, maxReceivableMsat: $maxReceivableMsat, maxSinglePaymentAmountMsat: $maxSinglePaymentAmountMsat, maxChanReserveMsats: $maxChanReserveMsats, connectedPeers: $connectedPeers, inboundLiquidityMsats: $inboundLiquidityMsats)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NodeStateImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.blockHeight, blockHeight) || other.blockHeight == blockHeight) &&
+            (identical(other.channelsBalanceMsat, channelsBalanceMsat) ||
+                other.channelsBalanceMsat == channelsBalanceMsat) &&
+            (identical(other.onchainBalanceMsat, onchainBalanceMsat) ||
+                other.onchainBalanceMsat == onchainBalanceMsat) &&
+            (identical(other.pendingOnchainBalanceMsat, pendingOnchainBalanceMsat) ||
+                other.pendingOnchainBalanceMsat == pendingOnchainBalanceMsat) &&
+            const DeepCollectionEquality().equals(other._utxos, _utxos) &&
+            (identical(other.maxPayableMsat, maxPayableMsat) || other.maxPayableMsat == maxPayableMsat) &&
+            (identical(other.maxReceivableMsat, maxReceivableMsat) ||
+                other.maxReceivableMsat == maxReceivableMsat) &&
+            (identical(other.maxSinglePaymentAmountMsat, maxSinglePaymentAmountMsat) ||
+                other.maxSinglePaymentAmountMsat == maxSinglePaymentAmountMsat) &&
+            (identical(other.maxChanReserveMsats, maxChanReserveMsats) ||
+                other.maxChanReserveMsats == maxChanReserveMsats) &&
+            const DeepCollectionEquality().equals(other._connectedPeers, _connectedPeers) &&
+            (identical(other.inboundLiquidityMsats, inboundLiquidityMsats) ||
+                other.inboundLiquidityMsats == inboundLiquidityMsats));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      blockHeight,
+      channelsBalanceMsat,
+      onchainBalanceMsat,
+      pendingOnchainBalanceMsat,
+      const DeepCollectionEquality().hash(_utxos),
+      maxPayableMsat,
+      maxReceivableMsat,
+      maxSinglePaymentAmountMsat,
+      maxChanReserveMsats,
+      const DeepCollectionEquality().hash(_connectedPeers),
+      inboundLiquidityMsats);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NodeStateImplCopyWith<_$NodeStateImpl> get copyWith =>
+      __$$NodeStateImplCopyWithImpl<_$NodeStateImpl>(this, _$identity);
+}
+
+abstract class _NodeState implements NodeState {
+  const factory _NodeState(
+      {required final String id,
+      required final int blockHeight,
+      required final int channelsBalanceMsat,
+      required final int onchainBalanceMsat,
+      required final int pendingOnchainBalanceMsat,
+      required final List<UnspentTransactionOutput> utxos,
+      required final int maxPayableMsat,
+      required final int maxReceivableMsat,
+      required final int maxSinglePaymentAmountMsat,
+      required final int maxChanReserveMsats,
+      required final List<String> connectedPeers,
+      required final int inboundLiquidityMsats}) = _$NodeStateImpl;
+
+  @override
+  String get id;
+  @override
+  int get blockHeight;
+  @override
+  int get channelsBalanceMsat;
+  @override
+  int get onchainBalanceMsat;
+  @override
+  int get pendingOnchainBalanceMsat;
+  @override
+  List<UnspentTransactionOutput> get utxos;
+  @override
+  int get maxPayableMsat;
+  @override
+  int get maxReceivableMsat;
+  @override
+  int get maxSinglePaymentAmountMsat;
+  @override
+  int get maxChanReserveMsats;
+  @override
+  List<String> get connectedPeers;
+  @override
+  int get inboundLiquidityMsats;
+  @override
+  @JsonKey(ignore: true)
+  _$$NodeStateImplCopyWith<_$NodeStateImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$OpeningFeeParams {
+  int get minMsat => throw _privateConstructorUsedError;
+  int get proportional => throw _privateConstructorUsedError;
+  String get validUntil => throw _privateConstructorUsedError;
+  int get maxIdleTime => throw _privateConstructorUsedError;
+  int get maxClientToSelfDelay => throw _privateConstructorUsedError;
+  String get promise => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $OpeningFeeParamsCopyWith<OpeningFeeParams> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $OpeningFeeParamsCopyWith<$Res> {
+  factory $OpeningFeeParamsCopyWith(OpeningFeeParams value, $Res Function(OpeningFeeParams) then) =
+      _$OpeningFeeParamsCopyWithImpl<$Res, OpeningFeeParams>;
+  @useResult
+  $Res call(
+      {int minMsat,
+      int proportional,
+      String validUntil,
+      int maxIdleTime,
+      int maxClientToSelfDelay,
+      String promise});
+}
+
+/// @nodoc
+class _$OpeningFeeParamsCopyWithImpl<$Res, $Val extends OpeningFeeParams>
+    implements $OpeningFeeParamsCopyWith<$Res> {
+  _$OpeningFeeParamsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? minMsat = null,
+    Object? proportional = null,
+    Object? validUntil = null,
+    Object? maxIdleTime = null,
+    Object? maxClientToSelfDelay = null,
+    Object? promise = null,
+  }) {
+    return _then(_value.copyWith(
+      minMsat: null == minMsat
+          ? _value.minMsat
+          : minMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      proportional: null == proportional
+          ? _value.proportional
+          : proportional // ignore: cast_nullable_to_non_nullable
+              as int,
+      validUntil: null == validUntil
+          ? _value.validUntil
+          : validUntil // ignore: cast_nullable_to_non_nullable
+              as String,
+      maxIdleTime: null == maxIdleTime
+          ? _value.maxIdleTime
+          : maxIdleTime // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxClientToSelfDelay: null == maxClientToSelfDelay
+          ? _value.maxClientToSelfDelay
+          : maxClientToSelfDelay // ignore: cast_nullable_to_non_nullable
+              as int,
+      promise: null == promise
+          ? _value.promise
+          : promise // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$OpeningFeeParamsImplCopyWith<$Res> implements $OpeningFeeParamsCopyWith<$Res> {
+  factory _$$OpeningFeeParamsImplCopyWith(
+          _$OpeningFeeParamsImpl value, $Res Function(_$OpeningFeeParamsImpl) then) =
+      __$$OpeningFeeParamsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int minMsat,
+      int proportional,
+      String validUntil,
+      int maxIdleTime,
+      int maxClientToSelfDelay,
+      String promise});
+}
+
+/// @nodoc
+class __$$OpeningFeeParamsImplCopyWithImpl<$Res>
+    extends _$OpeningFeeParamsCopyWithImpl<$Res, _$OpeningFeeParamsImpl>
+    implements _$$OpeningFeeParamsImplCopyWith<$Res> {
+  __$$OpeningFeeParamsImplCopyWithImpl(
+      _$OpeningFeeParamsImpl _value, $Res Function(_$OpeningFeeParamsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? minMsat = null,
+    Object? proportional = null,
+    Object? validUntil = null,
+    Object? maxIdleTime = null,
+    Object? maxClientToSelfDelay = null,
+    Object? promise = null,
+  }) {
+    return _then(_$OpeningFeeParamsImpl(
+      minMsat: null == minMsat
+          ? _value.minMsat
+          : minMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      proportional: null == proportional
+          ? _value.proportional
+          : proportional // ignore: cast_nullable_to_non_nullable
+              as int,
+      validUntil: null == validUntil
+          ? _value.validUntil
+          : validUntil // ignore: cast_nullable_to_non_nullable
+              as String,
+      maxIdleTime: null == maxIdleTime
+          ? _value.maxIdleTime
+          : maxIdleTime // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxClientToSelfDelay: null == maxClientToSelfDelay
+          ? _value.maxClientToSelfDelay
+          : maxClientToSelfDelay // ignore: cast_nullable_to_non_nullable
+              as int,
+      promise: null == promise
+          ? _value.promise
+          : promise // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$OpeningFeeParamsImpl implements _OpeningFeeParams {
+  const _$OpeningFeeParamsImpl(
+      {required this.minMsat,
+      required this.proportional,
+      required this.validUntil,
+      required this.maxIdleTime,
+      required this.maxClientToSelfDelay,
+      required this.promise});
+
+  @override
+  final int minMsat;
+  @override
+  final int proportional;
+  @override
+  final String validUntil;
+  @override
+  final int maxIdleTime;
+  @override
+  final int maxClientToSelfDelay;
+  @override
+  final String promise;
+
+  @override
+  String toString() {
+    return 'OpeningFeeParams(minMsat: $minMsat, proportional: $proportional, validUntil: $validUntil, maxIdleTime: $maxIdleTime, maxClientToSelfDelay: $maxClientToSelfDelay, promise: $promise)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OpeningFeeParamsImpl &&
+            (identical(other.minMsat, minMsat) || other.minMsat == minMsat) &&
+            (identical(other.proportional, proportional) || other.proportional == proportional) &&
+            (identical(other.validUntil, validUntil) || other.validUntil == validUntil) &&
+            (identical(other.maxIdleTime, maxIdleTime) || other.maxIdleTime == maxIdleTime) &&
+            (identical(other.maxClientToSelfDelay, maxClientToSelfDelay) ||
+                other.maxClientToSelfDelay == maxClientToSelfDelay) &&
+            (identical(other.promise, promise) || other.promise == promise));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, minMsat, proportional, validUntil, maxIdleTime, maxClientToSelfDelay, promise);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OpeningFeeParamsImplCopyWith<_$OpeningFeeParamsImpl> get copyWith =>
+      __$$OpeningFeeParamsImplCopyWithImpl<_$OpeningFeeParamsImpl>(this, _$identity);
+}
+
+abstract class _OpeningFeeParams implements OpeningFeeParams {
+  const factory _OpeningFeeParams(
+      {required final int minMsat,
+      required final int proportional,
+      required final String validUntil,
+      required final int maxIdleTime,
+      required final int maxClientToSelfDelay,
+      required final String promise}) = _$OpeningFeeParamsImpl;
+
+  @override
+  int get minMsat;
+  @override
+  int get proportional;
+  @override
+  String get validUntil;
+  @override
+  int get maxIdleTime;
+  @override
+  int get maxClientToSelfDelay;
+  @override
+  String get promise;
+  @override
+  @JsonKey(ignore: true)
+  _$$OpeningFeeParamsImplCopyWith<_$OpeningFeeParamsImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$OpeningFeeParamsMenu {
+  List<OpeningFeeParams> get values => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $OpeningFeeParamsMenuCopyWith<OpeningFeeParamsMenu> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $OpeningFeeParamsMenuCopyWith<$Res> {
+  factory $OpeningFeeParamsMenuCopyWith(
+          OpeningFeeParamsMenu value, $Res Function(OpeningFeeParamsMenu) then) =
+      _$OpeningFeeParamsMenuCopyWithImpl<$Res, OpeningFeeParamsMenu>;
+  @useResult
+  $Res call({List<OpeningFeeParams> values});
+}
+
+/// @nodoc
+class _$OpeningFeeParamsMenuCopyWithImpl<$Res, $Val extends OpeningFeeParamsMenu>
+    implements $OpeningFeeParamsMenuCopyWith<$Res> {
+  _$OpeningFeeParamsMenuCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? values = null,
+  }) {
+    return _then(_value.copyWith(
+      values: null == values
+          ? _value.values
+          : values // ignore: cast_nullable_to_non_nullable
+              as List<OpeningFeeParams>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$OpeningFeeParamsMenuImplCopyWith<$Res> implements $OpeningFeeParamsMenuCopyWith<$Res> {
+  factory _$$OpeningFeeParamsMenuImplCopyWith(
+          _$OpeningFeeParamsMenuImpl value, $Res Function(_$OpeningFeeParamsMenuImpl) then) =
+      __$$OpeningFeeParamsMenuImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<OpeningFeeParams> values});
+}
+
+/// @nodoc
+class __$$OpeningFeeParamsMenuImplCopyWithImpl<$Res>
+    extends _$OpeningFeeParamsMenuCopyWithImpl<$Res, _$OpeningFeeParamsMenuImpl>
+    implements _$$OpeningFeeParamsMenuImplCopyWith<$Res> {
+  __$$OpeningFeeParamsMenuImplCopyWithImpl(
+      _$OpeningFeeParamsMenuImpl _value, $Res Function(_$OpeningFeeParamsMenuImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? values = null,
+  }) {
+    return _then(_$OpeningFeeParamsMenuImpl(
+      values: null == values
+          ? _value._values
+          : values // ignore: cast_nullable_to_non_nullable
+              as List<OpeningFeeParams>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$OpeningFeeParamsMenuImpl implements _OpeningFeeParamsMenu {
+  const _$OpeningFeeParamsMenuImpl({required final List<OpeningFeeParams> values}) : _values = values;
+
+  final List<OpeningFeeParams> _values;
+  @override
+  List<OpeningFeeParams> get values {
+    if (_values is EqualUnmodifiableListView) return _values;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_values);
+  }
+
+  @override
+  String toString() {
+    return 'OpeningFeeParamsMenu(values: $values)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OpeningFeeParamsMenuImpl &&
+            const DeepCollectionEquality().equals(other._values, _values));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(_values));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OpeningFeeParamsMenuImplCopyWith<_$OpeningFeeParamsMenuImpl> get copyWith =>
+      __$$OpeningFeeParamsMenuImplCopyWithImpl<_$OpeningFeeParamsMenuImpl>(this, _$identity);
+}
+
+abstract class _OpeningFeeParamsMenu implements OpeningFeeParamsMenu {
+  const factory _OpeningFeeParamsMenu({required final List<OpeningFeeParams> values}) =
+      _$OpeningFeeParamsMenuImpl;
+
+  @override
+  List<OpeningFeeParams> get values;
+  @override
+  @JsonKey(ignore: true)
+  _$$OpeningFeeParamsMenuImplCopyWith<_$OpeningFeeParamsMenuImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$Payment {
+  String get id => throw _privateConstructorUsedError;
+  PaymentType get paymentType => throw _privateConstructorUsedError;
+  int get paymentTime => throw _privateConstructorUsedError;
+  int get amountMsat => throw _privateConstructorUsedError;
+  int get feeMsat => throw _privateConstructorUsedError;
+  PaymentStatus get status => throw _privateConstructorUsedError;
+  String? get error => throw _privateConstructorUsedError;
+  String? get description => throw _privateConstructorUsedError;
+  PaymentDetails get details => throw _privateConstructorUsedError;
+  String? get metadata => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $PaymentCopyWith<Payment> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PaymentCopyWith<$Res> {
+  factory $PaymentCopyWith(Payment value, $Res Function(Payment) then) = _$PaymentCopyWithImpl<$Res, Payment>;
+  @useResult
+  $Res call(
+      {String id,
+      PaymentType paymentType,
+      int paymentTime,
+      int amountMsat,
+      int feeMsat,
+      PaymentStatus status,
+      String? error,
+      String? description,
+      PaymentDetails details,
+      String? metadata});
+
+  $PaymentDetailsCopyWith<$Res> get details;
+}
+
+/// @nodoc
+class _$PaymentCopyWithImpl<$Res, $Val extends Payment> implements $PaymentCopyWith<$Res> {
+  _$PaymentCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? paymentType = null,
+    Object? paymentTime = null,
+    Object? amountMsat = null,
+    Object? feeMsat = null,
+    Object? status = null,
+    Object? error = freezed,
+    Object? description = freezed,
+    Object? details = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      paymentType: null == paymentType
+          ? _value.paymentType
+          : paymentType // ignore: cast_nullable_to_non_nullable
+              as PaymentType,
+      paymentTime: null == paymentTime
+          ? _value.paymentTime
+          : paymentTime // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      feeMsat: null == feeMsat
+          ? _value.feeMsat
+          : feeMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as PaymentStatus,
+      error: freezed == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as PaymentDetails,
+      metadata: freezed == metadata
+          ? _value.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PaymentDetailsCopyWith<$Res> get details {
+    return $PaymentDetailsCopyWith<$Res>(_value.details, (value) {
+      return _then(_value.copyWith(details: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$PaymentImplCopyWith<$Res> implements $PaymentCopyWith<$Res> {
+  factory _$$PaymentImplCopyWith(_$PaymentImpl value, $Res Function(_$PaymentImpl) then) =
+      __$$PaymentImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      PaymentType paymentType,
+      int paymentTime,
+      int amountMsat,
+      int feeMsat,
+      PaymentStatus status,
+      String? error,
+      String? description,
+      PaymentDetails details,
+      String? metadata});
+
+  @override
+  $PaymentDetailsCopyWith<$Res> get details;
+}
+
+/// @nodoc
+class __$$PaymentImplCopyWithImpl<$Res> extends _$PaymentCopyWithImpl<$Res, _$PaymentImpl>
+    implements _$$PaymentImplCopyWith<$Res> {
+  __$$PaymentImplCopyWithImpl(_$PaymentImpl _value, $Res Function(_$PaymentImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? paymentType = null,
+    Object? paymentTime = null,
+    Object? amountMsat = null,
+    Object? feeMsat = null,
+    Object? status = null,
+    Object? error = freezed,
+    Object? description = freezed,
+    Object? details = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_$PaymentImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      paymentType: null == paymentType
+          ? _value.paymentType
+          : paymentType // ignore: cast_nullable_to_non_nullable
+              as PaymentType,
+      paymentTime: null == paymentTime
+          ? _value.paymentTime
+          : paymentTime // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      feeMsat: null == feeMsat
+          ? _value.feeMsat
+          : feeMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as PaymentStatus,
+      error: freezed == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as PaymentDetails,
+      metadata: freezed == metadata
+          ? _value.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PaymentImpl implements _Payment {
+  const _$PaymentImpl(
+      {required this.id,
+      required this.paymentType,
+      required this.paymentTime,
+      required this.amountMsat,
+      required this.feeMsat,
+      required this.status,
+      this.error,
+      this.description,
+      required this.details,
+      this.metadata});
+
+  @override
+  final String id;
+  @override
+  final PaymentType paymentType;
+  @override
+  final int paymentTime;
+  @override
+  final int amountMsat;
+  @override
+  final int feeMsat;
+  @override
+  final PaymentStatus status;
+  @override
+  final String? error;
+  @override
+  final String? description;
+  @override
+  final PaymentDetails details;
+  @override
+  final String? metadata;
+
+  @override
+  String toString() {
+    return 'Payment(id: $id, paymentType: $paymentType, paymentTime: $paymentTime, amountMsat: $amountMsat, feeMsat: $feeMsat, status: $status, error: $error, description: $description, details: $details, metadata: $metadata)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PaymentImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.paymentType, paymentType) || other.paymentType == paymentType) &&
+            (identical(other.paymentTime, paymentTime) || other.paymentTime == paymentTime) &&
+            (identical(other.amountMsat, amountMsat) || other.amountMsat == amountMsat) &&
+            (identical(other.feeMsat, feeMsat) || other.feeMsat == feeMsat) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.error, error) || other.error == error) &&
+            (identical(other.description, description) || other.description == description) &&
+            (identical(other.details, details) || other.details == details) &&
+            (identical(other.metadata, metadata) || other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, paymentType, paymentTime, amountMsat, feeMsat, status,
+      error, description, details, metadata);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PaymentImplCopyWith<_$PaymentImpl> get copyWith =>
+      __$$PaymentImplCopyWithImpl<_$PaymentImpl>(this, _$identity);
+}
+
+abstract class _Payment implements Payment {
+  const factory _Payment(
+      {required final String id,
+      required final PaymentType paymentType,
+      required final int paymentTime,
+      required final int amountMsat,
+      required final int feeMsat,
+      required final PaymentStatus status,
+      final String? error,
+      final String? description,
+      required final PaymentDetails details,
+      final String? metadata}) = _$PaymentImpl;
+
+  @override
+  String get id;
+  @override
+  PaymentType get paymentType;
+  @override
+  int get paymentTime;
+  @override
+  int get amountMsat;
+  @override
+  int get feeMsat;
+  @override
+  PaymentStatus get status;
+  @override
+  String? get error;
+  @override
+  String? get description;
+  @override
+  PaymentDetails get details;
+  @override
+  String? get metadata;
+  @override
+  @JsonKey(ignore: true)
+  _$$PaymentImplCopyWith<_$PaymentImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$PaymentDetails {
   Object get data => throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -4960,6 +10377,8 @@ abstract class _$$PaymentDetails_LnImplCopyWith<$Res> {
       __$$PaymentDetails_LnImplCopyWithImpl<$Res>;
   @useResult
   $Res call({LnPaymentDetails data});
+
+  $LnPaymentDetailsCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -4981,6 +10400,14 @@ class __$$PaymentDetails_LnImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as LnPaymentDetails,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LnPaymentDetailsCopyWith<$Res> get data {
+    return $LnPaymentDetailsCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -5094,6 +10521,8 @@ abstract class _$$PaymentDetails_ClosedChannelImplCopyWith<$Res> {
       __$$PaymentDetails_ClosedChannelImplCopyWithImpl<$Res>;
   @useResult
   $Res call({ClosedChannelPaymentDetails data});
+
+  $ClosedChannelPaymentDetailsCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -5115,6 +10544,14 @@ class __$$PaymentDetails_ClosedChannelImplCopyWithImpl<$Res>
           : data // ignore: cast_nullable_to_non_nullable
               as ClosedChannelPaymentDetails,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ClosedChannelPaymentDetailsCopyWith<$Res> get data {
+    return $ClosedChannelPaymentDetailsCopyWith<$Res>(_value.data, (value) {
+      return _then(_value.copyWith(data: value));
+    });
   }
 }
 
@@ -5219,6 +10656,578 @@ abstract class PaymentDetails_ClosedChannel implements PaymentDetails {
   ClosedChannelPaymentDetails get data;
   @JsonKey(ignore: true)
   _$$PaymentDetails_ClosedChannelImplCopyWith<_$PaymentDetails_ClosedChannelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ReceiveOnchainRequest {
+  OpeningFeeParams? get openingFeeParams => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReceiveOnchainRequestCopyWith<ReceiveOnchainRequest> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReceiveOnchainRequestCopyWith<$Res> {
+  factory $ReceiveOnchainRequestCopyWith(
+          ReceiveOnchainRequest value, $Res Function(ReceiveOnchainRequest) then) =
+      _$ReceiveOnchainRequestCopyWithImpl<$Res, ReceiveOnchainRequest>;
+  @useResult
+  $Res call({OpeningFeeParams? openingFeeParams});
+
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class _$ReceiveOnchainRequestCopyWithImpl<$Res, $Val extends ReceiveOnchainRequest>
+    implements $ReceiveOnchainRequestCopyWith<$Res> {
+  _$ReceiveOnchainRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? openingFeeParams = freezed,
+  }) {
+    return _then(_value.copyWith(
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams {
+    if (_value.openingFeeParams == null) {
+      return null;
+    }
+
+    return $OpeningFeeParamsCopyWith<$Res>(_value.openingFeeParams!, (value) {
+      return _then(_value.copyWith(openingFeeParams: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ReceiveOnchainRequestImplCopyWith<$Res> implements $ReceiveOnchainRequestCopyWith<$Res> {
+  factory _$$ReceiveOnchainRequestImplCopyWith(
+          _$ReceiveOnchainRequestImpl value, $Res Function(_$ReceiveOnchainRequestImpl) then) =
+      __$$ReceiveOnchainRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({OpeningFeeParams? openingFeeParams});
+
+  @override
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class __$$ReceiveOnchainRequestImplCopyWithImpl<$Res>
+    extends _$ReceiveOnchainRequestCopyWithImpl<$Res, _$ReceiveOnchainRequestImpl>
+    implements _$$ReceiveOnchainRequestImplCopyWith<$Res> {
+  __$$ReceiveOnchainRequestImplCopyWithImpl(
+      _$ReceiveOnchainRequestImpl _value, $Res Function(_$ReceiveOnchainRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? openingFeeParams = freezed,
+  }) {
+    return _then(_$ReceiveOnchainRequestImpl(
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReceiveOnchainRequestImpl implements _ReceiveOnchainRequest {
+  const _$ReceiveOnchainRequestImpl({this.openingFeeParams});
+
+  @override
+  final OpeningFeeParams? openingFeeParams;
+
+  @override
+  String toString() {
+    return 'ReceiveOnchainRequest(openingFeeParams: $openingFeeParams)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReceiveOnchainRequestImpl &&
+            (identical(other.openingFeeParams, openingFeeParams) ||
+                other.openingFeeParams == openingFeeParams));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, openingFeeParams);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReceiveOnchainRequestImplCopyWith<_$ReceiveOnchainRequestImpl> get copyWith =>
+      __$$ReceiveOnchainRequestImplCopyWithImpl<_$ReceiveOnchainRequestImpl>(this, _$identity);
+}
+
+abstract class _ReceiveOnchainRequest implements ReceiveOnchainRequest {
+  const factory _ReceiveOnchainRequest({final OpeningFeeParams? openingFeeParams}) =
+      _$ReceiveOnchainRequestImpl;
+
+  @override
+  OpeningFeeParams? get openingFeeParams;
+  @override
+  @JsonKey(ignore: true)
+  _$$ReceiveOnchainRequestImplCopyWith<_$ReceiveOnchainRequestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ReceivePaymentRequest {
+  int get amountMsat => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  Uint8List? get preimage => throw _privateConstructorUsedError;
+  OpeningFeeParams? get openingFeeParams => throw _privateConstructorUsedError;
+  bool? get useDescriptionHash => throw _privateConstructorUsedError;
+  int? get expiry => throw _privateConstructorUsedError;
+  int? get cltv => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReceivePaymentRequestCopyWith<ReceivePaymentRequest> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReceivePaymentRequestCopyWith<$Res> {
+  factory $ReceivePaymentRequestCopyWith(
+          ReceivePaymentRequest value, $Res Function(ReceivePaymentRequest) then) =
+      _$ReceivePaymentRequestCopyWithImpl<$Res, ReceivePaymentRequest>;
+  @useResult
+  $Res call(
+      {int amountMsat,
+      String description,
+      Uint8List? preimage,
+      OpeningFeeParams? openingFeeParams,
+      bool? useDescriptionHash,
+      int? expiry,
+      int? cltv});
+
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class _$ReceivePaymentRequestCopyWithImpl<$Res, $Val extends ReceivePaymentRequest>
+    implements $ReceivePaymentRequestCopyWith<$Res> {
+  _$ReceivePaymentRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? amountMsat = null,
+    Object? description = null,
+    Object? preimage = freezed,
+    Object? openingFeeParams = freezed,
+    Object? useDescriptionHash = freezed,
+    Object? expiry = freezed,
+    Object? cltv = freezed,
+  }) {
+    return _then(_value.copyWith(
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      preimage: freezed == preimage
+          ? _value.preimage
+          : preimage // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+      useDescriptionHash: freezed == useDescriptionHash
+          ? _value.useDescriptionHash
+          : useDescriptionHash // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      expiry: freezed == expiry
+          ? _value.expiry
+          : expiry // ignore: cast_nullable_to_non_nullable
+              as int?,
+      cltv: freezed == cltv
+          ? _value.cltv
+          : cltv // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams {
+    if (_value.openingFeeParams == null) {
+      return null;
+    }
+
+    return $OpeningFeeParamsCopyWith<$Res>(_value.openingFeeParams!, (value) {
+      return _then(_value.copyWith(openingFeeParams: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ReceivePaymentRequestImplCopyWith<$Res> implements $ReceivePaymentRequestCopyWith<$Res> {
+  factory _$$ReceivePaymentRequestImplCopyWith(
+          _$ReceivePaymentRequestImpl value, $Res Function(_$ReceivePaymentRequestImpl) then) =
+      __$$ReceivePaymentRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int amountMsat,
+      String description,
+      Uint8List? preimage,
+      OpeningFeeParams? openingFeeParams,
+      bool? useDescriptionHash,
+      int? expiry,
+      int? cltv});
+
+  @override
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class __$$ReceivePaymentRequestImplCopyWithImpl<$Res>
+    extends _$ReceivePaymentRequestCopyWithImpl<$Res, _$ReceivePaymentRequestImpl>
+    implements _$$ReceivePaymentRequestImplCopyWith<$Res> {
+  __$$ReceivePaymentRequestImplCopyWithImpl(
+      _$ReceivePaymentRequestImpl _value, $Res Function(_$ReceivePaymentRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? amountMsat = null,
+    Object? description = null,
+    Object? preimage = freezed,
+    Object? openingFeeParams = freezed,
+    Object? useDescriptionHash = freezed,
+    Object? expiry = freezed,
+    Object? cltv = freezed,
+  }) {
+    return _then(_$ReceivePaymentRequestImpl(
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      preimage: freezed == preimage
+          ? _value.preimage
+          : preimage // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+      useDescriptionHash: freezed == useDescriptionHash
+          ? _value.useDescriptionHash
+          : useDescriptionHash // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      expiry: freezed == expiry
+          ? _value.expiry
+          : expiry // ignore: cast_nullable_to_non_nullable
+              as int?,
+      cltv: freezed == cltv
+          ? _value.cltv
+          : cltv // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReceivePaymentRequestImpl implements _ReceivePaymentRequest {
+  const _$ReceivePaymentRequestImpl(
+      {required this.amountMsat,
+      required this.description,
+      this.preimage,
+      this.openingFeeParams,
+      this.useDescriptionHash,
+      this.expiry,
+      this.cltv});
+
+  @override
+  final int amountMsat;
+  @override
+  final String description;
+  @override
+  final Uint8List? preimage;
+  @override
+  final OpeningFeeParams? openingFeeParams;
+  @override
+  final bool? useDescriptionHash;
+  @override
+  final int? expiry;
+  @override
+  final int? cltv;
+
+  @override
+  String toString() {
+    return 'ReceivePaymentRequest(amountMsat: $amountMsat, description: $description, preimage: $preimage, openingFeeParams: $openingFeeParams, useDescriptionHash: $useDescriptionHash, expiry: $expiry, cltv: $cltv)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReceivePaymentRequestImpl &&
+            (identical(other.amountMsat, amountMsat) || other.amountMsat == amountMsat) &&
+            (identical(other.description, description) || other.description == description) &&
+            const DeepCollectionEquality().equals(other.preimage, preimage) &&
+            (identical(other.openingFeeParams, openingFeeParams) ||
+                other.openingFeeParams == openingFeeParams) &&
+            (identical(other.useDescriptionHash, useDescriptionHash) ||
+                other.useDescriptionHash == useDescriptionHash) &&
+            (identical(other.expiry, expiry) || other.expiry == expiry) &&
+            (identical(other.cltv, cltv) || other.cltv == cltv));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, amountMsat, description,
+      const DeepCollectionEquality().hash(preimage), openingFeeParams, useDescriptionHash, expiry, cltv);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReceivePaymentRequestImplCopyWith<_$ReceivePaymentRequestImpl> get copyWith =>
+      __$$ReceivePaymentRequestImplCopyWithImpl<_$ReceivePaymentRequestImpl>(this, _$identity);
+}
+
+abstract class _ReceivePaymentRequest implements ReceivePaymentRequest {
+  const factory _ReceivePaymentRequest(
+      {required final int amountMsat,
+      required final String description,
+      final Uint8List? preimage,
+      final OpeningFeeParams? openingFeeParams,
+      final bool? useDescriptionHash,
+      final int? expiry,
+      final int? cltv}) = _$ReceivePaymentRequestImpl;
+
+  @override
+  int get amountMsat;
+  @override
+  String get description;
+  @override
+  Uint8List? get preimage;
+  @override
+  OpeningFeeParams? get openingFeeParams;
+  @override
+  bool? get useDescriptionHash;
+  @override
+  int? get expiry;
+  @override
+  int? get cltv;
+  @override
+  @JsonKey(ignore: true)
+  _$$ReceivePaymentRequestImplCopyWith<_$ReceivePaymentRequestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ReceivePaymentResponse {
+  LNInvoice get lnInvoice => throw _privateConstructorUsedError;
+  OpeningFeeParams? get openingFeeParams => throw _privateConstructorUsedError;
+  int? get openingFeeMsat => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReceivePaymentResponseCopyWith<ReceivePaymentResponse> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReceivePaymentResponseCopyWith<$Res> {
+  factory $ReceivePaymentResponseCopyWith(
+          ReceivePaymentResponse value, $Res Function(ReceivePaymentResponse) then) =
+      _$ReceivePaymentResponseCopyWithImpl<$Res, ReceivePaymentResponse>;
+  @useResult
+  $Res call({LNInvoice lnInvoice, OpeningFeeParams? openingFeeParams, int? openingFeeMsat});
+
+  $LNInvoiceCopyWith<$Res> get lnInvoice;
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class _$ReceivePaymentResponseCopyWithImpl<$Res, $Val extends ReceivePaymentResponse>
+    implements $ReceivePaymentResponseCopyWith<$Res> {
+  _$ReceivePaymentResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? lnInvoice = null,
+    Object? openingFeeParams = freezed,
+    Object? openingFeeMsat = freezed,
+  }) {
+    return _then(_value.copyWith(
+      lnInvoice: null == lnInvoice
+          ? _value.lnInvoice
+          : lnInvoice // ignore: cast_nullable_to_non_nullable
+              as LNInvoice,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+      openingFeeMsat: freezed == openingFeeMsat
+          ? _value.openingFeeMsat
+          : openingFeeMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LNInvoiceCopyWith<$Res> get lnInvoice {
+    return $LNInvoiceCopyWith<$Res>(_value.lnInvoice, (value) {
+      return _then(_value.copyWith(lnInvoice: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams {
+    if (_value.openingFeeParams == null) {
+      return null;
+    }
+
+    return $OpeningFeeParamsCopyWith<$Res>(_value.openingFeeParams!, (value) {
+      return _then(_value.copyWith(openingFeeParams: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ReceivePaymentResponseImplCopyWith<$Res> implements $ReceivePaymentResponseCopyWith<$Res> {
+  factory _$$ReceivePaymentResponseImplCopyWith(
+          _$ReceivePaymentResponseImpl value, $Res Function(_$ReceivePaymentResponseImpl) then) =
+      __$$ReceivePaymentResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({LNInvoice lnInvoice, OpeningFeeParams? openingFeeParams, int? openingFeeMsat});
+
+  @override
+  $LNInvoiceCopyWith<$Res> get lnInvoice;
+  @override
+  $OpeningFeeParamsCopyWith<$Res>? get openingFeeParams;
+}
+
+/// @nodoc
+class __$$ReceivePaymentResponseImplCopyWithImpl<$Res>
+    extends _$ReceivePaymentResponseCopyWithImpl<$Res, _$ReceivePaymentResponseImpl>
+    implements _$$ReceivePaymentResponseImplCopyWith<$Res> {
+  __$$ReceivePaymentResponseImplCopyWithImpl(
+      _$ReceivePaymentResponseImpl _value, $Res Function(_$ReceivePaymentResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? lnInvoice = null,
+    Object? openingFeeParams = freezed,
+    Object? openingFeeMsat = freezed,
+  }) {
+    return _then(_$ReceivePaymentResponseImpl(
+      lnInvoice: null == lnInvoice
+          ? _value.lnInvoice
+          : lnInvoice // ignore: cast_nullable_to_non_nullable
+              as LNInvoice,
+      openingFeeParams: freezed == openingFeeParams
+          ? _value.openingFeeParams
+          : openingFeeParams // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+      openingFeeMsat: freezed == openingFeeMsat
+          ? _value.openingFeeMsat
+          : openingFeeMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReceivePaymentResponseImpl implements _ReceivePaymentResponse {
+  const _$ReceivePaymentResponseImpl({required this.lnInvoice, this.openingFeeParams, this.openingFeeMsat});
+
+  @override
+  final LNInvoice lnInvoice;
+  @override
+  final OpeningFeeParams? openingFeeParams;
+  @override
+  final int? openingFeeMsat;
+
+  @override
+  String toString() {
+    return 'ReceivePaymentResponse(lnInvoice: $lnInvoice, openingFeeParams: $openingFeeParams, openingFeeMsat: $openingFeeMsat)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReceivePaymentResponseImpl &&
+            (identical(other.lnInvoice, lnInvoice) || other.lnInvoice == lnInvoice) &&
+            (identical(other.openingFeeParams, openingFeeParams) ||
+                other.openingFeeParams == openingFeeParams) &&
+            (identical(other.openingFeeMsat, openingFeeMsat) || other.openingFeeMsat == openingFeeMsat));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, lnInvoice, openingFeeParams, openingFeeMsat);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReceivePaymentResponseImplCopyWith<_$ReceivePaymentResponseImpl> get copyWith =>
+      __$$ReceivePaymentResponseImplCopyWithImpl<_$ReceivePaymentResponseImpl>(this, _$identity);
+}
+
+abstract class _ReceivePaymentResponse implements ReceivePaymentResponse {
+  const factory _ReceivePaymentResponse(
+      {required final LNInvoice lnInvoice,
+      final OpeningFeeParams? openingFeeParams,
+      final int? openingFeeMsat}) = _$ReceivePaymentResponseImpl;
+
+  @override
+  LNInvoice get lnInvoice;
+  @override
+  OpeningFeeParams? get openingFeeParams;
+  @override
+  int? get openingFeeMsat;
+  @override
+  @JsonKey(ignore: true)
+  _$$ReceivePaymentResponseImplCopyWith<_$ReceivePaymentResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5424,6 +11433,1110 @@ abstract class ReportIssueRequest_PaymentFailure implements ReportIssueRequest {
   @override
   @JsonKey(ignore: true)
   _$$ReportIssueRequest_PaymentFailureImplCopyWith<_$ReportIssueRequest_PaymentFailureImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ReverseSwapInfo {
+  String get id => throw _privateConstructorUsedError;
+  String get claimPubkey => throw _privateConstructorUsedError;
+  String? get lockupTxid => throw _privateConstructorUsedError;
+  String? get claimTxid => throw _privateConstructorUsedError;
+  int get onchainAmountSat => throw _privateConstructorUsedError;
+  ReverseSwapStatus get status => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReverseSwapInfoCopyWith<ReverseSwapInfo> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReverseSwapInfoCopyWith<$Res> {
+  factory $ReverseSwapInfoCopyWith(ReverseSwapInfo value, $Res Function(ReverseSwapInfo) then) =
+      _$ReverseSwapInfoCopyWithImpl<$Res, ReverseSwapInfo>;
+  @useResult
+  $Res call(
+      {String id,
+      String claimPubkey,
+      String? lockupTxid,
+      String? claimTxid,
+      int onchainAmountSat,
+      ReverseSwapStatus status});
+}
+
+/// @nodoc
+class _$ReverseSwapInfoCopyWithImpl<$Res, $Val extends ReverseSwapInfo>
+    implements $ReverseSwapInfoCopyWith<$Res> {
+  _$ReverseSwapInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? claimPubkey = null,
+    Object? lockupTxid = freezed,
+    Object? claimTxid = freezed,
+    Object? onchainAmountSat = null,
+    Object? status = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      claimPubkey: null == claimPubkey
+          ? _value.claimPubkey
+          : claimPubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      lockupTxid: freezed == lockupTxid
+          ? _value.lockupTxid
+          : lockupTxid // ignore: cast_nullable_to_non_nullable
+              as String?,
+      claimTxid: freezed == claimTxid
+          ? _value.claimTxid
+          : claimTxid // ignore: cast_nullable_to_non_nullable
+              as String?,
+      onchainAmountSat: null == onchainAmountSat
+          ? _value.onchainAmountSat
+          : onchainAmountSat // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ReverseSwapStatus,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ReverseSwapInfoImplCopyWith<$Res> implements $ReverseSwapInfoCopyWith<$Res> {
+  factory _$$ReverseSwapInfoImplCopyWith(
+          _$ReverseSwapInfoImpl value, $Res Function(_$ReverseSwapInfoImpl) then) =
+      __$$ReverseSwapInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String claimPubkey,
+      String? lockupTxid,
+      String? claimTxid,
+      int onchainAmountSat,
+      ReverseSwapStatus status});
+}
+
+/// @nodoc
+class __$$ReverseSwapInfoImplCopyWithImpl<$Res>
+    extends _$ReverseSwapInfoCopyWithImpl<$Res, _$ReverseSwapInfoImpl>
+    implements _$$ReverseSwapInfoImplCopyWith<$Res> {
+  __$$ReverseSwapInfoImplCopyWithImpl(
+      _$ReverseSwapInfoImpl _value, $Res Function(_$ReverseSwapInfoImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? claimPubkey = null,
+    Object? lockupTxid = freezed,
+    Object? claimTxid = freezed,
+    Object? onchainAmountSat = null,
+    Object? status = null,
+  }) {
+    return _then(_$ReverseSwapInfoImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      claimPubkey: null == claimPubkey
+          ? _value.claimPubkey
+          : claimPubkey // ignore: cast_nullable_to_non_nullable
+              as String,
+      lockupTxid: freezed == lockupTxid
+          ? _value.lockupTxid
+          : lockupTxid // ignore: cast_nullable_to_non_nullable
+              as String?,
+      claimTxid: freezed == claimTxid
+          ? _value.claimTxid
+          : claimTxid // ignore: cast_nullable_to_non_nullable
+              as String?,
+      onchainAmountSat: null == onchainAmountSat
+          ? _value.onchainAmountSat
+          : onchainAmountSat // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ReverseSwapStatus,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReverseSwapInfoImpl implements _ReverseSwapInfo {
+  const _$ReverseSwapInfoImpl(
+      {required this.id,
+      required this.claimPubkey,
+      this.lockupTxid,
+      this.claimTxid,
+      required this.onchainAmountSat,
+      required this.status});
+
+  @override
+  final String id;
+  @override
+  final String claimPubkey;
+  @override
+  final String? lockupTxid;
+  @override
+  final String? claimTxid;
+  @override
+  final int onchainAmountSat;
+  @override
+  final ReverseSwapStatus status;
+
+  @override
+  String toString() {
+    return 'ReverseSwapInfo(id: $id, claimPubkey: $claimPubkey, lockupTxid: $lockupTxid, claimTxid: $claimTxid, onchainAmountSat: $onchainAmountSat, status: $status)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReverseSwapInfoImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.claimPubkey, claimPubkey) || other.claimPubkey == claimPubkey) &&
+            (identical(other.lockupTxid, lockupTxid) || other.lockupTxid == lockupTxid) &&
+            (identical(other.claimTxid, claimTxid) || other.claimTxid == claimTxid) &&
+            (identical(other.onchainAmountSat, onchainAmountSat) ||
+                other.onchainAmountSat == onchainAmountSat) &&
+            (identical(other.status, status) || other.status == status));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, claimPubkey, lockupTxid, claimTxid, onchainAmountSat, status);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReverseSwapInfoImplCopyWith<_$ReverseSwapInfoImpl> get copyWith =>
+      __$$ReverseSwapInfoImplCopyWithImpl<_$ReverseSwapInfoImpl>(this, _$identity);
+}
+
+abstract class _ReverseSwapInfo implements ReverseSwapInfo {
+  const factory _ReverseSwapInfo(
+      {required final String id,
+      required final String claimPubkey,
+      final String? lockupTxid,
+      final String? claimTxid,
+      required final int onchainAmountSat,
+      required final ReverseSwapStatus status}) = _$ReverseSwapInfoImpl;
+
+  @override
+  String get id;
+  @override
+  String get claimPubkey;
+  @override
+  String? get lockupTxid;
+  @override
+  String? get claimTxid;
+  @override
+  int get onchainAmountSat;
+  @override
+  ReverseSwapStatus get status;
+  @override
+  @JsonKey(ignore: true)
+  _$$ReverseSwapInfoImplCopyWith<_$ReverseSwapInfoImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$RouteHint {
+  List<RouteHintHop> get hops => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $RouteHintCopyWith<RouteHint> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RouteHintCopyWith<$Res> {
+  factory $RouteHintCopyWith(RouteHint value, $Res Function(RouteHint) then) =
+      _$RouteHintCopyWithImpl<$Res, RouteHint>;
+  @useResult
+  $Res call({List<RouteHintHop> hops});
+}
+
+/// @nodoc
+class _$RouteHintCopyWithImpl<$Res, $Val extends RouteHint> implements $RouteHintCopyWith<$Res> {
+  _$RouteHintCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hops = null,
+  }) {
+    return _then(_value.copyWith(
+      hops: null == hops
+          ? _value.hops
+          : hops // ignore: cast_nullable_to_non_nullable
+              as List<RouteHintHop>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$RouteHintImplCopyWith<$Res> implements $RouteHintCopyWith<$Res> {
+  factory _$$RouteHintImplCopyWith(_$RouteHintImpl value, $Res Function(_$RouteHintImpl) then) =
+      __$$RouteHintImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<RouteHintHop> hops});
+}
+
+/// @nodoc
+class __$$RouteHintImplCopyWithImpl<$Res> extends _$RouteHintCopyWithImpl<$Res, _$RouteHintImpl>
+    implements _$$RouteHintImplCopyWith<$Res> {
+  __$$RouteHintImplCopyWithImpl(_$RouteHintImpl _value, $Res Function(_$RouteHintImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hops = null,
+  }) {
+    return _then(_$RouteHintImpl(
+      hops: null == hops
+          ? _value._hops
+          : hops // ignore: cast_nullable_to_non_nullable
+              as List<RouteHintHop>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RouteHintImpl implements _RouteHint {
+  const _$RouteHintImpl({required final List<RouteHintHop> hops}) : _hops = hops;
+
+  final List<RouteHintHop> _hops;
+  @override
+  List<RouteHintHop> get hops {
+    if (_hops is EqualUnmodifiableListView) return _hops;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_hops);
+  }
+
+  @override
+  String toString() {
+    return 'RouteHint(hops: $hops)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RouteHintImpl &&
+            const DeepCollectionEquality().equals(other._hops, _hops));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(_hops));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RouteHintImplCopyWith<_$RouteHintImpl> get copyWith =>
+      __$$RouteHintImplCopyWithImpl<_$RouteHintImpl>(this, _$identity);
+}
+
+abstract class _RouteHint implements RouteHint {
+  const factory _RouteHint({required final List<RouteHintHop> hops}) = _$RouteHintImpl;
+
+  @override
+  List<RouteHintHop> get hops;
+  @override
+  @JsonKey(ignore: true)
+  _$$RouteHintImplCopyWith<_$RouteHintImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$RouteHintHop {
+  String get srcNodeId => throw _privateConstructorUsedError;
+  int get shortChannelId => throw _privateConstructorUsedError;
+  int get feesBaseMsat => throw _privateConstructorUsedError;
+  int get feesProportionalMillionths => throw _privateConstructorUsedError;
+  int get cltvExpiryDelta => throw _privateConstructorUsedError;
+  int? get htlcMinimumMsat => throw _privateConstructorUsedError;
+  int? get htlcMaximumMsat => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $RouteHintHopCopyWith<RouteHintHop> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RouteHintHopCopyWith<$Res> {
+  factory $RouteHintHopCopyWith(RouteHintHop value, $Res Function(RouteHintHop) then) =
+      _$RouteHintHopCopyWithImpl<$Res, RouteHintHop>;
+  @useResult
+  $Res call(
+      {String srcNodeId,
+      int shortChannelId,
+      int feesBaseMsat,
+      int feesProportionalMillionths,
+      int cltvExpiryDelta,
+      int? htlcMinimumMsat,
+      int? htlcMaximumMsat});
+}
+
+/// @nodoc
+class _$RouteHintHopCopyWithImpl<$Res, $Val extends RouteHintHop> implements $RouteHintHopCopyWith<$Res> {
+  _$RouteHintHopCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? srcNodeId = null,
+    Object? shortChannelId = null,
+    Object? feesBaseMsat = null,
+    Object? feesProportionalMillionths = null,
+    Object? cltvExpiryDelta = null,
+    Object? htlcMinimumMsat = freezed,
+    Object? htlcMaximumMsat = freezed,
+  }) {
+    return _then(_value.copyWith(
+      srcNodeId: null == srcNodeId
+          ? _value.srcNodeId
+          : srcNodeId // ignore: cast_nullable_to_non_nullable
+              as String,
+      shortChannelId: null == shortChannelId
+          ? _value.shortChannelId
+          : shortChannelId // ignore: cast_nullable_to_non_nullable
+              as int,
+      feesBaseMsat: null == feesBaseMsat
+          ? _value.feesBaseMsat
+          : feesBaseMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      feesProportionalMillionths: null == feesProportionalMillionths
+          ? _value.feesProportionalMillionths
+          : feesProportionalMillionths // ignore: cast_nullable_to_non_nullable
+              as int,
+      cltvExpiryDelta: null == cltvExpiryDelta
+          ? _value.cltvExpiryDelta
+          : cltvExpiryDelta // ignore: cast_nullable_to_non_nullable
+              as int,
+      htlcMinimumMsat: freezed == htlcMinimumMsat
+          ? _value.htlcMinimumMsat
+          : htlcMinimumMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+      htlcMaximumMsat: freezed == htlcMaximumMsat
+          ? _value.htlcMaximumMsat
+          : htlcMaximumMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$RouteHintHopImplCopyWith<$Res> implements $RouteHintHopCopyWith<$Res> {
+  factory _$$RouteHintHopImplCopyWith(_$RouteHintHopImpl value, $Res Function(_$RouteHintHopImpl) then) =
+      __$$RouteHintHopImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String srcNodeId,
+      int shortChannelId,
+      int feesBaseMsat,
+      int feesProportionalMillionths,
+      int cltvExpiryDelta,
+      int? htlcMinimumMsat,
+      int? htlcMaximumMsat});
+}
+
+/// @nodoc
+class __$$RouteHintHopImplCopyWithImpl<$Res> extends _$RouteHintHopCopyWithImpl<$Res, _$RouteHintHopImpl>
+    implements _$$RouteHintHopImplCopyWith<$Res> {
+  __$$RouteHintHopImplCopyWithImpl(_$RouteHintHopImpl _value, $Res Function(_$RouteHintHopImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? srcNodeId = null,
+    Object? shortChannelId = null,
+    Object? feesBaseMsat = null,
+    Object? feesProportionalMillionths = null,
+    Object? cltvExpiryDelta = null,
+    Object? htlcMinimumMsat = freezed,
+    Object? htlcMaximumMsat = freezed,
+  }) {
+    return _then(_$RouteHintHopImpl(
+      srcNodeId: null == srcNodeId
+          ? _value.srcNodeId
+          : srcNodeId // ignore: cast_nullable_to_non_nullable
+              as String,
+      shortChannelId: null == shortChannelId
+          ? _value.shortChannelId
+          : shortChannelId // ignore: cast_nullable_to_non_nullable
+              as int,
+      feesBaseMsat: null == feesBaseMsat
+          ? _value.feesBaseMsat
+          : feesBaseMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      feesProportionalMillionths: null == feesProportionalMillionths
+          ? _value.feesProportionalMillionths
+          : feesProportionalMillionths // ignore: cast_nullable_to_non_nullable
+              as int,
+      cltvExpiryDelta: null == cltvExpiryDelta
+          ? _value.cltvExpiryDelta
+          : cltvExpiryDelta // ignore: cast_nullable_to_non_nullable
+              as int,
+      htlcMinimumMsat: freezed == htlcMinimumMsat
+          ? _value.htlcMinimumMsat
+          : htlcMinimumMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+      htlcMaximumMsat: freezed == htlcMaximumMsat
+          ? _value.htlcMaximumMsat
+          : htlcMaximumMsat // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RouteHintHopImpl implements _RouteHintHop {
+  const _$RouteHintHopImpl(
+      {required this.srcNodeId,
+      required this.shortChannelId,
+      required this.feesBaseMsat,
+      required this.feesProportionalMillionths,
+      required this.cltvExpiryDelta,
+      this.htlcMinimumMsat,
+      this.htlcMaximumMsat});
+
+  @override
+  final String srcNodeId;
+  @override
+  final int shortChannelId;
+  @override
+  final int feesBaseMsat;
+  @override
+  final int feesProportionalMillionths;
+  @override
+  final int cltvExpiryDelta;
+  @override
+  final int? htlcMinimumMsat;
+  @override
+  final int? htlcMaximumMsat;
+
+  @override
+  String toString() {
+    return 'RouteHintHop(srcNodeId: $srcNodeId, shortChannelId: $shortChannelId, feesBaseMsat: $feesBaseMsat, feesProportionalMillionths: $feesProportionalMillionths, cltvExpiryDelta: $cltvExpiryDelta, htlcMinimumMsat: $htlcMinimumMsat, htlcMaximumMsat: $htlcMaximumMsat)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RouteHintHopImpl &&
+            (identical(other.srcNodeId, srcNodeId) || other.srcNodeId == srcNodeId) &&
+            (identical(other.shortChannelId, shortChannelId) || other.shortChannelId == shortChannelId) &&
+            (identical(other.feesBaseMsat, feesBaseMsat) || other.feesBaseMsat == feesBaseMsat) &&
+            (identical(other.feesProportionalMillionths, feesProportionalMillionths) ||
+                other.feesProportionalMillionths == feesProportionalMillionths) &&
+            (identical(other.cltvExpiryDelta, cltvExpiryDelta) || other.cltvExpiryDelta == cltvExpiryDelta) &&
+            (identical(other.htlcMinimumMsat, htlcMinimumMsat) || other.htlcMinimumMsat == htlcMinimumMsat) &&
+            (identical(other.htlcMaximumMsat, htlcMaximumMsat) || other.htlcMaximumMsat == htlcMaximumMsat));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, srcNodeId, shortChannelId, feesBaseMsat,
+      feesProportionalMillionths, cltvExpiryDelta, htlcMinimumMsat, htlcMaximumMsat);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RouteHintHopImplCopyWith<_$RouteHintHopImpl> get copyWith =>
+      __$$RouteHintHopImplCopyWithImpl<_$RouteHintHopImpl>(this, _$identity);
+}
+
+abstract class _RouteHintHop implements RouteHintHop {
+  const factory _RouteHintHop(
+      {required final String srcNodeId,
+      required final int shortChannelId,
+      required final int feesBaseMsat,
+      required final int feesProportionalMillionths,
+      required final int cltvExpiryDelta,
+      final int? htlcMinimumMsat,
+      final int? htlcMaximumMsat}) = _$RouteHintHopImpl;
+
+  @override
+  String get srcNodeId;
+  @override
+  int get shortChannelId;
+  @override
+  int get feesBaseMsat;
+  @override
+  int get feesProportionalMillionths;
+  @override
+  int get cltvExpiryDelta;
+  @override
+  int? get htlcMinimumMsat;
+  @override
+  int? get htlcMaximumMsat;
+  @override
+  @JsonKey(ignore: true)
+  _$$RouteHintHopImplCopyWith<_$RouteHintHopImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$SendOnchainResponse {
+  ReverseSwapInfo get reverseSwapInfo => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SendOnchainResponseCopyWith<SendOnchainResponse> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SendOnchainResponseCopyWith<$Res> {
+  factory $SendOnchainResponseCopyWith(SendOnchainResponse value, $Res Function(SendOnchainResponse) then) =
+      _$SendOnchainResponseCopyWithImpl<$Res, SendOnchainResponse>;
+  @useResult
+  $Res call({ReverseSwapInfo reverseSwapInfo});
+
+  $ReverseSwapInfoCopyWith<$Res> get reverseSwapInfo;
+}
+
+/// @nodoc
+class _$SendOnchainResponseCopyWithImpl<$Res, $Val extends SendOnchainResponse>
+    implements $SendOnchainResponseCopyWith<$Res> {
+  _$SendOnchainResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reverseSwapInfo = null,
+  }) {
+    return _then(_value.copyWith(
+      reverseSwapInfo: null == reverseSwapInfo
+          ? _value.reverseSwapInfo
+          : reverseSwapInfo // ignore: cast_nullable_to_non_nullable
+              as ReverseSwapInfo,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ReverseSwapInfoCopyWith<$Res> get reverseSwapInfo {
+    return $ReverseSwapInfoCopyWith<$Res>(_value.reverseSwapInfo, (value) {
+      return _then(_value.copyWith(reverseSwapInfo: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$SendOnchainResponseImplCopyWith<$Res> implements $SendOnchainResponseCopyWith<$Res> {
+  factory _$$SendOnchainResponseImplCopyWith(
+          _$SendOnchainResponseImpl value, $Res Function(_$SendOnchainResponseImpl) then) =
+      __$$SendOnchainResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({ReverseSwapInfo reverseSwapInfo});
+
+  @override
+  $ReverseSwapInfoCopyWith<$Res> get reverseSwapInfo;
+}
+
+/// @nodoc
+class __$$SendOnchainResponseImplCopyWithImpl<$Res>
+    extends _$SendOnchainResponseCopyWithImpl<$Res, _$SendOnchainResponseImpl>
+    implements _$$SendOnchainResponseImplCopyWith<$Res> {
+  __$$SendOnchainResponseImplCopyWithImpl(
+      _$SendOnchainResponseImpl _value, $Res Function(_$SendOnchainResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reverseSwapInfo = null,
+  }) {
+    return _then(_$SendOnchainResponseImpl(
+      reverseSwapInfo: null == reverseSwapInfo
+          ? _value.reverseSwapInfo
+          : reverseSwapInfo // ignore: cast_nullable_to_non_nullable
+              as ReverseSwapInfo,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SendOnchainResponseImpl implements _SendOnchainResponse {
+  const _$SendOnchainResponseImpl({required this.reverseSwapInfo});
+
+  @override
+  final ReverseSwapInfo reverseSwapInfo;
+
+  @override
+  String toString() {
+    return 'SendOnchainResponse(reverseSwapInfo: $reverseSwapInfo)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SendOnchainResponseImpl &&
+            (identical(other.reverseSwapInfo, reverseSwapInfo) || other.reverseSwapInfo == reverseSwapInfo));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, reverseSwapInfo);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SendOnchainResponseImplCopyWith<_$SendOnchainResponseImpl> get copyWith =>
+      __$$SendOnchainResponseImplCopyWithImpl<_$SendOnchainResponseImpl>(this, _$identity);
+}
+
+abstract class _SendOnchainResponse implements SendOnchainResponse {
+  const factory _SendOnchainResponse({required final ReverseSwapInfo reverseSwapInfo}) =
+      _$SendOnchainResponseImpl;
+
+  @override
+  ReverseSwapInfo get reverseSwapInfo;
+  @override
+  @JsonKey(ignore: true)
+  _$$SendOnchainResponseImplCopyWith<_$SendOnchainResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$SendPaymentResponse {
+  Payment get payment => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SendPaymentResponseCopyWith<SendPaymentResponse> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SendPaymentResponseCopyWith<$Res> {
+  factory $SendPaymentResponseCopyWith(SendPaymentResponse value, $Res Function(SendPaymentResponse) then) =
+      _$SendPaymentResponseCopyWithImpl<$Res, SendPaymentResponse>;
+  @useResult
+  $Res call({Payment payment});
+
+  $PaymentCopyWith<$Res> get payment;
+}
+
+/// @nodoc
+class _$SendPaymentResponseCopyWithImpl<$Res, $Val extends SendPaymentResponse>
+    implements $SendPaymentResponseCopyWith<$Res> {
+  _$SendPaymentResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? payment = null,
+  }) {
+    return _then(_value.copyWith(
+      payment: null == payment
+          ? _value.payment
+          : payment // ignore: cast_nullable_to_non_nullable
+              as Payment,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PaymentCopyWith<$Res> get payment {
+    return $PaymentCopyWith<$Res>(_value.payment, (value) {
+      return _then(_value.copyWith(payment: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$SendPaymentResponseImplCopyWith<$Res> implements $SendPaymentResponseCopyWith<$Res> {
+  factory _$$SendPaymentResponseImplCopyWith(
+          _$SendPaymentResponseImpl value, $Res Function(_$SendPaymentResponseImpl) then) =
+      __$$SendPaymentResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Payment payment});
+
+  @override
+  $PaymentCopyWith<$Res> get payment;
+}
+
+/// @nodoc
+class __$$SendPaymentResponseImplCopyWithImpl<$Res>
+    extends _$SendPaymentResponseCopyWithImpl<$Res, _$SendPaymentResponseImpl>
+    implements _$$SendPaymentResponseImplCopyWith<$Res> {
+  __$$SendPaymentResponseImplCopyWithImpl(
+      _$SendPaymentResponseImpl _value, $Res Function(_$SendPaymentResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? payment = null,
+  }) {
+    return _then(_$SendPaymentResponseImpl(
+      payment: null == payment
+          ? _value.payment
+          : payment // ignore: cast_nullable_to_non_nullable
+              as Payment,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SendPaymentResponseImpl implements _SendPaymentResponse {
+  const _$SendPaymentResponseImpl({required this.payment});
+
+  @override
+  final Payment payment;
+
+  @override
+  String toString() {
+    return 'SendPaymentResponse(payment: $payment)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SendPaymentResponseImpl &&
+            (identical(other.payment, payment) || other.payment == payment));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, payment);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SendPaymentResponseImplCopyWith<_$SendPaymentResponseImpl> get copyWith =>
+      __$$SendPaymentResponseImplCopyWithImpl<_$SendPaymentResponseImpl>(this, _$identity);
+}
+
+abstract class _SendPaymentResponse implements SendPaymentResponse {
+  const factory _SendPaymentResponse({required final Payment payment}) = _$SendPaymentResponseImpl;
+
+  @override
+  Payment get payment;
+  @override
+  @JsonKey(ignore: true)
+  _$$SendPaymentResponseImplCopyWith<_$SendPaymentResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$SendSpontaneousPaymentRequest {
+  String get nodeId => throw _privateConstructorUsedError;
+  int get amountMsat => throw _privateConstructorUsedError;
+  List<TlvEntry>? get extraTlvs => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SendSpontaneousPaymentRequestCopyWith<SendSpontaneousPaymentRequest> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SendSpontaneousPaymentRequestCopyWith<$Res> {
+  factory $SendSpontaneousPaymentRequestCopyWith(
+          SendSpontaneousPaymentRequest value, $Res Function(SendSpontaneousPaymentRequest) then) =
+      _$SendSpontaneousPaymentRequestCopyWithImpl<$Res, SendSpontaneousPaymentRequest>;
+  @useResult
+  $Res call({String nodeId, int amountMsat, List<TlvEntry>? extraTlvs});
+}
+
+/// @nodoc
+class _$SendSpontaneousPaymentRequestCopyWithImpl<$Res, $Val extends SendSpontaneousPaymentRequest>
+    implements $SendSpontaneousPaymentRequestCopyWith<$Res> {
+  _$SendSpontaneousPaymentRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? nodeId = null,
+    Object? amountMsat = null,
+    Object? extraTlvs = freezed,
+  }) {
+    return _then(_value.copyWith(
+      nodeId: null == nodeId
+          ? _value.nodeId
+          : nodeId // ignore: cast_nullable_to_non_nullable
+              as String,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      extraTlvs: freezed == extraTlvs
+          ? _value.extraTlvs
+          : extraTlvs // ignore: cast_nullable_to_non_nullable
+              as List<TlvEntry>?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SendSpontaneousPaymentRequestImplCopyWith<$Res>
+    implements $SendSpontaneousPaymentRequestCopyWith<$Res> {
+  factory _$$SendSpontaneousPaymentRequestImplCopyWith(_$SendSpontaneousPaymentRequestImpl value,
+          $Res Function(_$SendSpontaneousPaymentRequestImpl) then) =
+      __$$SendSpontaneousPaymentRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String nodeId, int amountMsat, List<TlvEntry>? extraTlvs});
+}
+
+/// @nodoc
+class __$$SendSpontaneousPaymentRequestImplCopyWithImpl<$Res>
+    extends _$SendSpontaneousPaymentRequestCopyWithImpl<$Res, _$SendSpontaneousPaymentRequestImpl>
+    implements _$$SendSpontaneousPaymentRequestImplCopyWith<$Res> {
+  __$$SendSpontaneousPaymentRequestImplCopyWithImpl(
+      _$SendSpontaneousPaymentRequestImpl _value, $Res Function(_$SendSpontaneousPaymentRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? nodeId = null,
+    Object? amountMsat = null,
+    Object? extraTlvs = freezed,
+  }) {
+    return _then(_$SendSpontaneousPaymentRequestImpl(
+      nodeId: null == nodeId
+          ? _value.nodeId
+          : nodeId // ignore: cast_nullable_to_non_nullable
+              as String,
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      extraTlvs: freezed == extraTlvs
+          ? _value._extraTlvs
+          : extraTlvs // ignore: cast_nullable_to_non_nullable
+              as List<TlvEntry>?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SendSpontaneousPaymentRequestImpl implements _SendSpontaneousPaymentRequest {
+  const _$SendSpontaneousPaymentRequestImpl(
+      {required this.nodeId, required this.amountMsat, final List<TlvEntry>? extraTlvs})
+      : _extraTlvs = extraTlvs;
+
+  @override
+  final String nodeId;
+  @override
+  final int amountMsat;
+  final List<TlvEntry>? _extraTlvs;
+  @override
+  List<TlvEntry>? get extraTlvs {
+    final value = _extraTlvs;
+    if (value == null) return null;
+    if (_extraTlvs is EqualUnmodifiableListView) return _extraTlvs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'SendSpontaneousPaymentRequest(nodeId: $nodeId, amountMsat: $amountMsat, extraTlvs: $extraTlvs)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SendSpontaneousPaymentRequestImpl &&
+            (identical(other.nodeId, nodeId) || other.nodeId == nodeId) &&
+            (identical(other.amountMsat, amountMsat) || other.amountMsat == amountMsat) &&
+            const DeepCollectionEquality().equals(other._extraTlvs, _extraTlvs));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, nodeId, amountMsat, const DeepCollectionEquality().hash(_extraTlvs));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SendSpontaneousPaymentRequestImplCopyWith<_$SendSpontaneousPaymentRequestImpl> get copyWith =>
+      __$$SendSpontaneousPaymentRequestImplCopyWithImpl<_$SendSpontaneousPaymentRequestImpl>(
+          this, _$identity);
+}
+
+abstract class _SendSpontaneousPaymentRequest implements SendSpontaneousPaymentRequest {
+  const factory _SendSpontaneousPaymentRequest(
+      {required final String nodeId,
+      required final int amountMsat,
+      final List<TlvEntry>? extraTlvs}) = _$SendSpontaneousPaymentRequestImpl;
+
+  @override
+  String get nodeId;
+  @override
+  int get amountMsat;
+  @override
+  List<TlvEntry>? get extraTlvs;
+  @override
+  @JsonKey(ignore: true)
+  _$$SendSpontaneousPaymentRequestImplCopyWith<_$SendSpontaneousPaymentRequestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ServiceHealthCheckResponse {
+  HealthCheckStatus get status => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ServiceHealthCheckResponseCopyWith<ServiceHealthCheckResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ServiceHealthCheckResponseCopyWith<$Res> {
+  factory $ServiceHealthCheckResponseCopyWith(
+          ServiceHealthCheckResponse value, $Res Function(ServiceHealthCheckResponse) then) =
+      _$ServiceHealthCheckResponseCopyWithImpl<$Res, ServiceHealthCheckResponse>;
+  @useResult
+  $Res call({HealthCheckStatus status});
+}
+
+/// @nodoc
+class _$ServiceHealthCheckResponseCopyWithImpl<$Res, $Val extends ServiceHealthCheckResponse>
+    implements $ServiceHealthCheckResponseCopyWith<$Res> {
+  _$ServiceHealthCheckResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+  }) {
+    return _then(_value.copyWith(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as HealthCheckStatus,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ServiceHealthCheckResponseImplCopyWith<$Res>
+    implements $ServiceHealthCheckResponseCopyWith<$Res> {
+  factory _$$ServiceHealthCheckResponseImplCopyWith(
+          _$ServiceHealthCheckResponseImpl value, $Res Function(_$ServiceHealthCheckResponseImpl) then) =
+      __$$ServiceHealthCheckResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({HealthCheckStatus status});
+}
+
+/// @nodoc
+class __$$ServiceHealthCheckResponseImplCopyWithImpl<$Res>
+    extends _$ServiceHealthCheckResponseCopyWithImpl<$Res, _$ServiceHealthCheckResponseImpl>
+    implements _$$ServiceHealthCheckResponseImplCopyWith<$Res> {
+  __$$ServiceHealthCheckResponseImplCopyWithImpl(
+      _$ServiceHealthCheckResponseImpl _value, $Res Function(_$ServiceHealthCheckResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+  }) {
+    return _then(_$ServiceHealthCheckResponseImpl(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as HealthCheckStatus,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ServiceHealthCheckResponseImpl implements _ServiceHealthCheckResponse {
+  const _$ServiceHealthCheckResponseImpl({required this.status});
+
+  @override
+  final HealthCheckStatus status;
+
+  @override
+  String toString() {
+    return 'ServiceHealthCheckResponse(status: $status)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ServiceHealthCheckResponseImpl &&
+            (identical(other.status, status) || other.status == status));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, status);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ServiceHealthCheckResponseImplCopyWith<_$ServiceHealthCheckResponseImpl> get copyWith =>
+      __$$ServiceHealthCheckResponseImplCopyWithImpl<_$ServiceHealthCheckResponseImpl>(this, _$identity);
+}
+
+abstract class _ServiceHealthCheckResponse implements ServiceHealthCheckResponse {
+  const factory _ServiceHealthCheckResponse({required final HealthCheckStatus status}) =
+      _$ServiceHealthCheckResponseImpl;
+
+  @override
+  HealthCheckStatus get status;
+  @override
+  @JsonKey(ignore: true)
+  _$$ServiceHealthCheckResponseImplCopyWith<_$ServiceHealthCheckResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5921,5 +13034,974 @@ abstract class SuccessActionProcessed_Url implements SuccessActionProcessed {
   UrlSuccessActionData get data;
   @JsonKey(ignore: true)
   _$$SuccessActionProcessed_UrlImplCopyWith<_$SuccessActionProcessed_UrlImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$SwapInfo {
+  String get bitcoinAddress => throw _privateConstructorUsedError;
+  int get createdAt => throw _privateConstructorUsedError;
+  int get lockHeight => throw _privateConstructorUsedError;
+  Uint8List get paymentHash => throw _privateConstructorUsedError;
+  Uint8List get preimage => throw _privateConstructorUsedError;
+  Uint8List get privateKey => throw _privateConstructorUsedError;
+  Uint8List get publicKey => throw _privateConstructorUsedError;
+  Uint8List get swapperPublicKey => throw _privateConstructorUsedError;
+  Uint8List get script => throw _privateConstructorUsedError;
+  String? get bolt11 => throw _privateConstructorUsedError;
+  int get paidMsat => throw _privateConstructorUsedError;
+  int get totalIncomingTxs => throw _privateConstructorUsedError;
+  int get confirmedSats => throw _privateConstructorUsedError;
+  int get unconfirmedSats => throw _privateConstructorUsedError;
+  SwapStatus get status => throw _privateConstructorUsedError;
+  List<String> get refundTxIds => throw _privateConstructorUsedError;
+  List<String> get unconfirmedTxIds => throw _privateConstructorUsedError;
+  List<String> get confirmedTxIds => throw _privateConstructorUsedError;
+  int get minAllowedDeposit => throw _privateConstructorUsedError;
+  int get maxAllowedDeposit => throw _privateConstructorUsedError;
+  String? get lastRedeemError => throw _privateConstructorUsedError;
+  OpeningFeeParams? get channelOpeningFees => throw _privateConstructorUsedError;
+  int? get confirmedAt => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SwapInfoCopyWith<SwapInfo> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SwapInfoCopyWith<$Res> {
+  factory $SwapInfoCopyWith(SwapInfo value, $Res Function(SwapInfo) then) =
+      _$SwapInfoCopyWithImpl<$Res, SwapInfo>;
+  @useResult
+  $Res call(
+      {String bitcoinAddress,
+      int createdAt,
+      int lockHeight,
+      Uint8List paymentHash,
+      Uint8List preimage,
+      Uint8List privateKey,
+      Uint8List publicKey,
+      Uint8List swapperPublicKey,
+      Uint8List script,
+      String? bolt11,
+      int paidMsat,
+      int totalIncomingTxs,
+      int confirmedSats,
+      int unconfirmedSats,
+      SwapStatus status,
+      List<String> refundTxIds,
+      List<String> unconfirmedTxIds,
+      List<String> confirmedTxIds,
+      int minAllowedDeposit,
+      int maxAllowedDeposit,
+      String? lastRedeemError,
+      OpeningFeeParams? channelOpeningFees,
+      int? confirmedAt});
+
+  $OpeningFeeParamsCopyWith<$Res>? get channelOpeningFees;
+}
+
+/// @nodoc
+class _$SwapInfoCopyWithImpl<$Res, $Val extends SwapInfo> implements $SwapInfoCopyWith<$Res> {
+  _$SwapInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? bitcoinAddress = null,
+    Object? createdAt = null,
+    Object? lockHeight = null,
+    Object? paymentHash = null,
+    Object? preimage = null,
+    Object? privateKey = null,
+    Object? publicKey = null,
+    Object? swapperPublicKey = null,
+    Object? script = null,
+    Object? bolt11 = freezed,
+    Object? paidMsat = null,
+    Object? totalIncomingTxs = null,
+    Object? confirmedSats = null,
+    Object? unconfirmedSats = null,
+    Object? status = null,
+    Object? refundTxIds = null,
+    Object? unconfirmedTxIds = null,
+    Object? confirmedTxIds = null,
+    Object? minAllowedDeposit = null,
+    Object? maxAllowedDeposit = null,
+    Object? lastRedeemError = freezed,
+    Object? channelOpeningFees = freezed,
+    Object? confirmedAt = freezed,
+  }) {
+    return _then(_value.copyWith(
+      bitcoinAddress: null == bitcoinAddress
+          ? _value.bitcoinAddress
+          : bitcoinAddress // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      lockHeight: null == lockHeight
+          ? _value.lockHeight
+          : lockHeight // ignore: cast_nullable_to_non_nullable
+              as int,
+      paymentHash: null == paymentHash
+          ? _value.paymentHash
+          : paymentHash // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      preimage: null == preimage
+          ? _value.preimage
+          : preimage // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      privateKey: null == privateKey
+          ? _value.privateKey
+          : privateKey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      publicKey: null == publicKey
+          ? _value.publicKey
+          : publicKey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      swapperPublicKey: null == swapperPublicKey
+          ? _value.swapperPublicKey
+          : swapperPublicKey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      script: null == script
+          ? _value.script
+          : script // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      bolt11: freezed == bolt11
+          ? _value.bolt11
+          : bolt11 // ignore: cast_nullable_to_non_nullable
+              as String?,
+      paidMsat: null == paidMsat
+          ? _value.paidMsat
+          : paidMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalIncomingTxs: null == totalIncomingTxs
+          ? _value.totalIncomingTxs
+          : totalIncomingTxs // ignore: cast_nullable_to_non_nullable
+              as int,
+      confirmedSats: null == confirmedSats
+          ? _value.confirmedSats
+          : confirmedSats // ignore: cast_nullable_to_non_nullable
+              as int,
+      unconfirmedSats: null == unconfirmedSats
+          ? _value.unconfirmedSats
+          : unconfirmedSats // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as SwapStatus,
+      refundTxIds: null == refundTxIds
+          ? _value.refundTxIds
+          : refundTxIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      unconfirmedTxIds: null == unconfirmedTxIds
+          ? _value.unconfirmedTxIds
+          : unconfirmedTxIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      confirmedTxIds: null == confirmedTxIds
+          ? _value.confirmedTxIds
+          : confirmedTxIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      minAllowedDeposit: null == minAllowedDeposit
+          ? _value.minAllowedDeposit
+          : minAllowedDeposit // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxAllowedDeposit: null == maxAllowedDeposit
+          ? _value.maxAllowedDeposit
+          : maxAllowedDeposit // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastRedeemError: freezed == lastRedeemError
+          ? _value.lastRedeemError
+          : lastRedeemError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      channelOpeningFees: freezed == channelOpeningFees
+          ? _value.channelOpeningFees
+          : channelOpeningFees // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+      confirmedAt: freezed == confirmedAt
+          ? _value.confirmedAt
+          : confirmedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $OpeningFeeParamsCopyWith<$Res>? get channelOpeningFees {
+    if (_value.channelOpeningFees == null) {
+      return null;
+    }
+
+    return $OpeningFeeParamsCopyWith<$Res>(_value.channelOpeningFees!, (value) {
+      return _then(_value.copyWith(channelOpeningFees: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$SwapInfoImplCopyWith<$Res> implements $SwapInfoCopyWith<$Res> {
+  factory _$$SwapInfoImplCopyWith(_$SwapInfoImpl value, $Res Function(_$SwapInfoImpl) then) =
+      __$$SwapInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String bitcoinAddress,
+      int createdAt,
+      int lockHeight,
+      Uint8List paymentHash,
+      Uint8List preimage,
+      Uint8List privateKey,
+      Uint8List publicKey,
+      Uint8List swapperPublicKey,
+      Uint8List script,
+      String? bolt11,
+      int paidMsat,
+      int totalIncomingTxs,
+      int confirmedSats,
+      int unconfirmedSats,
+      SwapStatus status,
+      List<String> refundTxIds,
+      List<String> unconfirmedTxIds,
+      List<String> confirmedTxIds,
+      int minAllowedDeposit,
+      int maxAllowedDeposit,
+      String? lastRedeemError,
+      OpeningFeeParams? channelOpeningFees,
+      int? confirmedAt});
+
+  @override
+  $OpeningFeeParamsCopyWith<$Res>? get channelOpeningFees;
+}
+
+/// @nodoc
+class __$$SwapInfoImplCopyWithImpl<$Res> extends _$SwapInfoCopyWithImpl<$Res, _$SwapInfoImpl>
+    implements _$$SwapInfoImplCopyWith<$Res> {
+  __$$SwapInfoImplCopyWithImpl(_$SwapInfoImpl _value, $Res Function(_$SwapInfoImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? bitcoinAddress = null,
+    Object? createdAt = null,
+    Object? lockHeight = null,
+    Object? paymentHash = null,
+    Object? preimage = null,
+    Object? privateKey = null,
+    Object? publicKey = null,
+    Object? swapperPublicKey = null,
+    Object? script = null,
+    Object? bolt11 = freezed,
+    Object? paidMsat = null,
+    Object? totalIncomingTxs = null,
+    Object? confirmedSats = null,
+    Object? unconfirmedSats = null,
+    Object? status = null,
+    Object? refundTxIds = null,
+    Object? unconfirmedTxIds = null,
+    Object? confirmedTxIds = null,
+    Object? minAllowedDeposit = null,
+    Object? maxAllowedDeposit = null,
+    Object? lastRedeemError = freezed,
+    Object? channelOpeningFees = freezed,
+    Object? confirmedAt = freezed,
+  }) {
+    return _then(_$SwapInfoImpl(
+      bitcoinAddress: null == bitcoinAddress
+          ? _value.bitcoinAddress
+          : bitcoinAddress // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      lockHeight: null == lockHeight
+          ? _value.lockHeight
+          : lockHeight // ignore: cast_nullable_to_non_nullable
+              as int,
+      paymentHash: null == paymentHash
+          ? _value.paymentHash
+          : paymentHash // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      preimage: null == preimage
+          ? _value.preimage
+          : preimage // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      privateKey: null == privateKey
+          ? _value.privateKey
+          : privateKey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      publicKey: null == publicKey
+          ? _value.publicKey
+          : publicKey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      swapperPublicKey: null == swapperPublicKey
+          ? _value.swapperPublicKey
+          : swapperPublicKey // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      script: null == script
+          ? _value.script
+          : script // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      bolt11: freezed == bolt11
+          ? _value.bolt11
+          : bolt11 // ignore: cast_nullable_to_non_nullable
+              as String?,
+      paidMsat: null == paidMsat
+          ? _value.paidMsat
+          : paidMsat // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalIncomingTxs: null == totalIncomingTxs
+          ? _value.totalIncomingTxs
+          : totalIncomingTxs // ignore: cast_nullable_to_non_nullable
+              as int,
+      confirmedSats: null == confirmedSats
+          ? _value.confirmedSats
+          : confirmedSats // ignore: cast_nullable_to_non_nullable
+              as int,
+      unconfirmedSats: null == unconfirmedSats
+          ? _value.unconfirmedSats
+          : unconfirmedSats // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as SwapStatus,
+      refundTxIds: null == refundTxIds
+          ? _value._refundTxIds
+          : refundTxIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      unconfirmedTxIds: null == unconfirmedTxIds
+          ? _value._unconfirmedTxIds
+          : unconfirmedTxIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      confirmedTxIds: null == confirmedTxIds
+          ? _value._confirmedTxIds
+          : confirmedTxIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      minAllowedDeposit: null == minAllowedDeposit
+          ? _value.minAllowedDeposit
+          : minAllowedDeposit // ignore: cast_nullable_to_non_nullable
+              as int,
+      maxAllowedDeposit: null == maxAllowedDeposit
+          ? _value.maxAllowedDeposit
+          : maxAllowedDeposit // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastRedeemError: freezed == lastRedeemError
+          ? _value.lastRedeemError
+          : lastRedeemError // ignore: cast_nullable_to_non_nullable
+              as String?,
+      channelOpeningFees: freezed == channelOpeningFees
+          ? _value.channelOpeningFees
+          : channelOpeningFees // ignore: cast_nullable_to_non_nullable
+              as OpeningFeeParams?,
+      confirmedAt: freezed == confirmedAt
+          ? _value.confirmedAt
+          : confirmedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SwapInfoImpl implements _SwapInfo {
+  const _$SwapInfoImpl(
+      {required this.bitcoinAddress,
+      required this.createdAt,
+      required this.lockHeight,
+      required this.paymentHash,
+      required this.preimage,
+      required this.privateKey,
+      required this.publicKey,
+      required this.swapperPublicKey,
+      required this.script,
+      this.bolt11,
+      required this.paidMsat,
+      required this.totalIncomingTxs,
+      required this.confirmedSats,
+      required this.unconfirmedSats,
+      required this.status,
+      required final List<String> refundTxIds,
+      required final List<String> unconfirmedTxIds,
+      required final List<String> confirmedTxIds,
+      required this.minAllowedDeposit,
+      required this.maxAllowedDeposit,
+      this.lastRedeemError,
+      this.channelOpeningFees,
+      this.confirmedAt})
+      : _refundTxIds = refundTxIds,
+        _unconfirmedTxIds = unconfirmedTxIds,
+        _confirmedTxIds = confirmedTxIds;
+
+  @override
+  final String bitcoinAddress;
+  @override
+  final int createdAt;
+  @override
+  final int lockHeight;
+  @override
+  final Uint8List paymentHash;
+  @override
+  final Uint8List preimage;
+  @override
+  final Uint8List privateKey;
+  @override
+  final Uint8List publicKey;
+  @override
+  final Uint8List swapperPublicKey;
+  @override
+  final Uint8List script;
+  @override
+  final String? bolt11;
+  @override
+  final int paidMsat;
+  @override
+  final int totalIncomingTxs;
+  @override
+  final int confirmedSats;
+  @override
+  final int unconfirmedSats;
+  @override
+  final SwapStatus status;
+  final List<String> _refundTxIds;
+  @override
+  List<String> get refundTxIds {
+    if (_refundTxIds is EqualUnmodifiableListView) return _refundTxIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_refundTxIds);
+  }
+
+  final List<String> _unconfirmedTxIds;
+  @override
+  List<String> get unconfirmedTxIds {
+    if (_unconfirmedTxIds is EqualUnmodifiableListView) return _unconfirmedTxIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_unconfirmedTxIds);
+  }
+
+  final List<String> _confirmedTxIds;
+  @override
+  List<String> get confirmedTxIds {
+    if (_confirmedTxIds is EqualUnmodifiableListView) return _confirmedTxIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_confirmedTxIds);
+  }
+
+  @override
+  final int minAllowedDeposit;
+  @override
+  final int maxAllowedDeposit;
+  @override
+  final String? lastRedeemError;
+  @override
+  final OpeningFeeParams? channelOpeningFees;
+  @override
+  final int? confirmedAt;
+
+  @override
+  String toString() {
+    return 'SwapInfo(bitcoinAddress: $bitcoinAddress, createdAt: $createdAt, lockHeight: $lockHeight, paymentHash: $paymentHash, preimage: $preimage, privateKey: $privateKey, publicKey: $publicKey, swapperPublicKey: $swapperPublicKey, script: $script, bolt11: $bolt11, paidMsat: $paidMsat, totalIncomingTxs: $totalIncomingTxs, confirmedSats: $confirmedSats, unconfirmedSats: $unconfirmedSats, status: $status, refundTxIds: $refundTxIds, unconfirmedTxIds: $unconfirmedTxIds, confirmedTxIds: $confirmedTxIds, minAllowedDeposit: $minAllowedDeposit, maxAllowedDeposit: $maxAllowedDeposit, lastRedeemError: $lastRedeemError, channelOpeningFees: $channelOpeningFees, confirmedAt: $confirmedAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SwapInfoImpl &&
+            (identical(other.bitcoinAddress, bitcoinAddress) || other.bitcoinAddress == bitcoinAddress) &&
+            (identical(other.createdAt, createdAt) || other.createdAt == createdAt) &&
+            (identical(other.lockHeight, lockHeight) || other.lockHeight == lockHeight) &&
+            const DeepCollectionEquality().equals(other.paymentHash, paymentHash) &&
+            const DeepCollectionEquality().equals(other.preimage, preimage) &&
+            const DeepCollectionEquality().equals(other.privateKey, privateKey) &&
+            const DeepCollectionEquality().equals(other.publicKey, publicKey) &&
+            const DeepCollectionEquality().equals(other.swapperPublicKey, swapperPublicKey) &&
+            const DeepCollectionEquality().equals(other.script, script) &&
+            (identical(other.bolt11, bolt11) || other.bolt11 == bolt11) &&
+            (identical(other.paidMsat, paidMsat) || other.paidMsat == paidMsat) &&
+            (identical(other.totalIncomingTxs, totalIncomingTxs) ||
+                other.totalIncomingTxs == totalIncomingTxs) &&
+            (identical(other.confirmedSats, confirmedSats) || other.confirmedSats == confirmedSats) &&
+            (identical(other.unconfirmedSats, unconfirmedSats) || other.unconfirmedSats == unconfirmedSats) &&
+            (identical(other.status, status) || other.status == status) &&
+            const DeepCollectionEquality().equals(other._refundTxIds, _refundTxIds) &&
+            const DeepCollectionEquality().equals(other._unconfirmedTxIds, _unconfirmedTxIds) &&
+            const DeepCollectionEquality().equals(other._confirmedTxIds, _confirmedTxIds) &&
+            (identical(other.minAllowedDeposit, minAllowedDeposit) ||
+                other.minAllowedDeposit == minAllowedDeposit) &&
+            (identical(other.maxAllowedDeposit, maxAllowedDeposit) ||
+                other.maxAllowedDeposit == maxAllowedDeposit) &&
+            (identical(other.lastRedeemError, lastRedeemError) || other.lastRedeemError == lastRedeemError) &&
+            (identical(other.channelOpeningFees, channelOpeningFees) ||
+                other.channelOpeningFees == channelOpeningFees) &&
+            (identical(other.confirmedAt, confirmedAt) || other.confirmedAt == confirmedAt));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        bitcoinAddress,
+        createdAt,
+        lockHeight,
+        const DeepCollectionEquality().hash(paymentHash),
+        const DeepCollectionEquality().hash(preimage),
+        const DeepCollectionEquality().hash(privateKey),
+        const DeepCollectionEquality().hash(publicKey),
+        const DeepCollectionEquality().hash(swapperPublicKey),
+        const DeepCollectionEquality().hash(script),
+        bolt11,
+        paidMsat,
+        totalIncomingTxs,
+        confirmedSats,
+        unconfirmedSats,
+        status,
+        const DeepCollectionEquality().hash(_refundTxIds),
+        const DeepCollectionEquality().hash(_unconfirmedTxIds),
+        const DeepCollectionEquality().hash(_confirmedTxIds),
+        minAllowedDeposit,
+        maxAllowedDeposit,
+        lastRedeemError,
+        channelOpeningFees,
+        confirmedAt
+      ]);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SwapInfoImplCopyWith<_$SwapInfoImpl> get copyWith =>
+      __$$SwapInfoImplCopyWithImpl<_$SwapInfoImpl>(this, _$identity);
+}
+
+abstract class _SwapInfo implements SwapInfo {
+  const factory _SwapInfo(
+      {required final String bitcoinAddress,
+      required final int createdAt,
+      required final int lockHeight,
+      required final Uint8List paymentHash,
+      required final Uint8List preimage,
+      required final Uint8List privateKey,
+      required final Uint8List publicKey,
+      required final Uint8List swapperPublicKey,
+      required final Uint8List script,
+      final String? bolt11,
+      required final int paidMsat,
+      required final int totalIncomingTxs,
+      required final int confirmedSats,
+      required final int unconfirmedSats,
+      required final SwapStatus status,
+      required final List<String> refundTxIds,
+      required final List<String> unconfirmedTxIds,
+      required final List<String> confirmedTxIds,
+      required final int minAllowedDeposit,
+      required final int maxAllowedDeposit,
+      final String? lastRedeemError,
+      final OpeningFeeParams? channelOpeningFees,
+      final int? confirmedAt}) = _$SwapInfoImpl;
+
+  @override
+  String get bitcoinAddress;
+  @override
+  int get createdAt;
+  @override
+  int get lockHeight;
+  @override
+  Uint8List get paymentHash;
+  @override
+  Uint8List get preimage;
+  @override
+  Uint8List get privateKey;
+  @override
+  Uint8List get publicKey;
+  @override
+  Uint8List get swapperPublicKey;
+  @override
+  Uint8List get script;
+  @override
+  String? get bolt11;
+  @override
+  int get paidMsat;
+  @override
+  int get totalIncomingTxs;
+  @override
+  int get confirmedSats;
+  @override
+  int get unconfirmedSats;
+  @override
+  SwapStatus get status;
+  @override
+  List<String> get refundTxIds;
+  @override
+  List<String> get unconfirmedTxIds;
+  @override
+  List<String> get confirmedTxIds;
+  @override
+  int get minAllowedDeposit;
+  @override
+  int get maxAllowedDeposit;
+  @override
+  String? get lastRedeemError;
+  @override
+  OpeningFeeParams? get channelOpeningFees;
+  @override
+  int? get confirmedAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$SwapInfoImplCopyWith<_$SwapInfoImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$Symbol {
+  String? get grapheme => throw _privateConstructorUsedError;
+  String? get template => throw _privateConstructorUsedError;
+  bool? get rtl => throw _privateConstructorUsedError;
+  int? get position => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $SymbolCopyWith<Symbol> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SymbolCopyWith<$Res> {
+  factory $SymbolCopyWith(Symbol value, $Res Function(Symbol) then) = _$SymbolCopyWithImpl<$Res, Symbol>;
+  @useResult
+  $Res call({String? grapheme, String? template, bool? rtl, int? position});
+}
+
+/// @nodoc
+class _$SymbolCopyWithImpl<$Res, $Val extends Symbol> implements $SymbolCopyWith<$Res> {
+  _$SymbolCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? grapheme = freezed,
+    Object? template = freezed,
+    Object? rtl = freezed,
+    Object? position = freezed,
+  }) {
+    return _then(_value.copyWith(
+      grapheme: freezed == grapheme
+          ? _value.grapheme
+          : grapheme // ignore: cast_nullable_to_non_nullable
+              as String?,
+      template: freezed == template
+          ? _value.template
+          : template // ignore: cast_nullable_to_non_nullable
+              as String?,
+      rtl: freezed == rtl
+          ? _value.rtl
+          : rtl // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      position: freezed == position
+          ? _value.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SymbolImplCopyWith<$Res> implements $SymbolCopyWith<$Res> {
+  factory _$$SymbolImplCopyWith(_$SymbolImpl value, $Res Function(_$SymbolImpl) then) =
+      __$$SymbolImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? grapheme, String? template, bool? rtl, int? position});
+}
+
+/// @nodoc
+class __$$SymbolImplCopyWithImpl<$Res> extends _$SymbolCopyWithImpl<$Res, _$SymbolImpl>
+    implements _$$SymbolImplCopyWith<$Res> {
+  __$$SymbolImplCopyWithImpl(_$SymbolImpl _value, $Res Function(_$SymbolImpl) _then) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? grapheme = freezed,
+    Object? template = freezed,
+    Object? rtl = freezed,
+    Object? position = freezed,
+  }) {
+    return _then(_$SymbolImpl(
+      grapheme: freezed == grapheme
+          ? _value.grapheme
+          : grapheme // ignore: cast_nullable_to_non_nullable
+              as String?,
+      template: freezed == template
+          ? _value.template
+          : template // ignore: cast_nullable_to_non_nullable
+              as String?,
+      rtl: freezed == rtl
+          ? _value.rtl
+          : rtl // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      position: freezed == position
+          ? _value.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SymbolImpl implements _Symbol {
+  const _$SymbolImpl({this.grapheme, this.template, this.rtl, this.position});
+
+  @override
+  final String? grapheme;
+  @override
+  final String? template;
+  @override
+  final bool? rtl;
+  @override
+  final int? position;
+
+  @override
+  String toString() {
+    return 'Symbol(grapheme: $grapheme, template: $template, rtl: $rtl, position: $position)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SymbolImpl &&
+            (identical(other.grapheme, grapheme) || other.grapheme == grapheme) &&
+            (identical(other.template, template) || other.template == template) &&
+            (identical(other.rtl, rtl) || other.rtl == rtl) &&
+            (identical(other.position, position) || other.position == position));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, grapheme, template, rtl, position);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SymbolImplCopyWith<_$SymbolImpl> get copyWith =>
+      __$$SymbolImplCopyWithImpl<_$SymbolImpl>(this, _$identity);
+}
+
+abstract class _Symbol implements Symbol {
+  const factory _Symbol(
+      {final String? grapheme, final String? template, final bool? rtl, final int? position}) = _$SymbolImpl;
+
+  @override
+  String? get grapheme;
+  @override
+  String? get template;
+  @override
+  bool? get rtl;
+  @override
+  int? get position;
+  @override
+  @JsonKey(ignore: true)
+  _$$SymbolImplCopyWith<_$SymbolImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$UnspentTransactionOutput {
+  Uint8List get txid => throw _privateConstructorUsedError;
+  int get outnum => throw _privateConstructorUsedError;
+  int get amountMillisatoshi => throw _privateConstructorUsedError;
+  String get address => throw _privateConstructorUsedError;
+  bool get reserved => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $UnspentTransactionOutputCopyWith<UnspentTransactionOutput> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UnspentTransactionOutputCopyWith<$Res> {
+  factory $UnspentTransactionOutputCopyWith(
+          UnspentTransactionOutput value, $Res Function(UnspentTransactionOutput) then) =
+      _$UnspentTransactionOutputCopyWithImpl<$Res, UnspentTransactionOutput>;
+  @useResult
+  $Res call({Uint8List txid, int outnum, int amountMillisatoshi, String address, bool reserved});
+}
+
+/// @nodoc
+class _$UnspentTransactionOutputCopyWithImpl<$Res, $Val extends UnspentTransactionOutput>
+    implements $UnspentTransactionOutputCopyWith<$Res> {
+  _$UnspentTransactionOutputCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? txid = null,
+    Object? outnum = null,
+    Object? amountMillisatoshi = null,
+    Object? address = null,
+    Object? reserved = null,
+  }) {
+    return _then(_value.copyWith(
+      txid: null == txid
+          ? _value.txid
+          : txid // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      outnum: null == outnum
+          ? _value.outnum
+          : outnum // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMillisatoshi: null == amountMillisatoshi
+          ? _value.amountMillisatoshi
+          : amountMillisatoshi // ignore: cast_nullable_to_non_nullable
+              as int,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      reserved: null == reserved
+          ? _value.reserved
+          : reserved // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$UnspentTransactionOutputImplCopyWith<$Res>
+    implements $UnspentTransactionOutputCopyWith<$Res> {
+  factory _$$UnspentTransactionOutputImplCopyWith(
+          _$UnspentTransactionOutputImpl value, $Res Function(_$UnspentTransactionOutputImpl) then) =
+      __$$UnspentTransactionOutputImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Uint8List txid, int outnum, int amountMillisatoshi, String address, bool reserved});
+}
+
+/// @nodoc
+class __$$UnspentTransactionOutputImplCopyWithImpl<$Res>
+    extends _$UnspentTransactionOutputCopyWithImpl<$Res, _$UnspentTransactionOutputImpl>
+    implements _$$UnspentTransactionOutputImplCopyWith<$Res> {
+  __$$UnspentTransactionOutputImplCopyWithImpl(
+      _$UnspentTransactionOutputImpl _value, $Res Function(_$UnspentTransactionOutputImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? txid = null,
+    Object? outnum = null,
+    Object? amountMillisatoshi = null,
+    Object? address = null,
+    Object? reserved = null,
+  }) {
+    return _then(_$UnspentTransactionOutputImpl(
+      txid: null == txid
+          ? _value.txid
+          : txid // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+      outnum: null == outnum
+          ? _value.outnum
+          : outnum // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMillisatoshi: null == amountMillisatoshi
+          ? _value.amountMillisatoshi
+          : amountMillisatoshi // ignore: cast_nullable_to_non_nullable
+              as int,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      reserved: null == reserved
+          ? _value.reserved
+          : reserved // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UnspentTransactionOutputImpl implements _UnspentTransactionOutput {
+  const _$UnspentTransactionOutputImpl(
+      {required this.txid,
+      required this.outnum,
+      required this.amountMillisatoshi,
+      required this.address,
+      required this.reserved});
+
+  @override
+  final Uint8List txid;
+  @override
+  final int outnum;
+  @override
+  final int amountMillisatoshi;
+  @override
+  final String address;
+  @override
+  final bool reserved;
+
+  @override
+  String toString() {
+    return 'UnspentTransactionOutput(txid: $txid, outnum: $outnum, amountMillisatoshi: $amountMillisatoshi, address: $address, reserved: $reserved)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UnspentTransactionOutputImpl &&
+            const DeepCollectionEquality().equals(other.txid, txid) &&
+            (identical(other.outnum, outnum) || other.outnum == outnum) &&
+            (identical(other.amountMillisatoshi, amountMillisatoshi) ||
+                other.amountMillisatoshi == amountMillisatoshi) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.reserved, reserved) || other.reserved == reserved));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(txid), outnum, amountMillisatoshi, address, reserved);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UnspentTransactionOutputImplCopyWith<_$UnspentTransactionOutputImpl> get copyWith =>
+      __$$UnspentTransactionOutputImplCopyWithImpl<_$UnspentTransactionOutputImpl>(this, _$identity);
+}
+
+abstract class _UnspentTransactionOutput implements UnspentTransactionOutput {
+  const factory _UnspentTransactionOutput(
+      {required final Uint8List txid,
+      required final int outnum,
+      required final int amountMillisatoshi,
+      required final String address,
+      required final bool reserved}) = _$UnspentTransactionOutputImpl;
+
+  @override
+  Uint8List get txid;
+  @override
+  int get outnum;
+  @override
+  int get amountMillisatoshi;
+  @override
+  String get address;
+  @override
+  bool get reserved;
+  @override
+  @JsonKey(ignore: true)
+  _$$UnspentTransactionOutputImplCopyWith<_$UnspentTransactionOutputImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
- All SDK structs exposed through Dart bindings that reference another SDK struct has to be annotated. Including the referenced struct.

- Not needed on structs that only has supported types so enums are excluded. https://cjycode.com/flutter_rust_bridge/v1/feature/lang_simple.html