### PR TITLE
Allow executing `generate_diagnostic_data` through `execute_command`

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1479,6 +1479,10 @@ impl NodeAPI for Greenlight {
                     .into_inner();
                 Ok(format!("{resp:?}"))
             }
+            NodeCommand::GenerateDiagnosticData => {
+                let resp = self.generate_diagnostic_data().await?;
+                Ok(format!("{resp:?}"))
+            }
             NodeCommand::Stop => {
                 let resp = self
                     .get_node_client()
@@ -1646,6 +1650,10 @@ impl NodeAPI for Greenlight {
 
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]
 enum NodeCommand {
+    /// Generates diagnostic data report.
+    #[strum(serialize = "generatediagnosticdata")]
+    GenerateDiagnosticData,
+
     /// Closes all channels of all peers.
     #[strum(serialize = "closeallchannels")]
     CloseAllChannels,

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -96,14 +96,10 @@ pub(crate) enum Commands {
     },
 
     /// [lnurl] Withdraw using lnurl withdraw
-    LnurlWithdraw {
-        lnurl: String,
-    },
+    LnurlWithdraw { lnurl: String },
 
     /// [lnurl] Authenticate using lnurl auth
-    LnurlAuth {
-        lnurl: String,
-    },
+    LnurlAuth { lnurl: String },
 
     /// [swap-in] Generate address to receive onchain
     ReceiveOnchain {},
@@ -190,9 +186,7 @@ pub(crate) enum Commands {
     },
 
     /// [sign] Sign a message with the node's private key
-    SignMessage {
-        message: String,
-    },
+    SignMessage { message: String },
 
     /// [sign] Verify a message with a node's public key
     CheckMessage {
@@ -292,9 +286,7 @@ pub(crate) enum Commands {
     },
 
     /// [node-mgmt] Retrieve a payment by its hash
-    PaymentByHash {
-        hash: String,
-    },
+    PaymentByHash { hash: String },
 
     /// [node-mgmt] The node credentials
     NodeCredentials {},
@@ -313,14 +305,10 @@ pub(crate) enum Commands {
     Disconnect {},
 
     /// [node-mgmt] Register a webhook URL, where the SDK will trigger a callback on specific events.
-    RegisterWebhook {
-        url: String,
-    },
+    RegisterWebhook { url: String },
 
     /// [buy] Generates an URL to buy bitcoin from a 3rd party provider
-    BuyBitcoin {
-        provider: BuyBitcoinProvider,
-    },
+    BuyBitcoin { provider: BuyBitcoinProvider },
 
     /// [fiat] List fiat currencies
     ListFiat {},
@@ -329,9 +317,8 @@ pub(crate) enum Commands {
     FetchFiatRates {},
 
     /// [dev] Execute a low level node command (used for debugging)
-    ExecuteDevCommand {
-        command: String,
-    },
+    ExecuteDevCommand { command: String },
 
+    /// [dev] Generates and retrieves a diagnostic data report from the sdk services (used for debugging)
     GenerateDiagnosticData {},
 }


### PR DESCRIPTION
This PR introduces required changes to 
- https://github.com/breez/c-breez/issues/877

and adds command description for `GenerateDiagnosticData` as continuation of
  -  #900 &
  -  #828 