### PR TITLE
Jitpack build: Remove unnecessary --insecure curl flag

### DIFF
--- a/libs/sdk-bindings/bindings-android/buildForJitpack.sh
+++ b/libs/sdk-bindings/bindings-android/buildForJitpack.sh
@@ -9,11 +9,10 @@ fi
 echo "JitPack building version $VERSION."
 cd $(dirname $0)
 
-# curl seems to be having issues with the cert of our repo, thus the insecure flag which is not ideal of course.
-curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION.aar --insecure --output bindings-android-$VERSION.aar
-curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION.module --insecure --output bindings-android-$VERSION.module
-curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION-sources.jar --insecure --output bindings-android-$VERSION-sources.jar
-curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION.pom --insecure --output bindings-android-$VERSION.pom
+curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION.aar --output bindings-android-$VERSION.aar
+curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION.module --output bindings-android-$VERSION.module
+curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION-sources.jar --output bindings-android-$VERSION-sources.jar
+curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/$VERSION/bindings-android-$VERSION.pom --output bindings-android-$VERSION.pom
 
 mvn org.apache.maven.plugins:maven-install-plugin:3.1.1:install-file -Dfile=bindings-android-$VERSION.aar -DpomFile=bindings-android-$VERSION.pom
 mvn org.apache.maven.plugins:maven-install-plugin:3.1.1:install-file -Dfile=bindings-android-$VERSION.module -DpomFile=bindings-android-$VERSION.pom


### PR DESCRIPTION
The certificate issues are fixed on our mvn server and `curl` works without the `--insecure` flag:

```sh
curl https://mvn.breez.technology/releases/breez_sdk/bindings-android/0.4.0-rc5/bindings-android-0.4.0-rc5.aar --output bindings-android-0.4.0-rc5.aar
```