### PR TITLE
CI: Add step to test if SDK compiles with latest dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,3 +273,56 @@ jobs:
 
       - name: dart-format
         run: dart format -o none --set-exit-if-changed -l 110 .
+
+  # Create a new plain Rust project, add the SDK as single dependency and try to compile it.
+  # This tests whether the SDK compiles with the latest version of the dependencies that can be updated.
+  #
+  # Our checked-in Cargo.lock contains the specific combination of all direct and transitive dependency versions.
+  # This dependency tree snapshot was tested against during development and is what we release.
+  #
+  # However, when integrating the SDK in a new Rust project, Cargo not use our Cargo.lock. Instead, it will try to generate
+  # a new Cargo.lock based on our (and our dependencies') Cargo.toml files. This means that, where a dependency version range
+  # is used in a Cargo.toml, Cargo will try to upgrade it to the latest matching version. If this happens, this new dependency
+  # version may even result in the whole project failing to compile. In that case, the only solution is to manually pin
+  # the problematic dependencies to the last known good versions, in the application's Cargo.toml.
+  #
+  # Since this is the situation new projects are faced with when adding the SDK as a Rust dependency, we simulate it here
+  # to get an early warning signal, should any newer dependency cause it to fail to compile.
+  #
+  # See discussion at https://github.com/breez/breez-sdk/issues/969#issuecomment-2104700522
+  check-sdk-as-dependency:
+    name: Check SDK as Rust dependency in fresh project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install rust
+        run: |
+          rustup set auto-self-update disable
+          rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            libs -> target
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.4"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: test-new-project-with-sdk-dependency
+        run: |
+          mkdir new-project
+          cd new-project
+          cargo init --name test_project --vcs none
+          
+          # A project might reference our SDK as a git repository
+          # cargo add --git https://github.com/breez/breez-sdk breez-sdk-core
+          
+          # In this test, we reference the checked out repo (e.g. this PR branch)
+          cargo add --path ../libs/sdk-core breez-sdk-core
+          
+          cargo clippy -- -D warnings

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1340,7 +1340,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=e38a37613da7558c853f24be700c193f194a6bc9#e38a37613da7558c853f24be700c193f194a6bc9"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=16fa13d40f4fc271cf99febf3f40246b6b23716a#16fa13d40f4fc271cf99febf3f40246b6b23716a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -16,7 +16,7 @@ hex = { workspace = true }
 # The switch to 0.2 will happen with https://github.com/breez/breez-sdk/pull/724
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "e38a37613da7558c853f24be700c193f194a6bc9" }
+], rev = "16fa13d40f4fc271cf99febf3f40246b6b23716a" }
 zbase32 = "0.1.2"
 base64 = { workspace = true }
 chrono = "0.4"

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=e38a37613da7558c853f24be700c193f194a6bc9#e38a37613da7558c853f24be700c193f194a6bc9"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=16fa13d40f4fc271cf99febf3f40246b6b23716a#16fa13d40f4fc271cf99febf3f40246b6b23716a"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
This PR adds a new CI step that creates a new plain Rust project, adds the SDK as single dependency and tries to compile it. This tests whether the SDK compiles with the latest version of the dependencies that can be updated.

TLDR: When this CI step fails, it's an early warning signal that allows us to become aware of and solve issues such as

- #584
- #969
- #1010 

before customers report them.

---

Our checked-in Cargo.lock contains the specific combination of all direct and transitive dependency versions. This dependency tree snapshot was tested against during development and is what we release.

However, when integrating the SDK in a new Rust project, Cargo not use our Cargo.lock. Instead, it will try to generate a new Cargo.lock based on our (and our dependencies') Cargo.toml files. This means that, where a dependency version range is used in a Cargo.toml, Cargo will try to upgrade it to the latest matching version. If this happens, this new dependency version may even result in the whole project failing to compile. In that case, the only solution is to manually pin the problematic dependencies to the last known good versions, in the application's Cargo.toml.

Since this is the situation new projects are faced with when adding the SDK as a Rust dependency, we simulate it here to get an early warning signal, should any newer dependency cause it to fail to compile.

See discussion at https://github.com/breez/breez-sdk/issues/969#issuecomment-2104700522