### PR TITLE
Document deprecated methods with `deprecated` macro

### DIFF
--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -325,10 +325,12 @@ impl BlockingBreezServices {
     }
 
     pub fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
+        #[allow(deprecated)]
         rt().block_on(self.breez_services.in_progress_reverse_swaps())
     }
 
     pub fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
+        #[allow(deprecated)]
         rt().block_on(self.breez_services.max_reverse_swap_amount())
     }
 
@@ -336,6 +338,7 @@ impl BlockingBreezServices {
         &self,
         req: SendOnchainRequest,
     ) -> Result<SendOnchainResponse, SendOnchainError> {
+        #[allow(deprecated)]
         rt().block_on(self.breez_services.send_onchain(req))
     }
 

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -367,12 +367,14 @@ pub fn list_fiat_currencies() -> Result<Vec<FiatCurrency>> {
 
 /// See [BreezServices::max_reverse_swap_amount]
 pub fn max_reverse_swap_amount() -> Result<MaxReverseSwapAmountResponse> {
+    #[allow(deprecated)]
     block_on(async { get_breez_services().await?.max_reverse_swap_amount().await })
         .map_err(anyhow::Error::new::<SdkError>)
 }
 
 /// See [BreezServices::send_onchain]
 pub fn send_onchain(req: SendOnchainRequest) -> Result<SendOnchainResponse> {
+    #[allow(deprecated)]
     block_on(async { get_breez_services().await?.send_onchain(req).await })
         .map_err(anyhow::Error::new::<SendOnchainError>)
 }
@@ -456,6 +458,7 @@ pub fn in_progress_swap() -> Result<Option<SwapInfo>> {
 
 /// See [BreezServices::in_progress_reverse_swaps]
 pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
+    #[allow(deprecated)]
     block_on(async {
         get_breez_services()
             .await?

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -854,8 +854,7 @@ impl BreezServices {
     /// minus the expected fees.
     /// This is possible since the route to the swapper node is known in advance and is expected
     /// to consist of maximum 3 hops.
-    ///
-    /// Deprecated. Please use [BreezServices::onchain_payment_limits] instead.
+    #[deprecated(note = "use onchain_payment_limits instead")]
     pub async fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
         // fetch the last hop hints from the swapper
         let last_hop = self.btc_send_swapper.last_hop_for_payment().await?;
@@ -883,8 +882,7 @@ impl BreezServices {
     }
 
     /// Creates a reverse swap and attempts to pay the HODL invoice
-    ///
-    /// Deprecated. Please use [BreezServices::pay_onchain] instead.
+    #[deprecated(note = "use pay_onchain instead")]
     pub async fn send_onchain(
         &self,
         req: SendOnchainRequest,
@@ -896,8 +894,7 @@ impl BreezServices {
     }
 
     /// Returns the blocking [ReverseSwapInfo]s that are in progress
-    ///
-    /// Deprecated. Please use [BreezServices::in_progress_onchain_payments] instead.
+    #[deprecated(note = "use in_progress_onchain_payments instead")]
     pub async fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
         let full_rsis = self.btc_send_swapper.list_blocking().await?;
 
@@ -939,6 +936,7 @@ impl BreezServices {
     pub async fn onchain_payment_limits(&self) -> SdkResult<OnchainPaymentLimitsResponse> {
         let fee_info = self.btc_send_swapper.fetch_reverse_swap_fees().await?;
         debug!("Reverse swap pair info: {fee_info:?}");
+        #[allow(deprecated)]
         let max_amt_current_channels = self.max_reverse_swap_amount().await?;
         debug!("Max send amount possible with current channels: {max_amt_current_channels:?}");
 
@@ -1030,7 +1028,7 @@ impl BreezServices {
     }
 
     async fn pay_onchain_common(&self, req: CreateReverseSwapArg) -> SdkResult<ReverseSwapInfo> {
-        ensure_sdk!(self.in_progress_reverse_swaps().await?.is_empty(), SdkError::Generic { err:
+        ensure_sdk!(self.in_progress_onchain_payments().await?.is_empty(), SdkError::Generic { err:
             "You can only start a new one after after the ongoing ones finish. \
             Use the in_progress_reverse_swaps method to get an overview of currently ongoing reverse swaps".into(),
         });
@@ -1050,6 +1048,7 @@ impl BreezServices {
     ///
     /// Supersedes [BreezServices::in_progress_reverse_swaps]
     pub async fn in_progress_onchain_payments(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
+        #[allow(deprecated)]
         self.in_progress_reverse_swaps().await
     }
 

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -42,7 +42,7 @@ struct CliEventListener {}
 
 impl EventListener for CliEventListener {
     fn on_event(&self, e: BreezEvent) {
-        info!("Received Breez event: {:?}", e);
+        info!("Received Breez event: {e:?}");
     }
 }
 
@@ -83,7 +83,7 @@ pub(crate) async fn handle_command(
             let mut config = persistence.get_or_create_config()?;
             config.env = env.clone();
             persistence.save_config(config)?;
-            Ok(format!("Environment was set to {:?}", env))
+            Ok(format!("Environment was set to {env:?}"))
         }
         Commands::Connect {
             partner_cert,
@@ -159,6 +159,7 @@ pub(crate) async fn handle_command(
                 .await
                 .map_err(|e| anyhow!("Failed to fetch reverse swap fee infos: {e}"))?;
 
+            #[allow(deprecated)]
             let rev_swap_res = sdk()?
                 .send_onchain(SendOnchainRequest {
                     amount_sat,
@@ -170,6 +171,7 @@ pub(crate) async fn handle_command(
             serde_json::to_string_pretty(&rev_swap_res.reverse_swap_info).map_err(|e| e.into())
         }
         Commands::MaxReverseSwapAmount {} => {
+            #[allow(deprecated)]
             let response = sdk()?.max_reverse_swap_amount().await?;
             serde_json::to_string_pretty(&response).map_err(|e| e.into())
         }
@@ -231,7 +233,7 @@ pub(crate) async fn handle_command(
         }
         Commands::InProgressReverseSwaps {} => {
             let mut res: Vec<String> = vec![];
-            for rsi in &sdk()?.in_progress_reverse_swaps().await? {
+            for rsi in &sdk()?.in_progress_onchain_payments().await? {
                 res.push(format!(
                     "Reverse swap {} is in progress with status {:?}",
                     rsi.id, rsi.status
@@ -390,7 +392,7 @@ pub(crate) async fn handle_command(
         }
         Commands::CloseLSPChannels {} => {
             let tx_ids = sdk()?.close_lsp_channels().await?;
-            Ok(format!("Closing transaction ids:\n{:?}", tx_ids))
+            Ok(format!("Closing transaction ids:\n{tx_ids:?}"))
         }
         Commands::Disconnect {} => {
             sdk()?.disconnect().await?;
@@ -498,8 +500,7 @@ pub(crate) async fn handle_command(
                     let user_input_min_msat = 2_001_000;
 
                     if user_input_max_msat < user_input_min_msat {
-                        error!("The LNURLw endpoint needs to accept at least {} msat, but min / max withdrawable are {} msat / {} msat",
-                            user_input_min_msat,
+                        error!("The LNURLw endpoint needs to accept at least {user_input_min_msat} msat, but min / max withdrawable are {} msat / {} msat",
                             wd.min_withdrawable,
                             wd.max_withdrawable
                         );
@@ -507,8 +508,7 @@ pub(crate) async fn handle_command(
                     }
 
                     let prompt = format!(
-                        "Amount to withdraw in msat (min {} msat, max {} msat: ",
-                        user_input_min_msat, user_input_max_msat,
+                        "Amount to withdraw in msat (min {user_input_min_msat} msat, max {user_input_max_msat} msat: "
                     );
                     let user_input_withdraw_amount_msat = rl.readline(&prompt)?;
 
@@ -574,7 +574,7 @@ pub(crate) async fn handle_command(
                     opening_fee_params: None,
                 })
                 .await?;
-            Ok(format!("Here your {:?} url: {}", provider, res.url))
+            Ok(format!("Here your {provider:?} url: {}", res.url))
         }
         Commands::Backup {} => {
             sdk().unwrap().backup().await?;
@@ -590,7 +590,7 @@ pub(crate) async fn handle_command(
             match backup_data.backup {
                 Some(backup) => {
                     let backup_str = serde_json::to_string_pretty(&backup)?;
-                    Ok(format!("Static backup data:\n{}", backup_str))
+                    Ok(format!("Static backup data:\n{backup_str}"))
                 }
                 None => Ok("No static backup data".into()),
             }


### PR DESCRIPTION
Rust compiler will issue a warning in case of usage of such method what helps spot the change.