### PR TITLE
Unregister webhook

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -897,6 +897,9 @@ interface BlockingBreezServices {
    [Throws=SdkError]
    void register_webhook(string webhook_url);
 
+   [Throws=SdkError]
+   void unregister_webhook(string webhook_url);
+
    [Throws=ReceiveOnchainError]
    SwapInfo receive_onchain(ReceiveOnchainRequest req);
 

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -259,6 +259,10 @@ impl BlockingBreezServices {
         rt().block_on(async { self.breez_services.register_webhook(webhook_url).await })
     }
 
+    pub fn unregister_webhook(&self, webhook_url: String) -> SdkResult<()> {
+        rt().block_on(async { self.breez_services.unregister_webhook(webhook_url).await })
+    }
+
     /// Onchain receive swap API
     pub fn receive_onchain(
         &self,

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -237,6 +237,16 @@ pub fn register_webhook(webhook_url: String) -> Result<()> {
     .map_err(anyhow::Error::new::<SdkError>)
 }
 
+pub fn unregister_webhook(webhook_url: String) -> Result<()> {
+    block_on(async {
+        get_breez_services()
+            .await?
+            .unregister_webhook(webhook_url)
+            .await
+    })
+    .map_err(anyhow::Error::new::<SdkError>)
+}
+
 /*  Backup API's */
 
 /// See [BreezServices::backup]

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -117,6 +117,11 @@ pub extern "C" fn wire_register_webhook(port_: i64, webhook_url: *mut wire_uint_
 }
 
 #[no_mangle]
+pub extern "C" fn wire_unregister_webhook(port_: i64, webhook_url: *mut wire_uint_8_list) {
+    wire_unregister_webhook_impl(port_, webhook_url)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_backup(port_: i64) {
     wire_backup_impl(port_)
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -400,6 +400,22 @@ fn wire_register_webhook_impl(port_: MessagePort, webhook_url: impl Wire2Api<Str
         },
     )
 }
+fn wire_unregister_webhook_impl(
+    port_: MessagePort,
+    webhook_url: impl Wire2Api<String> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
+        WrapInfo {
+            debug_name: "unregister_webhook",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_webhook_url = webhook_url.wire2api();
+            move |task_callback| unregister_webhook(api_webhook_url)
+        },
+    )
+}
 fn wire_backup_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
         WrapInfo {

--- a/libs/sdk-core/src/grpc/proto/breez.proto
+++ b/libs/sdk-core/src/grpc/proto/breez.proto
@@ -92,6 +92,7 @@ service InactiveNotifier {
 
 service PaymentNotifier {
   rpc RegisterPaymentNotification(RegisterPaymentNotificationRequest) returns (RegisterPaymentNotificationResponse) {}
+  rpc RemovePaymentNotification(RemovePaymentNotificationRequest) returns (RemovePaymentNotificationResponse) {}
 }
 
 service Signer {
@@ -122,6 +123,14 @@ message RegisterPaymentNotificationRequest {
 }
 
 message RegisterPaymentNotificationResponse {
+}
+
+message RemovePaymentNotificationRequest {
+  string lsp_id = 1;
+  bytes blob = 2;
+}
+
+message RemovePaymentNotificationResponse {
 }
 
 message ReceiverInfoRequest {}
@@ -464,3 +473,11 @@ message SubscribeNotificationsRequest {
 }
 
 message SubscribeNotificationsReply {}
+
+message UnsubscribeNotificationsRequest {
+  string url = 1;
+  string signature = 2;
+}
+
+message UnsubscribeNotificationsReply {
+}

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -22,7 +22,7 @@ use crate::error::SdkResult;
 use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{
     self, GetReverseRoutingNodeRequest, PaymentInformation, RegisterPaymentNotificationResponse,
-    RegisterPaymentReply,
+    RegisterPaymentReply, RemovePaymentNotificationResponse,
 };
 use crate::lnurl::pay::model::SuccessActionProcessed;
 use crate::lsp::LspInformation;
@@ -71,6 +71,17 @@ pub trait LspAPI: Send + Sync {
         webhook_url: String,
         webhook_url_signature: String,
     ) -> SdkResult<RegisterPaymentNotificationResponse>;
+
+    /// Unregister for webhook callbacks for the given `webhook_url`
+    async fn unregister_payment_notifications(
+        &self,
+        lsp_id: String,
+        lsp_pubkey: Vec<u8>,
+        webhook_url: String,
+        webhook_url_signature: String,
+    ) -> SdkResult<RemovePaymentNotificationResponse>;
+
+    /// Register a payment to open a new channel with the LSP
     async fn register_payment(
         &self,
         lsp_id: String,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -29,7 +29,7 @@ use crate::breez_services::{OpenChannelParams, Receiver};
 use crate::chain::{ChainService, OnchainTx, Outspend, RecommendedFees, TxStatus};
 use crate::error::{ReceivePaymentError, SdkError, SdkResult};
 use crate::fiat::{FiatCurrency, Rate};
-use crate::grpc::{PaymentInformation, RegisterPaymentNotificationResponse, RegisterPaymentReply};
+use crate::grpc::{PaymentInformation, RegisterPaymentNotificationResponse, RegisterPaymentReply, RemovePaymentNotificationResponse};
 use crate::invoice::{InvoiceError, InvoiceResult};
 use crate::lightning::ln::PaymentSecret;
 use crate::lightning_invoice::{Currency, InvoiceBuilder, RawBolt11Invoice};
@@ -663,6 +663,16 @@ impl LspAPI for MockBreezServer {
         _webhook_url_signature: String,
     ) -> SdkResult<RegisterPaymentNotificationResponse> {
         Ok(RegisterPaymentNotificationResponse {})
+    }
+
+    async fn unregister_payment_notifications(
+        &self,
+        _lsp_id: String,
+        _lsp_pubkey: Vec<u8>,
+        _webhook_url: String,
+        _webhook_url_signature: String,
+    ) -> SdkResult<RemovePaymentNotificationResponse> {
+        Ok(RemovePaymentNotificationResponse {})
     }
 
     async fn register_payment(

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -336,6 +336,8 @@ void wire_close_lsp_channels(int64_t port_);
 
 void wire_register_webhook(int64_t port_, struct wire_uint_8_list *webhook_url);
 
+void wire_unregister_webhook(int64_t port_, struct wire_uint_8_list *webhook_url);
+
 void wire_backup(int64_t port_);
 
 void wire_backup_status(int64_t port_);
@@ -519,6 +521,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_lsp_info);
     dummy_var ^= ((int64_t) (void*) wire_close_lsp_channels);
     dummy_var ^= ((int64_t) (void*) wire_register_webhook);
+    dummy_var ^= ((int64_t) (void*) wire_unregister_webhook);
     dummy_var ^= ((int64_t) (void*) wire_backup);
     dummy_var ^= ((int64_t) (void*) wire_backup_status);
     dummy_var ^= ((int64_t) (void*) wire_parse_invoice);

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -99,6 +99,11 @@ class BreezSDK {
     return _lnToolkit.registerWebhook(webhookUrl: webhookUrl);
   }
 
+  /// Unregister webhook callbacks for the given `webhook_url`.
+  Future<void> unregisterWebhook({required String webhookUrl}) async {
+    return _lnToolkit.unregisterWebhook(webhookUrl: webhookUrl);
+  }
+
   /// connect initializes the global NodeService, schedule the node to run in the cloud and
   /// run the signer. This must be called in order to start communicate with the node
   ///

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -127,6 +127,10 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kRegisterWebhookConstMeta;
 
+  Future<void> unregisterWebhook({required String webhookUrl, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kUnregisterWebhookConstMeta;
+
   /// See [BreezServices::backup]
   Future<void> backup({dynamic hint});
 
@@ -2465,6 +2469,23 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kRegisterWebhookConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "register_webhook",
+        argNames: ["webhookUrl"],
+      );
+
+  Future<void> unregisterWebhook({required String webhookUrl, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(webhookUrl);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_unregister_webhook(port_, arg0),
+      parseSuccessData: _wire2api_unit,
+      parseErrorData: _wire2api_FrbAnyhowException,
+      constMeta: kUnregisterWebhookConstMeta,
+      argValues: [webhookUrl],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kUnregisterWebhookConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "unregister_webhook",
         argNames: ["webhookUrl"],
       );
 
@@ -5464,6 +5485,22 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'wire_register_webhook');
   late final _wire_register_webhook =
       _wire_register_webhookPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_unregister_webhook(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> webhook_url,
+  ) {
+    return _wire_unregister_webhook(
+      port_,
+      webhook_url,
+    );
+  }
+
+  late final _wire_unregister_webhookPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_unregister_webhook');
+  late final _wire_unregister_webhook =
+      _wire_unregister_webhookPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_backup(
     int port_,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -659,6 +659,21 @@ class BreezSDKModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     }
 
     @ReactMethod
+    fun unregisterWebhook(
+        webhookUrl: String,
+        promise: Promise,
+    ) {
+        executor.execute {
+            try {
+                getBreezServices().unregisterWebhook(webhookUrl)
+                promise.resolve(readableMapOf("status" to "ok"))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun receiveOnchain(
         req: ReadableMap,
         promise: Promise,

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -217,6 +217,12 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    unregisterWebhook: (NSString*)webhookUrl
+    resolve: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     receiveOnchain: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -478,6 +478,16 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
+    @objc(unregisterWebhook:resolve:reject:)
+    func unregisterWebhook(_ webhookUrl: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            try getBreezServices().unregisterWebhook(webhookUrl: webhookUrl)
+            resolve(["status": "ok"])
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(receiveOnchain:resolve:reject:)
     func receiveOnchain(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -1028,6 +1028,10 @@ export const registerWebhook = async (webhookUrl: string): Promise<void> => {
     await BreezSDK.registerWebhook(webhookUrl)
 }
 
+export const unregisterWebhook = async (webhookUrl: string): Promise<void> => {
+    await BreezSDK.unregisterWebhook(webhookUrl)
+}
+
 export const receiveOnchain = async (req: ReceiveOnchainRequest): Promise<SwapInfo> => {
     const response = await BreezSDK.receiveOnchain(req)
     return response

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -599,6 +599,10 @@ pub(crate) async fn handle_command(
             sdk()?.register_webhook(url).await?;
             Ok("Url registered successfully".into())
         }
+        Commands::UnregisterWebhook { url } => {
+            sdk()?.unregister_webhook(url).await?;
+            Ok("Url unregistered successfully".into())
+        }
     }
 }
 

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -308,9 +308,7 @@ pub(crate) enum Commands {
     RegisterWebhook { url: String },
 
     /// [node-mgmt] Unregister a webhook URL.
-    UnregisterWebhook {
-        url: String,
-    },
+    UnregisterWebhook { url: String },
 
     /// [buy] Generates an URL to buy bitcoin from a 3rd party provider
     BuyBitcoin { provider: BuyBitcoinProvider },

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -307,6 +307,11 @@ pub(crate) enum Commands {
     /// [node-mgmt] Register a webhook URL, where the SDK will trigger a callback on specific events.
     RegisterWebhook { url: String },
 
+    /// [node-mgmt] Unregister a webhook URL.
+    UnregisterWebhook {
+        url: String,
+    },
+
     /// [buy] Generates an URL to buy bitcoin from a 3rd party provider
     BuyBitcoin { provider: BuyBitcoinProvider },
 


### PR DESCRIPTION
This PR adds the `unregister_webhook` method to the SDK and CLI to remove webhook notifications for a specific webhook URL. This removes notifications for:
- Payment notifications
- Swap confirmations for not yet refundable swap addresses 