### PR TITLE
Improve payment asynchronicity 

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -601,6 +601,7 @@ dictionary BitcoinAddressData {
 dictionary LnUrlPaySuccessData {
     SuccessActionProcessed? success_action;
     string payment_hash;
+    Payment payment;
 };
 
 dictionary LnUrlErrorData {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -616,6 +616,7 @@ dictionary LnUrlPayRequest {
     LnUrlPayRequestData data;
     u64 amount_msat;
     string? comment = null;
+    string? payment_metadata = null;
 };
 
 dictionary LnUrlPayRequestData {
@@ -743,12 +744,14 @@ dictionary RedeemOnchainFundsResponse {
 dictionary SendPaymentRequest {
     string bolt11;
     u64? amount_msat = null;
+    string? payment_metadata = null;
 };
 
 dictionary SendSpontaneousPaymentRequest {
     string node_id;
     u64 amount_msat;
     sequence<TlvEntry>? extra_tlvs = null;
+    string? payment_metadata = null;
 };
 
 dictionary SendPaymentResponse {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -617,7 +617,7 @@ dictionary LnUrlPayRequest {
     LnUrlPayRequestData data;
     u64 amount_msat;
     string? comment = null;
-    string? payment_metadata = null;
+    string? payment_label = null;
 };
 
 dictionary LnUrlPayRequestData {
@@ -745,14 +745,14 @@ dictionary RedeemOnchainFundsResponse {
 dictionary SendPaymentRequest {
     string bolt11;
     u64? amount_msat = null;
-    string? payment_metadata = null;
+    string? label = null;
 };
 
 dictionary SendSpontaneousPaymentRequest {
     string node_id;
     u64 amount_msat;
     sequence<TlvEntry>? extra_tlvs = null;
-    string? payment_metadata = null;
+    string? label = null;
 };
 
 dictionary SendPaymentResponse {

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -600,7 +600,6 @@ dictionary BitcoinAddressData {
 
 dictionary LnUrlPaySuccessData {
     SuccessActionProcessed? success_action;
-    string payment_hash;
     Payment payment;
 };
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -451,7 +451,6 @@ impl BreezServices {
 
                 Ok(LnUrlPayResult::EndpointSuccess {
                     data: LnUrlPaySuccessData {
-                        payment_hash: details.payment_hash.clone(),
                         payment,
                         success_action: maybe_sa_processed,
                     },

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -448,6 +448,7 @@ impl BreezServices {
                 Ok(LnUrlPayResult::EndpointSuccess {
                     data: LnUrlPaySuccessData {
                         payment_hash: details.payment_hash.clone(),
+                        payment,
                         success_action: maybe_sa_processed,
                     },
                 })

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -858,7 +858,7 @@ impl Wire2Api<LnUrlPayRequest> for wire_LnUrlPayRequest {
             data: self.data.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
             comment: self.comment.wire2api(),
-            payment_metadata: self.payment_metadata.wire2api(),
+            payment_label: self.payment_label.wire2api(),
         }
     }
 }
@@ -1069,7 +1069,7 @@ impl Wire2Api<SendPaymentRequest> for wire_SendPaymentRequest {
         SendPaymentRequest {
             bolt11: self.bolt11.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
-            payment_metadata: self.payment_metadata.wire2api(),
+            label: self.label.wire2api(),
         }
     }
 }
@@ -1079,7 +1079,7 @@ impl Wire2Api<SendSpontaneousPaymentRequest> for wire_SendSpontaneousPaymentRequ
             node_id: self.node_id.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
             extra_tlvs: self.extra_tlvs.wire2api(),
-            payment_metadata: self.payment_metadata.wire2api(),
+            label: self.label.wire2api(),
         }
     }
 }
@@ -1224,7 +1224,7 @@ pub struct wire_LnUrlPayRequest {
     data: wire_LnUrlPayRequestData,
     amount_msat: u64,
     comment: *mut wire_uint_8_list,
-    payment_metadata: *mut wire_uint_8_list,
+    payment_label: *mut wire_uint_8_list,
 }
 
 #[repr(C)]
@@ -1385,7 +1385,7 @@ pub struct wire_SendOnchainRequest {
 pub struct wire_SendPaymentRequest {
     bolt11: *mut wire_uint_8_list,
     amount_msat: *mut u64,
-    payment_metadata: *mut wire_uint_8_list,
+    label: *mut wire_uint_8_list,
 }
 
 #[repr(C)]
@@ -1394,7 +1394,7 @@ pub struct wire_SendSpontaneousPaymentRequest {
     node_id: *mut wire_uint_8_list,
     amount_msat: u64,
     extra_tlvs: *mut wire_list_tlv_entry,
-    payment_metadata: *mut wire_uint_8_list,
+    label: *mut wire_uint_8_list,
 }
 
 #[repr(C)]
@@ -1629,7 +1629,7 @@ impl NewWithNullPtr for wire_LnUrlPayRequest {
             data: Default::default(),
             amount_msat: Default::default(),
             comment: core::ptr::null_mut(),
-            payment_metadata: core::ptr::null_mut(),
+            payment_label: core::ptr::null_mut(),
         }
     }
 }
@@ -1990,7 +1990,7 @@ impl NewWithNullPtr for wire_SendPaymentRequest {
         Self {
             bolt11: core::ptr::null_mut(),
             amount_msat: core::ptr::null_mut(),
-            payment_metadata: core::ptr::null_mut(),
+            label: core::ptr::null_mut(),
         }
     }
 }
@@ -2007,7 +2007,7 @@ impl NewWithNullPtr for wire_SendSpontaneousPaymentRequest {
             node_id: core::ptr::null_mut(),
             amount_msat: Default::default(),
             extra_tlvs: core::ptr::null_mut(),
-            payment_metadata: core::ptr::null_mut(),
+            label: core::ptr::null_mut(),
         }
     }
 }

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -858,6 +858,7 @@ impl Wire2Api<LnUrlPayRequest> for wire_LnUrlPayRequest {
             data: self.data.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
             comment: self.comment.wire2api(),
+            payment_metadata: self.payment_metadata.wire2api(),
         }
     }
 }
@@ -1068,6 +1069,7 @@ impl Wire2Api<SendPaymentRequest> for wire_SendPaymentRequest {
         SendPaymentRequest {
             bolt11: self.bolt11.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
+            payment_metadata: self.payment_metadata.wire2api(),
         }
     }
 }
@@ -1077,6 +1079,7 @@ impl Wire2Api<SendSpontaneousPaymentRequest> for wire_SendSpontaneousPaymentRequ
             node_id: self.node_id.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
             extra_tlvs: self.extra_tlvs.wire2api(),
+            payment_metadata: self.payment_metadata.wire2api(),
         }
     }
 }
@@ -1221,6 +1224,7 @@ pub struct wire_LnUrlPayRequest {
     data: wire_LnUrlPayRequestData,
     amount_msat: u64,
     comment: *mut wire_uint_8_list,
+    payment_metadata: *mut wire_uint_8_list,
 }
 
 #[repr(C)]
@@ -1381,6 +1385,7 @@ pub struct wire_SendOnchainRequest {
 pub struct wire_SendPaymentRequest {
     bolt11: *mut wire_uint_8_list,
     amount_msat: *mut u64,
+    payment_metadata: *mut wire_uint_8_list,
 }
 
 #[repr(C)]
@@ -1389,6 +1394,7 @@ pub struct wire_SendSpontaneousPaymentRequest {
     node_id: *mut wire_uint_8_list,
     amount_msat: u64,
     extra_tlvs: *mut wire_list_tlv_entry,
+    payment_metadata: *mut wire_uint_8_list,
 }
 
 #[repr(C)]
@@ -1623,6 +1629,7 @@ impl NewWithNullPtr for wire_LnUrlPayRequest {
             data: Default::default(),
             amount_msat: Default::default(),
             comment: core::ptr::null_mut(),
+            payment_metadata: core::ptr::null_mut(),
         }
     }
 }
@@ -1983,6 +1990,7 @@ impl NewWithNullPtr for wire_SendPaymentRequest {
         Self {
             bolt11: core::ptr::null_mut(),
             amount_msat: core::ptr::null_mut(),
+            payment_metadata: core::ptr::null_mut(),
         }
     }
 }
@@ -1999,6 +2007,7 @@ impl NewWithNullPtr for wire_SendSpontaneousPaymentRequest {
             node_id: core::ptr::null_mut(),
             amount_msat: Default::default(),
             extra_tlvs: core::ptr::null_mut(),
+            payment_metadata: core::ptr::null_mut(),
         }
     }
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1509,6 +1509,7 @@ impl support::IntoDart for LnUrlPaySuccessData {
     fn into_dart(self) -> support::DartAbi {
         vec![
             self.payment_hash.into_into_dart().into_dart(),
+            self.payment.into_into_dart().into_dart(),
             self.success_action.into_dart(),
         ]
         .into_dart()

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1508,7 +1508,6 @@ impl rust2dart::IntoIntoDart<LnUrlPayResult> for LnUrlPayResult {
 impl support::IntoDart for LnUrlPaySuccessData {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.payment_hash.into_into_dart().into_dart(),
             self.payment.into_into_dart().into_dart(),
             self.success_action.into_dart(),
         ]

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -121,7 +121,7 @@ fn validate_invoice(user_amount_msat: u64, bolt11: &str, network: Network) -> Ln
 pub(crate) mod model {
     use crate::lnurl::error::{LnUrlError, LnUrlResult};
     use crate::lnurl::pay::{Aes256CbcDec, Aes256CbcEnc};
-    use crate::{ensure_sdk, input_parser::*};
+    use crate::{ensure_sdk, input_parser::*, Payment};
 
     use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
     use anyhow::{anyhow, Result};
@@ -144,6 +144,7 @@ pub(crate) mod model {
     /// * `PayError` indicates that an error occurred while trying to pay the invoice from the LNURL endpoint.
     /// This includes the payment hash of the failed invoice and the failure reason.
     #[derive(Debug, Serialize, Deserialize)]
+    #[allow(clippy::large_enum_variant)]
     pub enum LnUrlPayResult {
         EndpointSuccess { data: LnUrlPaySuccessData },
         EndpointError { data: LnUrlErrorData },
@@ -159,6 +160,7 @@ pub(crate) mod model {
     #[derive(Serialize, Deserialize, Debug)]
     pub struct LnUrlPaySuccessData {
         pub payment_hash: String,
+        pub payment: Payment,
         pub success_action: Option<SuccessActionProcessed>,
     }
 

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -895,7 +895,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await?
         {
@@ -939,7 +939,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await;
         // An unsupported Success Action results in an error
@@ -969,7 +969,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await?
         {
@@ -1002,7 +1002,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await?
         {
@@ -1050,7 +1050,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await
             .is_err());
@@ -1080,7 +1080,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await;
         assert!(matches!(res, Ok(LnUrlPayResult::EndpointError { data: _ })));
@@ -1117,7 +1117,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await?
         {
@@ -1202,7 +1202,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await?
         {
@@ -1286,7 +1286,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
-                payment_metadata: None,
+                payment_label: None,
             })
             .await?
         {

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -875,8 +875,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lnurl_pay_no_success_action() -> Result<()> {
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
         let inv = rand_invoice_with_description_hash(temp_desc)?;
         let user_amount_msat = inv.amount_milli_satoshis().unwrap();
@@ -917,13 +917,13 @@ mod tests {
         }
     }
 
-    static COMMENT_LENGHT: u16 = 10;
+    static COMMENT_LENGTH: u16 = 10;
 
     #[tokio::test]
     async fn test_lnurl_pay_unsupported_success_action() -> Result<()> {
         let user_amount_msat = 11000;
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let _m =
             mock_lnurl_pay_callback_endpoint_unsupported_success_action(LnurlPayCallbackParams {
                 pay_req: &pay_req,
@@ -950,8 +950,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lnurl_pay_success_payment_hash() -> Result<()> {
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
         let inv = rand_invoice_with_description_hash(temp_desc)?;
         let user_amount_msat = inv.amount_milli_satoshis().unwrap();
@@ -983,8 +983,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lnurl_pay_msg_success_action() -> Result<()> {
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
         let inv = rand_invoice_with_description_hash(temp_desc)?;
         let user_amount_msat = inv.amount_milli_satoshis().unwrap();
@@ -1031,8 +1031,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lnurl_pay_msg_success_action_incorrect_amount() -> Result<()> {
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
         let inv = rand_invoice_with_description_hash(temp_desc)?;
         let user_amount_msat = inv.amount_milli_satoshis().unwrap() + 1000;
@@ -1060,8 +1060,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lnurl_pay_msg_success_action_error_from_endpoint() -> Result<()> {
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
         let inv = rand_invoice_with_description_hash(temp_desc)?;
         let user_amount_msat = inv.amount_milli_satoshis().unwrap();
@@ -1098,8 +1098,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lnurl_pay_url_success_action() -> Result<()> {
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
         let inv = rand_invoice_with_description_hash(temp_desc)?;
         let user_amount_msat = inv.amount_milli_satoshis().unwrap();
@@ -1166,8 +1166,8 @@ mod tests {
         // Generate preimage
         let preimage = sha256::Hash::hash(&rand_vec_u8(10));
 
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
 
         // The invoice (served by LNURL-pay endpoint, matching preimage and description hash)
@@ -1243,8 +1243,8 @@ mod tests {
         // Generate preimage
         let preimage = sha256::Hash::hash(&rand_vec_u8(10));
 
-        let comment = rand_string(COMMENT_LENGHT as usize);
-        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGHT);
+        let comment = rand_string(COMMENT_LENGTH as usize);
+        let pay_req = get_test_pay_req_data(0, 100_000, COMMENT_LENGTH);
         let temp_desc = pay_req.metadata_str.clone();
 
         // The invoice (served by LNURL-pay endpoint, matching preimage and description hash)

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -159,7 +159,6 @@ pub(crate) mod model {
 
     #[derive(Serialize, Deserialize, Debug)]
     pub struct LnUrlPaySuccessData {
-        pub payment_hash: String,
         pub payment: Payment,
         pub success_action: Option<SuccessActionProcessed>,
     }
@@ -973,7 +972,7 @@ mod tests {
             })
             .await?
         {
-            LnUrlPayResult::EndpointSuccess { data } => match data.payment_hash {
+            LnUrlPayResult::EndpointSuccess { data } => match data.payment.id {
                 s if s == inv.payment_hash().to_hex() => Ok(()),
                 _ => Err(anyhow!("Unexpected payment hash")),
             },

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -893,6 +893,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await?
         {
@@ -936,6 +937,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await;
         // An unsupported Success Action results in an error
@@ -965,6 +967,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await?
         {
@@ -997,6 +1000,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await?
         {
@@ -1043,7 +1047,8 @@ mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
-                comment: Some(comment)
+                comment: Some(comment),
+                payment_metadata: None,
             })
             .await
             .is_err());
@@ -1073,6 +1078,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await;
         assert!(matches!(res, Ok(LnUrlPayResult::EndpointError { data: _ })));
@@ -1109,6 +1115,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await?
         {
@@ -1193,6 +1200,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await?
         {
@@ -1276,6 +1284,7 @@ mod tests {
                 data: pay_req,
                 amount_msat: user_amount_msat,
                 comment: Some(comment),
+                payment_metadata: None,
             })
             .await?
         {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -875,6 +875,8 @@ pub struct SendPaymentRequest {
     pub bolt11: String,
     /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
     pub amount_msat: Option<u64>,
+    /// The external metadata to be added to the [Payment]
+    pub payment_metadata: Option<String>,
 }
 
 /// Represents a TLV entry for a keysend payment.
@@ -895,6 +897,8 @@ pub struct SendSpontaneousPaymentRequest {
     pub amount_msat: u64,
     // Optional extra TLVs
     pub extra_tlvs: Option<Vec<TlvEntry>>,
+    /// The external metadata to be added to the [Payment]
+    pub payment_metadata: Option<String>,
 }
 
 /// Represents a send payment response.
@@ -1554,6 +1558,8 @@ pub struct LnUrlPayRequest {
     pub amount_msat: u64,
     /// An optional comment for this payment
     pub comment: Option<String>,
+    /// The external metadata to be added to the [Payment]
+    pub payment_metadata: Option<String>,
 }
 
 /// [LnUrlCallbackStatus] specific to LNURL-withdraw, where the success case contains the invoice.

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -875,8 +875,8 @@ pub struct SendPaymentRequest {
     pub bolt11: String,
     /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
     pub amount_msat: Option<u64>,
-    /// The external metadata to be added to the [Payment]
-    pub payment_metadata: Option<String>,
+    /// The external label or identifier of the [Payment]
+    pub label: Option<String>,
 }
 
 /// Represents a TLV entry for a keysend payment.
@@ -897,8 +897,8 @@ pub struct SendSpontaneousPaymentRequest {
     pub amount_msat: u64,
     // Optional extra TLVs
     pub extra_tlvs: Option<Vec<TlvEntry>>,
-    /// The external metadata to be added to the [Payment]
-    pub payment_metadata: Option<String>,
+    /// The external label or identifier of the [Payment]
+    pub label: Option<String>,
 }
 
 /// Represents a send payment response.
@@ -1558,8 +1558,8 @@ pub struct LnUrlPayRequest {
     pub amount_msat: u64,
     /// An optional comment for this payment
     pub comment: Option<String>,
-    /// The external metadata to be added to the [Payment]
-    pub payment_metadata: Option<String>,
+    /// The external label or identifier of the [Payment]
+    pub payment_label: Option<String>,
 }
 
 /// [LnUrlCallbackStatus] specific to LNURL-withdraw, where the success case contains the invoice.

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -85,12 +85,18 @@ pub trait NodeAPI: Send + Sync {
         balance_changed: bool,
     ) -> NodeResult<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_msat` is only needed when the invoice doesn't specify an amount
-    async fn send_payment(&self, bolt11: String, amount_msat: Option<u64>) -> NodeResult<Payment>;
+    async fn send_payment(
+        &self,
+        bolt11: String,
+        amount_msat: Option<u64>,
+        label: Option<String>,
+    ) -> NodeResult<Payment>;
     async fn send_spontaneous_payment(
         &self,
         node_id: String,
         amount_msat: u64,
         extra_tlvs: Option<Vec<TlvEntry>>,
+        label: Option<String>,
     ) -> NodeResult<Payment>;
     async fn start(&self) -> NodeResult<String>;
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -372,7 +372,12 @@ impl NodeAPI for MockNodeAPI {
         Err(NodeError::Generic(anyhow!("Not implemented")))
     }
 
-    async fn send_payment(&self, bolt11: String, _amount_msat: Option<u64>) -> NodeResult<Payment> {
+    async fn send_payment(
+        &self,
+        bolt11: String,
+        _amount_msat: Option<u64>,
+        _label: Option<String>,
+    ) -> NodeResult<Payment> {
         let payment = self.add_dummy_payment_for(bolt11, None, None).await?;
         Ok(payment)
     }
@@ -382,6 +387,7 @@ impl NodeAPI for MockNodeAPI {
         _node_id: String,
         _amount_msat: u64,
         _extra_tlvs: Option<Vec<TlvEntry>>,
+        _label: Option<String>,
     ) -> NodeResult<Payment> {
         let payment = self.add_dummy_payment_rand().await?;
         Ok(payment)

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -111,7 +111,7 @@ typedef struct wire_ListPaymentsRequest {
 typedef struct wire_SendPaymentRequest {
   struct wire_uint_8_list *bolt11;
   uint64_t *amount_msat;
-  struct wire_uint_8_list *payment_metadata;
+  struct wire_uint_8_list *label;
 } wire_SendPaymentRequest;
 
 typedef struct wire_TlvEntry {
@@ -128,7 +128,7 @@ typedef struct wire_SendSpontaneousPaymentRequest {
   struct wire_uint_8_list *node_id;
   uint64_t amount_msat;
   struct wire_list_tlv_entry *extra_tlvs;
-  struct wire_uint_8_list *payment_metadata;
+  struct wire_uint_8_list *label;
 } wire_SendSpontaneousPaymentRequest;
 
 typedef struct wire_OpeningFeeParams {
@@ -164,7 +164,7 @@ typedef struct wire_LnUrlPayRequest {
   struct wire_LnUrlPayRequestData data;
   uint64_t amount_msat;
   struct wire_uint_8_list *comment;
-  struct wire_uint_8_list *payment_metadata;
+  struct wire_uint_8_list *payment_label;
 } wire_LnUrlPayRequest;
 
 typedef struct wire_LnUrlWithdrawRequestData {

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -111,6 +111,7 @@ typedef struct wire_ListPaymentsRequest {
 typedef struct wire_SendPaymentRequest {
   struct wire_uint_8_list *bolt11;
   uint64_t *amount_msat;
+  struct wire_uint_8_list *payment_metadata;
 } wire_SendPaymentRequest;
 
 typedef struct wire_TlvEntry {
@@ -127,6 +128,7 @@ typedef struct wire_SendSpontaneousPaymentRequest {
   struct wire_uint_8_list *node_id;
   uint64_t amount_msat;
   struct wire_list_tlv_entry *extra_tlvs;
+  struct wire_uint_8_list *payment_metadata;
 } wire_SendSpontaneousPaymentRequest;
 
 typedef struct wire_OpeningFeeParams {
@@ -162,6 +164,7 @@ typedef struct wire_LnUrlPayRequest {
   struct wire_LnUrlPayRequestData data;
   uint64_t amount_msat;
   struct wire_uint_8_list *comment;
+  struct wire_uint_8_list *payment_metadata;
 } wire_LnUrlPayRequest;
 
 typedef struct wire_LnUrlWithdrawRequestData {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -958,12 +958,10 @@ sealed class LnUrlPayResult with _$LnUrlPayResult {
 }
 
 class LnUrlPaySuccessData {
-  final String paymentHash;
   final Payment payment;
   final SuccessActionProcessed? successAction;
 
   const LnUrlPaySuccessData({
-    required this.paymentHash,
     required this.payment,
     this.successAction,
   });
@@ -3642,11 +3640,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LnUrlPaySuccessData _wire2api_ln_url_pay_success_data(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return LnUrlPaySuccessData(
-      paymentHash: _wire2api_String(arr[0]),
-      payment: _wire2api_payment(arr[1]),
-      successAction: _wire2api_opt_box_autoadd_success_action_processed(arr[2]),
+      payment: _wire2api_payment(arr[0]),
+      successAction: _wire2api_opt_box_autoadd_success_action_processed(arr[1]),
     );
   }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -959,10 +959,12 @@ sealed class LnUrlPayResult with _$LnUrlPayResult {
 
 class LnUrlPaySuccessData {
   final String paymentHash;
+  final Payment payment;
   final SuccessActionProcessed? successAction;
 
   const LnUrlPaySuccessData({
     required this.paymentHash,
+    required this.payment,
     this.successAction,
   });
 }
@@ -3640,10 +3642,11 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LnUrlPaySuccessData _wire2api_ln_url_pay_success_data(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return LnUrlPaySuccessData(
       paymentHash: _wire2api_String(arr[0]),
-      successAction: _wire2api_opt_box_autoadd_success_action_processed(arr[1]),
+      payment: _wire2api_payment(arr[1]),
+      successAction: _wire2api_opt_box_autoadd_success_action_processed(arr[2]),
     );
   }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -890,10 +890,14 @@ class LnUrlPayRequest {
   /// An optional comment for this payment
   final String? comment;
 
+  /// The external metadata to be added to the [Payment]
+  final String? paymentMetadata;
+
   const LnUrlPayRequest({
     required this.data,
     required this.amountMsat,
     this.comment,
+    this.paymentMetadata,
   });
 }
 
@@ -1773,9 +1777,13 @@ class SendPaymentRequest {
   /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
   final int? amountMsat;
 
+  /// The external metadata to be added to the [Payment]
+  final String? paymentMetadata;
+
   const SendPaymentRequest({
     required this.bolt11,
     this.amountMsat,
+    this.paymentMetadata,
   });
 }
 
@@ -1797,10 +1805,14 @@ class SendSpontaneousPaymentRequest {
   final int amountMsat;
   final List<TlvEntry>? extraTlvs;
 
+  /// The external metadata to be added to the [Payment]
+  final String? paymentMetadata;
+
   const SendSpontaneousPaymentRequest({
     required this.nodeId,
     required this.amountMsat,
     this.extraTlvs,
+    this.paymentMetadata,
   });
 }
 
@@ -4849,6 +4861,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_ln_url_pay_request_data(apiObj.data, wireObj.data);
     wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
     wireObj.comment = api2wire_opt_String(apiObj.comment);
+    wireObj.payment_metadata = api2wire_opt_String(apiObj.paymentMetadata);
   }
 
   void _api_fill_to_wire_ln_url_pay_request_data(
@@ -5004,6 +5017,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_send_payment_request(SendPaymentRequest apiObj, wire_SendPaymentRequest wireObj) {
     wireObj.bolt11 = api2wire_String(apiObj.bolt11);
     wireObj.amount_msat = api2wire_opt_box_autoadd_u64(apiObj.amountMsat);
+    wireObj.payment_metadata = api2wire_opt_String(apiObj.paymentMetadata);
   }
 
   void _api_fill_to_wire_send_spontaneous_payment_request(
@@ -5011,6 +5025,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.node_id = api2wire_String(apiObj.nodeId);
     wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
     wireObj.extra_tlvs = api2wire_opt_list_tlv_entry(apiObj.extraTlvs);
+    wireObj.payment_metadata = api2wire_opt_String(apiObj.paymentMetadata);
   }
 
   void _api_fill_to_wire_sign_message_request(SignMessageRequest apiObj, wire_SignMessageRequest wireObj) {
@@ -6547,6 +6562,8 @@ final class wire_SendPaymentRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> bolt11;
 
   external ffi.Pointer<ffi.Uint64> amount_msat;
+
+  external ffi.Pointer<wire_uint_8_list> payment_metadata;
 }
 
 final class wire_TlvEntry extends ffi.Struct {
@@ -6570,6 +6587,8 @@ final class wire_SendSpontaneousPaymentRequest extends ffi.Struct {
   external int amount_msat;
 
   external ffi.Pointer<wire_list_tlv_entry> extra_tlvs;
+
+  external ffi.Pointer<wire_uint_8_list> payment_metadata;
 }
 
 final class wire_OpeningFeeParams extends ffi.Struct {
@@ -6633,6 +6652,8 @@ final class wire_LnUrlPayRequest extends ffi.Struct {
   external int amount_msat;
 
   external ffi.Pointer<wire_uint_8_list> comment;
+
+  external ffi.Pointer<wire_uint_8_list> payment_metadata;
 }
 
 final class wire_LnUrlWithdrawRequestData extends ffi.Struct {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -890,14 +890,14 @@ class LnUrlPayRequest {
   /// An optional comment for this payment
   final String? comment;
 
-  /// The external metadata to be added to the [Payment]
-  final String? paymentMetadata;
+  /// The external label or identifier of the [Payment]
+  final String? paymentLabel;
 
   const LnUrlPayRequest({
     required this.data,
     required this.amountMsat,
     this.comment,
-    this.paymentMetadata,
+    this.paymentLabel,
   });
 }
 
@@ -1779,13 +1779,13 @@ class SendPaymentRequest {
   /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
   final int? amountMsat;
 
-  /// The external metadata to be added to the [Payment]
-  final String? paymentMetadata;
+  /// The external label or identifier of the [Payment]
+  final String? label;
 
   const SendPaymentRequest({
     required this.bolt11,
     this.amountMsat,
-    this.paymentMetadata,
+    this.label,
   });
 }
 
@@ -1807,14 +1807,14 @@ class SendSpontaneousPaymentRequest {
   final int amountMsat;
   final List<TlvEntry>? extraTlvs;
 
-  /// The external metadata to be added to the [Payment]
-  final String? paymentMetadata;
+  /// The external label or identifier of the [Payment]
+  final String? label;
 
   const SendSpontaneousPaymentRequest({
     required this.nodeId,
     required this.amountMsat,
     this.extraTlvs,
-    this.paymentMetadata,
+    this.label,
   });
 }
 
@@ -4864,7 +4864,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_ln_url_pay_request_data(apiObj.data, wireObj.data);
     wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
     wireObj.comment = api2wire_opt_String(apiObj.comment);
-    wireObj.payment_metadata = api2wire_opt_String(apiObj.paymentMetadata);
+    wireObj.payment_label = api2wire_opt_String(apiObj.paymentLabel);
   }
 
   void _api_fill_to_wire_ln_url_pay_request_data(
@@ -5020,7 +5020,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_send_payment_request(SendPaymentRequest apiObj, wire_SendPaymentRequest wireObj) {
     wireObj.bolt11 = api2wire_String(apiObj.bolt11);
     wireObj.amount_msat = api2wire_opt_box_autoadd_u64(apiObj.amountMsat);
-    wireObj.payment_metadata = api2wire_opt_String(apiObj.paymentMetadata);
+    wireObj.label = api2wire_opt_String(apiObj.label);
   }
 
   void _api_fill_to_wire_send_spontaneous_payment_request(
@@ -5028,7 +5028,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.node_id = api2wire_String(apiObj.nodeId);
     wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
     wireObj.extra_tlvs = api2wire_opt_list_tlv_entry(apiObj.extraTlvs);
-    wireObj.payment_metadata = api2wire_opt_String(apiObj.paymentMetadata);
+    wireObj.label = api2wire_opt_String(apiObj.label);
   }
 
   void _api_fill_to_wire_sign_message_request(SignMessageRequest apiObj, wire_SignMessageRequest wireObj) {
@@ -6566,7 +6566,7 @@ final class wire_SendPaymentRequest extends ffi.Struct {
 
   external ffi.Pointer<ffi.Uint64> amount_msat;
 
-  external ffi.Pointer<wire_uint_8_list> payment_metadata;
+  external ffi.Pointer<wire_uint_8_list> label;
 }
 
 final class wire_TlvEntry extends ffi.Struct {
@@ -6591,7 +6591,7 @@ final class wire_SendSpontaneousPaymentRequest extends ffi.Struct {
 
   external ffi.Pointer<wire_list_tlv_entry> extra_tlvs;
 
-  external ffi.Pointer<wire_uint_8_list> payment_metadata;
+  external ffi.Pointer<wire_uint_8_list> label;
 }
 
 final class wire_OpeningFeeParams extends ffi.Struct {
@@ -6656,7 +6656,7 @@ final class wire_LnUrlPayRequest extends ffi.Struct {
 
   external ffi.Pointer<wire_uint_8_list> comment;
 
-  external ffi.Pointer<wire_uint_8_list> payment_metadata;
+  external ffi.Pointer<wire_uint_8_list> payment_label;
 }
 
 final class wire_LnUrlWithdrawRequestData extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1155,10 +1155,12 @@ fun asLnUrlPayRequest(lnUrlPayRequest: ReadableMap): LnUrlPayRequest? {
     val data = lnUrlPayRequest.getMap("data")?.let { asLnUrlPayRequestData(it) }!!
     val amountMsat = lnUrlPayRequest.getDouble("amountMsat").toULong()
     val comment = if (hasNonNullKey(lnUrlPayRequest, "comment")) lnUrlPayRequest.getString("comment") else null
+    val paymentMetadata = if (hasNonNullKey(lnUrlPayRequest, "paymentMetadata")) lnUrlPayRequest.getString("paymentMetadata") else null
     return LnUrlPayRequest(
         data,
         amountMsat,
         comment,
+        paymentMetadata,
     )
 }
 
@@ -1167,6 +1169,7 @@ fun readableMapOf(lnUrlPayRequest: LnUrlPayRequest): ReadableMap {
         "data" to readableMapOf(lnUrlPayRequest.data),
         "amountMsat" to lnUrlPayRequest.amountMsat,
         "comment" to lnUrlPayRequest.comment,
+        "paymentMetadata" to lnUrlPayRequest.paymentMetadata,
     )
 }
 
@@ -3217,9 +3220,20 @@ fun asSendPaymentRequest(sendPaymentRequest: ReadableMap): SendPaymentRequest? {
     }
     val bolt11 = sendPaymentRequest.getString("bolt11")!!
     val amountMsat = if (hasNonNullKey(sendPaymentRequest, "amountMsat")) sendPaymentRequest.getDouble("amountMsat").toULong() else null
+    val paymentMetadata =
+        if (hasNonNullKey(
+                sendPaymentRequest,
+                "paymentMetadata",
+            )
+        ) {
+            sendPaymentRequest.getString("paymentMetadata")
+        } else {
+            null
+        }
     return SendPaymentRequest(
         bolt11,
         amountMsat,
+        paymentMetadata,
     )
 }
 
@@ -3227,6 +3241,7 @@ fun readableMapOf(sendPaymentRequest: SendPaymentRequest): ReadableMap {
     return readableMapOf(
         "bolt11" to sendPaymentRequest.bolt11,
         "amountMsat" to sendPaymentRequest.amountMsat,
+        "paymentMetadata" to sendPaymentRequest.paymentMetadata,
     )
 }
 
@@ -3299,10 +3314,21 @@ fun asSendSpontaneousPaymentRequest(sendSpontaneousPaymentRequest: ReadableMap):
         } else {
             null
         }
+    val paymentMetadata =
+        if (hasNonNullKey(
+                sendSpontaneousPaymentRequest,
+                "paymentMetadata",
+            )
+        ) {
+            sendSpontaneousPaymentRequest.getString("paymentMetadata")
+        } else {
+            null
+        }
     return SendSpontaneousPaymentRequest(
         nodeId,
         amountMsat,
         extraTlvs,
+        paymentMetadata,
     )
 }
 
@@ -3311,6 +3337,7 @@ fun readableMapOf(sendSpontaneousPaymentRequest: SendSpontaneousPaymentRequest):
         "nodeId" to sendSpontaneousPaymentRequest.nodeId,
         "amountMsat" to sendSpontaneousPaymentRequest.amountMsat,
         "extraTlvs" to sendSpontaneousPaymentRequest.extraTlvs?.let { readableArrayOf(it) },
+        "paymentMetadata" to sendSpontaneousPaymentRequest.paymentMetadata,
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1245,6 +1245,7 @@ fun asLnUrlPaySuccessData(lnUrlPaySuccessData: ReadableMap): LnUrlPaySuccessData
             lnUrlPaySuccessData,
             arrayOf(
                 "paymentHash",
+                "payment",
             ),
         )
     ) {
@@ -1259,9 +1260,11 @@ fun asLnUrlPaySuccessData(lnUrlPaySuccessData: ReadableMap): LnUrlPaySuccessData
             null
         }
     val paymentHash = lnUrlPaySuccessData.getString("paymentHash")!!
+    val payment = lnUrlPaySuccessData.getMap("payment")?.let { asPayment(it) }!!
     return LnUrlPaySuccessData(
         successAction,
         paymentHash,
+        payment,
     )
 }
 
@@ -1269,6 +1272,7 @@ fun readableMapOf(lnUrlPaySuccessData: LnUrlPaySuccessData): ReadableMap {
     return readableMapOf(
         "successAction" to lnUrlPaySuccessData.successAction?.let { readableMapOf(it) },
         "paymentHash" to lnUrlPaySuccessData.paymentHash,
+        "payment" to readableMapOf(lnUrlPaySuccessData.payment),
     )
 }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1244,7 +1244,6 @@ fun asLnUrlPaySuccessData(lnUrlPaySuccessData: ReadableMap): LnUrlPaySuccessData
     if (!validateMandatoryFields(
             lnUrlPaySuccessData,
             arrayOf(
-                "paymentHash",
                 "payment",
             ),
         )
@@ -1259,11 +1258,9 @@ fun asLnUrlPaySuccessData(lnUrlPaySuccessData: ReadableMap): LnUrlPaySuccessData
         } else {
             null
         }
-    val paymentHash = lnUrlPaySuccessData.getString("paymentHash")!!
     val payment = lnUrlPaySuccessData.getMap("payment")?.let { asPayment(it) }!!
     return LnUrlPaySuccessData(
         successAction,
-        paymentHash,
         payment,
     )
 }
@@ -1271,7 +1268,6 @@ fun asLnUrlPaySuccessData(lnUrlPaySuccessData: ReadableMap): LnUrlPaySuccessData
 fun readableMapOf(lnUrlPaySuccessData: LnUrlPaySuccessData): ReadableMap {
     return readableMapOf(
         "successAction" to lnUrlPaySuccessData.successAction?.let { readableMapOf(it) },
-        "paymentHash" to lnUrlPaySuccessData.paymentHash,
         "payment" to readableMapOf(lnUrlPaySuccessData.payment),
     )
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1155,12 +1155,12 @@ fun asLnUrlPayRequest(lnUrlPayRequest: ReadableMap): LnUrlPayRequest? {
     val data = lnUrlPayRequest.getMap("data")?.let { asLnUrlPayRequestData(it) }!!
     val amountMsat = lnUrlPayRequest.getDouble("amountMsat").toULong()
     val comment = if (hasNonNullKey(lnUrlPayRequest, "comment")) lnUrlPayRequest.getString("comment") else null
-    val paymentMetadata = if (hasNonNullKey(lnUrlPayRequest, "paymentMetadata")) lnUrlPayRequest.getString("paymentMetadata") else null
+    val paymentLabel = if (hasNonNullKey(lnUrlPayRequest, "paymentLabel")) lnUrlPayRequest.getString("paymentLabel") else null
     return LnUrlPayRequest(
         data,
         amountMsat,
         comment,
-        paymentMetadata,
+        paymentLabel,
     )
 }
 
@@ -1169,7 +1169,7 @@ fun readableMapOf(lnUrlPayRequest: LnUrlPayRequest): ReadableMap {
         "data" to readableMapOf(lnUrlPayRequest.data),
         "amountMsat" to lnUrlPayRequest.amountMsat,
         "comment" to lnUrlPayRequest.comment,
-        "paymentMetadata" to lnUrlPayRequest.paymentMetadata,
+        "paymentLabel" to lnUrlPayRequest.paymentLabel,
     )
 }
 
@@ -3224,20 +3224,11 @@ fun asSendPaymentRequest(sendPaymentRequest: ReadableMap): SendPaymentRequest? {
     }
     val bolt11 = sendPaymentRequest.getString("bolt11")!!
     val amountMsat = if (hasNonNullKey(sendPaymentRequest, "amountMsat")) sendPaymentRequest.getDouble("amountMsat").toULong() else null
-    val paymentMetadata =
-        if (hasNonNullKey(
-                sendPaymentRequest,
-                "paymentMetadata",
-            )
-        ) {
-            sendPaymentRequest.getString("paymentMetadata")
-        } else {
-            null
-        }
+    val label = if (hasNonNullKey(sendPaymentRequest, "label")) sendPaymentRequest.getString("label") else null
     return SendPaymentRequest(
         bolt11,
         amountMsat,
-        paymentMetadata,
+        label,
     )
 }
 
@@ -3245,7 +3236,7 @@ fun readableMapOf(sendPaymentRequest: SendPaymentRequest): ReadableMap {
     return readableMapOf(
         "bolt11" to sendPaymentRequest.bolt11,
         "amountMsat" to sendPaymentRequest.amountMsat,
-        "paymentMetadata" to sendPaymentRequest.paymentMetadata,
+        "label" to sendPaymentRequest.label,
     )
 }
 
@@ -3318,21 +3309,12 @@ fun asSendSpontaneousPaymentRequest(sendSpontaneousPaymentRequest: ReadableMap):
         } else {
             null
         }
-    val paymentMetadata =
-        if (hasNonNullKey(
-                sendSpontaneousPaymentRequest,
-                "paymentMetadata",
-            )
-        ) {
-            sendSpontaneousPaymentRequest.getString("paymentMetadata")
-        } else {
-            null
-        }
+    val label = if (hasNonNullKey(sendSpontaneousPaymentRequest, "label")) sendSpontaneousPaymentRequest.getString("label") else null
     return SendSpontaneousPaymentRequest(
         nodeId,
         amountMsat,
         extraTlvs,
-        paymentMetadata,
+        label,
     )
 }
 
@@ -3341,7 +3323,7 @@ fun readableMapOf(sendSpontaneousPaymentRequest: SendSpontaneousPaymentRequest):
         "nodeId" to sendSpontaneousPaymentRequest.nodeId,
         "amountMsat" to sendSpontaneousPaymentRequest.amountMsat,
         "extraTlvs" to sendSpontaneousPaymentRequest.extraTlvs?.let { readableArrayOf(it) },
-        "paymentMetadata" to sendSpontaneousPaymentRequest.paymentMetadata,
+        "label" to sendSpontaneousPaymentRequest.label,
     )
 }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1393,9 +1393,6 @@ enum BreezSDKMapper {
             successAction = try asSuccessActionProcessed(successActionProcessed: successActionTmp)
         }
 
-        guard let paymentHash = lnUrlPaySuccessData["paymentHash"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnUrlPaySuccessData"))
-        }
         guard let paymentTmp = lnUrlPaySuccessData["payment"] as? [String: Any?] else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "LnUrlPaySuccessData"))
         }
@@ -1403,7 +1400,6 @@ enum BreezSDKMapper {
 
         return LnUrlPaySuccessData(
             successAction: successAction,
-            paymentHash: paymentHash,
             payment: payment
         )
     }
@@ -1411,7 +1407,6 @@ enum BreezSDKMapper {
     static func dictionaryOf(lnUrlPaySuccessData: LnUrlPaySuccessData) -> [String: Any?] {
         return [
             "successAction": lnUrlPaySuccessData.successAction == nil ? nil : dictionaryOf(successActionProcessed: lnUrlPaySuccessData.successAction!),
-            "paymentHash": lnUrlPaySuccessData.paymentHash,
             "payment": dictionaryOf(payment: lnUrlPaySuccessData.payment),
         ]
     }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1396,10 +1396,15 @@ enum BreezSDKMapper {
         guard let paymentHash = lnUrlPaySuccessData["paymentHash"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnUrlPaySuccessData"))
         }
+        guard let paymentTmp = lnUrlPaySuccessData["payment"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "LnUrlPaySuccessData"))
+        }
+        let payment = try asPayment(payment: paymentTmp)
 
         return LnUrlPaySuccessData(
             successAction: successAction,
-            paymentHash: paymentHash
+            paymentHash: paymentHash,
+            payment: payment
         )
     }
 
@@ -1407,6 +1412,7 @@ enum BreezSDKMapper {
         return [
             "successAction": lnUrlPaySuccessData.successAction == nil ? nil : dictionaryOf(successActionProcessed: lnUrlPaySuccessData.successAction!),
             "paymentHash": lnUrlPaySuccessData.paymentHash,
+            "payment": dictionaryOf(payment: lnUrlPaySuccessData.payment),
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1278,11 +1278,19 @@ enum BreezSDKMapper {
             }
             comment = commentTmp
         }
+        var paymentMetadata: String?
+        if hasNonNilKey(data: lnUrlPayRequest, key: "paymentMetadata") {
+            guard let paymentMetadataTmp = lnUrlPayRequest["paymentMetadata"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentMetadata"))
+            }
+            paymentMetadata = paymentMetadataTmp
+        }
 
         return LnUrlPayRequest(
             data: data,
             amountMsat: amountMsat,
-            comment: comment
+            comment: comment,
+            paymentMetadata: paymentMetadata
         )
     }
 
@@ -1291,6 +1299,7 @@ enum BreezSDKMapper {
             "data": dictionaryOf(lnUrlPayRequestData: lnUrlPayRequest.data),
             "amountMsat": lnUrlPayRequest.amountMsat,
             "comment": lnUrlPayRequest.comment == nil ? nil : lnUrlPayRequest.comment,
+            "paymentMetadata": lnUrlPayRequest.paymentMetadata == nil ? nil : lnUrlPayRequest.paymentMetadata,
         ]
     }
 
@@ -3505,10 +3514,18 @@ enum BreezSDKMapper {
             }
             amountMsat = amountMsatTmp
         }
+        var paymentMetadata: String?
+        if hasNonNilKey(data: sendPaymentRequest, key: "paymentMetadata") {
+            guard let paymentMetadataTmp = sendPaymentRequest["paymentMetadata"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentMetadata"))
+            }
+            paymentMetadata = paymentMetadataTmp
+        }
 
         return SendPaymentRequest(
             bolt11: bolt11,
-            amountMsat: amountMsat
+            amountMsat: amountMsat,
+            paymentMetadata: paymentMetadata
         )
     }
 
@@ -3516,6 +3533,7 @@ enum BreezSDKMapper {
         return [
             "bolt11": sendPaymentRequest.bolt11,
             "amountMsat": sendPaymentRequest.amountMsat == nil ? nil : sendPaymentRequest.amountMsat,
+            "paymentMetadata": sendPaymentRequest.paymentMetadata == nil ? nil : sendPaymentRequest.paymentMetadata,
         ]
     }
 
@@ -3581,10 +3599,19 @@ enum BreezSDKMapper {
             extraTlvs = try asTlvEntryList(arr: extraTlvsTmp)
         }
 
+        var paymentMetadata: String?
+        if hasNonNilKey(data: sendSpontaneousPaymentRequest, key: "paymentMetadata") {
+            guard let paymentMetadataTmp = sendSpontaneousPaymentRequest["paymentMetadata"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentMetadata"))
+            }
+            paymentMetadata = paymentMetadataTmp
+        }
+
         return SendSpontaneousPaymentRequest(
             nodeId: nodeId,
             amountMsat: amountMsat,
-            extraTlvs: extraTlvs
+            extraTlvs: extraTlvs,
+            paymentMetadata: paymentMetadata
         )
     }
 
@@ -3593,6 +3620,7 @@ enum BreezSDKMapper {
             "nodeId": sendSpontaneousPaymentRequest.nodeId,
             "amountMsat": sendSpontaneousPaymentRequest.amountMsat,
             "extraTlvs": sendSpontaneousPaymentRequest.extraTlvs == nil ? nil : arrayOf(tlvEntryList: sendSpontaneousPaymentRequest.extraTlvs!),
+            "paymentMetadata": sendSpontaneousPaymentRequest.paymentMetadata == nil ? nil : sendSpontaneousPaymentRequest.paymentMetadata,
         ]
     }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1278,19 +1278,19 @@ enum BreezSDKMapper {
             }
             comment = commentTmp
         }
-        var paymentMetadata: String?
-        if hasNonNilKey(data: lnUrlPayRequest, key: "paymentMetadata") {
-            guard let paymentMetadataTmp = lnUrlPayRequest["paymentMetadata"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentMetadata"))
+        var paymentLabel: String?
+        if hasNonNilKey(data: lnUrlPayRequest, key: "paymentLabel") {
+            guard let paymentLabelTmp = lnUrlPayRequest["paymentLabel"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentLabel"))
             }
-            paymentMetadata = paymentMetadataTmp
+            paymentLabel = paymentLabelTmp
         }
 
         return LnUrlPayRequest(
             data: data,
             amountMsat: amountMsat,
             comment: comment,
-            paymentMetadata: paymentMetadata
+            paymentLabel: paymentLabel
         )
     }
 
@@ -1299,7 +1299,7 @@ enum BreezSDKMapper {
             "data": dictionaryOf(lnUrlPayRequestData: lnUrlPayRequest.data),
             "amountMsat": lnUrlPayRequest.amountMsat,
             "comment": lnUrlPayRequest.comment == nil ? nil : lnUrlPayRequest.comment,
-            "paymentMetadata": lnUrlPayRequest.paymentMetadata == nil ? nil : lnUrlPayRequest.paymentMetadata,
+            "paymentLabel": lnUrlPayRequest.paymentLabel == nil ? nil : lnUrlPayRequest.paymentLabel,
         ]
     }
 
@@ -3520,18 +3520,18 @@ enum BreezSDKMapper {
             }
             amountMsat = amountMsatTmp
         }
-        var paymentMetadata: String?
-        if hasNonNilKey(data: sendPaymentRequest, key: "paymentMetadata") {
-            guard let paymentMetadataTmp = sendPaymentRequest["paymentMetadata"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentMetadata"))
+        var label: String?
+        if hasNonNilKey(data: sendPaymentRequest, key: "label") {
+            guard let labelTmp = sendPaymentRequest["label"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "label"))
             }
-            paymentMetadata = paymentMetadataTmp
+            label = labelTmp
         }
 
         return SendPaymentRequest(
             bolt11: bolt11,
             amountMsat: amountMsat,
-            paymentMetadata: paymentMetadata
+            label: label
         )
     }
 
@@ -3539,7 +3539,7 @@ enum BreezSDKMapper {
         return [
             "bolt11": sendPaymentRequest.bolt11,
             "amountMsat": sendPaymentRequest.amountMsat == nil ? nil : sendPaymentRequest.amountMsat,
-            "paymentMetadata": sendPaymentRequest.paymentMetadata == nil ? nil : sendPaymentRequest.paymentMetadata,
+            "label": sendPaymentRequest.label == nil ? nil : sendPaymentRequest.label,
         ]
     }
 
@@ -3605,19 +3605,19 @@ enum BreezSDKMapper {
             extraTlvs = try asTlvEntryList(arr: extraTlvsTmp)
         }
 
-        var paymentMetadata: String?
-        if hasNonNilKey(data: sendSpontaneousPaymentRequest, key: "paymentMetadata") {
-            guard let paymentMetadataTmp = sendSpontaneousPaymentRequest["paymentMetadata"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentMetadata"))
+        var label: String?
+        if hasNonNilKey(data: sendSpontaneousPaymentRequest, key: "label") {
+            guard let labelTmp = sendSpontaneousPaymentRequest["label"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "label"))
             }
-            paymentMetadata = paymentMetadataTmp
+            label = labelTmp
         }
 
         return SendSpontaneousPaymentRequest(
             nodeId: nodeId,
             amountMsat: amountMsat,
             extraTlvs: extraTlvs,
-            paymentMetadata: paymentMetadata
+            label: label
         )
     }
 
@@ -3626,7 +3626,7 @@ enum BreezSDKMapper {
             "nodeId": sendSpontaneousPaymentRequest.nodeId,
             "amountMsat": sendSpontaneousPaymentRequest.amountMsat,
             "extraTlvs": sendSpontaneousPaymentRequest.extraTlvs == nil ? nil : arrayOf(tlvEntryList: sendSpontaneousPaymentRequest.extraTlvs!),
-            "paymentMetadata": sendSpontaneousPaymentRequest.paymentMetadata == nil ? nil : sendSpontaneousPaymentRequest.paymentMetadata,
+            "label": sendSpontaneousPaymentRequest.label == nil ? nil : sendSpontaneousPaymentRequest.label,
         ]
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -202,6 +202,7 @@ export type LnUrlPayRequestData = {
 export type LnUrlPaySuccessData = {
     successAction?: SuccessActionProcessed
     paymentHash: string
+    payment: Payment
 }
 
 export type LnUrlWithdrawRequest = {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -201,7 +201,6 @@ export type LnUrlPayRequestData = {
 
 export type LnUrlPaySuccessData = {
     successAction?: SuccessActionProcessed
-    paymentHash: string
     payment: Payment
 }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -186,6 +186,7 @@ export type LnUrlPayRequest = {
     data: LnUrlPayRequestData
     amountMsat: number
     comment?: string
+    paymentMetadata?: string
 }
 
 export type LnUrlPayRequestData = {
@@ -486,6 +487,7 @@ export type SendOnchainResponse = {
 export type SendPaymentRequest = {
     bolt11: string
     amountMsat?: number
+    paymentMetadata?: string
 }
 
 export type SendPaymentResponse = {
@@ -496,6 +498,7 @@ export type SendSpontaneousPaymentRequest = {
     nodeId: string
     amountMsat: number
     extraTlvs?: TlvEntry[]
+    paymentMetadata?: string
 }
 
 export type ServiceHealthCheckResponse = {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -186,7 +186,7 @@ export type LnUrlPayRequest = {
     data: LnUrlPayRequestData
     amountMsat: number
     comment?: string
-    paymentMetadata?: string
+    paymentLabel?: string
 }
 
 export type LnUrlPayRequestData = {
@@ -488,7 +488,7 @@ export type SendOnchainResponse = {
 export type SendPaymentRequest = {
     bolt11: string
     amountMsat?: number
-    paymentMetadata?: string
+    label?: string
 }
 
 export type SendPaymentResponse = {
@@ -499,7 +499,7 @@ export type SendSpontaneousPaymentRequest = {
     nodeId: string
     amountMsat: number
     extraTlvs?: TlvEntry[]
-    paymentMetadata?: string
+    label?: string
 }
 
 export type ServiceHealthCheckResponse = {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -247,6 +247,7 @@ pub(crate) async fn handle_command(
                 .send_payment(SendPaymentRequest {
                     bolt11,
                     amount_msat,
+                    payment_metadata: None,
                 })
                 .await?;
             serde_json::to_string_pretty(&payment).map_err(|e| e.into())
@@ -260,6 +261,7 @@ pub(crate) async fn handle_command(
                     node_id,
                     amount_msat,
                     extra_tlvs: None,
+                    payment_metadata: None,
                 })
                 .await?;
             serde_json::to_string_pretty(&response.payment).map_err(|e| e.into())
@@ -473,6 +475,7 @@ pub(crate) async fn handle_command(
                         data: pd,
                         amount_msat: amount_msat.parse::<u64>()?,
                         comment: None,
+                        payment_metadata: None,
                     })
                     .await?;
                 //show_results(pay_res);

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -242,12 +242,13 @@ pub(crate) async fn handle_command(
         Commands::SendPayment {
             bolt11,
             amount_msat,
+            label,
         } => {
             let payment = sdk()?
                 .send_payment(SendPaymentRequest {
                     bolt11,
                     amount_msat,
-                    payment_metadata: None,
+                    label,
                 })
                 .await?;
             serde_json::to_string_pretty(&payment).map_err(|e| e.into())
@@ -255,13 +256,14 @@ pub(crate) async fn handle_command(
         Commands::SendSpontaneousPayment {
             node_id,
             amount_msat,
+            label,
         } => {
             let response = sdk()?
                 .send_spontaneous_payment(SendSpontaneousPaymentRequest {
                     node_id,
                     amount_msat,
                     extra_tlvs: None,
-                    payment_metadata: None,
+                    label,
                 })
                 .await?;
             serde_json::to_string_pretty(&response.payment).map_err(|e| e.into())
@@ -462,7 +464,7 @@ pub(crate) async fn handle_command(
             let res = sdk()?.check_message(req).await?;
             Ok(format!("Message was signed by node: {}", res.is_valid))
         }
-        Commands::LnurlPay { lnurl } => match parse(&lnurl).await? {
+        Commands::LnurlPay { lnurl, label } => match parse(&lnurl).await? {
             LnUrlPay { data: pd } => {
                 let prompt = format!(
                     "Amount to pay in millisatoshi (min {} msat, max {} msat: ",
@@ -475,7 +477,7 @@ pub(crate) async fn handle_command(
                         data: pd,
                         amount_msat: amount_msat.parse::<u64>()?,
                         comment: None,
-                        payment_metadata: None,
+                        payment_label: label,
                     })
                     .await?;
                 //show_results(pay_res);

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -46,12 +46,20 @@ pub(crate) enum Commands {
 
         #[clap(name = "amount_msat", short = 'a', long = "amt")]
         amount_msat: Option<u64>,
+
+        /// The external label or identifier of the payment
+        #[clap(name = "label", short = 'l', long = "label")]
+        label: Option<String>,
     },
 
     /// [pay] Send a spontaneous (keysend) payment
     SendSpontaneousPayment {
         node_id: String,
         amount_msat: u64,
+
+        /// The external label or identifier of the payment
+        #[clap(name = "label", short = 'l', long = "label")]
+        label: Option<String>,
     },
 
     /// [pay] Generate a bolt11 invoice
@@ -81,6 +89,10 @@ pub(crate) enum Commands {
     /// [lnurl] Pay using lnurl pay
     LnurlPay {
         lnurl: String,
+
+        /// The external label or identifier of the payment
+        #[clap(name = "label", short = 'l', long = "label")]
+        label: Option<String>,
     },
 
     /// [lnurl] Withdraw using lnurl withdraw


### PR DESCRIPTION
This PR changes the following:

- Allow payment metadata to be set during successful `pay_lnurl`, `send_payment` or `send_spontaneous_payment` requests. This is specifically added for `pay_lnurl` where the payment hash is not known beforehand and therefore cannot associate the request to the `PaymentSucceed` event which is emitted before the request finishes. Also added to `send_payment` and `send_spontaneous_payment` for consistency. 
- Add the payment details to the `LnUrlPaySuccessData` response when `pay_lnurl` is successful to be consistent with `send_payment` and `send_spontaneous_payment`.

Fixes #908 