### PR TITLE
input parser: add nip-57 fields

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -626,6 +626,8 @@ dictionary LnUrlPayRequestData {
     string metadata_str;
     u16 comment_allowed;
     string domain;
+    boolean allows_nostr;
+    string? nostr_pubkey;
     string? ln_address;
 };
 

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -870,6 +870,8 @@ impl Wire2Api<LnUrlPayRequestData> for wire_LnUrlPayRequestData {
             metadata_str: self.metadata_str.wire2api(),
             comment_allowed: self.comment_allowed.wire2api(),
             domain: self.domain.wire2api(),
+            allows_nostr: self.allows_nostr.wire2api(),
+            nostr_pubkey: self.nostr_pubkey.wire2api(),
             ln_address: self.ln_address.wire2api(),
         }
     }
@@ -1232,6 +1234,8 @@ pub struct wire_LnUrlPayRequestData {
     metadata_str: *mut wire_uint_8_list,
     comment_allowed: u16,
     domain: *mut wire_uint_8_list,
+    allows_nostr: bool,
+    nostr_pubkey: *mut wire_uint_8_list,
     ln_address: *mut wire_uint_8_list,
 }
 
@@ -1642,6 +1646,8 @@ impl NewWithNullPtr for wire_LnUrlPayRequestData {
             metadata_str: core::ptr::null_mut(),
             comment_allowed: Default::default(),
             domain: core::ptr::null_mut(),
+            allows_nostr: Default::default(),
+            nostr_pubkey: core::ptr::null_mut(),
             ln_address: core::ptr::null_mut(),
         }
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1474,6 +1474,8 @@ impl support::IntoDart for LnUrlPayRequestData {
             self.metadata_str.into_into_dart().into_dart(),
             self.comment_allowed.into_into_dart().into_dart(),
             self.domain.into_into_dart().into_dart(),
+            self.allows_nostr.into_into_dart().into_dart(),
+            self.nostr_pubkey.into_dart(),
             self.ln_address.into_dart(),
         ]
         .into_dart()

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -535,6 +535,19 @@ pub struct LnUrlPayRequestData {
     #[serde(skip_serializing, skip_deserializing)]
     pub domain: String,
 
+    /// Value indicating whether the recipient supports Nostr Zaps through NIP-57.
+    ///
+    /// See <https://github.com/nostr-protocol/nips/blob/master/57.md>
+    #[serde(default)]
+    pub allows_nostr: bool,
+
+    /// Optional recipient's lnurl provider's Nostr pubkey for NIP-57. If it exists it should be a
+    /// valid BIP 340 public key in hex.
+    ///
+    /// See <https://github.com/nostr-protocol/nips/blob/master/57.md>
+    /// See <https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki>
+    pub nostr_pubkey: Option<String>,
+
     /// If sending to a LN Address, this will be filled.
     #[serde(skip_serializing, skip_deserializing)]
     pub ln_address: Option<String>,

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -633,6 +633,8 @@ mod tests {
             metadata_str: "".into(),
             callback: "https://localhost/callback".into(),
             domain: "localhost".into(),
+            allows_nostr: false,
+            nostr_pubkey: None,
             ln_address: None,
         }
     }

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -155,6 +155,8 @@ typedef struct wire_LnUrlPayRequestData {
   struct wire_uint_8_list *metadata_str;
   uint16_t comment_allowed;
   struct wire_uint_8_list *domain;
+  bool allows_nostr;
+  struct wire_uint_8_list *nostr_pubkey;
   struct wire_uint_8_list *ln_address;
 } wire_LnUrlPayRequestData;
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -926,6 +926,18 @@ class LnUrlPayRequestData {
   /// Note: this is not the domain of the callback, but the domain of the LNURL-pay endpoint.
   final String domain;
 
+  /// Value indicating whether the recipient supports Nostr Zaps through NIP-57.
+  ///
+  /// See <https://github.com/nostr-protocol/nips/blob/master/57.md>
+  final bool allowsNostr;
+
+  /// Optional recipient's lnurl provider's Nostr pubkey for NIP-57. If it exists it should be a
+  /// valid BIP 340 public key in hex.
+  ///
+  /// See <https://github.com/nostr-protocol/nips/blob/master/57.md>
+  /// See <https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki>
+  final String? nostrPubkey;
+
   /// If sending to a LN Address, this will be filled.
   final String? lnAddress;
 
@@ -936,6 +948,8 @@ class LnUrlPayRequestData {
     required this.metadataStr,
     required this.commentAllowed,
     required this.domain,
+    required this.allowsNostr,
+    this.nostrPubkey,
     this.lnAddress,
   });
 }
@@ -3599,7 +3613,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LnUrlPayRequestData _wire2api_ln_url_pay_request_data(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 9) throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return LnUrlPayRequestData(
       callback: _wire2api_String(arr[0]),
       minSendable: _wire2api_u64(arr[1]),
@@ -3607,7 +3621,9 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       metadataStr: _wire2api_String(arr[3]),
       commentAllowed: _wire2api_u16(arr[4]),
       domain: _wire2api_String(arr[5]),
-      lnAddress: _wire2api_opt_String(arr[6]),
+      allowsNostr: _wire2api_bool(arr[6]),
+      nostrPubkey: _wire2api_opt_String(arr[7]),
+      lnAddress: _wire2api_opt_String(arr[8]),
     );
   }
 
@@ -4864,6 +4880,8 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.metadata_str = api2wire_String(apiObj.metadataStr);
     wireObj.comment_allowed = api2wire_u16(apiObj.commentAllowed);
     wireObj.domain = api2wire_String(apiObj.domain);
+    wireObj.allows_nostr = api2wire_bool(apiObj.allowsNostr);
+    wireObj.nostr_pubkey = api2wire_opt_String(apiObj.nostrPubkey);
     wireObj.ln_address = api2wire_opt_String(apiObj.lnAddress);
   }
 
@@ -6627,6 +6645,11 @@ final class wire_LnUrlPayRequestData extends ffi.Struct {
   external int comment_allowed;
 
   external ffi.Pointer<wire_uint_8_list> domain;
+
+  @ffi.Bool()
+  external bool allows_nostr;
+
+  external ffi.Pointer<wire_uint_8_list> nostr_pubkey;
 
   external ffi.Pointer<wire_uint_8_list> ln_address;
 }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1191,6 +1191,7 @@ fun asLnUrlPayRequestData(lnUrlPayRequestData: ReadableMap): LnUrlPayRequestData
                 "metadataStr",
                 "commentAllowed",
                 "domain",
+                "allowsNostr",
             ),
         )
     ) {
@@ -1202,6 +1203,8 @@ fun asLnUrlPayRequestData(lnUrlPayRequestData: ReadableMap): LnUrlPayRequestData
     val metadataStr = lnUrlPayRequestData.getString("metadataStr")!!
     val commentAllowed = lnUrlPayRequestData.getInt("commentAllowed").toUShort()
     val domain = lnUrlPayRequestData.getString("domain")!!
+    val allowsNostr = lnUrlPayRequestData.getBoolean("allowsNostr")
+    val nostrPubkey = if (hasNonNullKey(lnUrlPayRequestData, "nostrPubkey")) lnUrlPayRequestData.getString("nostrPubkey") else null
     val lnAddress = if (hasNonNullKey(lnUrlPayRequestData, "lnAddress")) lnUrlPayRequestData.getString("lnAddress") else null
     return LnUrlPayRequestData(
         callback,
@@ -1210,6 +1213,8 @@ fun asLnUrlPayRequestData(lnUrlPayRequestData: ReadableMap): LnUrlPayRequestData
         metadataStr,
         commentAllowed,
         domain,
+        allowsNostr,
+        nostrPubkey,
         lnAddress,
     )
 }
@@ -1222,6 +1227,8 @@ fun readableMapOf(lnUrlPayRequestData: LnUrlPayRequestData): ReadableMap {
         "metadataStr" to lnUrlPayRequestData.metadataStr,
         "commentAllowed" to lnUrlPayRequestData.commentAllowed,
         "domain" to lnUrlPayRequestData.domain,
+        "allowsNostr" to lnUrlPayRequestData.allowsNostr,
+        "nostrPubkey" to lnUrlPayRequestData.nostrPubkey,
         "lnAddress" to lnUrlPayRequestData.lnAddress,
     )
 }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1330,6 +1330,16 @@ enum BreezSDKMapper {
         guard let domain = lnUrlPayRequestData["domain"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "domain", typeName: "LnUrlPayRequestData"))
         }
+        guard let allowsNostr = lnUrlPayRequestData["allowsNostr"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "allowsNostr", typeName: "LnUrlPayRequestData"))
+        }
+        var nostrPubkey: String?
+        if hasNonNilKey(data: lnUrlPayRequestData, key: "nostrPubkey") {
+            guard let nostrPubkeyTmp = lnUrlPayRequestData["nostrPubkey"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "nostrPubkey"))
+            }
+            nostrPubkey = nostrPubkeyTmp
+        }
         var lnAddress: String?
         if hasNonNilKey(data: lnUrlPayRequestData, key: "lnAddress") {
             guard let lnAddressTmp = lnUrlPayRequestData["lnAddress"] as? String else {
@@ -1345,6 +1355,8 @@ enum BreezSDKMapper {
             metadataStr: metadataStr,
             commentAllowed: commentAllowed,
             domain: domain,
+            allowsNostr: allowsNostr,
+            nostrPubkey: nostrPubkey,
             lnAddress: lnAddress
         )
     }
@@ -1357,6 +1369,8 @@ enum BreezSDKMapper {
             "metadataStr": lnUrlPayRequestData.metadataStr,
             "commentAllowed": lnUrlPayRequestData.commentAllowed,
             "domain": lnUrlPayRequestData.domain,
+            "allowsNostr": lnUrlPayRequestData.allowsNostr,
+            "nostrPubkey": lnUrlPayRequestData.nostrPubkey == nil ? nil : lnUrlPayRequestData.nostrPubkey,
             "lnAddress": lnUrlPayRequestData.lnAddress == nil ? nil : lnUrlPayRequestData.lnAddress,
         ]
     }

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -195,6 +195,8 @@ export type LnUrlPayRequestData = {
     metadataStr: string
     commentAllowed: number
     domain: string
+    allowsNostr: boolean
+    nostrPubkey?: string
     lnAddress?: string
 }
 


### PR DESCRIPTION
Adds fields to `LnurlPayRequestData` relevant for Nostr Zaps ([NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md)).

Tested manually the input parser with lnurlp with zap support and without zap support.

Fixes https://github.com/breez/breez-sdk/issues/840

