### PR TITLE
Bump GL dependency

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1340,7 +1340,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=e38a37613da7558c853f24be700c193f194a6bc9#e38a37613da7558c853f24be700c193f194a6bc9"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=16fa13d40f4fc271cf99febf3f40246b6b23716a#16fa13d40f4fc271cf99febf3f40246b6b23716a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -16,7 +16,7 @@ hex = { workspace = true }
 # The switch to 0.2 will happen with https://github.com/breez/breez-sdk/pull/724
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "e38a37613da7558c853f24be700c193f194a6bc9" }
+], rev = "16fa13d40f4fc271cf99febf3f40246b6b23716a" }
 zbase32 = "0.1.2"
 base64 = { workspace = true }
 chrono = "0.4"

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=e38a37613da7558c853f24be700c193f194a6bc9#e38a37613da7558c853f24be700c193f194a6bc9"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=16fa13d40f4fc271cf99febf3f40246b6b23716a#16fa13d40f4fc271cf99febf3f40246b6b23716a"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Fixes #1010

GL restricted the semantic version of `cln-grpc` one commit after the one we were using.

Therefore, this PR bumps `gl-client` to the commit that brings in this change: https://github.com/Blockstream/greenlight/commit/16fa13d40f4fc271cf99febf3f40246b6b23716a