### PR TITLE
Add the payment label to the PaymentFailed event

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -389,6 +389,7 @@ dictionary PaymentFailedData {
     string error;
     string node_id;
     LNInvoice? invoice;
+    string? label;
 };
 
 dictionary BackupFailedData {

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1870,6 +1870,7 @@ impl support::IntoDart for PaymentFailedData {
             self.error.into_into_dart().into_dart(),
             self.node_id.into_into_dart().into_dart(),
             self.invoice.into_dart(),
+            self.label.into_dart(),
         ]
         .into_dart()
     }

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1355,11 +1355,13 @@ class PaymentFailedData {
   final String error;
   final String nodeId;
   final LNInvoice? invoice;
+  final String? label;
 
   const PaymentFailedData({
     required this.error,
     required this.nodeId,
     this.invoice,
+    this.label,
   });
 }
 
@@ -3958,11 +3960,12 @@ class BreezSdkCoreImpl implements BreezSdkCore {
 
   PaymentFailedData _wire2api_payment_failed_data(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return PaymentFailedData(
       error: _wire2api_String(arr[0]),
       nodeId: _wire2api_String(arr[1]),
       invoice: _wire2api_opt_box_autoadd_ln_invoice(arr[2]),
+      label: _wire2api_opt_String(arr[3]),
     );
   }
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -2168,10 +2168,12 @@ fun asPaymentFailedData(paymentFailedData: ReadableMap): PaymentFailedData? {
     val error = paymentFailedData.getString("error")!!
     val nodeId = paymentFailedData.getString("nodeId")!!
     val invoice = if (hasNonNullKey(paymentFailedData, "invoice")) paymentFailedData.getMap("invoice")?.let { asLnInvoice(it) } else null
+    val label = if (hasNonNullKey(paymentFailedData, "label")) paymentFailedData.getString("label") else null
     return PaymentFailedData(
         error,
         nodeId,
         invoice,
+        label,
     )
 }
 
@@ -2180,6 +2182,7 @@ fun readableMapOf(paymentFailedData: PaymentFailedData): ReadableMap {
         "error" to paymentFailedData.error,
         "nodeId" to paymentFailedData.nodeId,
         "invoice" to paymentFailedData.invoice?.let { readableMapOf(it) },
+        "label" to paymentFailedData.label,
     )
 }
 

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2413,10 +2413,19 @@ enum BreezSDKMapper {
             invoice = try asLnInvoice(lnInvoice: invoiceTmp)
         }
 
+        var label: String?
+        if hasNonNilKey(data: paymentFailedData, key: "label") {
+            guard let labelTmp = paymentFailedData["label"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "label"))
+            }
+            label = labelTmp
+        }
+
         return PaymentFailedData(
             error: error,
             nodeId: nodeId,
-            invoice: invoice
+            invoice: invoice,
+            label: label
         )
     }
 
@@ -2425,6 +2434,7 @@ enum BreezSDKMapper {
             "error": paymentFailedData.error,
             "nodeId": paymentFailedData.nodeId,
             "invoice": paymentFailedData.invoice == nil ? nil : dictionaryOf(lnInvoice: paymentFailedData.invoice!),
+            "label": paymentFailedData.label == nil ? nil : paymentFailedData.label,
         ]
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -341,6 +341,7 @@ export type PaymentFailedData = {
     error: string
     nodeId: string
     invoice?: LnInvoice
+    label?: string
 }
 
 export type PrepareOnchainPaymentRequest = {


### PR DESCRIPTION
This PR adds the optional payment label to the PaymentFailed event so that the failure can be tracked by the label identifier.

Fixes #908 