### PR TITLE
Add Reverse Swap notification

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/Constants.kt
@@ -5,10 +5,10 @@ object Constants {
     const val SHUTDOWN_DELAY_MS = 60 * 1000L
 
     // Notification Channels
+    const val NOTIFICATION_CHANNEL_ADDRESS_TXS_CONFIRMED = "ADDRESS_TXS_CONFIRMED"
     const val NOTIFICATION_CHANNEL_FOREGROUND_SERVICE = "FOREGROUND_SERVICE"
     const val NOTIFICATION_CHANNEL_LNURL_PAY = "LNURL_PAY"
     const val NOTIFICATION_CHANNEL_PAYMENT_RECEIVED = "PAYMENT_RECEIVED"
-    const val NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED = "SWAP_TX_CONFIRMED"
 
     // Notification Ids
     const val NOTIFICATION_ID_FOREGROUND_SERVICE = 100
@@ -28,6 +28,14 @@ object Constants {
     const val MESSAGE_TYPE_PAYMENT_RECEIVED = "payment_received"
 
     // Resource Identifiers
+    const val ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION =
+        "address_txs_confirmed_notification_channel_description"
+    const val ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_NAME =
+        "address_txs_confirmed_notification_channel_name"
+    const val ADDRESS_TXS_CONFIRMED_WORKGROUP_ID = "txs_confirmed"
+    const val ADDRESS_TXS_CONFIRMED_WORKGROUP_DESCRIPTION =
+        "address_txs_confirmed_work_group_description"
+    const val ADDRESS_TXS_CONFIRMED_WORKGROUP_NAME = "address_txs_confirmed_work_group_name"
     const val FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION =
         "foreground_service_notification_channel_description"
     const val FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME =
@@ -65,22 +73,21 @@ object Constants {
     const val OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION =
         "offline_payments_work_group_description"
     const val OFFLINE_PAYMENTS_WORKGROUP_NAME = "offline_payments_work_group_name"
-    const val SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION =
-        "swap_tx_confirmed_notification_channel_description"
-    const val SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME =
-        "swap_tx_confirmed_notification_channel_name"
     const val SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TEXT =
         "swap_tx_confirmed_notification_failure_text"
     const val SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE =
         "swap_tx_confirmed_notification_failure_title"
     const val SWAP_TX_CONFIRMED_NOTIFICATION_TITLE =
         "swap_tx_confirmed_notification_title"
-    const val SWAP_TX_CONFIRMED_WORKGROUP_ID = "swap_tx"
-    const val SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION =
-        "swap_tx_confirmed_work_group_description"
-    const val SWAP_TX_CONFIRMED_WORKGROUP_NAME = "swap_tx_confirmed_work_group_name"
 
     // Resource Identifier Defaults
+    const val DEFAULT_ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION =
+        "Notifications for confirmed transactions when the application is in the background"
+    const val DEFAULT_ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_NAME =
+        "Confirmed Transactions"
+    const val DEFAULT_ADDRESS_TXS_CONFIRMED_WORKGROUP_DESCRIPTION =
+        "Required to handle confirmed transactions when the application is in the background"
+    const val DEFAULT_ADDRESS_TXS_CONFIRMED_WORKGROUP_NAME = "Confirmed Transactions"
     const val DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION =
         "Shown when the application is in the background"
     const val DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME =
@@ -114,17 +121,10 @@ object Constants {
     const val DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_DESCRIPTION =
         "Required to receive payments when the application is in the background"
     const val DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_NAME = "Offline Payments"
-    const val DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION =
-        "Notifications for received swaps when the application is in the background"
-    const val DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME =
-        "Received Swaps"
     const val DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TEXT =
         "Tap to complete swap"
     const val DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE =
         "Swap Ongoing"
     const val DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE =
         "Swap Confirmed"
-    const val DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION =
-        "Required to handle swaps when the application is in the background"
-    const val DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_NAME = "Swap Transactions"
 }

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/ForegroundService.kt
@@ -19,11 +19,11 @@ import breez_sdk_notification.Constants.NOTIFICATION_ID_FOREGROUND_SERVICE
 import breez_sdk_notification.Constants.SERVICE_TIMEOUT_MS
 import breez_sdk_notification.Constants.SHUTDOWN_DELAY_MS
 import breez_sdk_notification.NotificationHelper.Companion.notifyForegroundService
+import breez_sdk_notification.job.ConfirmTransactionJob
 import breez_sdk_notification.job.Job
 import breez_sdk_notification.job.LnurlPayInfoJob
 import breez_sdk_notification.job.LnurlPayInvoiceJob
 import breez_sdk_notification.job.ReceivePaymentJob
-import breez_sdk_notification.job.RedeemSwapJob
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -147,7 +147,7 @@ abstract class ForegroundService : SdkForegroundService, EventListener, Service(
         return Message.createFromIntent(intent)?.let { message ->
             message.payload?.let { payload ->
                 when (message.type) {
-                    MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED -> RedeemSwapJob(
+                    MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED -> ConfirmTransactionJob(
                         applicationContext,
                         this,
                         payload,

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/NotificationHelper.kt
@@ -17,6 +17,15 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import breez_sdk_notification.Constants.ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.ADDRESS_TXS_CONFIRMED_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.ADDRESS_TXS_CONFIRMED_WORKGROUP_ID
+import breez_sdk_notification.Constants.ADDRESS_TXS_CONFIRMED_WORKGROUP_NAME
+import breez_sdk_notification.Constants.DEFAULT_ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_NAME
+import breez_sdk_notification.Constants.DEFAULT_ADDRESS_TXS_CONFIRMED_WORKGROUP_DESCRIPTION
+import breez_sdk_notification.Constants.DEFAULT_ADDRESS_TXS_CONFIRMED_WORKGROUP_NAME
 import breez_sdk_notification.Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION
 import breez_sdk_notification.Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME
 import breez_sdk_notification.Constants.DEFAULT_FOREGROUND_SERVICE_NOTIFICATION_TITLE
@@ -29,10 +38,6 @@ import breez_sdk_notification.Constants.DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_DESCR
 import breez_sdk_notification.Constants.DEFAULT_OFFLINE_PAYMENTS_WORKGROUP_NAME
 import breez_sdk_notification.Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION
 import breez_sdk_notification.Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME
-import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
-import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME
-import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION
-import breez_sdk_notification.Constants.DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_NAME
 import breez_sdk_notification.Constants.FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_DESCRIPTION
 import breez_sdk_notification.Constants.FOREGROUND_SERVICE_NOTIFICATION_CHANNEL_NAME
 import breez_sdk_notification.Constants.FOREGROUND_SERVICE_NOTIFICATION_TITLE
@@ -41,10 +46,10 @@ import breez_sdk_notification.Constants.LNURL_PAY_NOTIFICATION_CHANNEL_NAME
 import breez_sdk_notification.Constants.LNURL_PAY_WORKGROUP_DESCRIPTION
 import breez_sdk_notification.Constants.LNURL_PAY_WORKGROUP_ID
 import breez_sdk_notification.Constants.LNURL_PAY_WORKGROUP_NAME
+import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_ADDRESS_TXS_CONFIRMED
 import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_FOREGROUND_SERVICE
 import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_LNURL_PAY
 import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_PAYMENT_RECEIVED
-import breez_sdk_notification.Constants.NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED
 import breez_sdk_notification.Constants.NOTIFICATION_COLOR
 import breez_sdk_notification.Constants.NOTIFICATION_ICON
 import breez_sdk_notification.Constants.NOTIFICATION_ID_FOREGROUND_SERVICE
@@ -53,11 +58,6 @@ import breez_sdk_notification.Constants.OFFLINE_PAYMENTS_WORKGROUP_ID
 import breez_sdk_notification.Constants.OFFLINE_PAYMENTS_WORKGROUP_NAME
 import breez_sdk_notification.Constants.PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_DESCRIPTION
 import breez_sdk_notification.Constants.PAYMENT_RECEIVED_NOTIFICATION_CHANNEL_NAME
-import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
-import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME
-import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION
-import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_WORKGROUP_ID
-import breez_sdk_notification.Constants.SWAP_TX_CONFIRMED_WORKGROUP_NAME
 import breez_sdk_notification.ResourceHelper.Companion.getColor
 import breez_sdk_notification.ResourceHelper.Companion.getDrawable
 import breez_sdk_notification.ResourceHelper.Companion.getString
@@ -194,20 +194,20 @@ class NotificationHelper {
                 group = LNURL_PAY_WORKGROUP_ID
             }
             val swapTxConfirmedNotificationChannel = NotificationChannel(
-                "${applicationId}.${NOTIFICATION_CHANNEL_SWAP_TX_CONFIRMED}",
+                "${applicationId}.${NOTIFICATION_CHANNEL_ADDRESS_TXS_CONFIRMED}",
                 getString(
                     context,
-                    SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME,
-                    DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_NAME
+                    ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_NAME,
+                    DEFAULT_ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_NAME
                 ),
                 NotificationManager.IMPORTANCE_DEFAULT
             ).apply {
                 description = getString(
                     context,
-                    SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION,
-                    DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
+                    ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION,
+                    DEFAULT_ADDRESS_TXS_CONFIRMED_NOTIFICATION_CHANNEL_DESCRIPTION
                 )
-                group = SWAP_TX_CONFIRMED_WORKGROUP_ID
+                group = ADDRESS_TXS_CONFIRMED_WORKGROUP_ID
             }
             notificationManager.createNotificationChannels(
                 listOf(
@@ -241,11 +241,11 @@ class NotificationHelper {
                 ),
             )
             val swapTxConfirmedNotificationChannelGroup = NotificationChannelGroup(
-                SWAP_TX_CONFIRMED_WORKGROUP_ID,
+                ADDRESS_TXS_CONFIRMED_WORKGROUP_ID,
                 getString(
                     context,
-                    SWAP_TX_CONFIRMED_WORKGROUP_NAME,
-                    DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_NAME
+                    ADDRESS_TXS_CONFIRMED_WORKGROUP_NAME,
+                    DEFAULT_ADDRESS_TXS_CONFIRMED_WORKGROUP_NAME
                 ),
             )
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -261,8 +261,8 @@ class NotificationHelper {
                 )
                 swapTxConfirmedNotificationChannelGroup.description = getString(
                     context,
-                    SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION,
-                    DEFAULT_SWAP_TX_CONFIRMED_WORKGROUP_DESCRIPTION
+                    ADDRESS_TXS_CONFIRMED_WORKGROUP_DESCRIPTION,
+                    DEFAULT_ADDRESS_TXS_CONFIRMED_WORKGROUP_DESCRIPTION
                 )
             }
 

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/Constants.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/Constants.swift
@@ -2,9 +2,9 @@ import Foundation
 
 struct Constants {
     // Notification Threads
+    static let NOTIFICATION_THREAD_ADDRESS_TXS_CONFIRMED = "ADDRESS_TXS_CONFIRMED"
     static let NOTIFICATION_THREAD_LNURL_PAY = "LNURL_PAY"
     static let NOTIFICATION_THREAD_PAYMENT_RECEIVED = "PAYMENT_RECEIVED"
-    static let NOTIFICATION_THREAD_SWAP_TX_CONFIRMED = "SWAP_TX_CONFIRMED"
 
     // Message Data
     static let MESSAGE_DATA_TYPE = "notification_type"

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/SDKNotificationService.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/SDKNotificationService.swift
@@ -71,7 +71,7 @@ open class SDKNotificationService: UNNotificationServiceExtension {
         self.logger.log(tag: TAG, line: "\(notificationType) data string: \(payload)", level: "INFO")
         switch(notificationType) {
         case Constants.MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED:
-            return RedeemSwapTask(payload: payload, logger: self.logger, contentHandler: contentHandler, bestAttemptContent: bestAttemptContent)
+            return ConfirmTransactionTask(payload: payload, logger: self.logger, contentHandler: contentHandler, bestAttemptContent: bestAttemptContent)
         case Constants.MESSAGE_TYPE_LNURL_PAY_INFO:
             return LnurlPayInfoTask(payload: payload, logger: self.logger, config: self.config, contentHandler: contentHandler, bestAttemptContent: bestAttemptContent)
         case Constants.MESSAGE_TYPE_LNURL_PAY_INVOICE:

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/Task/ConfirmTransaction.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/Task/ConfirmTransaction.swift
@@ -5,14 +5,14 @@ struct AddressTxsConfirmedRequest: Codable {
     let address: String
 }
 
-class RedeemSwapTask : TaskProtocol {
-    fileprivate let TAG = "RedeemSwapTask"
+class ConfirmTransactionTask : TaskProtocol {
+    fileprivate let TAG = "ConfirmTransactionTask"
     
     internal var payload: String
     internal var contentHandler: ((UNNotificationContent) -> Void)?
     internal var bestAttemptContent: UNMutableNotificationContent?
     internal var logger: ServiceLogger
-    internal var swapAddress: String? = nil
+    internal var bitcoinAddress: String? = nil
     
     init(payload: String, logger: ServiceLogger, contentHandler: ((UNNotificationContent) -> Void)? = nil, bestAttemptContent: UNMutableNotificationContent? = nil) {
         self.payload = payload
@@ -22,15 +22,19 @@ class RedeemSwapTask : TaskProtocol {
     }
     
     public func onEvent(e: BreezEvent) {
-        if let address = self.swapAddress {
+        if let address = self.bitcoinAddress {
             switch e {
+            case .reverseSwapUpdated(details: let revSwapInfo):
+                self.logger.log(tag: TAG, line: "Received reverse swap updated event: \(revSwapInfo.id), current address: \(address) status: \(revSwapInfo.status)\n", level: "INFO")
+                if case .completedSeen = revSwapInfo.status, case  .completedConfirmed = revSwapInfo.status {
+                    self.notifySuccess()
+                }
+                break
             case .swapUpdated(details: let swapInfo):
                 self.logger.log(tag: TAG, line: "Received swap updated event: \(swapInfo.bitcoinAddress), current address: \(address) status: \(swapInfo.status)\n", level: "INFO")
                 if address == swapInfo.bitcoinAddress {
                     if (swapInfo.paidMsat > 0) {
-                        self.logger.log(tag: TAG, line: "Swap address \(swapInfo.bitcoinAddress) redeemed succesfully", level: "INFO")
-                        let notificationTitle = ResourceHelper.shared.getString(key: Constants.SWAP_TX_CONFIRMED_NOTIFICATION_TITLE, fallback: Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE)
-                        self.displayPushNotification(title: notificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_SWAP_TX_CONFIRMED)
+                        self.notifySuccess()
                     }
                 }
                 break
@@ -43,15 +47,15 @@ class RedeemSwapTask : TaskProtocol {
     func start(breezSDK: BlockingBreezServices) throws {
         do {
             let addressTxsConfirmedRequest = try JSONDecoder().decode(AddressTxsConfirmedRequest.self, from: self.payload.data(using: .utf8)!)
-            swapAddress = addressTxsConfirmedRequest.address
+            self.bitcoinAddress = addressTxsConfirmedRequest.address
         } catch let e {
-            self.logger.log(tag: TAG, line: "failed to decode payload: \(e)", level: "ERROR")
+            self.logger.log(tag: TAG, line: "Failed to decode payload: \(e)", level: "ERROR")
             self.onShutdown()
             throw e
         }
         
-        guard let address = swapAddress else {
-            self.logger.log(tag: TAG, line: "Failed to process swap notification: swap address not in payload", level: "ERROR")
+        guard let address = bitcoinAddress else {
+            self.logger.log(tag: TAG, line: "Address not in payload", level: "ERROR")
             self.onShutdown()
             return
         }
@@ -59,14 +63,28 @@ class RedeemSwapTask : TaskProtocol {
         do {
             try breezSDK.redeemSwap(swapAddress: address)
             self.logger.log(tag: TAG, line: "Found swap for \(address)", level: "DEBUG")
+            return
         } catch let e {
-            self.logger.log(tag: TAG, line: "Failed to manually redeem swap notification: \(e)", level: "ERROR")
+            self.logger.log(tag: TAG, line: "Failed to redeem swap: \(e)", level: "ERROR")
+        }
+        
+        do {
+            try breezSDK.processReverseSwap(lockupAddress: address)
+            self.logger.log(tag: TAG, line: "Found reverse swap for \(address)", level: "DEBUG")
+        } catch let e {
+            self.logger.log(tag: TAG, line: "Failed to process reverse swap: \(e)", level: "ERROR")
         }
     }
 
     func onShutdown() {
         let notificationTitle = ResourceHelper.shared.getString(key: Constants.SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE, fallback: Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TITLE)
         let notificationBody = ResourceHelper.shared.getString(key: Constants.SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TEXT, fallback: Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_FAILURE_TEXT)
-        self.displayPushNotification(title: notificationTitle, body: notificationBody, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_SWAP_TX_CONFIRMED)
+        self.displayPushNotification(title: notificationTitle, body: notificationBody, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_ADDRESS_TXS_CONFIRMED)
+    }
+
+    func notifySuccess() {
+        self.logger.log(tag: TAG, line: "Address \(self.bitcoinAddress) processed successfully", level: "INFO")
+        let notificationTitle = ResourceHelper.shared.getString(key: Constants.SWAP_TX_CONFIRMED_NOTIFICATION_TITLE, fallback: Constants.DEFAULT_SWAP_TX_CONFIRMED_NOTIFICATION_TITLE)
+        self.displayPushNotification(title: notificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_ADDRESS_TXS_CONFIRMED)
     }
 }

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -411,6 +411,7 @@ interface BreezEvent {
     BackupStarted();
     BackupSucceeded();
     BackupFailed(BackupFailedData details);
+    ReverseSwapUpdated(ReverseSwapInfo details);
     SwapUpdated(SwapInfo details);
 };
 
@@ -940,6 +941,9 @@ interface BlockingBreezServices {
    [Throws=SdkError]
    sequence<ReverseSwapInfo> in_progress_reverse_swaps();
    
+   [Throws=SdkError]
+   void process_reverse_swap(string lockup_address);
+
    [Throws=SdkError]
    MaxReverseSwapAmountResponse max_reverse_swap_amount();
 

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -942,7 +942,7 @@ interface BlockingBreezServices {
    sequence<ReverseSwapInfo> in_progress_reverse_swaps();
    
    [Throws=SdkError]
-   void process_reverse_swap(string lockup_address);
+   void claim_reverse_swap(string lockup_address);
 
    [Throws=SdkError]
    MaxReverseSwapAmountResponse max_reverse_swap_amount();

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -332,8 +332,8 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.in_progress_reverse_swaps())
     }
 
-    pub fn process_reverse_swap(&self, lockup_address: String) -> SdkResult<()> {
-        rt().block_on(self.breez_services.process_reverse_swap(lockup_address))
+    pub fn claim_reverse_swap(&self, lockup_address: String) -> SdkResult<()> {
+        rt().block_on(self.breez_services.claim_reverse_swap(lockup_address))
     }
 
     pub fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -332,6 +332,10 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.in_progress_reverse_swaps())
     }
 
+    pub fn process_reverse_swap(&self, lockup_address: String) -> SdkResult<()> {
+        rt().block_on(self.breez_services.process_reverse_swap(lockup_address))
+    }
+
     pub fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
         #[allow(deprecated)]
         rt().block_on(self.breez_services.max_reverse_swap_amount())

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -705,6 +705,17 @@ pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
     .map_err(anyhow::Error::new::<SdkError>)
 }
 
+/// See [BreezServices::process_reverse_swap]
+pub fn process_reverse_swap(lockup_address: String) -> Result<()> {
+    block_on(async {
+        get_breez_services()
+            .await?
+            .process_reverse_swap(lockup_address)
+            .await
+    })
+    .map_err(anyhow::Error::new::<SdkError>)
+}
+
 /*  Swap Fee API's */
 
 /// See [BreezServices::open_channel_fee]

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -705,12 +705,12 @@ pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
     .map_err(anyhow::Error::new::<SdkError>)
 }
 
-/// See [BreezServices::process_reverse_swap]
-pub fn process_reverse_swap(lockup_address: String) -> Result<()> {
+/// See [BreezServices::claim_reverse_swap]
+pub fn claim_reverse_swap(lockup_address: String) -> Result<()> {
     block_on(async {
         get_breez_services()
             .await?
-            .process_reverse_swap(lockup_address)
+            .claim_reverse_swap(lockup_address)
             .await
     })
     .map_err(anyhow::Error::new::<SdkError>)

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -796,16 +796,16 @@ impl BreezServices {
         Ok(())
     }
 
-    /// Processes an individual reverse swap.
+    /// Claims an individual reverse swap.
     ///
     /// To be used only in the context of mobile notifications, where the notification triggers
-    /// an individual reverse swap to be processed.
+    /// an individual reverse swap to be claimed.
     ///
     /// This is taken care of automatically in the context of typical SDK usage.
-    pub async fn process_reverse_swap(&self, lockup_address: String) -> SdkResult<()> {
+    pub async fn claim_reverse_swap(&self, lockup_address: String) -> SdkResult<()> {
         Ok(self
             .btc_send_swapper
-            .process_reverse_swap(lockup_address)
+            .claim_reverse_swap(lockup_address)
             .await?)
     }
 

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -282,8 +282,8 @@ pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_process_reverse_swap(port_: i64, lockup_address: *mut wire_uint_8_list) {
-    wire_process_reverse_swap_impl(port_, lockup_address)
+pub extern "C" fn wire_claim_reverse_swap(port_: i64, lockup_address: *mut wire_uint_8_list) {
+    wire_claim_reverse_swap_impl(port_, lockup_address)
 }
 
 #[no_mangle]

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -282,6 +282,11 @@ pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_process_reverse_swap(port_: i64, lockup_address: *mut wire_uint_8_list) {
+    wire_process_reverse_swap_impl(port_, lockup_address)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_open_channel_fee(port_: i64, req: *mut wire_OpenChannelFeeRequest) {
     wire_open_channel_fee_impl(port_, req)
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -785,6 +785,22 @@ fn wire_in_progress_reverse_swaps_impl(port_: MessagePort) {
         move || move |task_callback| in_progress_reverse_swaps(),
     )
 }
+fn wire_process_reverse_swap_impl(
+    port_: MessagePort,
+    lockup_address: impl Wire2Api<String> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
+        WrapInfo {
+            debug_name: "process_reverse_swap",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_lockup_address = lockup_address.wire2api();
+            move |task_callback| process_reverse_swap(api_lockup_address)
+        },
+    )
+}
 fn wire_open_channel_fee_impl(
     port_: MessagePort,
     req: impl Wire2Api<OpenChannelFeeRequest> + UnwindSafe,
@@ -1381,8 +1397,11 @@ impl support::IntoDart for BreezEvent {
             Self::BackupFailed { details } => {
                 vec![7.into_dart(), details.into_into_dart().into_dart()]
             }
-            Self::SwapUpdated { details } => {
+            Self::ReverseSwapUpdated { details } => {
                 vec![8.into_dart(), details.into_into_dart().into_dart()]
+            }
+            Self::SwapUpdated { details } => {
+                vec![9.into_dart(), details.into_into_dart().into_dart()]
             }
         }
         .into_dart()

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -785,19 +785,19 @@ fn wire_in_progress_reverse_swaps_impl(port_: MessagePort) {
         move || move |task_callback| in_progress_reverse_swaps(),
     )
 }
-fn wire_process_reverse_swap_impl(
+fn wire_claim_reverse_swap_impl(
     port_: MessagePort,
     lockup_address: impl Wire2Api<String> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
         WrapInfo {
-            debug_name: "process_reverse_swap",
+            debug_name: "claim_reverse_swap",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
         move || {
             let api_lockup_address = lockup_address.wire2api();
-            move |task_callback| process_reverse_swap(api_lockup_address)
+            move |task_callback| claim_reverse_swap(api_lockup_address)
         },
     )
 }

--- a/libs/sdk-core/src/persist/reverseswap.rs
+++ b/libs/sdk-core/src/persist/reverseswap.rs
@@ -1,6 +1,6 @@
 use super::{db::SqliteStorage, error::PersistResult};
 use crate::{FullReverseSwapInfo, ReverseSwapInfoCached, ReverseSwapStatus};
-use rusqlite::{named_params, Row, TransactionBehavior};
+use rusqlite::{named_params, OptionalExtension, Row, TransactionBehavior};
 
 impl SqliteStorage {
     pub(crate) fn insert_reverse_swap(&self, rsi: &FullReverseSwapInfo) -> PersistResult<()> {
@@ -90,6 +90,17 @@ impl SqliteStorage {
         )?;
 
         Ok(())
+    }
+
+    pub(crate) fn get_reverse_swap(&self, id: &str) -> PersistResult<Option<FullReverseSwapInfo>> {
+        Ok(self
+            .get_connection()?
+            .query_row(
+                &self.select_reverse_swap_query("reverse_swaps.id = ?1", ""),
+                [id],
+                |row| self.sql_row_to_reverse_swap(row, ""),
+            )
+            .optional()?)
     }
 
     pub(crate) fn list_reverse_swaps(&self) -> PersistResult<Vec<FullReverseSwapInfo>> {

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -622,10 +622,10 @@ impl BTCSendSwap {
     async fn process_monitored_reverse_swaps(&self) -> Result<()> {
         let monitored = self.list_monitored().await?;
         debug!("Found {} monitored reverse swaps", monitored.len());
-        self.process_reverse_swaps(monitored).await
+        self.claim_reverse_swaps(monitored).await
     }
 
-    async fn process_reverse_swaps(&self, reverse_swaps: Vec<FullReverseSwapInfo>) -> Result<()> {
+    async fn claim_reverse_swaps(&self, reverse_swaps: Vec<FullReverseSwapInfo>) -> Result<()> {
         for rsi in reverse_swaps {
             debug!("Processing reverse swap {rsi:?}");
 
@@ -682,7 +682,7 @@ impl BTCSendSwap {
         Ok(())
     }
 
-    pub async fn process_reverse_swap(&self, lockup_address: String) -> ReverseSwapResult<()> {
+    pub async fn claim_reverse_swap(&self, lockup_address: String) -> ReverseSwapResult<()> {
         let rsis: Vec<FullReverseSwapInfo> = self
             .list_monitored()
             .await?
@@ -700,7 +700,7 @@ impl BTCSendSwap {
                 "Reverse swap address {} was not found",
                 lockup_address
             ))),
-            false => Ok(self.process_reverse_swaps(rsis).await?),
+            false => Ok(self.claim_reverse_swaps(rsis).await?),
         }
     }
 

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, ensure, Result};
 use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
 use tokio::time::{sleep, Duration};
 
 use super::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus::*};
@@ -110,6 +111,7 @@ pub(crate) struct BTCSendSwap {
     persister: Arc<crate::persist::db::SqliteStorage>,
     chain_service: Arc<dyn ChainService>,
     node_api: Arc<dyn NodeAPI>,
+    status_changes_notifier: broadcast::Sender<BreezEvent>,
 }
 
 impl BTCSendSwap {
@@ -121,6 +123,7 @@ impl BTCSendSwap {
         chain_service: Arc<dyn ChainService>,
         node_api: Arc<dyn NodeAPI>,
     ) -> Self {
+        let (status_changes_notifier, _) = broadcast::channel::<BreezEvent>(100);
         Self {
             config,
             reverse_swapper_api,
@@ -128,6 +131,36 @@ impl BTCSendSwap {
             persister,
             chain_service,
             node_api,
+            status_changes_notifier,
+        }
+    }
+
+    pub(crate) fn subscribe_status_changes(&self) -> broadcast::Receiver<BreezEvent> {
+        self.status_changes_notifier.subscribe()
+    }
+
+    async fn emit_reverse_swap_updated(&self, id: &str) -> Result<()> {
+        let full_rsi = self
+            .persister
+            .get_reverse_swap(id)?
+            .ok_or_else(|| anyhow!(format!("reverse swap {} was not found", id)))?;
+        self.status_changes_notifier
+            .send(BreezEvent::ReverseSwapUpdated {
+                details: self.convert_reverse_swap_info(full_rsi).await?,
+            })
+            .map_err(anyhow::Error::msg)?;
+        Ok(())
+    }
+
+    pub(crate) async fn on_event(&self, e: BreezEvent) -> Result<()> {
+        match e {
+            BreezEvent::Synced => {
+                // Since this relies on the most up-to-date states of the reverse swap HODL invoice payments,
+                // a fresh [BreezServices::sync] *must* be called before this method.
+                // Therefore we specifically call this on the Synced event
+                self.process_monitored_reverse_swaps().await
+            }
+            _ => Ok(()),
         }
     }
 
@@ -261,11 +294,14 @@ impl BTCSendSwap {
                 self.persister
                     .update_reverse_swap_status(&created_rsi.id, &InProgress)?;
                 self.persister
-                    .update_reverse_swap_lockup_txid(&created_rsi.id, lockup_txid)?
+                    .update_reverse_swap_lockup_txid(&created_rsi.id, lockup_txid)?;
+                self.emit_reverse_swap_updated(&created_rsi.id).await?
             }
-            Err(_) => self
-                .persister
-                .update_reverse_swap_status(&created_rsi.id, &Cancelled)?,
+            Err(_) => {
+                self.persister
+                    .update_reverse_swap_status(&created_rsi.id, &Cancelled)?;
+                self.emit_reverse_swap_updated(&created_rsi.id).await?
+            }
         }
 
         Ok(res?)
@@ -353,18 +389,6 @@ impl BTCSendSwap {
                     "(Boltz) Failed to create reverse swap: {error}"
                 )))
             }
-        }
-    }
-
-    pub(crate) async fn on_event(&self, e: BreezEvent) -> Result<()> {
-        match e {
-            BreezEvent::Synced => {
-                // Since this relies on the most up-to-date states of the reverse swap HODL invoice payments,
-                // a fresh [BreezServices::sync] *must* be called before this method.
-                // Therefore we specifically call this on the Synced event
-                self.process_monitored_reverse_swaps().await
-            }
-            _ => Ok(()),
         }
     }
 
@@ -598,9 +622,12 @@ impl BTCSendSwap {
     async fn process_monitored_reverse_swaps(&self) -> Result<()> {
         let monitored = self.list_monitored().await?;
         debug!("Found {} monitored reverse swaps", monitored.len());
+        self.process_reverse_swaps(monitored).await
+    }
 
-        for rsi in monitored {
-            debug!("Processing monitored reverse swap {rsi:?}");
+    async fn process_reverse_swaps(&self, reverse_swaps: Vec<FullReverseSwapInfo>) -> Result<()> {
+        for rsi in reverse_swaps {
+            debug!("Processing reverse swap {rsi:?}");
 
             // Look for lockup and claim txs on chain
             let lockup_tx = self.get_lockup_tx(&rsi).await?;
@@ -615,6 +642,7 @@ impl BTCSendSwap {
             {
                 self.persister
                     .update_reverse_swap_status(&rsi.id, &new_status)?;
+                self.emit_reverse_swap_updated(&rsi.id).await?;
             }
 
             // (Re-)Broadcast the claim tx for monitored reverse swaps that have a confirmed lockup tx
@@ -638,6 +666,7 @@ impl BTCSendSwap {
             if rsi.cache.lockup_txid.is_none() {
                 self.persister
                     .update_reverse_swap_lockup_txid(&rsi.id, lockup_tx.map(|tx| tx.txid))?;
+                self.emit_reverse_swap_updated(&rsi.id).await?;
             }
             if rsi.cache.claim_txid.is_none() {
                 self.persister.update_reverse_swap_claim_txid(
@@ -646,10 +675,33 @@ impl BTCSendSwap {
                         .map(|tx| tx.txid)
                         .or(broadcasted_claim_tx.map(|tx| tx.txid().to_string())),
                 )?;
+                self.emit_reverse_swap_updated(&rsi.id).await?;
             }
         }
 
         Ok(())
+    }
+
+    pub async fn process_reverse_swap(&self, lockup_address: String) -> ReverseSwapResult<()> {
+        let rsis: Vec<FullReverseSwapInfo> = self
+            .list_monitored()
+            .await?
+            .into_iter()
+            .filter(|rev_swap| {
+                lockup_address
+                    == rev_swap
+                        .get_lockup_address(self.config.network)
+                        .map(|a| a.to_string())
+                        .unwrap_or_default()
+            })
+            .collect();
+        match rsis.is_empty() {
+            true => Err(ReverseSwapError::Generic(format!(
+                "Reverse swap address {} was not found",
+                lockup_address
+            ))),
+            false => Ok(self.process_reverse_swaps(rsis).await?),
+        }
     }
 
     /// Returns the ongoing reverse swaps which have a status that block the creation of new reverse swaps

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -405,6 +405,8 @@ void wire_in_progress_swap(int64_t port_);
 
 void wire_in_progress_reverse_swaps(int64_t port_);
 
+void wire_process_reverse_swap(int64_t port_, struct wire_uint_8_list *lockup_address);
+
 void wire_open_channel_fee(int64_t port_, struct wire_OpenChannelFeeRequest *req);
 
 void wire_fetch_reverse_swap_fees(int64_t port_, struct wire_ReverseSwapFeesRequest *req);
@@ -556,6 +558,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_redeem_swap);
     dummy_var ^= ((int64_t) (void*) wire_in_progress_swap);
     dummy_var ^= ((int64_t) (void*) wire_in_progress_reverse_swaps);
+    dummy_var ^= ((int64_t) (void*) wire_process_reverse_swap);
     dummy_var ^= ((int64_t) (void*) wire_open_channel_fee);
     dummy_var ^= ((int64_t) (void*) wire_fetch_reverse_swap_fees);
     dummy_var ^= ((int64_t) (void*) wire_onchain_payment_limits);

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -405,7 +405,7 @@ void wire_in_progress_swap(int64_t port_);
 
 void wire_in_progress_reverse_swaps(int64_t port_);
 
-void wire_process_reverse_swap(int64_t port_, struct wire_uint_8_list *lockup_address);
+void wire_claim_reverse_swap(int64_t port_, struct wire_uint_8_list *lockup_address);
 
 void wire_open_channel_fee(int64_t port_, struct wire_OpenChannelFeeRequest *req);
 
@@ -558,7 +558,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_redeem_swap);
     dummy_var ^= ((int64_t) (void*) wire_in_progress_swap);
     dummy_var ^= ((int64_t) (void*) wire_in_progress_reverse_swaps);
-    dummy_var ^= ((int64_t) (void*) wire_process_reverse_swap);
+    dummy_var ^= ((int64_t) (void*) wire_claim_reverse_swap);
     dummy_var ^= ((int64_t) (void*) wire_open_channel_fee);
     dummy_var ^= ((int64_t) (void*) wire_fetch_reverse_swap_fees);
     dummy_var ^= ((int64_t) (void*) wire_onchain_payment_limits);

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -427,6 +427,18 @@ class BreezSDK {
   )
   Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async => _lnToolkit.inProgressReverseSwaps();
 
+  /// Processes an individual reverse swap.
+  ///
+  /// To be used only in the context of mobile notifications, where the notification triggers
+  /// an individual reverse swap to be processed.
+  ///
+  /// This is taken care of automatically in the context of typical SDK usage.
+  Future<void> processReverseSwap({
+    required String lockupAddress,
+  }) async {
+    return await _lnToolkit.processReverseSwap(lockupAddress: lockupAddress);
+  }
+
   /* Swap Fee API's */
 
   /// Gets the fees required to open a channel for a given amount.

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -427,16 +427,16 @@ class BreezSDK {
   )
   Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async => _lnToolkit.inProgressReverseSwaps();
 
-  /// Processes an individual reverse swap.
+  /// Claims an individual reverse swap.
   ///
   /// To be used only in the context of mobile notifications, where the notification triggers
-  /// an individual reverse swap to be processed.
+  /// an individual reverse swap to be claimed.
   ///
   /// This is taken care of automatically in the context of typical SDK usage.
-  Future<void> processReverseSwap({
+  Future<void> claimReverseSwap({
     required String lockupAddress,
   }) async {
-    return await _lnToolkit.processReverseSwap(lockupAddress: lockupAddress);
+    return await _lnToolkit.claimReverseSwap(lockupAddress: lockupAddress);
   }
 
   /* Swap Fee API's */

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -282,6 +282,11 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta;
 
+  /// See [BreezServices::process_reverse_swap]
+  Future<void> processReverseSwap({required String lockupAddress, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kProcessReverseSwapConstMeta;
+
   /// See [BreezServices::open_channel_fee]
   Future<OpenChannelFeeResponse> openChannelFee({required OpenChannelFeeRequest req, dynamic hint});
 
@@ -415,6 +420,15 @@ sealed class BreezEvent with _$BreezEvent {
   const factory BreezEvent.backupFailed({
     required BackupFailedData details,
   }) = BreezEvent_BackupFailed;
+
+  /// Indicates that a reverse swap has been updated which may also
+  /// include a status change
+  const factory BreezEvent.reverseSwapUpdated({
+    required ReverseSwapInfo details,
+  }) = BreezEvent_ReverseSwapUpdated;
+
+  /// Indicates that a swap has been updated which may also
+  /// include a status change
   const factory BreezEvent.swapUpdated({
     required SwapInfo details,
   }) = BreezEvent_SwapUpdated;
@@ -2862,6 +2876,23 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
+  Future<void> processReverseSwap({required String lockupAddress, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(lockupAddress);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_process_reverse_swap(port_, arg0),
+      parseSuccessData: _wire2api_unit,
+      parseErrorData: _wire2api_FrbAnyhowException,
+      constMeta: kProcessReverseSwapConstMeta,
+      argValues: [lockupAddress],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kProcessReverseSwapConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "process_reverse_swap",
+        argNames: ["lockupAddress"],
+      );
+
   Future<OpenChannelFeeResponse> openChannelFee({required OpenChannelFeeRequest req, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_open_channel_fee_request(req);
     return _platform.executeNormal(FlutterRustBridgeTask(
@@ -3227,6 +3258,10 @@ class BreezSdkCoreImpl implements BreezSdkCore {
           details: _wire2api_box_autoadd_backup_failed_data(raw[1]),
         );
       case 8:
+        return BreezEvent_ReverseSwapUpdated(
+          details: _wire2api_box_autoadd_reverse_swap_info(raw[1]),
+        );
+      case 9:
         return BreezEvent_SwapUpdated(
           details: _wire2api_box_autoadd_swap_info(raw[1]),
         );
@@ -5820,6 +5855,22 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_reverse_swaps');
   late final _wire_in_progress_reverse_swaps =
       _wire_in_progress_reverse_swapsPtr.asFunction<void Function(int)>();
+
+  void wire_process_reverse_swap(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> lockup_address,
+  ) {
+    return _wire_process_reverse_swap(
+      port_,
+      lockup_address,
+    );
+  }
+
+  late final _wire_process_reverse_swapPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_process_reverse_swap');
+  late final _wire_process_reverse_swap =
+      _wire_process_reverse_swapPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_open_channel_fee(
     int port_,

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -282,10 +282,10 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta;
 
-  /// See [BreezServices::process_reverse_swap]
-  Future<void> processReverseSwap({required String lockupAddress, dynamic hint});
+  /// See [BreezServices::claim_reverse_swap]
+  Future<void> claimReverseSwap({required String lockupAddress, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kProcessReverseSwapConstMeta;
+  FlutterRustBridgeTaskConstMeta get kClaimReverseSwapConstMeta;
 
   /// See [BreezServices::open_channel_fee]
   Future<OpenChannelFeeResponse> openChannelFee({required OpenChannelFeeRequest req, dynamic hint});
@@ -2876,20 +2876,20 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
-  Future<void> processReverseSwap({required String lockupAddress, dynamic hint}) {
+  Future<void> claimReverseSwap({required String lockupAddress, dynamic hint}) {
     var arg0 = _platform.api2wire_String(lockupAddress);
     return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_process_reverse_swap(port_, arg0),
+      callFfi: (port_) => _platform.inner.wire_claim_reverse_swap(port_, arg0),
       parseSuccessData: _wire2api_unit,
       parseErrorData: _wire2api_FrbAnyhowException,
-      constMeta: kProcessReverseSwapConstMeta,
+      constMeta: kClaimReverseSwapConstMeta,
       argValues: [lockupAddress],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kProcessReverseSwapConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "process_reverse_swap",
+  FlutterRustBridgeTaskConstMeta get kClaimReverseSwapConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "claim_reverse_swap",
         argNames: ["lockupAddress"],
       );
 
@@ -5856,21 +5856,21 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
   late final _wire_in_progress_reverse_swaps =
       _wire_in_progress_reverse_swapsPtr.asFunction<void Function(int)>();
 
-  void wire_process_reverse_swap(
+  void wire_claim_reverse_swap(
     int port_,
     ffi.Pointer<wire_uint_8_list> lockup_address,
   ) {
-    return _wire_process_reverse_swap(
+    return _wire_claim_reverse_swap(
       port_,
       lockup_address,
     );
   }
 
-  late final _wire_process_reverse_swapPtr =
+  late final _wire_claim_reverse_swapPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_process_reverse_swap');
-  late final _wire_process_reverse_swap =
-      _wire_process_reverse_swapPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+          'wire_claim_reverse_swap');
+  late final _wire_claim_reverse_swap =
+      _wire_claim_reverse_swapPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_open_channel_fee(
     int port_,

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -359,6 +359,7 @@ mixin _$BreezEvent {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) =>
       throw _privateConstructorUsedError;
@@ -372,6 +373,7 @@ mixin _$BreezEvent {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) =>
       throw _privateConstructorUsedError;
@@ -385,6 +387,7 @@ mixin _$BreezEvent {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) =>
@@ -399,6 +402,7 @@ mixin _$BreezEvent {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) =>
       throw _privateConstructorUsedError;
@@ -412,6 +416,7 @@ mixin _$BreezEvent {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) =>
       throw _privateConstructorUsedError;
@@ -425,6 +430,7 @@ mixin _$BreezEvent {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) =>
@@ -519,6 +525,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return newBlock(block);
@@ -535,6 +542,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return newBlock?.call(block);
@@ -551,6 +559,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -571,6 +580,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return newBlock(this);
@@ -587,6 +597,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return newBlock?.call(this);
@@ -603,6 +614,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -694,6 +706,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return invoicePaid(details);
@@ -710,6 +723,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return invoicePaid?.call(details);
@@ -726,6 +740,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -746,6 +761,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return invoicePaid(this);
@@ -762,6 +778,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return invoicePaid?.call(this);
@@ -778,6 +795,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -843,6 +861,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return synced();
@@ -859,6 +878,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return synced?.call();
@@ -875,6 +895,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -895,6 +916,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return synced(this);
@@ -911,6 +933,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return synced?.call(this);
@@ -927,6 +950,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1013,6 +1037,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return paymentSucceed(details);
@@ -1029,6 +1054,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return paymentSucceed?.call(details);
@@ -1045,6 +1071,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1065,6 +1092,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return paymentSucceed(this);
@@ -1081,6 +1109,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return paymentSucceed?.call(this);
@@ -1097,6 +1126,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1188,6 +1218,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return paymentFailed(details);
@@ -1204,6 +1235,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return paymentFailed?.call(details);
@@ -1220,6 +1252,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1240,6 +1273,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return paymentFailed(this);
@@ -1256,6 +1290,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return paymentFailed?.call(this);
@@ -1272,6 +1307,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1338,6 +1374,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return backupStarted();
@@ -1354,6 +1391,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return backupStarted?.call();
@@ -1370,6 +1408,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1390,6 +1429,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return backupStarted(this);
@@ -1406,6 +1446,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return backupStarted?.call(this);
@@ -1422,6 +1463,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1482,6 +1524,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return backupSucceeded();
@@ -1498,6 +1541,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return backupSucceeded?.call();
@@ -1514,6 +1558,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1534,6 +1579,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return backupSucceeded(this);
@@ -1550,6 +1596,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return backupSucceeded?.call(this);
@@ -1566,6 +1613,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1652,6 +1700,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return backupFailed(details);
@@ -1668,6 +1717,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return backupFailed?.call(details);
@@ -1684,6 +1734,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1704,6 +1755,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return backupFailed(this);
@@ -1720,6 +1772,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return backupFailed?.call(this);
@@ -1736,6 +1789,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1753,6 +1807,189 @@ abstract class BreezEvent_BackupFailed implements BreezEvent {
   BackupFailedData get details;
   @JsonKey(ignore: true)
   _$$BreezEvent_BackupFailedImplCopyWith<_$BreezEvent_BackupFailedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$BreezEvent_ReverseSwapUpdatedImplCopyWith<$Res> {
+  factory _$$BreezEvent_ReverseSwapUpdatedImplCopyWith(_$BreezEvent_ReverseSwapUpdatedImpl value,
+          $Res Function(_$BreezEvent_ReverseSwapUpdatedImpl) then) =
+      __$$BreezEvent_ReverseSwapUpdatedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ReverseSwapInfo details});
+}
+
+/// @nodoc
+class __$$BreezEvent_ReverseSwapUpdatedImplCopyWithImpl<$Res>
+    extends _$BreezEventCopyWithImpl<$Res, _$BreezEvent_ReverseSwapUpdatedImpl>
+    implements _$$BreezEvent_ReverseSwapUpdatedImplCopyWith<$Res> {
+  __$$BreezEvent_ReverseSwapUpdatedImplCopyWithImpl(
+      _$BreezEvent_ReverseSwapUpdatedImpl _value, $Res Function(_$BreezEvent_ReverseSwapUpdatedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? details = null,
+  }) {
+    return _then(_$BreezEvent_ReverseSwapUpdatedImpl(
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as ReverseSwapInfo,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BreezEvent_ReverseSwapUpdatedImpl implements BreezEvent_ReverseSwapUpdated {
+  const _$BreezEvent_ReverseSwapUpdatedImpl({required this.details});
+
+  @override
+  final ReverseSwapInfo details;
+
+  @override
+  String toString() {
+    return 'BreezEvent.reverseSwapUpdated(details: $details)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BreezEvent_ReverseSwapUpdatedImpl &&
+            (identical(other.details, details) || other.details == details));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, details);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BreezEvent_ReverseSwapUpdatedImplCopyWith<_$BreezEvent_ReverseSwapUpdatedImpl> get copyWith =>
+      __$$BreezEvent_ReverseSwapUpdatedImplCopyWithImpl<_$BreezEvent_ReverseSwapUpdatedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int block) newBlock,
+    required TResult Function(InvoicePaidDetails details) invoicePaid,
+    required TResult Function() synced,
+    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
+    required TResult Function(SwapInfo details) swapUpdated,
+  }) {
+    return reverseSwapUpdated(details);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int block)? newBlock,
+    TResult? Function(InvoicePaidDetails details)? invoicePaid,
+    TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
+    TResult? Function(SwapInfo details)? swapUpdated,
+  }) {
+    return reverseSwapUpdated?.call(details);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int block)? newBlock,
+    TResult Function(InvoicePaidDetails details)? invoicePaid,
+    TResult Function()? synced,
+    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
+    TResult Function(SwapInfo details)? swapUpdated,
+    required TResult orElse(),
+  }) {
+    if (reverseSwapUpdated != null) {
+      return reverseSwapUpdated(details);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(BreezEvent_NewBlock value) newBlock,
+    required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
+    required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
+    required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
+    required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
+  }) {
+    return reverseSwapUpdated(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(BreezEvent_NewBlock value)? newBlock,
+    TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
+    TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
+  }) {
+    return reverseSwapUpdated?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(BreezEvent_NewBlock value)? newBlock,
+    TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
+    TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
+    required TResult orElse(),
+  }) {
+    if (reverseSwapUpdated != null) {
+      return reverseSwapUpdated(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class BreezEvent_ReverseSwapUpdated implements BreezEvent {
+  const factory BreezEvent_ReverseSwapUpdated({required final ReverseSwapInfo details}) =
+      _$BreezEvent_ReverseSwapUpdatedImpl;
+
+  ReverseSwapInfo get details;
+  @JsonKey(ignore: true)
+  _$$BreezEvent_ReverseSwapUpdatedImplCopyWith<_$BreezEvent_ReverseSwapUpdatedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1828,6 +2065,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     required TResult Function() backupStarted,
     required TResult Function() backupSucceeded,
     required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(ReverseSwapInfo details) reverseSwapUpdated,
     required TResult Function(SwapInfo details) swapUpdated,
   }) {
     return swapUpdated(details);
@@ -1844,6 +2082,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult? Function()? backupStarted,
     TResult? Function()? backupSucceeded,
     TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult? Function(SwapInfo details)? swapUpdated,
   }) {
     return swapUpdated?.call(details);
@@ -1860,6 +2099,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult Function()? backupStarted,
     TResult Function()? backupSucceeded,
     TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(ReverseSwapInfo details)? reverseSwapUpdated,
     TResult Function(SwapInfo details)? swapUpdated,
     required TResult orElse(),
   }) {
@@ -1880,6 +2120,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
     required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
     required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_ReverseSwapUpdated value) reverseSwapUpdated,
     required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
   }) {
     return swapUpdated(this);
@@ -1896,6 +2137,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
   }) {
     return swapUpdated?.call(this);
@@ -1912,6 +2154,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
     TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
     TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_ReverseSwapUpdated value)? reverseSwapUpdated,
     TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
     required TResult orElse(),
   }) {

--- a/libs/sdk-flutter/makefile
+++ b/libs/sdk-flutter/makefile
@@ -26,12 +26,12 @@ ios: $(SOURCES) flutter_rust_bridge
 .PHONY: android
 android: $(SOURCES) flutter_rust_bridge
 	make -C ../sdk-bindings kotlin
-	mkdir -p ./android/src/main/jniLibs
-	cp -r ../sdk-bindings/ffi/kotlin/jniLibs/* ./android/src/main/jniLibs
-	mkdir -p ./android/src/main/kotlin/breez_sdk/
-	cp -r ../sdk-bindings/ffi/kotlin/breez_sdk/* ./android/src/main/kotlin/breez_sdk/
-	mkdir -p ./android/src/main/kotlin/breez_sdk_notification/
-	cp -r ../sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/* ./android/src/main/kotlin/breez_sdk_notification/
+	rm -rf android/src/main/jniLibs
+	rm -rf android/src/main/kotlin/breez_sdk
+	rm -rf android/src/main/kotlin/breez_sdk_notification
+	cp -r ../sdk-bindings/ffi/kotlin/jniLibs android/src/main/
+	cp -r ../sdk-bindings/ffi/kotlin/breez_sdk android/src/main/kotlin/
+	cp -r ../sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification android/src/main/kotlin/
 
 ## desktop: compiles for x86_64-unknown-linux-gnu by default, other targets can be specified
 ## with the TARGET variable eg. make desktop TARGET=aarch64-unknown-linux-gnu

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -3814,6 +3814,9 @@ fun asBreezEvent(breezEvent: ReadableMap): BreezEvent? {
     if (type == "backupFailed") {
         return BreezEvent.BackupFailed(breezEvent.getMap("details")?.let { asBackupFailedData(it) }!!)
     }
+    if (type == "reverseSwapUpdated") {
+        return BreezEvent.ReverseSwapUpdated(breezEvent.getMap("details")?.let { asReverseSwapInfo(it) }!!)
+    }
     if (type == "swapUpdated") {
         return BreezEvent.SwapUpdated(breezEvent.getMap("details")?.let { asSwapInfo(it) }!!)
     }
@@ -3850,6 +3853,10 @@ fun readableMapOf(breezEvent: BreezEvent): ReadableMap? {
         }
         is BreezEvent.BackupFailed -> {
             pushToMap(map, "type", "backupFailed")
+            pushToMap(map, "details", readableMapOf(breezEvent.details))
+        }
+        is BreezEvent.ReverseSwapUpdated -> {
+            pushToMap(map, "type", "reverseSwapUpdated")
             pushToMap(map, "details", readableMapOf(breezEvent.details))
         }
         is BreezEvent.SwapUpdated -> {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -825,6 +825,21 @@ class BreezSDKModule(
     }
 
     @ReactMethod
+    fun processReverseSwap(
+        lockupAddress: String,
+        promise: Promise,
+    ) {
+        executor.execute {
+            try {
+                getBreezServices().processReverseSwap(lockupAddress)
+                promise.resolve(readableMapOf("status" to "ok"))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun maxReverseSwapAmount(promise: Promise) {
         executor.execute {
             try {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -825,13 +825,13 @@ class BreezSDKModule(
     }
 
     @ReactMethod
-    fun processReverseSwap(
+    fun claimReverseSwap(
         lockupAddress: String,
         promise: Promise,
     ) {
         executor.execute {
             try {
-                getBreezServices().processReverseSwap(lockupAddress)
+                getBreezServices().claimReverseSwap(lockupAddress)
                 promise.resolve(readableMapOf("status" to "ok"))
             } catch (e: Exception) {
                 promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -4335,6 +4335,14 @@ enum BreezSDKMapper {
 
             return BreezEvent.backupFailed(details: _details)
         }
+        if type == "reverseSwapUpdated" {
+            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
+            }
+            let _details = try asReverseSwapInfo(reverseSwapInfo: detailsTmp)
+
+            return BreezEvent.reverseSwapUpdated(details: _details)
+        }
         if type == "swapUpdated" {
             guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
@@ -4402,6 +4410,14 @@ enum BreezSDKMapper {
             return [
                 "type": "backupFailed",
                 "details": dictionaryOf(backupFailedData: details),
+            ]
+
+        case let .reverseSwapUpdated(
+            details
+        ):
+            return [
+                "type": "reverseSwapUpdated",
+                "details": dictionaryOf(reverseSwapInfo: details),
             ]
 
         case let .swapUpdated(

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -289,6 +289,12 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    processReverseSwap: (NSString*)lockupAddress
+    resolve: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     maxReverseSwapAmount: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -289,7 +289,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    processReverseSwap: (NSString*)lockupAddress
+    claimReverseSwap: (NSString*)lockupAddress
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -617,6 +617,16 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
+    @objc(processReverseSwap:resolve:reject:)
+    func processReverseSwap(_ lockupAddress: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            try getBreezServices().processReverseSwap(lockupAddress: lockupAddress)
+            resolve(["status": "ok"])
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(maxReverseSwapAmount:reject:)
     func maxReverseSwapAmount(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -617,10 +617,10 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
-    @objc(processReverseSwap:resolve:reject:)
-    func processReverseSwap(_ lockupAddress: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(claimReverseSwap:resolve:reject:)
+    func claimReverseSwap(_ lockupAddress: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
-            try getBreezServices().processReverseSwap(lockupAddress: lockupAddress)
+            try getBreezServices().claimReverseSwap(lockupAddress: lockupAddress)
             resolve(["status": "ok"])
         } catch let err {
             rejectErr(err: err, reject: reject)

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -1098,8 +1098,8 @@ export const inProgressReverseSwaps = async (): Promise<ReverseSwapInfo[]> => {
     return response
 }
 
-export const processReverseSwap = async (lockupAddress: string): Promise<void> => {
-    await BreezSDK.processReverseSwap(lockupAddress)
+export const claimReverseSwap = async (lockupAddress: string): Promise<void> => {
+    await BreezSDK.claimReverseSwap(lockupAddress)
 }
 
 export const maxReverseSwapAmount = async (): Promise<MaxReverseSwapAmountResponse> => {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -603,6 +603,7 @@ export enum BreezEventVariant {
     BACKUP_STARTED = "backupStarted",
     BACKUP_SUCCEEDED = "backupSucceeded",
     BACKUP_FAILED = "backupFailed",
+    REVERSE_SWAP_UPDATED = "reverseSwapUpdated",
     SWAP_UPDATED = "swapUpdated"
 }
 
@@ -627,6 +628,9 @@ export type BreezEvent = {
 } | {
     type: BreezEventVariant.BACKUP_FAILED,
     details: BackupFailedData
+} | {
+    type: BreezEventVariant.REVERSE_SWAP_UPDATED,
+    details: ReverseSwapInfo
 } | {
     type: BreezEventVariant.SWAP_UPDATED,
     details: SwapInfo
@@ -1092,6 +1096,10 @@ export const inProgressOnchainPayments = async (): Promise<ReverseSwapInfo[]> =>
 export const inProgressReverseSwaps = async (): Promise<ReverseSwapInfo[]> => {
     const response = await BreezSDK.inProgressReverseSwaps()
     return response
+}
+
+export const processReverseSwap = async (lockupAddress: string): Promise<void> => {
+    await BreezSDK.processReverseSwap(lockupAddress)
 }
 
 export const maxReverseSwapAmount = async (): Promise<MaxReverseSwapAmountResponse> => {


### PR DESCRIPTION
This PR adds background processing of the reverse swap flow using webhooks:

- [x] Register a reverse swap lockup address for notifications
- [x] Add `process_reverse_swap` method to handle processing an individual reverse swap by address
- [x] Adapt notification plugin handling for the push notification
- [x] Add ReverseSwapUpdated event

Fixes #924