### PR TITLE
Verify notification manager exist before starting service

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/MessagingService.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/MessagingService.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.util.Log
 import breez_sdk_notification.Constants.MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED
 import breez_sdk_notification.Constants.MESSAGE_TYPE_PAYMENT_RECEIVED
+import breez_sdk_notification.NotificationHelper.Companion.getNotificationManager
 
 @Suppress("unused")
 interface MessagingService {
@@ -22,12 +23,13 @@ interface MessagingService {
     /** Check if the foreground service is needed depending on the
      *  message type and foreground state of the application. */
     fun startServiceIfNeeded(context: Context, message: Message) {
+        val notificationManager = getNotificationManager(context)
         val isServiceNeeded = when (message.type) {
             MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED -> !isAppForeground(context)
             MESSAGE_TYPE_PAYMENT_RECEIVED -> !isAppForeground(context)
             else -> true
         }
-        if (isServiceNeeded) startForegroundService(message)
+        if (notificationManager != null && isServiceNeeded) startForegroundService(message)
         else Log.w(TAG, "Ignoring message ${message.type}: ${message.payload}")
     }
 

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
@@ -72,7 +72,7 @@ class NotificationHelper {
         private const val TAG = "NotificationHelper"
         private var defaultClickAction: String? = null
 
-        private fun getNotificationManager(context: Context): NotificationManager? {
+        fun getNotificationManager(context: Context): NotificationManager? {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val notificationManager =
                     context.getSystemService(Context.NOTIFICATION_SERVICE)
@@ -85,7 +85,7 @@ class NotificationHelper {
         }
 
         @SuppressLint("NewApi")
-        private fun createNotificationChannelGroup(
+        fun createNotificationChannelGroup(
             context: Context,
             groupId: String,
             groupName: String,


### PR DESCRIPTION
This PR is a fix on v0.4.0 to pre-check the android notification manager exists before starting the foreground service. 

It could be that the device receives a push message but the application doesn't have permissions to post notifications. In this case the plugin is trying to create the foreground service notification to call `startForeground`, but results in the application crashing with:
```
android.app.RemoteServiceException$CannotPostForegroundServiceNotificationException: 
    Bad notification for startForeground
```
So we first check in the MessageService if we should start the foreground service by checking the existence on the notification manager.