### PR TITLE
Update Android build clang to 17

### DIFF
--- a/libs/sdk-bindings/build.rs
+++ b/libs/sdk-bindings/build.rs
@@ -2,7 +2,7 @@ use anyhow::*;
 use std::env;
 use std::path::Path;
 
-const DEFAULT_CLANG_VERSION: &str = "14.0.7";
+const DEFAULT_CLANG_VERSION: &str = "17";
 
 /// Adds a temporary workaround for an issue with the Rust compiler and Android
 /// in x86_64 devices: https://github.com/rust-lang/rust/issues/109717.
@@ -23,14 +23,14 @@ fn setup_x86_64_android_workaround() {
         let clang_version =
             env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
         let linux_x86_64_lib_dir = format!(
-            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
+            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib/clang/{clang_version}/lib/linux/"
         );
         let linkpath = format!("{android_ndk_home}/{linux_x86_64_lib_dir}");
         if Path::new(&linkpath).exists() {
             println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
             println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
         } else {
-            panic!("Path {linkpath} not exists");
+            panic!("Path {linkpath} not exists. Try setting the NDK_CLANG_VERSION environment variable.");
         }
     }
 }


### PR DESCRIPTION
This PR updates the clang version used to build android libraries to 17