### PR TITLE
Allow HTTP status code check in GET response parsing

### DIFF
--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -337,20 +337,20 @@ impl MempoolSpace {
 #[tonic::async_trait]
 impl ChainService for MempoolSpace {
     async fn recommended_fees(&self) -> SdkResult<RecommendedFees> {
-        get_parse_and_log_response(&format!("{}/v1/fees/recommended", self.base_url)).await
+        get_parse_and_log_response(&format!("{}/v1/fees/recommended", self.base_url), true).await
     }
 
     async fn address_transactions(&self, address: String) -> SdkResult<Vec<OnchainTx>> {
-        get_parse_and_log_response(&format!("{}/address/{address}/txs", self.base_url)).await
+        get_parse_and_log_response(&format!("{}/address/{address}/txs", self.base_url), true).await
     }
 
     async fn current_tip(&self) -> SdkResult<u32> {
-        get_parse_and_log_response(&format!("{}/blocks/tip/height", self.base_url)).await
+        get_parse_and_log_response(&format!("{}/blocks/tip/height", self.base_url), true).await
     }
 
     async fn transaction_outspends(&self, txid: String) -> SdkResult<Vec<Outspend>> {
         let url = format!("{}/tx/{txid}/outspends", self.base_url);
-        get_parse_and_log_response(&url).await
+        get_parse_and_log_response(&url, true).await
     }
 
     async fn broadcast_transaction(&self, tx: Vec<u8>) -> SdkResult<String> {

--- a/libs/sdk-core/src/input_parser.rs
+++ b/libs/sdk-core/src/input_parser.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use bip21::Uri;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -214,7 +215,7 @@ pub async fn parse(input: &str) -> Result<InputType> {
         }
 
         lnurl_endpoint = maybe_replace_host_with_mockito_test_host(lnurl_endpoint)?;
-        let lnurl_data: LnUrlRequestData = get_parse_and_log_response(&lnurl_endpoint)
+        let lnurl_data: LnUrlRequestData = get_parse_and_log_response(&lnurl_endpoint, false)
             .await
             .map_err(|_| anyhow!("Failed to parse response"))?;
         let temp = lnurl_data.into();
@@ -258,7 +259,8 @@ pub(crate) async fn post_and_log_response(url: &str, body: Option<String>) -> Sd
 /// Makes a GET request to the specified `url` and logs on DEBUG:
 /// - the URL
 /// - the raw response body
-pub(crate) async fn get_and_log_response(url: &str) -> SdkResult<String> {
+/// - the response HTTP status code
+pub(crate) async fn get_and_log_response(url: &str) -> SdkResult<(String, StatusCode)> {
     debug!("Making GET request to: {url}");
 
     let response = get_reqwest_client()?
@@ -266,31 +268,42 @@ pub(crate) async fn get_and_log_response(url: &str) -> SdkResult<String> {
         .send()
         .await
         .map_err(|e| SdkError::ServiceConnectivity { err: e.to_string() })?;
-    match response.status().is_success() {
-        true => response
-            .text()
-            .await
-            .map_err(|e| SdkError::ServiceConnectivity { err: e.to_string() }),
-        false => {
-            let err = format!(
-                "GET request {} failed with status: {}",
-                url,
-                response.status()
-            );
-            error!("{err}");
-            Err(SdkError::ServiceConnectivity { err })
-        }
-    }
+    let status = response.status();
+    let raw_body = response
+        .text()
+        .await
+        .map_err(|e| SdkError::ServiceConnectivity { err: e.to_string() })?;
+    debug!("Received response, status: {status}, raw response body: {raw_body}");
+
+    Ok((raw_body, status))
 }
 
-/// Wrapper around [get_and_log_response] that, in addition, parses the payload into an expected type
-pub(crate) async fn get_parse_and_log_response<T>(url: &str) -> SdkResult<T>
+/// Wrapper around [get_and_log_response] that, in addition, parses the payload into an expected type.
+///
+/// ### Arguments
+///
+/// - `url`: the URL on which GET will be called
+/// - `enforce_status_check`: if true, the HTTP status code is checked in addition to trying to
+/// parse the payload. In this case, an HTTP error code will automatically cause this function to
+/// return `Err`, regardless of the payload. If false, the result type will be determined only
+/// by the result of parsing the payload into the desired target type.
+pub(crate) async fn get_parse_and_log_response<T>(
+    url: &str,
+    enforce_status_check: bool,
+) -> SdkResult<T>
 where
     for<'a> T: serde::de::Deserialize<'a>,
 {
-    let raw_body = get_and_log_response(url).await?;
+    let (raw_body, status) = get_and_log_response(url).await?;
+    let parse_res = serde_json::from_str::<T>(&raw_body);
 
-    Ok(serde_json::from_str(&raw_body)?)
+    if enforce_status_check && !status.is_success() {
+        let err = format!("GET request {url} failed with status: {status}");
+        error!("{err}");
+        return Err(SdkError::ServiceConnectivity { err });
+    }
+
+    parse_res.map_err(Into::into)
 }
 
 /// Prepends the given prefix to the input, if the input doesn't already start with it

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -39,7 +39,7 @@ pub(crate) async fn perform_lnurl_auth(
         .query_pairs_mut()
         .append_pair("key", &linking_keys.public_key().to_hex());
 
-    get_parse_and_log_response(callback_url.as_ref())
+    get_parse_and_log_response(callback_url.as_ref(), false)
         .await
         .map_err(|e| LnUrlError::ServiceConnectivity(e.to_string()))
 }

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -29,7 +29,7 @@ pub(crate) async fn validate_lnurl_pay(
     )?;
 
     let callback_url = build_pay_callback_url(user_amount_msat, comment, req_data)?;
-    let callback_resp_text = get_and_log_response(&callback_url)
+    let (callback_resp_text, _) = get_and_log_response(&callback_url)
         .await
         .map_err(|e| LnUrlError::ServiceConnectivity(e.to_string()))?;
 

--- a/libs/sdk-core/src/lnurl/withdraw.rs
+++ b/libs/sdk-core/src/lnurl/withdraw.rs
@@ -38,7 +38,7 @@ pub(crate) async fn validate_lnurl_withdraw(
 
     // Send invoice to the LNURL-w endpoint via the callback
     let callback_url = build_withdraw_callback_url(&req_data, &invoice)?;
-    let callback_res: LnUrlCallbackStatus = get_parse_and_log_response(&callback_url)
+    let callback_res: LnUrlCallbackStatus = get_parse_and_log_response(&callback_url, false)
         .await
         .map_err(|e| LnUrlError::ServiceConnectivity(e.to_string()))?;
     let withdraw_status = match callback_res {

--- a/libs/sdk-core/src/swap_out/boltzswap.rs
+++ b/libs/sdk-core/src/swap_out/boltzswap.rs
@@ -340,7 +340,7 @@ impl ReverseSwapServiceAPI for BoltzApi {
 }
 
 pub async fn reverse_swap_pair_info() -> ReverseSwapResult<ReverseSwapPairInfo> {
-    let pairs: Pairs = get_parse_and_log_response(GET_PAIRS_ENDPOINT).await?;
+    let pairs: Pairs = get_parse_and_log_response(GET_PAIRS_ENDPOINT, true).await?;
     match pairs.pairs.get("BTC/BTC") {
         None => Err(ReverseSwapError::generic("BTC pair not found")),
         Some(btc_pair) => {


### PR DESCRIPTION
We want to support two kinds of GET response parsing:
- first, where an error HTTP status code results automatically in `Err` (mempool.space, boltz API)
- second, where the HTTP status code is not checked, but we attempt to parse the payload into possibly an error payload (LNURL)

This PR adds support for the first type, in addition to the second which was already supported.