### PR TITLE
Add Android short service timeout

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
@@ -1,8 +1,9 @@
 package breez_sdk_notification
 
 object Constants {
+    const val SERVICE_TIMEOUT_MS = 3 * 60 * 1000L
     const val SHUTDOWN_DELAY_MS = 60 * 1000L
-    
+
     // Notification Channels
     const val NOTIFICATION_CHANNEL_FOREGROUND_SERVICE = "FOREGROUND_SERVICE"
     const val NOTIFICATION_CHANNEL_LNURL_PAY = "LNURL_PAY"

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/Job.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/Job.kt
@@ -4,5 +4,13 @@ import breez_sdk.BlockingBreezServices
 import breez_sdk.EventListener
 
 interface Job : EventListener {
+    /** When the notification service is connected to the Breez SDK
+     *  it calls `start` to initiate the job.
+     */
     fun start(breezSDK: BlockingBreezServices)
+
+    /** When the short service timeout is reached it calls `onShutdown` 
+     *  to cleanup the job.
+     */
+    fun onShutdown()
 }

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
@@ -118,4 +118,6 @@ class LnurlPayInfoJob(
 
         fgService.onFinished(this)
     }
+
+    override fun onShutdown() {}
 }

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
@@ -118,4 +118,6 @@ class LnurlPayInvoiceJob(
 
         fgService.onFinished(this)
     }
+
+    override fun onShutdown() {}
 }

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
@@ -68,6 +68,8 @@ class ReceivePaymentJob(
         }
     }
 
+    override fun onShutdown() {}
+
     private fun handleReceivedPayment(
         bolt11: String,
         paymentHash: String,

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/RedeemSwap.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/RedeemSwap.kt
@@ -38,7 +38,7 @@ class RedeemSwapJob(
             breezSDK.redeemSwap(request.address)
             logger.log(TAG, "Found swap for ${request.address}", "INFO")
         } catch (e: Exception) {
-            logger.log(TAG, "Failed to manually reedeem swap notification: ${e.message}", "WARN")
+            logger.log(TAG, "Failed to manually redeem swap notification: ${e.message}", "WARN")
         }
     }
 
@@ -47,7 +47,7 @@ class RedeemSwapJob(
             when (e) {
                 is BreezEvent.SwapUpdated -> {
                     val swapInfo = e.details
-                    logger.log(TAG, "Received swap updated event: ${swapInfo.bitcoinAddress} current address: ${address} status: ${swapInfo.status}", "TRACE")
+                    logger.log(TAG, "Received swap updated event: ${swapInfo.bitcoinAddress} current address: $address status: ${swapInfo.status}", "TRACE")
                     if (swapInfo.bitcoinAddress == address) {
                         if (swapInfo.paidMsat.toLong() > 0) {
                             notifySuccessAndShutdown(address)
@@ -60,8 +60,10 @@ class RedeemSwapJob(
         }
     }
 
+    override fun onShutdown() {}
+
     private  fun notifySuccessAndShutdown(address: String) {
-        logger.log(TAG, "Swap address ${address} redeemed succesfully", "INFO")
+        logger.log(TAG, "Swap address $address redeemed successfully", "INFO")
         notifyChannel(
             context,
             NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED,


### PR DESCRIPTION
This PR is a fix on v0.4.0 to add a Notification Plugin service timeout of 3 minutes to the running short service in Android. If the service runs for an extended period of time or does not respect the timeout of the short service, the application will be declared ANR (Application Not Responsive). We add the manual timeout instead of using `Service.onTimeout` because the plugin targets compile API level 33 and the function `onTimeout` was introduced in API level 34.
