### PR TITLE
Improve nested error handling

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "breez_sdk"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "breez-sdk-core",

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 
 [workspace.dependencies]
 uniffi = "0.23.0"

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -39,12 +39,8 @@ impl From<bip32::Error> for ConnectError {
 impl From<NodeError> for ConnectError {
     fn from(value: NodeError) -> Self {
         match value {
-            NodeError::RestoreOnly(err) => Self::RestoreOnly {
-                err: err.to_string(),
-            },
-            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            NodeError::RestoreOnly(err) => Self::RestoreOnly { err },
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -63,10 +59,8 @@ impl From<PersistError> for ConnectError {
 impl From<SdkError> for ConnectError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -91,12 +85,8 @@ pub enum LnUrlAuthError {
 impl From<LnUrlError> for LnUrlAuthError {
     fn from(value: LnUrlError) -> Self {
         match value {
-            LnUrlError::InvalidUri(err) => Self::InvalidUri {
-                err: err.to_string(),
-            },
-            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            LnUrlError::InvalidUri(err) => Self::InvalidUri { err },
+            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -107,10 +97,8 @@ impl From<LnUrlError> for LnUrlAuthError {
 impl From<SdkError> for LnUrlAuthError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -189,12 +177,9 @@ impl From<crate::bitcoin::hashes::hex::Error> for LnUrlPayError {
 impl From<InvoiceError> for LnUrlPayError {
     fn from(value: InvoiceError) -> Self {
         match value {
-            InvoiceError::InvalidNetwork(err) => Self::InvalidNetwork {
-                err: err.to_string(),
-            },
-            _ => Self::InvalidInvoice {
-                err: value.to_string(),
-            },
+            InvoiceError::InvalidNetwork(err) => Self::InvalidNetwork { err },
+            InvoiceError::Validation(err) => Self::InvalidInvoice { err },
+            InvoiceError::Generic(err) => Self::Generic { err },
         }
     }
 }
@@ -202,13 +187,9 @@ impl From<InvoiceError> for LnUrlPayError {
 impl From<LnUrlError> for LnUrlPayError {
     fn from(value: LnUrlError) -> Self {
         match value {
-            LnUrlError::InvalidUri(err) => Self::InvalidUri {
-                err: err.to_string(),
-            },
+            LnUrlError::InvalidUri(err) => Self::InvalidUri { err },
             LnUrlError::InvalidInvoice(err) => err.into(),
-            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -227,10 +208,8 @@ impl From<PersistError> for LnUrlPayError {
 impl From<SdkError> for LnUrlPayError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -239,6 +218,7 @@ impl From<SendPaymentError> for LnUrlPayError {
     fn from(value: SendPaymentError) -> Self {
         match value {
             SendPaymentError::AlreadyPaid => Self::AlreadyPaid,
+            SendPaymentError::Generic { err } => Self::Generic { err },
             SendPaymentError::InvalidAmount { err } => Self::InvalidAmount { err },
             SendPaymentError::InvalidInvoice { err } => Self::InvalidInvoice { err },
             SendPaymentError::InvalidNetwork { err } => Self::InvalidNetwork { err },
@@ -248,9 +228,6 @@ impl From<SendPaymentError> for LnUrlPayError {
             SendPaymentError::RouteNotFound { err } => Self::RouteNotFound { err },
             SendPaymentError::RouteTooExpensive { err } => Self::RouteTooExpensive { err },
             SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -286,21 +263,24 @@ pub enum LnUrlWithdrawError {
     ServiceConnectivity { err: String },
 }
 
-impl From<LnUrlError> for LnUrlWithdrawError {
-    fn from(value: LnUrlError) -> Self {
+impl From<InvoiceError> for LnUrlWithdrawError {
+    fn from(value: InvoiceError) -> Self {
         match value {
-            LnUrlError::InvalidUri(err) => Self::InvalidUri {
-                err: err.to_string(),
-            },
-            LnUrlError::InvalidInvoice(err) => Self::InvalidInvoice {
-                err: err.to_string(),
-            },
-            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            InvoiceError::Validation(err) => Self::InvalidInvoice { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
+        }
+    }
+}
+
+impl From<LnUrlError> for LnUrlWithdrawError {
+    fn from(value: LnUrlError) -> Self {
+        match value {
+            LnUrlError::Generic(err) => Self::Generic { err },
+            LnUrlError::InvalidUri(err) => Self::InvalidUri { err },
+            LnUrlError::InvalidInvoice(err) => err.into(),
+            LnUrlError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
         }
     }
 }
@@ -316,15 +296,16 @@ impl From<PersistError> for LnUrlWithdrawError {
 impl From<ReceivePaymentError> for LnUrlWithdrawError {
     fn from(value: ReceivePaymentError) -> Self {
         match value {
+            ReceivePaymentError::Generic { err }
+            | ReceivePaymentError::InvoiceExpired { err }
+            | ReceivePaymentError::InvoiceNoDescription { err }
+            | ReceivePaymentError::InvoicePreimageAlreadyExists { err } => Self::Generic { err },
             ReceivePaymentError::InvalidAmount { err } => Self::InvalidAmount { err },
             ReceivePaymentError::InvalidInvoice { err } => Self::InvalidInvoice { err },
             ReceivePaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
             ReceivePaymentError::InvoiceNoRoutingHints { err } => {
                 Self::InvoiceNoRoutingHints { err }
             }
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -332,10 +313,8 @@ impl From<ReceivePaymentError> for LnUrlWithdrawError {
 impl From<SdkError> for LnUrlWithdrawError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -372,10 +351,8 @@ impl From<anyhow::Error> for ReceiveOnchainError {
 impl From<SdkError> for ReceiveOnchainError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -383,9 +360,7 @@ impl From<SdkError> for ReceiveOnchainError {
 impl From<SwapError> for ReceiveOnchainError {
     fn from(value: SwapError) -> Self {
         match value {
-            SwapError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            SwapError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -396,7 +371,7 @@ impl From<SwapError> for ReceiveOnchainError {
 impl From<PersistError> for ReceiveOnchainError {
     fn from(err: PersistError) -> Self {
         Self::Generic {
-            err: format!("Error when accessing local DB: {err}"),
+            err: err.to_string(),
         }
     }
 }
@@ -450,9 +425,12 @@ impl From<anyhow::Error> for ReceivePaymentError {
 }
 
 impl From<InvoiceError> for ReceivePaymentError {
-    fn from(err: InvoiceError) -> Self {
-        Self::InvalidInvoice {
-            err: err.to_string(),
+    fn from(value: InvoiceError) -> Self {
+        match value {
+            InvoiceError::Validation(err) => Self::InvalidInvoice { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
         }
     }
 }
@@ -460,18 +438,12 @@ impl From<InvoiceError> for ReceivePaymentError {
 impl From<NodeError> for ReceivePaymentError {
     fn from(value: NodeError) -> Self {
         match value {
-            NodeError::InvoiceExpired(err) => Self::InvoiceExpired {
-                err: err.to_string(),
-            },
-            NodeError::InvoiceNoDescription(err) => Self::InvoiceNoDescription {
-                err: err.to_string(),
-            },
-            NodeError::InvoicePreimageAlreadyExists(err) => Self::InvoicePreimageAlreadyExists {
-                err: err.to_string(),
-            },
-            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            NodeError::InvoiceExpired(err) => Self::InvoiceExpired { err },
+            NodeError::InvoiceNoDescription(err) => Self::InvoiceNoDescription { err },
+            NodeError::InvoicePreimageAlreadyExists(err) => {
+                Self::InvoicePreimageAlreadyExists { err }
+            }
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -490,10 +462,8 @@ impl From<PersistError> for ReceivePaymentError {
 impl From<SdkError> for ReceivePaymentError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -514,6 +484,12 @@ pub enum SdkError {
 impl SdkError {
     pub(crate) fn generic(err: &str) -> Self {
         Self::Generic {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn service_connectivity(err: &str) -> Self {
+        Self::ServiceConnectivity {
             err: err.to_string(),
         }
     }
@@ -554,9 +530,7 @@ impl From<LnUrlError> for SdkError {
 impl From<NodeError> for SdkError {
     fn from(value: NodeError) -> Self {
         match value {
-            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -575,9 +549,7 @@ impl From<PersistError> for SdkError {
 impl From<ReverseSwapError> for SdkError {
     fn from(value: ReverseSwapError) -> Self {
         match value {
-            ReverseSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            ReverseSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -612,11 +584,19 @@ impl From<tonic::Status> for SdkError {
 impl From<SendPaymentError> for SdkError {
     fn from(value: SendPaymentError) -> Self {
         match value {
-            SendPaymentError::Generic { err } => Self::Generic { err },
-            SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
+            SendPaymentError::AlreadyPaid => Self::Generic {
                 err: value.to_string(),
             },
+            SendPaymentError::Generic { err }
+            | SendPaymentError::InvalidAmount { err }
+            | SendPaymentError::InvalidInvoice { err }
+            | SendPaymentError::InvalidNetwork { err }
+            | SendPaymentError::InvoiceExpired { err }
+            | SendPaymentError::PaymentFailed { err }
+            | SendPaymentError::PaymentTimeout { err }
+            | SendPaymentError::RouteNotFound { err }
+            | SendPaymentError::RouteTooExpensive { err } => Self::Generic { err },
+            SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
         }
     }
 }
@@ -670,15 +650,9 @@ impl From<anyhow::Error> for SendOnchainError {
 impl From<NodeError> for SendOnchainError {
     fn from(value: NodeError) -> Self {
         match value {
-            NodeError::PaymentFailed(err) => Self::PaymentFailed {
-                err: err.to_string(),
-            },
-            NodeError::PaymentTimeout(err) => Self::PaymentTimeout {
-                err: err.to_string(),
-            },
-            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            NodeError::PaymentFailed(err) => Self::PaymentFailed { err },
+            NodeError::PaymentTimeout(err) => Self::PaymentTimeout { err },
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -689,10 +663,8 @@ impl From<NodeError> for SendOnchainError {
 impl From<SdkError> for SendOnchainError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }
@@ -700,12 +672,10 @@ impl From<SdkError> for SendOnchainError {
 impl From<ReverseSwapError> for SendOnchainError {
     fn from(value: ReverseSwapError) -> Self {
         match value {
-            ReverseSwapError::InvalidDestinationAddress(err) => Self::InvalidDestinationAddress {
-                err: err.to_string(),
-            },
-            ReverseSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            ReverseSwapError::InvalidDestinationAddress(err) => {
+                Self::InvalidDestinationAddress { err }
+            }
+            ReverseSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             ReverseSwapError::Node(err) => err.into(),
             _ => Self::Generic {
                 err: value.to_string(),
@@ -777,12 +747,9 @@ impl From<anyhow::Error> for SendPaymentError {
 impl From<InvoiceError> for SendPaymentError {
     fn from(value: InvoiceError) -> Self {
         match value {
-            InvoiceError::InvalidNetwork(err) => Self::InvalidNetwork {
-                err: err.to_string(),
-            },
-            _ => Self::InvalidInvoice {
-                err: value.to_string(),
-            },
+            InvoiceError::InvalidNetwork(err) => Self::InvalidNetwork { err },
+            InvoiceError::Validation(err) => Self::InvalidInvoice { err },
+            InvoiceError::Generic(err) => Self::Generic { err },
         }
     }
 }
@@ -790,24 +757,12 @@ impl From<InvoiceError> for SendPaymentError {
 impl From<NodeError> for SendPaymentError {
     fn from(value: NodeError) -> Self {
         match value {
-            NodeError::InvoiceExpired(err) => Self::InvoiceExpired {
-                err: err.to_string(),
-            },
-            NodeError::PaymentFailed(err) => Self::PaymentFailed {
-                err: err.to_string(),
-            },
-            NodeError::PaymentTimeout(err) => Self::PaymentTimeout {
-                err: err.to_string(),
-            },
-            NodeError::RouteNotFound(err) => Self::RouteNotFound {
-                err: err.to_string(),
-            },
-            NodeError::RouteTooExpensive(err) => Self::RouteTooExpensive {
-                err: err.to_string(),
-            },
-            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity {
-                err: err.to_string(),
-            },
+            NodeError::InvoiceExpired(err) => Self::InvoiceExpired { err },
+            NodeError::PaymentFailed(err) => Self::PaymentFailed { err },
+            NodeError::PaymentTimeout(err) => Self::PaymentTimeout { err },
+            NodeError::RouteNotFound(err) => Self::RouteNotFound { err },
+            NodeError::RouteTooExpensive(err) => Self::RouteTooExpensive { err },
+            NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -826,10 +781,8 @@ impl From<PersistError> for SendPaymentError {
 impl From<SdkError> for SendPaymentError {
     fn from(value: SdkError) -> Self {
         match value {
+            SdkError::Generic { err } => Self::Generic { err },
             SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
-            _ => Self::Generic {
-                err: value.to_string(),
-            },
         }
     }
 }

--- a/libs/sdk-core/src/greenlight/error.rs
+++ b/libs/sdk-core/src/greenlight/error.rs
@@ -4,9 +4,7 @@ use anyhow::{anyhow, Result};
 use regex::Regex;
 use strum_macros::FromRepr;
 
-use crate::{
-    bitcoin::secp256k1, invoice::InvoiceError, node_api::NodeError, persist::error::PersistError,
-};
+use crate::{bitcoin::secp256k1, node_api::NodeError};
 
 #[derive(FromRepr, Debug, PartialEq)]
 #[repr(i16)]
@@ -114,55 +112,43 @@ pub(crate) enum JsonRpcErrCode {
 
 impl From<anyhow::Error> for NodeError {
     fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err)
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<crate::bitcoin::util::address::Error> for NodeError {
     fn from(err: crate::bitcoin::util::address::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<crate::bitcoin::util::bip32::Error> for NodeError {
     fn from(err: crate::bitcoin::util::bip32::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<hex::FromHexError> for NodeError {
     fn from(err: hex::FromHexError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
-    }
-}
-
-impl From<InvoiceError> for NodeError {
-    fn from(err: InvoiceError) -> Self {
-        Self::InvalidInvoice(err)
-    }
-}
-
-impl From<PersistError> for NodeError {
-    fn from(err: PersistError) -> Self {
-        Self::Persistance(err)
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<secp256k1::Error> for NodeError {
     fn from(err: secp256k1::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<serde_json::Error> for NodeError {
     fn from(err: serde_json::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<SystemTimeError> for NodeError {
     fn from(err: SystemTimeError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
@@ -171,12 +157,12 @@ impl From<tonic::Status> for NodeError {
         match parse_cln_error(status.clone()) {
             Ok(code) => match code {
                 // Pay errors
-                JsonRpcErrCode::PayInvoiceExpired => Self::InvoiceExpired(status.into()),
+                JsonRpcErrCode::PayInvoiceExpired => Self::InvoiceExpired(status.to_string()),
                 JsonRpcErrCode::PayTryOtherRoute | JsonRpcErrCode::PayRouteNotFound => {
-                    Self::RouteNotFound(status.into())
+                    Self::RouteNotFound(status.to_string())
                 }
-                JsonRpcErrCode::PayRouteTooExpensive => Self::RouteTooExpensive(status.into()),
-                JsonRpcErrCode::PayStoppedRetrying => Self::PaymentTimeout(status.into()),
+                JsonRpcErrCode::PayRouteTooExpensive => Self::RouteTooExpensive(status.to_string()),
+                JsonRpcErrCode::PayStoppedRetrying => Self::PaymentTimeout(status.to_string()),
                 JsonRpcErrCode::PayRhashAlreadyUsed
                 | JsonRpcErrCode::PayUnparseableOnion
                 | JsonRpcErrCode::PayDestinationPermFail
@@ -186,24 +172,28 @@ impl From<tonic::Status> for NodeError {
                 | JsonRpcErrCode::PayInvoiceRequestInvalid
                 | JsonRpcErrCode::PayInvoicePreapprovalDeclined
                 | JsonRpcErrCode::PayKeysendPreapprovalDeclined => {
-                    Self::PaymentFailed(status.into())
+                    Self::PaymentFailed(status.to_string())
                 }
                 // Invoice errors
-                JsonRpcErrCode::InvoiceExpiredDuringWait => Self::InvoiceExpired(status.into()),
-                JsonRpcErrCode::InvoiceNoDescription => Self::InvoiceNoDescription(status.into()),
-                JsonRpcErrCode::InvoicePreimageAlreadyExists => {
-                    Self::InvoicePreimageAlreadyExists(status.into())
+                JsonRpcErrCode::InvoiceExpiredDuringWait => {
+                    Self::InvoiceExpired(status.to_string())
                 }
-                _ => Self::Generic(status.into()),
+                JsonRpcErrCode::InvoiceNoDescription => {
+                    Self::InvoiceNoDescription(status.to_string())
+                }
+                JsonRpcErrCode::InvoicePreimageAlreadyExists => {
+                    Self::InvoicePreimageAlreadyExists(status.to_string())
+                }
+                _ => Self::Generic(status.to_string()),
             },
-            _ => Self::Generic(status.into()),
+            _ => Self::Generic(status.to_string()),
         }
     }
 }
 
 impl From<TryFromIntError> for NodeError {
     fn from(err: TryFromIntError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 

--- a/libs/sdk-core/src/lnurl/error.rs
+++ b/libs/sdk-core/src/lnurl/error.rs
@@ -1,7 +1,5 @@
 use std::{array::TryFromSliceError, string::FromUtf8Error};
 
-use anyhow::anyhow;
-
 use crate::bitcoin::{bech32, secp256k1, util::bip32};
 use crate::{invoice::InvoiceError, node_api::NodeError};
 
@@ -9,79 +7,89 @@ pub type LnUrlResult<T, E = LnUrlError> = Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum LnUrlError {
-    #[error("Generic: {0}")]
-    Generic(#[from] anyhow::Error),
+    #[error("{0}")]
+    Generic(String),
 
     #[error(transparent)]
     InvalidInvoice(#[from] InvoiceError),
 
-    #[error("Invalid uri: {0}")]
-    InvalidUri(anyhow::Error),
+    #[error("{0}")]
+    InvalidUri(String),
 
-    #[error("Service connectivity: {0}")]
-    ServiceConnectivity(anyhow::Error),
+    #[error("{0}")]
+    ServiceConnectivity(String),
+}
+
+impl LnUrlError {
+    pub(crate) fn generic(err: &str) -> Self {
+        Self::Generic(err.to_string())
+    }
+
+    pub(crate) fn invalid_uri(err: &str) -> Self {
+        Self::InvalidUri(err.to_string())
+    }
 }
 
 impl From<aes::cipher::InvalidLength> for LnUrlError {
     fn from(err: aes::cipher::InvalidLength) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<aes::cipher::block_padding::UnpadError> for LnUrlError {
     fn from(err: aes::cipher::block_padding::UnpadError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<base64::DecodeError> for LnUrlError {
     fn from(err: base64::DecodeError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<bip32::Error> for LnUrlError {
     fn from(err: bip32::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<bech32::Error> for LnUrlError {
     fn from(err: bech32::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<FromUtf8Error> for LnUrlError {
     fn from(err: FromUtf8Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<NodeError> for LnUrlError {
-    fn from(err: NodeError) -> Self {
-        match err {
+    fn from(value: NodeError) -> Self {
+        match value {
             NodeError::InvalidInvoice(err) => Self::InvalidInvoice(err),
             NodeError::ServiceConnectivity(err) => Self::ServiceConnectivity(err),
-            _ => Self::Generic(anyhow!(err.to_string())),
+            _ => Self::Generic(value.to_string()),
         }
     }
 }
 
 impl From<secp256k1::Error> for LnUrlError {
     fn from(err: secp256k1::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<serde_json::Error> for LnUrlError {
     fn from(err: serde_json::Error) -> Self {
-        Self::ServiceConnectivity(anyhow::Error::new(err))
+        Self::ServiceConnectivity(err.to_string())
     }
 }
 
 impl From<TryFromSliceError> for LnUrlError {
     fn from(err: TryFromSliceError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }

--- a/libs/sdk-core/src/lnurl/mod.rs
+++ b/libs/sdk-core/src/lnurl/mod.rs
@@ -16,14 +16,14 @@ pub(crate) fn maybe_replace_host_with_mockito_test_host(
     use self::error::LnUrlError;
 
     let server = crate::input_parser::tests::MOCK_HTTP_SERVER.lock().unwrap();
-    let mockito_endpoint_url = reqwest::Url::parse(&server.url())
-        .map_err(|e| LnUrlError::InvalidUri(anyhow::Error::new(e)))?;
-    let mut parsed_lnurl_endpoint = reqwest::Url::parse(&lnurl_endpoint)
-        .map_err(|e| LnUrlError::InvalidUri(anyhow::Error::new(e)))?;
+    let mockito_endpoint_url =
+        reqwest::Url::parse(&server.url()).map_err(|e| LnUrlError::InvalidUri(e.to_string()))?;
+    let mut parsed_lnurl_endpoint =
+        reqwest::Url::parse(&lnurl_endpoint).map_err(|e| LnUrlError::InvalidUri(e.to_string()))?;
 
     parsed_lnurl_endpoint
         .set_host(mockito_endpoint_url.host_str())
-        .map_err(|e| LnUrlError::InvalidUri(anyhow::Error::new(e)))?;
+        .map_err(|e| LnUrlError::InvalidUri(e.to_string()))?;
     let _ = parsed_lnurl_endpoint.set_scheme(mockito_endpoint_url.scheme());
     let _ = parsed_lnurl_endpoint.set_port(mockito_endpoint_url.port());
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -278,9 +278,9 @@ impl FullReverseSwapInfo {
         // Validate if received invoice has the same amount as requested by the user
         let amount_from_invoice_msat = inv.amount_milli_satoshis().unwrap_or_default();
         match amount_from_invoice_msat == expected_amount_msat {
-            false => Err(ReverseSwapError::UnexpectedInvoiceAmount(anyhow!(
-                "Does not match the request"
-            ))),
+            false => Err(ReverseSwapError::unexpected_invoice_amount(
+                "Does not match the request",
+            )),
             true => Ok(()),
         }
     }
@@ -298,9 +298,9 @@ impl FullReverseSwapInfo {
         let preimage_hash_from_invoice = inv.payment_hash();
         let preimage_hash_from_req = &self.get_preimage_hash();
         match preimage_hash_from_invoice == preimage_hash_from_req {
-            false => Err(ReverseSwapError::UnexpectedPaymentHash(anyhow!(
-                "Does not match the request"
-            ))),
+            false => Err(ReverseSwapError::unexpected_payment_hash(
+                "Does not match the request",
+            )),
             true => Ok(()),
         }
     }

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -19,41 +19,47 @@ pub type NodeResult<T, E = NodeError> = Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum NodeError {
-    #[error("Generic: {0}")]
-    Generic(anyhow::Error),
+    #[error("{0}")]
+    Generic(String),
 
     #[error(transparent)]
-    InvalidInvoice(InvoiceError),
+    InvalidInvoice(#[from] InvoiceError),
 
-    #[error("Invoice expired: {0}")]
-    InvoiceExpired(anyhow::Error),
+    #[error("{0}")]
+    InvoiceExpired(String),
 
-    #[error("Invoice no description: {0}")]
-    InvoiceNoDescription(anyhow::Error),
+    #[error("{0}")]
+    InvoiceNoDescription(String),
 
-    #[error("Invoice preimage already exists: {0}")]
-    InvoicePreimageAlreadyExists(anyhow::Error),
+    #[error("{0}")]
+    InvoicePreimageAlreadyExists(String),
 
-    #[error("Payment failed: {0}")]
-    PaymentFailed(anyhow::Error),
+    #[error("{0}")]
+    PaymentFailed(String),
 
-    #[error("Payment timeout: {0}")]
-    PaymentTimeout(anyhow::Error),
+    #[error("{0}")]
+    PaymentTimeout(String),
 
     #[error(transparent)]
-    Persistance(PersistError),
+    Persistance(#[from] PersistError),
 
-    #[error("Restore only: {0}")]
-    RestoreOnly(anyhow::Error),
+    #[error("{0}")]
+    RestoreOnly(String),
 
-    #[error("Route too expensive: {0}")]
-    RouteTooExpensive(anyhow::Error),
+    #[error("{0}")]
+    RouteTooExpensive(String),
 
-    #[error("Route not found: {0}")]
-    RouteNotFound(anyhow::Error),
+    #[error("{0}")]
+    RouteNotFound(String),
 
-    #[error("Service connectivity: {0}")]
-    ServiceConnectivity(anyhow::Error),
+    #[error("{0}")]
+    ServiceConnectivity(String),
+}
+
+impl NodeError {
+    pub(crate) fn generic(err: &str) -> Self {
+        Self::Generic(err.to_string())
+    }
 }
 
 pub struct CreateInvoiceRequest {

--- a/libs/sdk-core/src/persist/error.rs
+++ b/libs/sdk-core/src/persist/error.rs
@@ -2,24 +2,48 @@ pub type PersistResult<T, E = PersistError> = Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PersistError {
-    #[error("Generic: {0}")]
-    Generic(#[from] anyhow::Error),
+    #[error("{0}")]
+    Generic(String),
 
-    #[error("Migration: {0}")]
-    Migration(#[from] rusqlite_migration::Error),
+    #[error("{0}")]
+    Migration(String),
 
-    #[error("SQL: {0}")]
-    Sql(#[from] rusqlite::Error),
+    #[error("Sql persistence: {0}")]
+    Sql(String),
+}
+
+impl PersistError {
+    pub(crate) fn generic(err: &str) -> Self {
+        Self::Generic(err.to_string())
+    }
+}
+
+impl From<anyhow::Error> for PersistError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic(err.to_string())
+    }
 }
 
 impl From<hex::FromHexError> for PersistError {
     fn from(err: hex::FromHexError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
+    }
+}
+
+impl From<rusqlite::Error> for PersistError {
+    fn from(err: rusqlite::Error) -> Self {
+        Self::Sql(err.to_string())
+    }
+}
+
+impl From<rusqlite_migration::Error> for PersistError {
+    fn from(err: rusqlite_migration::Error) -> Self {
+        Self::Migration(err.to_string())
     }
 }
 
 impl From<serde_json::Error> for PersistError {
     fn from(err: serde_json::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }

--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -6,7 +6,6 @@ use super::{
     error::PersistResult,
 };
 use crate::OpeningFeeParams;
-use anyhow::anyhow;
 use rusqlite::{named_params, OptionalExtension, Params, Row, Transaction, TransactionBehavior};
 
 #[derive(Debug, Clone)]
@@ -88,7 +87,7 @@ impl SqliteStorage {
             &tx,
             swap_info.bitcoin_address,
             swap_info.channel_opening_fees.ok_or_else(|| {
-                PersistError::Generic(anyhow!("Dynamic fees must be set when creating a new swap"))
+                PersistError::generic("Dynamic fees must be set when creating a new swap")
             })?,
         )?;
 

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -2,7 +2,6 @@ use super::db::SqliteStorage;
 use super::error::{PersistError, PersistResult};
 use crate::lnurl::pay::model::SuccessActionProcessed;
 use crate::{ensure_sdk, models::*};
-use anyhow::anyhow;
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Row;
 use rusqlite::{named_params, params, OptionalExtension};
@@ -115,7 +114,7 @@ impl SqliteStorage {
     ) -> PersistResult<()> {
         ensure_sdk!(
             new_metadata.len() <= METADATA_MAX_LEN,
-            PersistError::Generic(anyhow!(
+            PersistError::Generic(format!(
                 "Max metadata size ({} characters) has been exceeded",
                 METADATA_MAX_LEN
             ))
@@ -130,7 +129,7 @@ impl SqliteStorage {
             .exists(params![payment_hash])?;
 
         if !payment_exists {
-            return Err(PersistError::Generic(anyhow!("Payment not found")));
+            return Err(PersistError::generic("Payment not found"));
         }
 
         self.get_connection()?.execute(

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -179,7 +179,7 @@ impl BTCReceiveSwap {
         let node_state = self
             .persister
             .get_node_state()?
-            .ok_or(anyhow!("Node info not found"))?;
+            .ok_or(SwapError::generic("Node info not found"))?;
 
         // Calculate max_allowed_deposit based on absolute max and current node state
         let fn_max_allowed_deposit = |max_allowed_deposit_abs: i64| {
@@ -239,7 +239,7 @@ impl BTCReceiveSwap {
 
         // Ensure our address generation match the service
         if address_str != swap_reply.bitcoin_address {
-            return Err(SwapError::Generic(anyhow!("Wrong address: {address_str}")));
+            return Err(SwapError::Generic(format!("Wrong address: {address_str}")));
         }
 
         let swap_info = SwapInfo {

--- a/libs/sdk-core/src/swap_out/error.rs
+++ b/libs/sdk-core/src/swap_out/error.rs
@@ -1,5 +1,3 @@
-use anyhow::anyhow;
-
 use crate::{
     bitcoin::{hashes, secp256k1},
     error::SdkError,
@@ -11,95 +9,110 @@ pub type ReverseSwapResult<T, E = ReverseSwapError> = Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ReverseSwapError {
-    #[error("Generic: {0}")]
-    Generic(#[from] anyhow::Error),
+    #[error("{0}")]
+    Generic(String),
 
     #[error("Claim tx feerate is too low")]
     ClaimFeerateTooLow,
 
-    #[error("Invalid destination address: {0}")]
-    InvalidDestinationAddress(anyhow::Error),
+    #[error("{0}")]
+    InvalidDestinationAddress(String),
 
     #[error(transparent)]
     Node(#[from] NodeError),
 
-    #[error("Service connectivity: {0}")]
-    ServiceConnectivity(anyhow::Error),
+    #[error("{0}")]
+    RouteNotFound(String),
 
-    #[error("Unexpected invoice amount: {0}")]
-    UnexpectedInvoiceAmount(anyhow::Error),
+    #[error("{0}")]
+    ServiceConnectivity(String),
+
+    #[error("{0}")]
+    UnexpectedInvoiceAmount(String),
 
     #[error("Unexpected lockup address")]
     UnexpectedLockupAddress,
 
-    #[error("Unexpected payment hash: {0}")]
-    UnexpectedPaymentHash(anyhow::Error),
+    #[error("{0}")]
+    UnexpectedPaymentHash(String),
 
     #[error("Unexpected redeem script")]
     UnexpectedRedeemScript,
-
-    #[error("Route not found: {0}")]
-    RouteNotFound(anyhow::Error),
 }
+
 impl ReverseSwapError {
     pub(crate) fn generic(err: &str) -> Self {
-        Self::Generic(anyhow!(err.to_string()))
+        Self::Generic(err.to_string())
+    }
+
+    pub(crate) fn unexpected_invoice_amount(err: &str) -> Self {
+        Self::UnexpectedInvoiceAmount(err.to_string())
+    }
+
+    pub(crate) fn unexpected_payment_hash(err: &str) -> Self {
+        Self::UnexpectedPaymentHash(err.to_string())
+    }
+}
+
+impl From<anyhow::Error> for ReverseSwapError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<hashes::hex::Error> for ReverseSwapError {
     fn from(err: hashes::hex::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<hex::FromHexError> for ReverseSwapError {
     fn from(err: hex::FromHexError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<crate::lightning_invoice::ParseOrSemanticError> for ReverseSwapError {
     fn from(err: crate::lightning_invoice::ParseOrSemanticError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<PersistError> for ReverseSwapError {
     fn from(err: PersistError) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<reqwest::Error> for ReverseSwapError {
     fn from(err: reqwest::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<SdkError> for ReverseSwapError {
     fn from(value: SdkError) -> Self {
         match value {
-            SdkError::Generic { err } => Self::Generic(anyhow!(err)),
-            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity(anyhow!(err)),
+            SdkError::Generic { err } => Self::Generic(err),
+            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity(err),
         }
     }
 }
 
 impl From<secp256k1::Error> for ReverseSwapError {
     fn from(err: secp256k1::Error) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }
 
 impl From<serde_json::Error> for ReverseSwapError {
     fn from(err: serde_json::Error) -> Self {
-        Self::ServiceConnectivity(anyhow::Error::new(err))
+        Self::ServiceConnectivity(err.to_string())
     }
 }
 
 impl From<tonic::Status> for ReverseSwapError {
     fn from(err: tonic::Status) -> Self {
-        Self::Generic(anyhow::Error::new(err))
+        Self::Generic(err.to_string())
     }
 }

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "aes",
  "anyhow",


### PR DESCRIPTION
This PR aims to remove wrapping of error strings rendered from nested errors within the SDK. The result being only outwardly facing errors prefix their variant name to the error string

Example 1:
```
Generic: Failed to create invoice: Invalid amount: Receive amount must be more than 0
```
```
Invalid amount: Receive amount must be more than 0
```

Example 2:
```
Generic: Generic: status: Unknown, message: "transport error", details: [], metadata: MetadataMap { headers: {} })
```
```
Service connectivity: status: Unknown, message: "transport error", details: [], metadata: MetadataMap { headers: {} })
```

Inspired by #885, but may not solve the Flutter issue