### PR TITLE
Fix db deadlock

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2058,9 +2058,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.6+3.1.4"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
@@ -41,7 +41,7 @@ class ReceivePaymentJob(
             if (payment != null) {
                 this.receivedPayment = payment
                 logger.log(TAG, "Found payment for hash: ${request.paymentHash}", "INFO")
-                fgService.shutdown()
+                fgService.onFinished(this)
             }
         } catch (e: Exception) {
             logger.log(TAG, "Failed to call start of receive payment notification: ${e.message}", "WARN")

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -33,9 +33,9 @@ prost = "^0.11"
 querystring = "1"
 rusqlite = { version = "0.29", features = [
     "serde_json",
-    "bundled",
-    "load_extension",
+    "bundled",    
     "backup",
+    "trace",
     "hooks",
 ] }
 rusqlite_migration = "1.0"
@@ -52,7 +52,7 @@ tonic = { version = "^0.8", features = [
 lazy_static = "^1.4.0"
 log = "0.4"
 once_cell = "1"
-openssl = { version = "0.10", features = ["vendored"] }
+openssl = { version = "0.10", features = ["vendored"]}
 strum = "0.25"
 strum_macros = "0.25"
 tempfile = "3"

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -293,11 +293,11 @@ impl SqliteStorage {
            ON
             p.id = o.payment_hash
           LEFT JOIN ({swap_query}) as swaps
-            ON
-              json_extract(p.details, '$.payment_hash') = hex(swaps_payment_hash) COLLATE NOCASE
+           ON
+            p.id = hex(swaps_payment_hash) COLLATE NOCASE
           LEFT JOIN ({rev_swap_query}) as revswaps
-            ON
-              json_extract(p.details, '$.payment_preimage') = hex(revswaps_preimage) COLLATE NOCASE
+           ON
+            json_extract(p.details, '$.payment_preimage') = hex(revswaps_preimage) COLLATE NOCASE
           {where_clause}
           ORDER BY payment_time DESC
           LIMIT {limit}

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -215,45 +215,8 @@ impl SqliteStorage {
         let offset = req.offset.unwrap_or(0u32);
         let limit = req.limit.unwrap_or(u32::MAX);
         let con = self.get_connection()?;
-        let mut stmt = con.prepare(
-            format!(
-                "
-            SELECT 
-             p.id,
-             p.payment_type,
-             p.payment_time,
-             p.amount_msat,
-             p.fee_msat,
-             p.status,
-             p.description,
-             p.details,
-             e.lnurl_success_action,
-             e.lnurl_metadata,
-             e.ln_address,
-             e.lnurl_withdraw_endpoint,
-             e.attempted_amount_msat,
-             e.attempted_error,
-             o.payer_amount_msat,
-             o.open_channel_bolt11,
-             m.metadata,
-             e.lnurl_pay_domain
-            FROM payments p
-            LEFT JOIN sync.payments_external_info e
-            ON
-             p.id = e.payment_id
-            LEFT JOIN sync.payments_metadata m
-            ON
-              p.id = m.payment_id
-            LEFT JOIN sync.open_channel_payment_info o
-             ON
-              p.id = o.payment_hash
-            {where_clause} ORDER BY payment_time DESC
-            LIMIT {limit}
-            OFFSET {offset}
-          "
-            )
-            .as_str(),
-        )?;
+        let query = self.select_payments_query(where_clause.as_str(), offset, limit)?;
+        let mut stmt = con.prepare(query.as_str())?;
 
         let mut params: HashMap<String, String> = HashMap::new();
 
@@ -283,8 +246,66 @@ impl SqliteStorage {
             )?
             .map(|i| i.unwrap())
             .collect();
-
         Ok(vec)
+    }
+
+    pub fn select_payments_query(
+        &self,
+        where_clause: &str,
+        offset: u32,
+        limit: u32,
+    ) -> PersistResult<String> {
+        let swap_fields = self.select_swap_fields("swaps_");
+        let swap_query = self.select_swap_query("true", "swaps_");
+        let rev_swap_fields = self.select_reverse_swap_fields("revswaps_");
+        let rev_swap_query = self.select_reverse_swap_query("true", "revswaps_");
+        let query = format!(
+            "
+          SELECT 
+           p.id,
+           p.payment_type,
+           p.payment_time,
+           p.amount_msat,
+           p.fee_msat,
+           p.status,
+           p.description,
+           p.details,
+           e.lnurl_success_action,
+           e.lnurl_metadata,
+           e.ln_address,
+           e.lnurl_withdraw_endpoint,
+           e.attempted_amount_msat,
+           e.attempted_error,
+           o.payer_amount_msat,
+           o.open_channel_bolt11,
+           m.metadata,
+           e.lnurl_pay_domain,
+           {swap_fields},
+           {rev_swap_fields}
+          FROM payments p
+          LEFT JOIN sync.payments_external_info e
+          ON
+           p.id = e.payment_id
+          LEFT JOIN sync.payments_metadata m
+          ON
+            p.id = m.payment_id
+          LEFT JOIN sync.open_channel_payment_info o
+           ON
+            p.id = o.payment_hash
+          LEFT JOIN ({swap_query}) as swaps
+            ON
+              json_extract(p.details, '$.payment_hash') = hex(swaps_payment_hash) COLLATE NOCASE
+          LEFT JOIN ({rev_swap_query}) as revswaps
+            ON
+              json_extract(p.details, '$.payment_preimage') = hex(revswaps_preimage) COLLATE NOCASE
+          {where_clause}
+          ORDER BY payment_time DESC
+          LIMIT {limit}
+          OFFSET {offset}
+        "
+        );
+
+        Ok(query)
     }
 
     /// This queries a single payment by hash, which may be pending, completed or failed.
@@ -293,44 +314,10 @@ impl SqliteStorage {
     ///
     /// To query all payments, see [Self::list_payments]
     pub(crate) fn get_payment_by_hash(&self, hash: &String) -> PersistResult<Option<Payment>> {
+        let query = self.select_payments_query("where id = ?1", 0, 1)?;
         Ok(self
             .get_connection()?
-            .query_row(
-                "
-                SELECT
-                 p.id,
-                 p.payment_type,
-                 p.payment_time,
-                 p.amount_msat,
-                 p.fee_msat,
-                 p.status,
-                 p.description,
-                 p.details,
-                 e.lnurl_success_action,
-                 e.lnurl_metadata,
-                 e.ln_address,
-                 e.lnurl_withdraw_endpoint,
-                 e.attempted_amount_msat,
-                 e.attempted_error,
-                 o.payer_amount_msat,
-                 o.open_channel_bolt11,
-                 m.metadata,
-                 e.lnurl_pay_domain
-                FROM payments p
-                LEFT JOIN sync.payments_external_info e
-                ON
-                 p.id = e.payment_id
-                LEFT JOIN sync.payments_metadata m
-                ON
-                  p.id = m.payment_id
-                LEFT JOIN sync.open_channel_payment_info o
-                 ON
-                  p.id = o.payment_hash
-                WHERE
-                 id = ?1",
-                [hash],
-                |row| self.sql_row_to_payment(row),
-            )
+            .query_row(query.as_str(), [hash], |row| self.sql_row_to_payment(row))
             .optional()?)
     }
 
@@ -394,15 +381,10 @@ impl SqliteStorage {
             data.lnurl_metadata = row.get(9)?;
             data.ln_address = row.get(10)?;
             data.lnurl_withdraw_endpoint = row.get(11)?;
-            data.swap_info = self
-                .get_swap_info_by_hash(&hex::decode(&payment.id).unwrap_or_default())
-                .unwrap_or(None);
-            data.reverse_swap_info = self
-                .get_reverse_swap_by_preimage(
-                    &hex::decode(&data.payment_preimage).unwrap_or_default(),
-                )
-                .unwrap_or(None)
-                .map(|i| i.get_reverse_swap_info_using_cached_values());
+            data.swap_info = self.sql_row_to_swap(row, "swaps_").ok();
+            if let Ok(fr) = self.sql_row_to_reverse_swap(row, "revswaps_") {
+                data.reverse_swap_info = Some(fr.get_reverse_swap_info_using_cached_values());
+            }
         }
 
         // In case we have a record of the open channel fee, let's use it.

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -1962,9 +1962,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.3+3.1.2"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
This PR fixes the deadlock that happens sometimes on the sqlite database.
The reason for the deadlock origins in the way we load payments.
Before this PR we select from the payments list and then to load the associated swaps and reverse swaps we execute a query for each payment.
That would be OK if we have reused the same connection to load the associations but since we opened a new connection it was blocked at times there was a pending writer waiting, result in a deadlock.
It is better to use join for such query and I tried to do that without duplicating the queries.
Currently the `sql_row_to_payment` function that creates a Payment from an SQL Row uses internally `sql_row_to_swap` and `sql_row_to_reverse_swap` to create the associated information, where both of these methods are used also to create the stand alone versions of swaps as well. The fields in the Row are keyed differently (using a given prefix) on the stand alone query than on the JOIN query.