### PR TITLE
Persist LNURL-pay comment sent to the recipient

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -308,6 +308,7 @@ dictionary LnPaymentDetails {
     string? open_channel_bolt11;
     SuccessActionProcessed? lnurl_success_action;
     string? lnurl_pay_domain;
+    string? lnurl_pay_comment;
     string? lnurl_metadata;
     string? ln_address;
     string? lnurl_withdraw_endpoint;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -364,8 +364,8 @@ impl BreezServices {
     pub async fn lnurl_pay(&self, req: LnUrlPayRequest) -> Result<LnUrlPayResult, LnUrlPayError> {
         match validate_lnurl_pay(
             req.amount_msat,
-            req.comment,
-            req.data.clone(),
+            &req.comment,
+            &req.data,
             self.config.network,
         )
         .await?
@@ -441,6 +441,7 @@ impl BreezServices {
                     PaymentExternalInfo {
                         lnurl_pay_success_action: maybe_sa_processed.clone(),
                         lnurl_pay_domain,
+                        lnurl_pay_comment: req.comment,
                         lnurl_metadata: Some(req.data.metadata_str),
                         ln_address: req.data.ln_address,
                         lnurl_withdraw_endpoint: None,
@@ -489,6 +490,7 @@ impl BreezServices {
                 PaymentExternalInfo {
                     lnurl_pay_success_action: None,
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: Some(lnurl_w_endpoint),
@@ -1186,6 +1188,7 @@ impl BreezServices {
                         bolt11: invoice.bolt11.clone(),
                         lnurl_success_action: None,
                         lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
                         ln_address: None,
                         lnurl_metadata: None,
                         lnurl_withdraw_endpoint: None,
@@ -1205,6 +1208,7 @@ impl BreezServices {
             PaymentExternalInfo {
                 lnurl_pay_success_action: None,
                 lnurl_pay_domain: None,
+                lnurl_pay_comment: None,
                 lnurl_metadata: None,
                 ln_address: None,
                 lnurl_withdraw_endpoint: None,
@@ -2764,6 +2768,7 @@ pub(crate) mod tests {
                         bolt11: "1111".to_string(),
                         lnurl_success_action: None,
                         lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
                         lnurl_metadata: None,
                         ln_address: None,
                         lnurl_withdraw_endpoint: None,
@@ -2794,6 +2799,7 @@ pub(crate) mod tests {
                         bolt11: "1111".to_string(),
                         lnurl_success_action: None,
                         lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
                         lnurl_metadata: None,
                         ln_address: None,
                         lnurl_withdraw_endpoint: Some(test_lnurl_withdraw_endpoint.to_string()),
@@ -2824,6 +2830,7 @@ pub(crate) mod tests {
                         bolt11: "123".to_string(),
                         lnurl_success_action: Some(sa.clone()),
                         lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
                         lnurl_metadata: Some(lnurl_metadata.to_string()),
                         ln_address: Some(test_ln_address.to_string()),
                         lnurl_withdraw_endpoint: None,
@@ -2854,6 +2861,7 @@ pub(crate) mod tests {
                         bolt11: "312".to_string(),
                         lnurl_success_action: None,
                         lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
                         lnurl_metadata: None,
                         ln_address: None,
                         lnurl_withdraw_endpoint: None,
@@ -2885,6 +2893,7 @@ pub(crate) mod tests {
                         lnurl_success_action: None,
                         lnurl_metadata: None,
                         lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
                         ln_address: None,
                         lnurl_withdraw_endpoint: None,
                         swap_info: None,
@@ -2907,6 +2916,7 @@ pub(crate) mod tests {
             PaymentExternalInfo {
                 lnurl_pay_success_action: Some(sa.clone()),
                 lnurl_pay_domain: None,
+                lnurl_pay_comment: None,
                 lnurl_metadata: Some(lnurl_metadata.to_string()),
                 ln_address: Some(test_ln_address.to_string()),
                 lnurl_withdraw_endpoint: None,
@@ -2919,6 +2929,7 @@ pub(crate) mod tests {
             PaymentExternalInfo {
                 lnurl_pay_success_action: None,
                 lnurl_pay_domain: None,
+                lnurl_pay_comment: None,
                 lnurl_metadata: None,
                 ln_address: None,
                 lnurl_withdraw_endpoint: Some(test_lnurl_withdraw_endpoint.to_string()),

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1386,6 +1386,7 @@ impl support::IntoDart for LnPaymentDetails {
             self.open_channel_bolt11.into_dart(),
             self.lnurl_success_action.into_dart(),
             self.lnurl_pay_domain.into_dart(),
+            self.lnurl_pay_comment.into_dart(),
             self.ln_address.into_dart(),
             self.lnurl_metadata.into_dart(),
             self.lnurl_withdraw_endpoint.into_dart(),

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1818,6 +1818,7 @@ impl TryFrom<OffChainPayment> for Payment {
                     bolt11: p.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
                     lnurl_pay_domain: None,     // For received payments, this is None
+                    lnurl_pay_comment: None,    // For received payments, this is None
                     lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -1862,6 +1863,7 @@ impl TryFrom<gl_client::signer::model::greenlight::Invoice> for Payment {
                     bolt11: invoice.bolt11,
                     lnurl_success_action: None, // For received payments, this is None
                     lnurl_pay_domain: None,     // For received payments, this is None
+                    lnurl_pay_comment: None,    // For received payments, this is None
                     lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -1921,6 +1923,7 @@ impl TryFrom<gl_client::signer::model::greenlight::Payment> for Payment {
                     bolt11: payment.bolt11,
                     lnurl_success_action: None,
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -1967,6 +1970,7 @@ impl TryFrom<cln::ListinvoicesInvoices> for Payment {
                     bolt11: invoice.bolt11.unwrap_or_default(),
                     lnurl_success_action: None, // For received payments, this is None
                     lnurl_pay_domain: None,     // For received payments, this is None
+                    lnurl_pay_comment: None,    // For received payments, this is None
                     lnurl_metadata: None,       // For received payments, this is None
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -2036,6 +2040,7 @@ impl TryFrom<cln::ListpaysPays> for Payment {
                     bolt11: payment.bolt11.unwrap_or_default(),
                     lnurl_success_action: None,
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -17,19 +17,19 @@ type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
 /// See the [parse] docs for more detail on the full workflow.
 pub(crate) async fn validate_lnurl_pay(
     user_amount_msat: u64,
-    comment: Option<String>,
-    req_data: LnUrlPayRequestData,
+    comment: &Option<String>,
+    req_data: &LnUrlPayRequestData,
     network: Network,
 ) -> LnUrlResult<ValidatedCallbackResponse> {
     validate_user_input(
         user_amount_msat,
-        &comment,
+        comment,
         req_data.min_sendable,
         req_data.max_sendable,
         req_data.comment_allowed,
     )?;
 
-    let callback_url = build_pay_callback_url(user_amount_msat, &comment, &req_data)?;
+    let callback_url = build_pay_callback_url(user_amount_msat, comment, req_data)?;
     let callback_resp_text = get_and_log_response(&callback_url)
         .await
         .map_err(LnUrlError::ServiceConnectivity)?;
@@ -42,7 +42,7 @@ pub(crate) async fn validate_lnurl_pay(
             match sa {
                 SuccessAction::Aes(data) => data.validate()?,
                 SuccessAction::Message(data) => data.validate()?,
-                SuccessAction::Url(data) => data.validate(&req_data)?,
+                SuccessAction::Url(data) => data.validate(req_data)?,
             }
         }
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -705,6 +705,7 @@ pub struct Payment {
 pub struct PaymentExternalInfo {
     pub lnurl_pay_success_action: Option<SuccessActionProcessed>,
     pub lnurl_pay_domain: Option<String>,
+    pub lnurl_pay_comment: Option<String>,
     pub lnurl_metadata: Option<String>,
     pub ln_address: Option<String>,
     pub lnurl_withdraw_endpoint: Option<String>,
@@ -780,6 +781,9 @@ pub struct LnPaymentDetails {
 
     /// Only set for [PaymentType::Sent] payments if it is not a payment to a Lightning Address
     pub lnurl_pay_domain: Option<String>,
+
+    /// Only set for [PaymentType::Sent] payments if the user sent the comment using LNURL-pay
+    pub lnurl_pay_comment: Option<String>,
 
     /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address
     pub ln_address: Option<String>,

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -612,5 +612,6 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
         ALTER TABLE swaps ADD COLUMN max_swapper_payable INTEGER NOT NULL DEFAULT 0;
         UPDATE swaps SET max_swapper_payable = max_allowed_deposit;
         ",
-    ]
+        "ALTER TABLE payments_external_info ADD COLUMN lnurl_pay_comment TEXT;",
+	]
 }

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -172,7 +172,8 @@ impl SqliteStorage {
               lnurl_withdraw_endpoint,
               attempted_amount_msat,
               attempted_error,
-              lnurl_pay_domain
+              lnurl_pay_domain,
+              lnurl_pay_comment
              FROM remote_sync.payments_external_info
              WHERE payment_id NOT IN (SELECT payment_id FROM sync.payments_external_info);",
             [],

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -83,13 +83,14 @@ impl SqliteStorage {
            payment_id,
            lnurl_success_action,
            lnurl_pay_domain,
+           lnurl_pay_comment,
            lnurl_metadata,
            ln_address,
            lnurl_withdraw_endpoint,
            attempted_amount_msat,
            attempted_error
          )
-         VALUES (?1,?2,?3,?4,?5,?6,?7,?8)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
         ",
         )?;
 
@@ -97,6 +98,7 @@ impl SqliteStorage {
             payment_hash,
             payment_external_info.lnurl_pay_success_action,
             payment_external_info.lnurl_pay_domain,
+            payment_external_info.lnurl_pay_comment,
             payment_external_info.lnurl_metadata,
             payment_external_info.ln_address,
             payment_external_info.lnurl_withdraw_endpoint,
@@ -280,6 +282,7 @@ impl SqliteStorage {
            o.open_channel_bolt11,
            m.metadata,
            e.lnurl_pay_domain,
+           e.lnurl_pay_comment,
            {swap_fields},
            {rev_swap_fields}
           FROM payments p
@@ -378,6 +381,7 @@ impl SqliteStorage {
         if let PaymentDetails::Ln { ref mut data } = payment.details {
             data.lnurl_success_action = row.get(8)?;
             data.lnurl_pay_domain = row.get(17)?;
+            data.lnurl_pay_comment = row.get(18)?;
             data.lnurl_metadata = row.get(9)?;
             data.ln_address = row.get(10)?;
             data.lnurl_withdraw_endpoint = row.get(11)?;
@@ -524,6 +528,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
     let lnurl_metadata = "{'key': 'sample-metadata-val'}";
     let test_ln_address = "test@ln.adddress.com";
     let test_lnurl_pay_domain = "example.com";
+    let test_lnurl_pay_comment = "Thank you Satoshi!";
     let sa = SuccessActionProcessed::Message {
         data: MessageSuccessActionData {
             message: "test message".into(),
@@ -616,6 +621,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                     bolt11: "bolt11".to_string(),
                     lnurl_success_action: Some(sa.clone()),
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     lnurl_metadata: Some(lnurl_metadata.to_string()),
                     ln_address: Some(test_ln_address.to_string()),
                     lnurl_withdraw_endpoint: None,
@@ -646,6 +652,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                     bolt11: "bolt11".to_string(),
                     lnurl_success_action: None,
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: Some(lnurl_withdraw_url.to_string()),
@@ -676,6 +683,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                     bolt11: "swap_bolt11".to_string(),
                     lnurl_success_action: None,
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -707,6 +715,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                     lnurl_success_action: None,
                     lnurl_metadata: None,
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
                     swap_info: None,
@@ -736,6 +745,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                     bolt11: "bolt11".to_string(),
                     lnurl_success_action: None,
                     lnurl_pay_domain: Some(test_lnurl_pay_domain.to_string()),
+                    lnurl_pay_comment: Some(test_lnurl_pay_comment.to_string()),
                     lnurl_metadata: Some(lnurl_metadata.to_string()),
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,
@@ -767,6 +777,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                 bolt11: "bolt11".to_string(),
                 lnurl_success_action: None,
                 lnurl_pay_domain: None,
+                lnurl_pay_comment: None,
                 lnurl_metadata: None,
                 ln_address: None,
                 lnurl_withdraw_endpoint: None,
@@ -787,6 +798,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
         PaymentExternalInfo {
             lnurl_pay_success_action: Some(sa.clone()),
             lnurl_pay_domain: None,
+            lnurl_pay_comment: None,
             lnurl_metadata: Some(lnurl_metadata.to_string()),
             ln_address: Some(test_ln_address.to_string()),
             lnurl_withdraw_endpoint: None,
@@ -799,6 +811,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
         PaymentExternalInfo {
             lnurl_pay_success_action: None,
             lnurl_pay_domain: None,
+            lnurl_pay_comment: None,
             lnurl_metadata: None,
             ln_address: None,
             lnurl_withdraw_endpoint: Some(lnurl_withdraw_url.to_string()),
@@ -816,6 +829,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
         PaymentExternalInfo {
             lnurl_pay_success_action: None,
             lnurl_pay_domain: Some(test_lnurl_pay_domain.to_string()),
+            lnurl_pay_comment: Some(test_lnurl_pay_comment.to_string()),
             lnurl_metadata: Some(lnurl_metadata.to_string()),
             ln_address: None,
             lnurl_withdraw_endpoint: None,

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -1154,6 +1154,7 @@ mod tests {
                     bolt11: "".to_string(),
                     lnurl_success_action: None,
                     lnurl_pay_domain: None,
+                    lnurl_pay_comment: None,
                     lnurl_metadata: None,
                     ln_address: None,
                     lnurl_withdraw_endpoint: None,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -784,6 +784,9 @@ class LnPaymentDetails {
   /// Only set for [PaymentType::Sent] payments if it is not a payment to a Lightning Address
   final String? lnurlPayDomain;
 
+  /// Only set for [PaymentType::Sent] payments if the user sent the comment using LNURL-pay
+  final String? lnurlPayComment;
+
   /// Only set for [PaymentType::Sent] payments that are sent to a Lightning Address
   final String? lnAddress;
 
@@ -812,6 +815,7 @@ class LnPaymentDetails {
     this.openChannelBolt11,
     this.lnurlSuccessAction,
     this.lnurlPayDomain,
+    this.lnurlPayComment,
     this.lnAddress,
     this.lnurlMetadata,
     this.lnurlWithdrawEndpoint,
@@ -3562,7 +3566,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   LnPaymentDetails _wire2api_ln_payment_details(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
+    if (arr.length != 16) throw Exception('unexpected arr length: expect 16 but see ${arr.length}');
     return LnPaymentDetails(
       paymentHash: _wire2api_String(arr[0]),
       label: _wire2api_String(arr[1]),
@@ -3573,12 +3577,13 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       openChannelBolt11: _wire2api_opt_String(arr[6]),
       lnurlSuccessAction: _wire2api_opt_box_autoadd_success_action_processed(arr[7]),
       lnurlPayDomain: _wire2api_opt_String(arr[8]),
-      lnAddress: _wire2api_opt_String(arr[9]),
-      lnurlMetadata: _wire2api_opt_String(arr[10]),
-      lnurlWithdrawEndpoint: _wire2api_opt_String(arr[11]),
-      swapInfo: _wire2api_opt_box_autoadd_swap_info(arr[12]),
-      reverseSwapInfo: _wire2api_opt_box_autoadd_reverse_swap_info(arr[13]),
-      pendingExpirationBlock: _wire2api_opt_box_autoadd_u32(arr[14]),
+      lnurlPayComment: _wire2api_opt_String(arr[9]),
+      lnAddress: _wire2api_opt_String(arr[10]),
+      lnurlMetadata: _wire2api_opt_String(arr[11]),
+      lnurlWithdrawEndpoint: _wire2api_opt_String(arr[12]),
+      swapInfo: _wire2api_opt_box_autoadd_swap_info(arr[13]),
+      reverseSwapInfo: _wire2api_opt_box_autoadd_reverse_swap_info(arr[14]),
+      pendingExpirationBlock: _wire2api_opt_box_autoadd_u32(arr[15]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -946,6 +946,7 @@ fun asLnPaymentDetails(lnPaymentDetails: ReadableMap): LnPaymentDetails? {
             null
         }
     val lnurlPayDomain = if (hasNonNullKey(lnPaymentDetails, "lnurlPayDomain")) lnPaymentDetails.getString("lnurlPayDomain") else null
+    val lnurlPayComment = if (hasNonNullKey(lnPaymentDetails, "lnurlPayComment")) lnPaymentDetails.getString("lnurlPayComment") else null
     val lnurlMetadata = if (hasNonNullKey(lnPaymentDetails, "lnurlMetadata")) lnPaymentDetails.getString("lnurlMetadata") else null
     val lnAddress = if (hasNonNullKey(lnPaymentDetails, "lnAddress")) lnPaymentDetails.getString("lnAddress") else null
     val lnurlWithdrawEndpoint =
@@ -987,6 +988,7 @@ fun asLnPaymentDetails(lnPaymentDetails: ReadableMap): LnPaymentDetails? {
         openChannelBolt11,
         lnurlSuccessAction,
         lnurlPayDomain,
+        lnurlPayComment,
         lnurlMetadata,
         lnAddress,
         lnurlWithdrawEndpoint,
@@ -1007,6 +1009,7 @@ fun readableMapOf(lnPaymentDetails: LnPaymentDetails): ReadableMap {
         "openChannelBolt11" to lnPaymentDetails.openChannelBolt11,
         "lnurlSuccessAction" to lnPaymentDetails.lnurlSuccessAction?.let { readableMapOf(it) },
         "lnurlPayDomain" to lnPaymentDetails.lnurlPayDomain,
+        "lnurlPayComment" to lnPaymentDetails.lnurlPayComment,
         "lnurlMetadata" to lnPaymentDetails.lnurlMetadata,
         "lnAddress" to lnPaymentDetails.lnAddress,
         "lnurlWithdrawEndpoint" to lnPaymentDetails.lnurlWithdrawEndpoint,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1045,6 +1045,13 @@ enum BreezSDKMapper {
             }
             lnurlPayDomain = lnurlPayDomainTmp
         }
+        var lnurlPayComment: String?
+        if hasNonNilKey(data: lnPaymentDetails, key: "lnurlPayComment") {
+            guard let lnurlPayCommentTmp = lnPaymentDetails["lnurlPayComment"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlPayComment"))
+            }
+            lnurlPayComment = lnurlPayCommentTmp
+        }
         var lnurlMetadata: String?
         if hasNonNilKey(data: lnPaymentDetails, key: "lnurlMetadata") {
             guard let lnurlMetadataTmp = lnPaymentDetails["lnurlMetadata"] as? String else {
@@ -1094,6 +1101,7 @@ enum BreezSDKMapper {
             openChannelBolt11: openChannelBolt11,
             lnurlSuccessAction: lnurlSuccessAction,
             lnurlPayDomain: lnurlPayDomain,
+            lnurlPayComment: lnurlPayComment,
             lnurlMetadata: lnurlMetadata,
             lnAddress: lnAddress,
             lnurlWithdrawEndpoint: lnurlWithdrawEndpoint,
@@ -1114,6 +1122,7 @@ enum BreezSDKMapper {
             "openChannelBolt11": lnPaymentDetails.openChannelBolt11 == nil ? nil : lnPaymentDetails.openChannelBolt11,
             "lnurlSuccessAction": lnPaymentDetails.lnurlSuccessAction == nil ? nil : dictionaryOf(successActionProcessed: lnPaymentDetails.lnurlSuccessAction!),
             "lnurlPayDomain": lnPaymentDetails.lnurlPayDomain == nil ? nil : lnPaymentDetails.lnurlPayDomain,
+            "lnurlPayComment": lnPaymentDetails.lnurlPayComment == nil ? nil : lnPaymentDetails.lnurlPayComment,
             "lnurlMetadata": lnPaymentDetails.lnurlMetadata == nil ? nil : lnPaymentDetails.lnurlMetadata,
             "lnAddress": lnPaymentDetails.lnAddress == nil ? nil : lnPaymentDetails.lnAddress,
             "lnurlWithdrawEndpoint": lnPaymentDetails.lnurlWithdrawEndpoint == nil ? nil : lnPaymentDetails.lnurlWithdrawEndpoint,

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -158,6 +158,7 @@ export type LnPaymentDetails = {
     openChannelBolt11?: string
     lnurlSuccessAction?: SuccessActionProcessed
     lnurlPayDomain?: string
+    lnurlPayComment?: string
     lnurlMetadata?: string
     lnAddress?: string
     lnurlWithdrawEndpoint?: string


### PR DESCRIPTION
We want to persist and expose the comment the user sends to the recipient when using LNURL-pay. Do you like this approach?