### PR TITLE
Consider shutdown signal during entire signer loop

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -218,11 +218,13 @@ impl Greenlight {
 
         loop {
             debug!("Start of the signer loop, getting node_info from scheduler");
-            let node_info_res = scheduler.get_node_info(NodeInfoRequest {
-                node_id: self.signer.node_id(),
-                // Purposely not using the `wait` parameter
-                wait: false,
-            }).await;
+            let node_info_res = scheduler
+                .get_node_info(NodeInfoRequest {
+                    node_id: self.signer.node_id(),
+                    // Purposely not using the `wait` parameter
+                    wait: false,
+                })
+                .await;
 
             let node_info = match node_info_res.map(|v| v.into_inner()) {
                 Ok(v) => {
@@ -230,10 +232,7 @@ impl Greenlight {
                     v
                 }
                 Err(e) => {
-                    trace!(
-                                "Got an error from the scheduler: {}. Sleeping before retrying",
-                                e
-                            );
+                    trace!("Got an error from the scheduler: {e}. Sleeping before retrying");
                     sleep(Duration::from_millis(1000)).await;
                     continue;
                 }
@@ -245,8 +244,12 @@ impl Greenlight {
                 continue;
             }
 
-            if let Err(e) = self.signer.run_once(Uri::from_maybe_shared(node_info.grpc_uri)?).await {
-                warn!("Error running against node: {}", e);
+            if let Err(e) = self
+                .signer
+                .run_once(Uri::from_maybe_shared(node_info.grpc_uri)?)
+                .await
+            {
+                warn!("Error running against node: {e}");
             }
         }
     }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -172,7 +172,10 @@ impl Greenlight {
         })
     }
 
-    async fn run_forever_signer(&self) -> Result<(), anyhow::Error> {
+    /// The actual signer loop. Connects to, upgrades and keeps alive the connection to the signer.
+    ///
+    /// Used as inner loop for `run_forever`.
+    async fn run_forever_inner(&self) -> Result<(), anyhow::Error> {
         let channel = Endpoint::from_shared(utils::scheduler_uri())?
             .tls_config(self.tls_config.client_tls_config())?
             .tcp_keepalive(Some(Duration::from_secs(30)))
@@ -256,7 +259,7 @@ impl Greenlight {
 
     async fn run_forever(&self, mut shutdown: mpsc::Receiver<()>) -> Result<(), anyhow::Error> {
         tokio::select! {
-            run_forever_res = self.run_forever_signer() => {
+            run_forever_res = self.run_forever_inner() => {
                 match run_forever_res {
                     Ok(_) => info!("Inner signer loop exited"),
                     Err(e) => error!("Inner signer loop exited with error: {e:?}"),


### PR DESCRIPTION
Before this PR, the signer loop consisted of
- signer upgrade loop
  - which disregards the shutdown signal
- signer loop
  - which reacts to shutdown signal, but only when `signer.run_once` is not running, which may take 10 minutes to return. In other words, in the worst case the shutdown signal is handled (e.g. signer loop exits) 10 minutes after it's sent.

This PR wraps both loops above in a single `run_forever_inner` thread. In parallel to it, it listens to the shutdown signal and exits the thread as soon as the signal is received.

Possibly overrides #934.

---

**Note to reviewers / Open question**

I'm not sure if the signer upgrade loop (`scheduler.maybe_upgrade`) should be interrupted in the case of an upgrade. WIth this PR, it would be interrupted if we get a shutdown signal.

On the other hand, as described in #934, if we disregard the shutdown signal while we're in the signer upgrade loop, we may end up in an endless loop in the case when the GL scheduler is not reachable.

What do you think? How to best handle the upgrade loop?