### PR TITLE
Only consider pending_timeout_sec if it is set

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -328,33 +328,23 @@ impl BreezServices {
                 self.notify_event_listeners(BreezEvent::payment_started(pending_payment.clone()))
                     .await?;
 
-                let pending_timeout_sec = req.pending_timeout_sec.unwrap_or(u64::MAX);
-                let (tx, rx) = std::sync::mpsc::channel();
-                let cloned = self.clone();
-                tokio::spawn(async move {
-                    let payment_res = cloned
+                tokio::select! {
+                    payment_res = self
                         .node_api
-                        .send_payment(
-                            parsed_invoice.bolt11.clone(),
-                            req.amount_msat,
-                            req.label.clone(),
-                        )
-                        .map_err(Into::into)
-                        .await;
-                    let result = cloned
-                        .on_payment_completed(
-                            parsed_invoice.payee_pubkey.clone(),
-                            Some(parsed_invoice),
-                            req.label,
-                            payment_res,
-                        )
-                        .await;
-                    let _ = tx.send(result);
-                });
-
-                match rx.recv_timeout(Duration::from_secs(pending_timeout_sec)) {
-                    Ok(result) => result.map(SendPaymentResponse::from_payment),
-                    Err(_) => Ok(SendPaymentResponse::from_payment(pending_payment)),
+                        .send_payment(parsed_invoice.bolt11.clone(), req.amount_msat, req.label.clone())
+                        .map_err(Into::into) =>
+                    {
+                        let payee_pk = parsed_invoice.payee_pubkey.clone();
+                        self
+                            .on_payment_completed(payee_pk, Some(parsed_invoice), req.label, payment_res)
+                            .await
+                            .map(SendPaymentResponse::from_payment)
+                    },
+                    _ = tokio::time::sleep(Duration::from_secs(req.pending_timeout_sec.unwrap_or(u64::MAX))),
+                            if req.pending_timeout_sec.is_some() =>
+                    {
+                        Ok(SendPaymentResponse::from_payment(pending_payment))
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR uses `tokio::select` with a conditional `tokio::sleep`, which allows us to conditionally sleep.

If `pending_timeout_sec` is set, the first of `send_payment`, `sleep` will return. So if the timeout occurs first, the method will return.

If `pending_timeout_sec` is not set, it will only execute `send_payment`, because the second branch of `tokio::select` is ignored.