### PR TITLE
use `to_us_msat` for `pending_onchain_balance`

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -551,7 +551,7 @@ impl Greenlight {
     ) -> Result<u64> {
         let pending_onchain_balance = peer_channels.iter().fold(0, |a, b| match b.state() {
             ChanneldShuttingDown | ClosingdSigexchange | ClosingdComplete | AwaitingUnilateral
-            | FundingSpendSeen => a + b.min_to_us_msat.clone().unwrap_or_default().msat,
+            | FundingSpendSeen => a + b.to_us_msat.clone().unwrap_or_default().msat,
 
             // When we  unilaterally close the channel it will get status as `AwaitingUnilateral`
             // first, but when the closing transaction is confirmed onchain the funds receive status
@@ -563,7 +563,7 @@ impl Greenlight {
                         .last()
                         .is_some_and(|status| status.contains("DELAYED_OUTPUT_TO_US"))
                 {
-                    a + b.min_to_us_msat.clone().unwrap_or_default().msat
+                    a + b.to_us_msat.clone().unwrap_or_default().msat
                 } else {
                     a
                 }


### PR DESCRIPTION
Previously `pending_onchain_balance` was defined by `min_to_us_msat`. However, it confused users, because it appears that the funds were gone while eventually they would resolve to the user. Theoretically the peer could steal the difference between `to_us_msat` and `min_to_us_msat`, but since this scenario is highly unlikely given we have a watchtower and/or the node will come online every week or so. So use `to_us_msat` instead, which should reflect the real balance the user is receiving in 99.99% of the scenarios.