### PR TITLE
Handle `max_allowed_deposit`

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -555,6 +555,7 @@ dictionary SwapInfo {
     sequence<string> confirmed_tx_ids;
     i64 min_allowed_deposit;
     i64 max_allowed_deposit;
+    i64 max_allowed_deposit_abs;
     string? last_redeem_error;
     OpeningFeeParams? channel_opening_fees;
     u32? confirmed_at;

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -555,7 +555,7 @@ dictionary SwapInfo {
     sequence<string> confirmed_tx_ids;
     i64 min_allowed_deposit;
     i64 max_allowed_deposit;
-    i64 max_allowed_deposit_abs;
+    i64 max_swapper_payable;
     string? last_redeem_error;
     OpeningFeeParams? channel_opening_fees;
     u32? confirmed_at;

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -780,7 +780,7 @@ mod tests {
             confirmed_tx_ids: Vec::new(),
             min_allowed_deposit: 0,
             max_allowed_deposit: 100,
-            max_allowed_deposit_abs: 200,
+            max_swapper_payable: 200,
             last_redeem_error: None,
             channel_opening_fees: Some(get_test_ofp_48h(1, 1).into()),
             confirmed_at: Some(555),

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -780,6 +780,7 @@ mod tests {
             confirmed_tx_ids: Vec::new(),
             min_allowed_deposit: 0,
             max_allowed_deposit: 100,
+            max_allowed_deposit_abs: 200,
             last_redeem_error: None,
             channel_opening_fees: Some(get_test_ofp_48h(1, 1).into()),
             confirmed_at: Some(555),

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2697,6 +2697,7 @@ pub(crate) mod tests {
             confirmed_tx_ids: vec![],
             min_allowed_deposit: 5_000,
             max_allowed_deposit: 1_000_000,
+            max_allowed_deposit_abs: 2_000_000,
             last_redeem_error: None,
             channel_opening_fees: Some(OpeningFeeParams {
                 min_msat: 5_000_000,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2697,7 +2697,7 @@ pub(crate) mod tests {
             confirmed_tx_ids: vec![],
             min_allowed_deposit: 5_000,
             max_allowed_deposit: 1_000_000,
-            max_allowed_deposit_abs: 2_000_000,
+            max_swapper_payable: 2_000_000,
             last_redeem_error: None,
             channel_opening_fees: Some(OpeningFeeParams {
                 min_msat: 5_000_000,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -3139,15 +3139,15 @@ pub(crate) mod tests {
             id: "tx1".to_string(),
             block_height: 1,
             channels_balance_msat: 100,
-            onchain_balance_msat: 1000,
+            onchain_balance_msat: 1_000,
             pending_onchain_balance_msat: 100,
             utxos: vec![],
             max_payable_msat: 95,
-            max_receivable_msat: 4000000000,
-            max_single_payment_amount_msat: 1000,
+            max_receivable_msat: 4_000_000_000,
+            max_single_payment_amount_msat: 1_000,
             max_chan_reserve_msats: 0,
             connected_peers: vec!["1111".to_string()],
-            inbound_liquidity_msats: 2000,
+            inbound_liquidity_msats: 2_000,
         }
     }
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -2239,7 +2239,7 @@ impl support::IntoDart for SwapInfo {
             self.confirmed_tx_ids.into_into_dart().into_dart(),
             self.min_allowed_deposit.into_into_dart().into_dart(),
             self.max_allowed_deposit.into_into_dart().into_dart(),
-            self.max_allowed_deposit_abs.into_into_dart().into_dart(),
+            self.max_swapper_payable.into_into_dart().into_dart(),
             self.last_redeem_error.into_dart(),
             self.channel_opening_fees.into_dart(),
             self.confirmed_at.into_dart(),

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -2239,6 +2239,7 @@ impl support::IntoDart for SwapInfo {
             self.confirmed_tx_ids.into_into_dart().into_dart(),
             self.min_allowed_deposit.into_into_dart().into_dart(),
             self.max_allowed_deposit.into_into_dart().into_dart(),
+            self.max_allowed_deposit_abs.into_into_dart().into_dart(),
             self.last_redeem_error.into_dart(),
             self.channel_opening_fees.into_dart(),
             self.confirmed_at.into_dart(),

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1374,10 +1374,12 @@ pub struct SwapInfo {
     pub unconfirmed_tx_ids: Vec<String>,
     /// Transaction IDs that have been confirmed on-chain.
     pub confirmed_tx_ids: Vec<String>,
-    /// The minimum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].   
+    /// The minimum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
     pub min_allowed_deposit: i64,
-    /// The maximum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
+    /// The maximum amount of sats one can send in order for the swap to succeed. This is determined based on `max_allowed_deposit_abs` and the node's local balance.
     pub max_allowed_deposit: i64,
+    /// The absolute maximum value, set by the swapper. Received from [SwapperAPI::create_swap].
+    pub max_allowed_deposit_abs: i64,
     /// Error reason for when swap fails.
     pub last_redeem_error: Option<String>,
     /// The dynamic fees which is set if a channel opening is needed.

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -97,9 +97,9 @@ pub struct Swap {
     pub error_message: String,
     pub required_reserve: i64,
     /// Absolute minimum amount, in sats, allowed by the swapper for a successful swap
-    pub min_allowed_deposit_abs: i64,
+    pub swapper_min_payable: i64,
     /// Absolute maximum amount, in sats, allowed by the swapper for a successful swap
-    pub max_allowed_deposit_abs: i64,
+    pub swapper_max_payable: i64,
 }
 
 /// Trait covering functionality involving swaps
@@ -1378,10 +1378,10 @@ pub struct SwapInfo {
     pub confirmed_tx_ids: Vec<String>,
     /// The minimum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
     pub min_allowed_deposit: i64,
-    /// The maximum amount of sats one can send in order for the swap to succeed. This is determined based on `max_allowed_deposit_abs` and the node's local balance.
+    /// The maximum amount of sats one can send in order for the swap to succeed. This is determined based on `max_swapper_payable` and the node's local balance.
     pub max_allowed_deposit: i64,
-    /// The absolute maximum value, set by the swapper. Received from [SwapperAPI::create_swap].
-    pub max_allowed_deposit_abs: i64,
+    /// The absolute maximum value payable by the swapper. Received from [SwapperAPI::create_swap].
+    pub max_swapper_payable: i64,
     /// Error reason for when swap fails.
     pub last_redeem_error: Option<String>,
     /// The dynamic fees which is set if a channel opening is needed.
@@ -1480,10 +1480,10 @@ impl SwapInfo {
         }
     }
 
-    pub(crate) fn validate_max_allowed_deposit(&self) -> SwapResult<()> {
+    pub(crate) fn validate_swap_limits(&self) -> SwapResult<()> {
         ensure_sdk!(
             self.max_allowed_deposit >= self.min_allowed_deposit,
-            SwapError::Generic(anyhow!("No allowed deposit amounts"))
+            SwapError::unsupported_swap_limits("No allowed deposit amounts")
         );
         Ok(())
     }

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -427,6 +427,11 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ALTER TABLE swaps_info ADD COLUMN total_incoming_txs INTEGER;
        UPDATE swaps_info SET status = 0;
        ",
+       // Add max absolute value. For existing swaps, initialize it to max_allowed_deposit.
+       "
+       ALTER TABLE sync.swaps ADD COLUMN max_allowed_deposit_abs INTEGER NOT NULL;
+       UPDATE sync.swaps SET max_allowed_deposit_abs = max_allowed_deposit;
+       "
     ]
 }
 

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -427,10 +427,10 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ALTER TABLE swaps_info ADD COLUMN total_incoming_txs INTEGER;
        UPDATE swaps_info SET status = 0;
        ",
-       // Add max absolute value. For existing swaps, initialize it to max_allowed_deposit.
+       // Add max absolute value payable by the swapper. For existing swaps, initialize it to max_allowed_deposit.
        "
-       ALTER TABLE sync.swaps ADD COLUMN max_allowed_deposit_abs INTEGER NOT NULL;
-       UPDATE sync.swaps SET max_allowed_deposit_abs = max_allowed_deposit;
+       ALTER TABLE sync.swaps ADD COLUMN max_swapper_payable INTEGER NOT NULL;
+       UPDATE sync.swaps SET max_swapper_payable = max_allowed_deposit;
        "
     ]
 }

--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -36,9 +36,10 @@ impl SqliteStorage {
            swapper_public_key, 
            script,
            min_allowed_deposit, 
-           max_allowed_deposit
+           max_allowed_deposit,
+           max_allowed_deposit_abs
          )
-         VALUES (:bitcoin_address, :created_at, :lock_height, :payment_hash, :preimage, :private_key, :public_key, :swapper_public_key, :script, :min_allowed_deposit, :max_allowed_deposit)",
+         VALUES (:bitcoin_address, :created_at, :lock_height, :payment_hash, :preimage, :private_key, :public_key, :swapper_public_key, :script, :min_allowed_deposit, :max_allowed_deposit, :max_allowed_deposit_abs)",
          named_params! {
              ":bitcoin_address": swap_info.bitcoin_address,
              ":created_at": swap_info.created_at,
@@ -50,7 +51,8 @@ impl SqliteStorage {
              ":swapper_public_key": swap_info.swapper_public_key,            
              ":script": swap_info.script,             
              ":min_allowed_deposit": swap_info.min_allowed_deposit,
-             ":max_allowed_deposit": swap_info.max_allowed_deposit
+             ":max_allowed_deposit": swap_info.max_allowed_deposit,
+             ":max_allowed_deposit_abs": swap_info.max_allowed_deposit_abs,
          },
         )?;
 
@@ -225,6 +227,7 @@ impl SqliteStorage {
           script as {prefix}script,
           min_allowed_deposit as {prefix}min_allowed_deposit,
           max_allowed_deposit as {prefix}max_allowed_deposit,
+          max_allowed_deposit_abs as {prefix}max_allowed_deposit_abs,
           bolt11 as {prefix}bolt11,
           paid_msat as {prefix}paid_msat,
           unconfirmed_sats as {prefix}unconfirmed_sats,
@@ -267,6 +270,7 @@ impl SqliteStorage {
           {prefix}script,
           {prefix}min_allowed_deposit,
           {prefix}max_allowed_deposit,
+          {prefix}max_allowed_deposit_abs,
           {prefix}bolt11,
           {prefix}paid_msat,
           {prefix}unconfirmed_sats,
@@ -389,6 +393,8 @@ impl SqliteStorage {
             confirmed_tx_ids: confirmed_txs_raw.0,
             min_allowed_deposit: row.get(format!("{prefix}min_allowed_deposit").as_str())?,
             max_allowed_deposit: row.get(format!("{prefix}max_allowed_deposit").as_str())?,
+            max_allowed_deposit_abs: row
+                .get(format!("{prefix}max_allowed_deposit_abs").as_str())?,
             last_redeem_error: row.get(format!("{prefix}last_redeem_error").as_str())?,
             channel_opening_fees: row.get(format!("{prefix}channel_opening_fees").as_str())?,
             confirmed_at: row.get(format!("{prefix}confirmed_at").as_str())?,
@@ -440,6 +446,7 @@ mod tests {
             confirmed_tx_ids: Vec::new(),
             min_allowed_deposit: 0,
             max_allowed_deposit: 100,
+            max_allowed_deposit_abs: 200,
             last_redeem_error: None,
             channel_opening_fees: Some(get_test_ofp_48h(1, 1).into()),
             confirmed_at: None,

--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -37,9 +37,9 @@ impl SqliteStorage {
            script,
            min_allowed_deposit, 
            max_allowed_deposit,
-           max_allowed_deposit_abs
+           max_swapper_payable
          )
-         VALUES (:bitcoin_address, :created_at, :lock_height, :payment_hash, :preimage, :private_key, :public_key, :swapper_public_key, :script, :min_allowed_deposit, :max_allowed_deposit, :max_allowed_deposit_abs)",
+         VALUES (:bitcoin_address, :created_at, :lock_height, :payment_hash, :preimage, :private_key, :public_key, :swapper_public_key, :script, :min_allowed_deposit, :max_allowed_deposit, :max_swapper_payable)",
          named_params! {
              ":bitcoin_address": swap_info.bitcoin_address,
              ":created_at": swap_info.created_at,
@@ -52,7 +52,7 @@ impl SqliteStorage {
              ":script": swap_info.script,             
              ":min_allowed_deposit": swap_info.min_allowed_deposit,
              ":max_allowed_deposit": swap_info.max_allowed_deposit,
-             ":max_allowed_deposit_abs": swap_info.max_allowed_deposit_abs,
+             ":max_swapper_payable": swap_info.max_swapper_payable,
          },
         )?;
 
@@ -243,7 +243,7 @@ impl SqliteStorage {
           script as {prefix}script,
           min_allowed_deposit as {prefix}min_allowed_deposit,
           max_allowed_deposit as {prefix}max_allowed_deposit,
-          max_allowed_deposit_abs as {prefix}max_allowed_deposit_abs,
+          max_swapper_payable as {prefix}max_swapper_payable,
           bolt11 as {prefix}bolt11,
           paid_msat as {prefix}paid_msat,
           unconfirmed_sats as {prefix}unconfirmed_sats,
@@ -286,7 +286,7 @@ impl SqliteStorage {
           {prefix}script,
           {prefix}min_allowed_deposit,
           {prefix}max_allowed_deposit,
-          {prefix}max_allowed_deposit_abs,
+          {prefix}max_swapper_payable,
           {prefix}bolt11,
           {prefix}paid_msat,
           {prefix}unconfirmed_sats,
@@ -409,8 +409,7 @@ impl SqliteStorage {
             confirmed_tx_ids: confirmed_txs_raw.0,
             min_allowed_deposit: row.get(format!("{prefix}min_allowed_deposit").as_str())?,
             max_allowed_deposit: row.get(format!("{prefix}max_allowed_deposit").as_str())?,
-            max_allowed_deposit_abs: row
-                .get(format!("{prefix}max_allowed_deposit_abs").as_str())?,
+            max_swapper_payable: row.get(format!("{prefix}max_swapper_payable").as_str())?,
             last_redeem_error: row.get(format!("{prefix}last_redeem_error").as_str())?,
             channel_opening_fees: row.get(format!("{prefix}channel_opening_fees").as_str())?,
             confirmed_at: row.get(format!("{prefix}confirmed_at").as_str())?,
@@ -462,7 +461,7 @@ mod tests {
             confirmed_tx_ids: Vec::new(),
             min_allowed_deposit: 0,
             max_allowed_deposit: 100,
-            max_allowed_deposit_abs: 200,
+            max_swapper_payable: 200,
             last_redeem_error: None,
             channel_opening_fees: Some(get_test_ofp_48h(1, 1).into()),
             confirmed_at: None,

--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -113,6 +113,22 @@ impl SqliteStorage {
         Ok(())
     }
 
+    pub(crate) fn update_swap_max_allowed_deposit(
+        &self,
+        bitcoin_address: String,
+        max_allowed_deposit: i64,
+    ) -> PersistResult<()> {
+        self.get_connection()?.execute(
+            "UPDATE sync.swaps SET max_allowed_deposit=:max_allowed_deposit where bitcoin_address=:bitcoin_address",
+            named_params! {
+             ":max_allowed_deposit": max_allowed_deposit,
+             ":bitcoin_address": bitcoin_address,
+            },
+        )?;
+
+        Ok(())
+    }
+
     pub(crate) fn update_swap_redeem_error(
         &self,
         bitcoin_address: String,

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -142,7 +142,7 @@ impl SqliteStorage {
            script,
            min_allowed_deposit,
            max_allowed_deposit,
-           max_allowed_deposit_abs
+           max_swapper_payable
           FROM remote_sync.swaps
           WHERE bitcoin_address NOT IN (SELECT bitcoin_address FROM sync.swaps);",
             [],
@@ -470,7 +470,7 @@ mod tests {
             confirmed_tx_ids: Vec::new(),
             min_allowed_deposit: 0,
             max_allowed_deposit: 100,
-            max_allowed_deposit_abs: 200,
+            max_swapper_payable: 200,
             last_redeem_error: None,
             channel_opening_fees: Some(get_test_ofp_48h(random(), random()).into()),
             confirmed_at: None,

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -141,7 +141,8 @@ impl SqliteStorage {
            swapper_public_key,
            script,
            min_allowed_deposit,
-           max_allowed_deposit
+           max_allowed_deposit,
+           max_allowed_deposit_abs
           FROM remote_sync.swaps
           WHERE bitcoin_address NOT IN (SELECT bitcoin_address FROM sync.swaps);",
             [],
@@ -469,6 +470,7 @@ mod tests {
             confirmed_tx_ids: Vec::new(),
             min_allowed_deposit: 0,
             max_allowed_deposit: 100,
+            max_allowed_deposit_abs: 200,
             last_redeem_error: None,
             channel_opening_fees: Some(get_test_ofp_48h(random(), random()).into()),
             confirmed_at: None,

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -557,7 +557,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
         confirmed_tx_ids: vec![],
         min_allowed_deposit: 5_000,
         max_allowed_deposit: 1_000_000,
-        max_allowed_deposit_abs: 2_000_000,
+        max_swapper_payable: 2_000_000,
         last_redeem_error: None,
         channel_opening_fees: Some(OpeningFeeParams {
             min_msat: 5_000_000,

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -557,6 +557,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
         confirmed_tx_ids: vec![],
         min_allowed_deposit: 5_000,
         max_allowed_deposit: 1_000_000,
+        max_allowed_deposit_abs: 2_000_000,
         last_redeem_error: None,
         channel_opening_fees: Some(OpeningFeeParams {
             min_msat: 5_000_000,

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -14,6 +14,14 @@ pub enum SwapError {
 
     #[error("Service connectivity: {0}")]
     ServiceConnectivity(anyhow::Error),
+
+    #[error("Unsupported swap limits: {0}")]
+    UnsupportedSwapLimits(anyhow::Error),
+}
+impl SwapError {
+    pub(crate) fn unsupported_swap_limits(err: &str) -> Self {
+        Self::UnsupportedSwapLimits(anyhow!(err.to_string()))
+    }
 }
 
 impl From<SdkError> for SwapError {

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -217,9 +217,10 @@ impl BTCReceiveSwap {
             return Err(SwapError::Generic(anyhow!("Wrong address: {address_str}")));
         }
 
+        let max_allowed_deposit_abs = swap_reply.max_allowed_deposit;
         let max_allowed_deposit = std::cmp::min(
             (node_state.max_receivable_msat / 1000) as i64,
-            swap_reply.max_allowed_deposit,
+            max_allowed_deposit_abs,
         );
         if max_allowed_deposit < swap_reply.min_allowed_deposit {
             return Err(SwapError::Generic(anyhow!("No allowed deposit amounts")));
@@ -248,6 +249,7 @@ impl BTCReceiveSwap {
             status: SwapStatus::Initial,
             min_allowed_deposit: swap_reply.min_allowed_deposit,
             max_allowed_deposit,
+            max_allowed_deposit_abs,
             last_redeem_error: None,
             channel_opening_fees: Some(channel_opening_fees),
             confirmed_at: None,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -142,10 +142,10 @@ impl SwapperAPI for MockSwapperAPI {
             bitcoin_address: address.to_string(),
             swapper_pubkey: swapper_pub_key,
             lock_height: 144,
-            max_allowed_deposit: 4000000,
+            max_allowed_deposit_abs: 4_000_000,
             error_message: "".to_string(),
             required_reserve: 0,
-            min_allowed_deposit: 3000,
+            min_allowed_deposit_abs: 3_000,
         })
     }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -142,10 +142,10 @@ impl SwapperAPI for MockSwapperAPI {
             bitcoin_address: address.to_string(),
             swapper_pubkey: swapper_pub_key,
             lock_height: 144,
-            max_allowed_deposit_abs: 4_000_000,
+            swapper_max_payable: 4_000_000,
             error_message: "".to_string(),
             required_reserve: 0,
-            min_allowed_deposit_abs: 3_000,
+            swapper_min_payable: 3_000,
         })
     }
 

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1940,11 +1940,11 @@ class SwapInfo {
   /// The minimum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
   final int minAllowedDeposit;
 
-  /// The maximum amount of sats one can send in order for the swap to succeed. This is determined based on `max_allowed_deposit_abs` and the node's local balance.
+  /// The maximum amount of sats one can send in order for the swap to succeed. This is determined based on `max_swapper_payable` and the node's local balance.
   final int maxAllowedDeposit;
 
-  /// The absolute maximum value, set by the swapper. Received from [SwapperAPI::create_swap].
-  final int maxAllowedDepositAbs;
+  /// The absolute maximum value payable by the swapper. Received from [SwapperAPI::create_swap].
+  final int maxSwapperPayable;
 
   /// Error reason for when swap fails.
   final String? lastRedeemError;
@@ -1980,7 +1980,7 @@ class SwapInfo {
     required this.confirmedTxIds,
     required this.minAllowedDeposit,
     required this.maxAllowedDeposit,
-    required this.maxAllowedDepositAbs,
+    required this.maxSwapperPayable,
     this.lastRedeemError,
     this.channelOpeningFees,
     this.confirmedAt,
@@ -4161,7 +4161,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       confirmedTxIds: _wire2api_StringList(arr[17]),
       minAllowedDeposit: _wire2api_i64(arr[18]),
       maxAllowedDeposit: _wire2api_i64(arr[19]),
-      maxAllowedDepositAbs: _wire2api_i64(arr[20]),
+      maxSwapperPayable: _wire2api_i64(arr[20]),
       lastRedeemError: _wire2api_opt_String(arr[21]),
       channelOpeningFees: _wire2api_opt_box_autoadd_opening_fee_params(arr[22]),
       confirmedAt: _wire2api_opt_box_autoadd_u32(arr[23]),

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1940,8 +1940,11 @@ class SwapInfo {
   /// The minimum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
   final int minAllowedDeposit;
 
-  /// The maximum amount of sats one can send in order for the swap to succeed. Received from [SwapperAPI::create_swap].
+  /// The maximum amount of sats one can send in order for the swap to succeed. This is determined based on `max_allowed_deposit_abs` and the node's local balance.
   final int maxAllowedDeposit;
+
+  /// The absolute maximum value, set by the swapper. Received from [SwapperAPI::create_swap].
+  final int maxAllowedDepositAbs;
 
   /// Error reason for when swap fails.
   final String? lastRedeemError;
@@ -1977,6 +1980,7 @@ class SwapInfo {
     required this.confirmedTxIds,
     required this.minAllowedDeposit,
     required this.maxAllowedDeposit,
+    required this.maxAllowedDepositAbs,
     this.lastRedeemError,
     this.channelOpeningFees,
     this.confirmedAt,
@@ -4135,7 +4139,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   SwapInfo _wire2api_swap_info(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 23) throw Exception('unexpected arr length: expect 23 but see ${arr.length}');
+    if (arr.length != 24) throw Exception('unexpected arr length: expect 24 but see ${arr.length}');
     return SwapInfo(
       bitcoinAddress: _wire2api_String(arr[0]),
       createdAt: _wire2api_i64(arr[1]),
@@ -4157,9 +4161,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       confirmedTxIds: _wire2api_StringList(arr[17]),
       minAllowedDeposit: _wire2api_i64(arr[18]),
       maxAllowedDeposit: _wire2api_i64(arr[19]),
-      lastRedeemError: _wire2api_opt_String(arr[20]),
-      channelOpeningFees: _wire2api_opt_box_autoadd_opening_fee_params(arr[21]),
-      confirmedAt: _wire2api_opt_box_autoadd_u32(arr[22]),
+      maxAllowedDepositAbs: _wire2api_i64(arr[20]),
+      lastRedeemError: _wire2api_opt_String(arr[21]),
+      channelOpeningFees: _wire2api_opt_box_autoadd_opening_fee_params(arr[22]),
+      confirmedAt: _wire2api_opt_box_autoadd_u32(arr[23]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -3520,7 +3520,7 @@ fun asSwapInfo(swapInfo: ReadableMap): SwapInfo? {
                 "confirmedTxIds",
                 "minAllowedDeposit",
                 "maxAllowedDeposit",
-                "maxAllowedDepositAbs",
+                "maxSwapperPayable",
             ),
         )
     ) {
@@ -3546,7 +3546,7 @@ fun asSwapInfo(swapInfo: ReadableMap): SwapInfo? {
     val confirmedTxIds = swapInfo.getArray("confirmedTxIds")?.let { asStringList(it) }!!
     val minAllowedDeposit = swapInfo.getDouble("minAllowedDeposit").toLong()
     val maxAllowedDeposit = swapInfo.getDouble("maxAllowedDeposit").toLong()
-    val maxAllowedDepositAbs = swapInfo.getDouble("maxAllowedDepositAbs").toLong()
+    val maxSwapperPayable = swapInfo.getDouble("maxSwapperPayable").toLong()
     val lastRedeemError = if (hasNonNullKey(swapInfo, "lastRedeemError")) swapInfo.getString("lastRedeemError") else null
     val channelOpeningFees =
         if (hasNonNullKey(swapInfo, "channelOpeningFees")) {
@@ -3578,7 +3578,7 @@ fun asSwapInfo(swapInfo: ReadableMap): SwapInfo? {
         confirmedTxIds,
         minAllowedDeposit,
         maxAllowedDeposit,
-        maxAllowedDepositAbs,
+        maxSwapperPayable,
         lastRedeemError,
         channelOpeningFees,
         confirmedAt,
@@ -3607,7 +3607,7 @@ fun readableMapOf(swapInfo: SwapInfo): ReadableMap {
         "confirmedTxIds" to readableArrayOf(swapInfo.confirmedTxIds),
         "minAllowedDeposit" to swapInfo.minAllowedDeposit,
         "maxAllowedDeposit" to swapInfo.maxAllowedDeposit,
-        "maxAllowedDepositAbs" to swapInfo.maxAllowedDepositAbs,
+        "maxSwapperPayable" to swapInfo.maxSwapperPayable,
         "lastRedeemError" to swapInfo.lastRedeemError,
         "channelOpeningFees" to swapInfo.channelOpeningFees?.let { readableMapOf(it) },
         "confirmedAt" to swapInfo.confirmedAt,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -3520,6 +3520,7 @@ fun asSwapInfo(swapInfo: ReadableMap): SwapInfo? {
                 "confirmedTxIds",
                 "minAllowedDeposit",
                 "maxAllowedDeposit",
+                "maxAllowedDepositAbs",
             ),
         )
     ) {
@@ -3545,6 +3546,7 @@ fun asSwapInfo(swapInfo: ReadableMap): SwapInfo? {
     val confirmedTxIds = swapInfo.getArray("confirmedTxIds")?.let { asStringList(it) }!!
     val minAllowedDeposit = swapInfo.getDouble("minAllowedDeposit").toLong()
     val maxAllowedDeposit = swapInfo.getDouble("maxAllowedDeposit").toLong()
+    val maxAllowedDepositAbs = swapInfo.getDouble("maxAllowedDepositAbs").toLong()
     val lastRedeemError = if (hasNonNullKey(swapInfo, "lastRedeemError")) swapInfo.getString("lastRedeemError") else null
     val channelOpeningFees =
         if (hasNonNullKey(swapInfo, "channelOpeningFees")) {
@@ -3576,6 +3578,7 @@ fun asSwapInfo(swapInfo: ReadableMap): SwapInfo? {
         confirmedTxIds,
         minAllowedDeposit,
         maxAllowedDeposit,
+        maxAllowedDepositAbs,
         lastRedeemError,
         channelOpeningFees,
         confirmedAt,
@@ -3604,6 +3607,7 @@ fun readableMapOf(swapInfo: SwapInfo): ReadableMap {
         "confirmedTxIds" to readableArrayOf(swapInfo.confirmedTxIds),
         "minAllowedDeposit" to swapInfo.minAllowedDeposit,
         "maxAllowedDeposit" to swapInfo.maxAllowedDeposit,
+        "maxAllowedDepositAbs" to swapInfo.maxAllowedDepositAbs,
         "lastRedeemError" to swapInfo.lastRedeemError,
         "channelOpeningFees" to swapInfo.channelOpeningFees?.let { readableMapOf(it) },
         "confirmedAt" to swapInfo.confirmedAt,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -3845,6 +3845,9 @@ enum BreezSDKMapper {
         guard let maxAllowedDeposit = swapInfo["maxAllowedDeposit"] as? Int64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxAllowedDeposit", typeName: "SwapInfo"))
         }
+        guard let maxAllowedDepositAbs = swapInfo["maxAllowedDepositAbs"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxAllowedDepositAbs", typeName: "SwapInfo"))
+        }
         var lastRedeemError: String?
         if hasNonNilKey(data: swapInfo, key: "lastRedeemError") {
             guard let lastRedeemErrorTmp = swapInfo["lastRedeemError"] as? String else {
@@ -3886,6 +3889,7 @@ enum BreezSDKMapper {
             confirmedTxIds: confirmedTxIds,
             minAllowedDeposit: minAllowedDeposit,
             maxAllowedDeposit: maxAllowedDeposit,
+            maxAllowedDepositAbs: maxAllowedDepositAbs,
             lastRedeemError: lastRedeemError,
             channelOpeningFees: channelOpeningFees,
             confirmedAt: confirmedAt
@@ -3914,6 +3918,7 @@ enum BreezSDKMapper {
             "confirmedTxIds": swapInfo.confirmedTxIds,
             "minAllowedDeposit": swapInfo.minAllowedDeposit,
             "maxAllowedDeposit": swapInfo.maxAllowedDeposit,
+            "maxAllowedDepositAbs": swapInfo.maxAllowedDepositAbs,
             "lastRedeemError": swapInfo.lastRedeemError == nil ? nil : swapInfo.lastRedeemError,
             "channelOpeningFees": swapInfo.channelOpeningFees == nil ? nil : dictionaryOf(openingFeeParams: swapInfo.channelOpeningFees!),
             "confirmedAt": swapInfo.confirmedAt == nil ? nil : swapInfo.confirmedAt,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -3845,8 +3845,8 @@ enum BreezSDKMapper {
         guard let maxAllowedDeposit = swapInfo["maxAllowedDeposit"] as? Int64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxAllowedDeposit", typeName: "SwapInfo"))
         }
-        guard let maxAllowedDepositAbs = swapInfo["maxAllowedDepositAbs"] as? Int64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxAllowedDepositAbs", typeName: "SwapInfo"))
+        guard let maxSwapperPayable = swapInfo["maxSwapperPayable"] as? Int64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxSwapperPayable", typeName: "SwapInfo"))
         }
         var lastRedeemError: String?
         if hasNonNilKey(data: swapInfo, key: "lastRedeemError") {
@@ -3889,7 +3889,7 @@ enum BreezSDKMapper {
             confirmedTxIds: confirmedTxIds,
             minAllowedDeposit: minAllowedDeposit,
             maxAllowedDeposit: maxAllowedDeposit,
-            maxAllowedDepositAbs: maxAllowedDepositAbs,
+            maxSwapperPayable: maxSwapperPayable,
             lastRedeemError: lastRedeemError,
             channelOpeningFees: channelOpeningFees,
             confirmedAt: confirmedAt
@@ -3918,7 +3918,7 @@ enum BreezSDKMapper {
             "confirmedTxIds": swapInfo.confirmedTxIds,
             "minAllowedDeposit": swapInfo.minAllowedDeposit,
             "maxAllowedDeposit": swapInfo.maxAllowedDeposit,
-            "maxAllowedDepositAbs": swapInfo.maxAllowedDepositAbs,
+            "maxSwapperPayable": swapInfo.maxSwapperPayable,
             "lastRedeemError": swapInfo.lastRedeemError == nil ? nil : swapInfo.lastRedeemError,
             "channelOpeningFees": swapInfo.channelOpeningFees == nil ? nil : dictionaryOf(openingFeeParams: swapInfo.channelOpeningFees!),
             "confirmedAt": swapInfo.confirmedAt == nil ? nil : swapInfo.confirmedAt,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -539,6 +539,7 @@ export type SwapInfo = {
     confirmedTxIds: string[]
     minAllowedDeposit: number
     maxAllowedDeposit: number
+    maxAllowedDepositAbs: number
     lastRedeemError?: string
     channelOpeningFees?: OpeningFeeParams
     confirmedAt?: number

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -539,7 +539,7 @@ export type SwapInfo = {
     confirmedTxIds: string[]
     minAllowedDeposit: number
     maxAllowedDeposit: number
-    maxAllowedDepositAbs: number
+    maxSwapperPayable: number
     lastRedeemError?: string
     channelOpeningFees?: OpeningFeeParams
     confirmedAt?: number


### PR DESCRIPTION
Fixes #871 

This PR adds the following behaviors:
- refactor: when new swaps are created, `max_allowed_deposit` is determined based on absolute max and the node `max_receivable_msat`
- new: when an existing swap is fetched, the `max_allowed_deposit` is recalculated, validated and persisted
- new: store the `max_allowed_deposit_abs` per swap, indicating the swapper max value at the moment this swap was created