### PR TITLE
log reason for invoice wrapping failure

### DIFF
--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -512,8 +512,8 @@ impl BTCReceiveSwap {
                                         None => None,
                                     },
                                     None,
-                                ).await.map_err(|_|anyhow!(
-                                    "Preimage already known, invoice found, failed to ensure route hint"
+                                ).await.map_err(|e|anyhow!(
+                                    "Preimage already known, invoice found, failed to ensure route hint: {:?}", e
                                 ))?
                             }
                         }


### PR DESCRIPTION
There was a case where the preimage was already on the node, but wrapping the invoice fails. The logs don't contain the reason for failure wrapping the invoice. They contain `Preimage already known, invoice found, failed to ensure route hint`. This PR adds the failure reason to the logs.