### PR TITLE
fix balance update after receiving payments

### DIFF
--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -88,7 +88,7 @@ pub trait NodeAPI: Send + Sync {
     async fn pull_changed(
         &self,
         since_timestamp: u64,
-        balance_changed: bool,
+        match_local_balance: bool,
     ) -> NodeResult<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_msat` is only needed when the invoice doesn't specify an amount
     async fn send_payment(


### PR DESCRIPTION
fixes #992 

This turns out to be a regression by this: https://github.com/breez/breez-sdk/pull/858
Due to the way lighting works, when the node settle the invoice (and release the preimage) which triggers the invoice paid event the channels balance is not yet updated with the last received amount.
the node actually waits for the last htlc revocation which causes the delay.
Historically we applied a work around for this case to keep polling for the balance until it is changed compare to the local balance which ensured we end up with the changed amount included.
The PR above has changed the behavior to include the received amount in the local balance before we sync (so it will be consistent with the new received payment) and as a result it caused the opposite of what we wanted to achieve with the work around since the wrong balance was different than the local correct balance causing the polling to stop.

The fix is to actually poll until the balance matches the local balance at which point we know the channels states are up to date.
This is only needed in receiving payment so I also removed this work around from the sync after sending payments.