### PR TITLE
Wait for channel to be swept before marking as closed

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -2188,7 +2188,6 @@ impl From<cln::ListpeersPeersChannels> for Channel {
                 ChannelState::PendingOpen
             }
             ChanneldNormal => ChannelState::Opened,
-            Onchain => ChannelState::Closed,
             _ => ChannelState::PendingClose,
         };
 

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -2435,7 +2435,7 @@ mod tests {
         }
 
         let c: models::Channel = cln_channel(&Onchain).into();
-        assert_eq!(c.state, models::ChannelState::Closed);
+        assert_eq!(c.state, models::ChannelState::PendingClose);
 
         Ok(())
     }


### PR DESCRIPTION
When a channel is force closed, during the time period between the closing tx confirmation and the fully swept funds the channels is till returned in `listpeerchannels` API and its status is set to `onchain`.
Perviously we wrongly marked this channel as Closed while it should be still PendingClose as it is not fully swept.
Once the channel will be removed from this list it will be marked as closed.
Note that it might take a delay of 100 blocks after the sweep is finished but this is better than having it closed and misleading the user potentially for a much longer time.
