### PR TITLE
Extract Breez Server URLs to `sdk-common`

### DIFF
--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -16,6 +16,9 @@ use crate::grpc::swapper_client::SwapperClient;
 use crate::grpc::{ChainApiServersRequest, PingRequest};
 use crate::prelude::ServiceConnectivityError;
 
+pub static PRODUCTION_BREEZSERVER_URL: &str = "https://bs1.breez.technology:443";
+pub static STAGING_BREEZSERVER_URL: &str = "https://bs1-st.breez.technology:443";
+
 pub struct BreezServer {
     grpc_channel: Channel,
     api_key: Option<String>,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -479,9 +479,6 @@ pub struct Config {
     pub node_config: NodeConfig,
 }
 
-pub(crate) static PRODUCTION_BREEZSERVER_URL: &str = "https://bs1.breez.technology:443";
-pub(crate) static STAGING_BREEZSERVER_URL: &str = "https://bs1-st.breez.technology:443";
-
 impl Config {
     pub fn production(api_key: String, node_config: NodeConfig) -> Self {
         Config {


### PR DESCRIPTION
This allows other projects, like Liquid SDK, to reference them without hardcoding the URL.