### PR TITLE
add error source to tonic errors for more detail

### DIFF
--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -568,7 +568,7 @@ impl From<serde_json::Error> for SdkError {
 impl From<tonic::transport::Error> for SdkError {
     fn from(err: tonic::transport::Error) -> Self {
         Self::ServiceConnectivity {
-            err: err.to_string(),
+            err: crate::tonic_wrap::TransportError(err).to_string(),
         }
     }
 }
@@ -576,7 +576,7 @@ impl From<tonic::transport::Error> for SdkError {
 impl From<tonic::Status> for SdkError {
     fn from(err: tonic::Status) -> Self {
         Self::Generic {
-            err: err.to_string(),
+            err: crate::tonic_wrap::Status(err).to_string(),
         }
     }
 }

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -189,6 +189,7 @@ mod persist;
 mod support;
 mod swap_in;
 mod swap_out;
+mod tonic_wrap;
 
 // Re-use crates from gl_client for consistency
 use gl_client::bitcoin;

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -44,6 +44,6 @@ impl From<SdkError> for SwapError {
 
 impl From<tonic::Status> for SwapError {
     fn from(status: tonic::Status) -> Self {
-        Self::Generic(status.to_string())
+        Self::Generic(crate::tonic_wrap::Status(status).to_string())
     }
 }

--- a/libs/sdk-core/src/swap_out/error.rs
+++ b/libs/sdk-core/src/swap_out/error.rs
@@ -113,6 +113,6 @@ impl From<serde_json::Error> for ReverseSwapError {
 
 impl From<tonic::Status> for ReverseSwapError {
     fn from(err: tonic::Status) -> Self {
-        Self::Generic(err.to_string())
+        Self::Generic(crate::tonic_wrap::Status(err).to_string())
     }
 }

--- a/libs/sdk-core/src/tonic_wrap/mod.rs
+++ b/libs/sdk-core/src/tonic_wrap/mod.rs
@@ -1,0 +1,30 @@
+use std::{error::Error, fmt::Display};
+
+pub struct Status(pub tonic::Status);
+
+impl Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "status: {:?}, message: {:?}, details: {:?}, metadata: {:?}, source: {:?}",
+            self.0.code(),
+            self.0.message(),
+            self.0.details(),
+            self.0.metadata(),
+            self.0.source(),
+        )
+    }
+}
+
+pub struct TransportError(pub tonic::transport::Error);
+
+impl Display for TransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "description: {:?}, source: {:?}",
+            self.0.to_string(),
+            self.0.source(),
+        )
+    }
+}


### PR DESCRIPTION
Transport errors really don't mean much. But with a little more logging we may be able to distinguish some more types of transport errors. This PR logs the error 'source' for tonic errors, which is the underlying error that caused the tonic error.

Example, turning off WiFi during a call to receive_payment:

```
Error: Generic: status: Unknown, message: "transport error", details: [], metadata: MetadataMap { headers: {} }, source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Kind(AddrNotAvailable))))
```