### PR TITLE
Fix kotlin SCM reference

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -86,7 +86,7 @@ publishing {
                     }
                 }
                 scm {
-                    connection.set("scm:git:github.com/breez/breez-sdk-ffi.git")
+                    connection.set("scm:git:github.com/breez/breez-sdk.git")
                     developerConnection.set("scm:git:ssh://github.com/breez/breez-sdk.git")
                     url.set("https://github.com/breez/breez-sdk")
                 }


### PR DESCRIPTION
Before, it was referencing an inexistent repo.