### PR TITLE
Change test mnemonic

### DIFF
--- a/libs/sdk-bindings/bindings-csharp/test/Program.cs
+++ b/libs/sdk-bindings/bindings-csharp/test/Program.cs
@@ -3,10 +3,11 @@ using Breez.Sdk;
 
 try
 {
- var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
+ var seed = BreezSdkMethods.MnemonicToSeed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder");
  BreezSdkMethods.SetLogStream(new LogStreamListener());
- var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
- BlockingBreezServices sdkServices = BreezSdkMethods.Connect(config, seed, new SDKListener());
+ var config = BreezSdkMethods.DefaultConfig(EnvironmentType.PRODUCTION, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, null)));
+ var connectRequest = new ConnectRequest(config, seed);
+ BlockingBreezServices sdkServices = BreezSdkMethods.Connect(connectRequest, new SDKListener());
  NodeState? nodeInfo = sdkServices.NodeInfo();
  Console.WriteLine(nodeInfo!.id);
 }

--- a/libs/sdk-bindings/bindings-swift/Tests/BreezSDKTests/BreezSDKTests.swift
+++ b/libs/sdk-bindings/bindings-swift/Tests/BreezSDKTests/BreezSDKTests.swift
@@ -9,12 +9,12 @@ class SDKListener: EventListener {
 
 final class BreezSDKTests: XCTestCase {
     func testExample() throws {
-        let seedPhraseForTesting = "cruise clever syrup coil cute execute laundry general cover prevent law sheriff"
+        let seedPhraseForTesting = "repeat hawk combine screen network rhythm ritual social neither casual volcano powder"
         let seedForTesting = try mnemonicToSeed(phrase: seedPhraseForTesting)
         let credentials = try recoverNode(network: Network.bitcoin, seed: seedForTesting)
         
         let sdkServices = try initServices(
-            config: BreezSDK.defaultConfig(envType: EnvironmentType.staging),
+            config: BreezSDK.defaultConfig(envType: EnvironmentType.production),
             seed: seedForTesting,
             creds: credentials,
             listener: SDKListener()

--- a/libs/sdk-bindings/tests/bindings/csharp/Program.cs
+++ b/libs/sdk-bindings/tests/bindings/csharp/Program.cs
@@ -3,9 +3,9 @@ using Breez.Sdk;
 
 try
 {
- var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
+ var seed = BreezSdkMethods.MnemonicToSeed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder");
  BreezSdkMethods.SetLogStream(new LogStreamListener());
- var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
+ var config = BreezSdkMethods.DefaultConfig(EnvironmentType.PRODUCTION, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, null)));
  var connectRequest = new ConnectRequest(config, seed);
  BlockingBreezServices sdkServices = BreezSdkMethods.Connect(connectRequest, new SDKListener());
  NodeState? nodeInfo = sdkServices.NodeInfo();

--- a/libs/sdk-bindings/tests/bindings/golang/test_breez_sdk.go
+++ b/libs/sdk-bindings/tests/bindings/golang/test_breez_sdk.go
@@ -24,14 +24,18 @@ func main() {
 
 	breez_sdk.SetLogStream(breezListener)
 
-	seed, err := breez_sdk.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff")
+	seed, err := breez_sdk.MnemonicToSeed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder")
 
 	if err != nil {
 		log.Fatalf("MnemonicToSeed failed: %#v", err)
 	}
 
-	inviteCode := "code"
-	config := breez_sdk.DefaultConfig(breez_sdk.EnvironmentTypeStaging, "", breez_sdk.NodeConfigGreenlight{Config: breez_sdk.GreenlightNodeConfig{PartnerCredentials: nil, InviteCode: &inviteCode}})
+	config := breez_sdk.DefaultConfig(breez_sdk.EnvironmentTypeProduction, "code", breez_sdk.NodeConfigGreenlight{
+		Config: breez_sdk.GreenlightNodeConfig{
+			PartnerCredentials: nil,
+			InviteCode:         nil,
+		},
+	})
 	connectRequest := breez_sdk.ConnectRequest{Config: config, Seed: seed}
 	sdkServices, err := breez_sdk.Connect(connectRequest, breezListener)
 

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.cs
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.cs
@@ -3,9 +3,9 @@ using breez.breez_sdk;
 
 try
 {
- var seed = BreezSdkMethods.MnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
+ var seed = BreezSdkMethods.MnemonicToSeed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder");
  BreezSdkMethods.SetLogStream(new LogStreamListener());
- var config = BreezSdkMethods.DefaultConfig(EnvironmentType.STAGING, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, "")));
+ var config = BreezSdkMethods.DefaultConfig(EnvironmentType.PRODUCTION, "code", new NodeConfig.Greenlight(new GreenlightNodeConfig(null, null)));
  var connectRequest = new ConnectRequest(config, seed);
  BlockingBreezServices sdkServices = BreezSdkMethods.Connect(connectRequest, new SDKListener());
  NodeState? nodeInfo = sdkServices.NodeInfo();

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.kts
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.kts
@@ -17,12 +17,12 @@ class LogStreamListener: breez_sdk.LogStream {
 
 try {
     breez_sdk.setLogStream(LogStreamListener());
-    var seed = breez_sdk.mnemonicToSeed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
-    var config = breez_sdk.defaultConfig(breez_sdk.EnvironmentType.STAGING, "code", breez_sdk.NodeConfig.Greenlight(breez_sdk.GreenlightNodeConfig(null, "")))
+    var seed = breez_sdk.mnemonicToSeed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder");
+    var config = breez_sdk.defaultConfig(breez_sdk.EnvironmentType.PRODUCTION, "code", breez_sdk.NodeConfig.Greenlight(breez_sdk.GreenlightNodeConfig(null, null)))
     var connectRequest = breez_sdk.ConnectRequest(config, seed)
     var sdkServices = breez_sdk.connect(connectRequest, SDKListener());    
     var nodeInfo = sdkServices.nodeInfo();
-    assert(nodeInfo.id.equals("0352a918bdba7d7a69893a7d52a449f3e6df8e15a0edcc7fe59060be70d6f416f0"));
+    assert(nodeInfo.id.equals("027e2b899f9f75b92a1ad210da21d74e7314e3499375213a71c6bf3e1b4b4394a1"));
 }catch (ex: Exception) {
     throw RuntimeException(ex.toString())
 }

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.py
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.py
@@ -7,8 +7,8 @@ class SDKListener(breez_sdk.EventListener):
 
 
 def test():        
-     seed = breez_sdk.mnemonic_to_seed("cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
-     config = breez_sdk.default_config(breez_sdk.EnvironmentType.STAGING, "code",  breez_sdk.NodeConfig.GREENLIGHT(breez_sdk.GreenlightNodeConfig(None, "")))
+     seed = breez_sdk.mnemonic_to_seed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder");
+     config = breez_sdk.default_config(breez_sdk.EnvironmentType.PRODUCTION, "code", breez_sdk.NodeConfig.GREENLIGHT(breez_sdk.GreenlightNodeConfig(None, None)))
      connect_request = breez_sdk.ConnectRequest(config, seed)
      sdk_services = breez_sdk.connect(connect_request, SDKListener())     
      node_info = sdk_services.node_info()    

--- a/libs/sdk-bindings/tests/bindings/test_breez_sdk.swift
+++ b/libs/sdk-bindings/tests/bindings/test_breez_sdk.swift
@@ -17,12 +17,12 @@ class LogStreamListener: LogStream {
 
 do {
     try setLogStream(logStream: LogStreamListener());
-    let seed = try mnemonicToSeed(phrase: "cruise clever syrup coil cute execute laundry general cover prevent law sheriff");
-    let config = breez_sdk.defaultConfig(envType: EnvironmentType.staging, apiKey: "", nodeConfig: NodeConfig.greenlight(config: GreenlightNodeConfig(partnerCredentials: nil,inviteCode:  "code")));
+    let seed = try mnemonicToSeed(phrase: "repeat hawk combine screen network rhythm ritual social neither casual volcano powder");
+    let config = breez_sdk.defaultConfig(envType: EnvironmentType.production, apiKey: "code", nodeConfig: NodeConfig.greenlight(config: GreenlightNodeConfig(partnerCredentials: nil, inviteCode: nil)));
     let connectRequest = ConnectRequest(config: config, seed: seed)
     let sdkServices = try connect(req: connectRequest, listener: SDKListener());    
     let nodeInfo = try sdkServices.nodeInfo();
-    assert(nodeInfo.id == "0352a918bdba7d7a69893a7d52a449f3e6df8e15a0edcc7fe59060be70d6f416f0", "nodeInfo.id");
+    assert(nodeInfo.id == "027e2b899f9f75b92a1ad210da21d74e7314e3499375213a71c6bf3e1b4b4394a1", "nodeInfo.id");
 }catch {
  fatalError("Should have not thrown!")
 }


### PR DESCRIPTION
This PR changes the mnemonic used in tests to fix the CI sdk-bindings failure issue:

```
Generic: Generic: status: Unavailable, message: "error trying to connect: tcp connect error: Operation timed out (os error 60)
```

```
VALIDATION FAILED: Policy("validate_holder_commitment_tx: validate_commitment_tx: validate_fee: feerate above maximum: 37291 > 25000")
tx=Transaction {
    version: 2,
    lock_time: PackedLockTime(
        537509241,
    ),
    input: [
        TxIn {
            previous_output: OutPoint {
                txid: c902d17dc44b4867fa3d0feb73611bb2720749b9fa4a39875660a63110c5d6f6,
                vout: 0,
            },
            script_sig: Script(),
            sequence: Sequence(
                2163643980,
            ),
            witness: Witness {
                content: [],
                witness_elements: 0,
                last: 0,
                second_to_last: 0,
            },
        },
    ],
    output: [
        TxOut {
            value: 76002,
            script_pubkey: Script(OP_0 OP_PUSHBYTES_20 b0579bf0fa7be58ba9df3b4b3779062594d73baa),
        },
    ],
}
setup=ChannelSetup {
    is_outbound: false,
    channel_value_sat: 103000,
    push_value_msat: 0,
    funding_outpoint: OutPoint {
        txid: c902d17dc44b4867fa3d0feb73611bb2720749b9fa4a39875660a63110c5d6f6,
        vout: 0,
    },
    holder_selected_contest_delay: 144,
    holder_shutdown_script: None,
  53: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/core.rs:328:17
  54: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/loom/std/unsafe_cell.rs:16:9
      tokio::runtime::task::core::Core<T,S>::poll
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/core.rs:317:13
  55: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:485:19
  56: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/panic/unwind_safe.rs:272:9
  57: std::panicking::try::do_call
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:554:40
  58: ___rust_try
  59: std::panicking::try
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:518:19
  60: std::panic::catch_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panic.rs:142:14
  61: tokio::runtime::task::harness::poll_future
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:473:18
  62: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:208:27
  63: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/harness.rs:153:15
  64: tokio::runtime::task::raw::poll
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/raw.rs:271:5
  65: tokio::runtime::task::raw::RawTask::poll
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/raw.rs:201:18
  66: tokio::runtime::task::UnownedTask<S>::run
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/task/mod.rs:445:9
  67: tokio::runtime::blocking::pool::Task::run
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/blocking/pool.rs:159:9
  68: tokio::runtime::blocking::pool::Inner::run
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/blocking/pool.rs:513:17
  69: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/runtime/blocking/pool.rs:471:13
  70: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/sys_common/backtrace.rs:155:18
  71: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/thread/mod.rs:529:17
  72: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/panic/unwind_safe.rs:272:9
  73: std::panicking::try::do_call
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:554:40
  74: ___rust_try
  75: std::panicking::try
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:518:19
  76: std::panic::catch_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panic.rs:142:14
      std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/thread/mod.rs:528:30
  77: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/ops/function.rs:250:5
  78: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/boxed.rs:2015:9
      <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/boxed.rs:2015:9
      std::sys::pal::unix::thread::Thread::new::thread_start
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/sys/pal/unix/thread.rs:108:17
  79: __pthread_start
Signing(Status { code: FailedPrecondition, message: "policy failure: validate_holder_commitment_tx: validate_commitment_tx: validate_fee: feerate above maximum: 37291 > 25000" })
Ignoring error other: processing request: Signing(Status { code: FailedPrecondition, message: "policy failure: validate_holder_commitment_tx: validate_commitment_tx: validate_fee: feerate above maximum: 37291 > 25000" }) for request 
```