### PR TITLE
`sdk-common`: remove `rusqlite` dependency

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2801,7 +2801,6 @@ dependencies = [
  "querystring",
  "regex",
  "reqwest",
- "rusqlite",
  "serde",
  "serde_json",
  "strum_macros",

--- a/libs/sdk-common/Cargo.toml
+++ b/libs/sdk-common/Cargo.toml
@@ -18,7 +18,6 @@ querystring = "1"
 prost = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
-rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum_macros = { workspace = true }

--- a/libs/sdk-common/src/lnurl/specs/pay.rs
+++ b/libs/sdk-common/src/lnurl/specs/pay.rs
@@ -113,14 +113,11 @@ pub fn validate_invoice(user_amount_msat: u64, bolt11: &str, network: Network) -
 pub mod model {
     use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
     use anyhow::Result;
-    use rusqlite::types::{FromSql, FromSqlError, ToSqlOutput};
-    use rusqlite::ToSql;
     use serde::{Deserialize, Serialize};
     use thiserror::Error;
 
     use crate::prelude::specs::pay::{Aes256CbcDec, Aes256CbcEnc};
     use crate::prelude::*;
-    // use crate::Payment;
 
     /// Represents a LNURL-pay request.
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -216,22 +213,6 @@ pub mod model {
 
         /// See [SuccessAction::Url]
         Url { data: UrlSuccessActionData },
-    }
-
-    impl FromSql for SuccessActionProcessed {
-        fn column_result(
-            value: rusqlite::types::ValueRef<'_>,
-        ) -> rusqlite::types::FromSqlResult<Self> {
-            serde_json::from_str(value.as_str()?).map_err(|_| FromSqlError::InvalidType)
-        }
-    }
-
-    impl ToSql for SuccessActionProcessed {
-        fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-            Ok(ToSqlOutput::from(
-                serde_json::to_string(&self).map_err(|_| FromSqlError::InvalidType)?,
-            ))
-        }
     }
 
     /// Supported success action types

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
+use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, Type, ValueRef};
 use rusqlite::Row;
 use rusqlite::{named_params, params, OptionalExtension};
 use sdk_common::prelude::*;
@@ -96,7 +96,7 @@ impl SqliteStorage {
 
         _ = prep_statement.execute((
             payment_hash,
-            payment_external_info.lnurl_pay_success_action,
+            serde_json::to_string(&payment_external_info.lnurl_pay_success_action)?,
             payment_external_info.lnurl_pay_domain,
             payment_external_info.lnurl_pay_comment,
             payment_external_info.lnurl_metadata,
@@ -379,7 +379,14 @@ impl SqliteStorage {
         };
 
         if let PaymentDetails::Ln { ref mut data } = payment.details {
-            data.lnurl_success_action = row.get(8)?;
+            let lnurl_success_action_str: Option<String> = row.get(8)?;
+            data.lnurl_success_action = match lnurl_success_action_str {
+                None => None,
+                Some(s) => serde_json::from_str(&s).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(8, Type::Text, Box::new(e))
+                })?,
+            };
+
             data.lnurl_pay_domain = row.get(17)?;
             data.lnurl_pay_comment = row.get(18)?;
             data.lnurl_metadata = row.get(9)?;


### PR DESCRIPTION
This PR removes `rusqlite` as a dependency from `sdk-common`, which is a pre-requisite for https://github.com/breez/breez-liquid-sdk/pull/308 .