### PR TITLE
Register and un-register for notifications on all used LSPs

### DIFF
--- a/libs/sdk-common/src/grpc/proto/breez.proto
+++ b/libs/sdk-common/src/grpc/proto/breez.proto
@@ -31,7 +31,7 @@ service Information {
 
 service ChannelOpener {
   rpc LSPList(LSPListRequest) returns (LSPListReply) {}
-  rpc OpenLSPChannel(OpenLSPChannelRequest) returns (OpenLSPChannelReply) {}
+  rpc LSPFullList(LSPFullListRequest) returns (LSPFullListReply) {}
   rpc RegisterPayment(RegisterPaymentRequest) returns (RegisterPaymentReply) {}
   rpc CheckChannels(CheckChannelsRequest) returns (CheckChannelsReply) {}
 }
@@ -147,6 +147,11 @@ message LSPListRequest {
   // The identity pubkey of the client
   string pubkey = 2 [ json_name = "pubkey" ];
 }
+
+message LSPFullListRequest {
+  /// The identity pubkey of the client
+  string pubkey = 1 [json_name = "pubkey"];
+}
 message LSPInformation {
   string name = 1 [ json_name = "name" ];
   string widget_url = 2 [ json_name = "widget_url" ];
@@ -160,7 +165,9 @@ message LSPInformation {
 
   bytes lsp_pubkey = 12;
 
-  repeated OpeningFeeParams opening_fee_params_list = 15;
+  repeated OpeningFeeParams opening_fee_params_menu = 15;
+
+  string id = 16;
 }
 
 // Fee parameters for opening a channel, received from the LSP.
@@ -174,6 +181,10 @@ message OpeningFeeParams {
 }
 message LSPListReply {
   map<string, LSPInformation> lsps = 1; // The key is the lsp id
+}
+
+message LSPFullListReply {
+  repeated LSPInformation lsps = 1;
 }
 
 message RegisterPaymentRequest {

--- a/libs/sdk-common/src/grpc/proto/breez.proto
+++ b/libs/sdk-common/src/grpc/proto/breez.proto
@@ -31,7 +31,11 @@ service Information {
 
 service ChannelOpener {
   rpc LSPList(LSPListRequest) returns (LSPListReply) {}
+
+  // Returns active and historical LSPs used by a node.
+  // In the response, the LSP with a non-empty fee list is active, the LSPs with an empty fee list are historical.
   rpc LSPFullList(LSPFullListRequest) returns (LSPFullListReply) {}
+
   rpc RegisterPayment(RegisterPaymentRequest) returns (RegisterPaymentReply) {}
   rpc CheckChannels(CheckChannelsRequest) returns (CheckChannelsReply) {}
 }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2481,12 +2481,13 @@ impl PaymentReceiver {
         invoice: &str,
         lsp_info: &LspInformation,
     ) -> Result<String, ReceivePaymentError> {
-        ensure_sdk!(
-            self.node_api.has_active_channel_to(lsp_info).await?,
-            ReceivePaymentError::InvoiceNoRoutingHints {
+        info!("Getting routing hints from node");
+        let (mut hints, has_public_channel) = self.node_api.get_routing_hints(lsp_info).await?;
+        if !has_public_channel && hints.is_empty() {
+            return Err(ReceivePaymentError::InvoiceNoRoutingHints {
                 err: "Must have at least one active channel".into(),
-            }
-        );
+            });
+        }
 
         let parsed_invoice = parse_invoice(invoice)?;
 
@@ -2494,8 +2495,6 @@ impl PaymentReceiver {
         info!("Existing routing hints {:?}", parsed_invoice.routing_hints);
 
         // limit the hints to max 3 and extract the lsp one.
-        info!("Getting routing hints from node");
-        let (mut hints, _) = self.node_api.get_routing_hints(lsp_info).await?;
         if let Some(lsp_hint) = Self::limit_and_extract_lsp_hint(&mut hints, lsp_info) {
             if parsed_invoice.contains_hint_for_node(lsp_info.pubkey.as_str()) {
                 return Ok(String::from(invoice));
@@ -2659,7 +2658,9 @@ async fn get_notification_lsps(
             }
             false => {
                 // Consider only historical LSPs with whom we have an active channel
-                if node_api.has_active_channel_to(&lsp).await? {
+                // TODO
+                let has_active_channel_to_lsp = false;
+                if has_active_channel_to_lsp {
                     notification_lsps.push(lsp);
                 }
             }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2681,7 +2681,7 @@ async fn get_notification_lsps(
     let active_lsp_id = persister
         .get_lsp_id()?
         .ok_or(SdkError::generic("No active LSP ID found"))?;
-    let open_peer_channels = node_api.get_open_peer_channels().await?;
+    let open_peers = node_api.get_open_peers().await?;
 
     let mut notification_lsps = vec![];
     for lsp in lsp_api.list_used_lsps(node_pubkey).await? {
@@ -2692,7 +2692,7 @@ async fn get_notification_lsps(
             }
             false => {
                 // Consider only historical LSPs with whom we have an active channel
-                let has_active_channel_to_lsp = open_peer_channels.contains_key(&lsp.lsp_pubkey);
+                let has_active_channel_to_lsp = open_peers.contains(&lsp.lsp_pubkey);
                 if has_active_channel_to_lsp {
                     notification_lsps.push(lsp);
                 }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2706,13 +2706,13 @@ async fn get_notification_lsps(
         .get_node_state()?
         .ok_or(SdkError::generic("Node info not found"))?
         .id;
-    let maybe_active_lsp_id = persister.get_lsp_id()?;
     let open_peers = node_api.get_open_peers().await?;
 
     let mut notification_lsps = vec![];
     for lsp in lsp_api.list_used_lsps(node_pubkey).await? {
-        match matches!(maybe_active_lsp_id, Some(ref active_lsp_id) if active_lsp_id == &lsp.id) {
+        match !lsp.opening_fee_params_list.values.is_empty() {
             true => {
+                // Non-empty fee params list = this is the active LSP
                 // Always consider the active LSP for notifications
                 notification_lsps.push(lsp);
             }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1931,6 +1931,9 @@ impl BreezServices {
         let message = webhook_url.clone();
         let sign_request = SignMessageRequest { message };
         let sign_response = self.sign_message(sign_request).await?;
+
+        // Attempt register call for all relevant LSPs
+        let mut error_found = false;
         for lsp_info in get_notification_lsps(
             self.persister.clone(),
             self.lsp_api.clone(),
@@ -1949,11 +1952,17 @@ impl BreezServices {
                 )
                 .await;
             if res.is_err() {
+                error_found = true;
                 warn!("Failed to register notifications for LSP {lsp_id}: {res:?}");
             }
         }
 
-        Ok(())
+        match error_found {
+            true => Err(SdkError::generic(
+                "Failed to register notifications for at least one LSP, see logs for details",
+            )),
+            false => Ok(()),
+        }
     }
 
     /// Unregisters lightning payment notifications with the current LSP for the `webhook_url`.
@@ -1964,6 +1973,9 @@ impl BreezServices {
         let message = webhook_url.clone();
         let sign_request = SignMessageRequest { message };
         let sign_response = self.sign_message(sign_request).await?;
+
+        // Attempt register call for all relevant LSPs
+        let mut error_found = false;
         for lsp_info in get_notification_lsps(
             self.persister.clone(),
             self.lsp_api.clone(),
@@ -1982,11 +1994,17 @@ impl BreezServices {
                 )
                 .await;
             if res.is_err() {
+                error_found = true;
                 warn!("Failed to un-register notifications for LSP {lsp_id}: {res:?}");
             }
         }
 
-        Ok(())
+        match error_found {
+            true => Err(SdkError::generic(
+                "Failed to un-register notifications for at least one LSP, see logs for details",
+            )),
+            false => Ok(()),
+        }
     }
 
     /// Registers for a onchain tx notification. When a new transaction to the specified `address`

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2706,14 +2706,12 @@ async fn get_notification_lsps(
         .get_node_state()?
         .ok_or(SdkError::generic("Node info not found"))?
         .id;
-    let active_lsp_id = persister
-        .get_lsp_id()?
-        .ok_or(SdkError::generic("No active LSP ID found"))?;
+    let maybe_active_lsp_id = persister.get_lsp_id()?;
     let open_peers = node_api.get_open_peers().await?;
 
     let mut notification_lsps = vec![];
     for lsp in lsp_api.list_used_lsps(node_pubkey).await? {
-        match lsp.id == active_lsp_id {
+        match matches!(maybe_active_lsp_id, Some(ref active_lsp_id) if active_lsp_id == &lsp.id) {
             true => {
                 // Always consider the active LSP for notifications
                 notification_lsps.push(lsp);

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2681,6 +2681,7 @@ async fn get_notification_lsps(
     let active_lsp_id = persister
         .get_lsp_id()?
         .ok_or(SdkError::generic("No active LSP ID found"))?;
+    let open_peer_channels = node_api.get_open_peer_channels().await?;
 
     let mut notification_lsps = vec![];
     for lsp in lsp_api.list_used_lsps(node_pubkey).await? {
@@ -2691,8 +2692,7 @@ async fn get_notification_lsps(
             }
             false => {
                 // Consider only historical LSPs with whom we have an active channel
-                // TODO
-                let has_active_channel_to_lsp = false;
+                let has_active_channel_to_lsp = open_peer_channels.contains_key(&lsp.lsp_pubkey);
                 if has_active_channel_to_lsp {
                     notification_lsps.push(lsp);
                 }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1938,14 +1938,19 @@ impl BreezServices {
         )
         .await?
         {
-            self.lsp_api
+            let lsp_id = lsp_info.id;
+            let res = self
+                .lsp_api
                 .register_payment_notifications(
-                    lsp_info.id,
+                    lsp_id.clone(),
                     lsp_info.lsp_pubkey,
                     webhook_url.clone(),
                     sign_response.signature.clone(),
                 )
-                .await?;
+                .await;
+            if res.is_err() {
+                warn!("Failed to register notifications for LSP {lsp_id}: {res:?}");
+            }
         }
 
         Ok(())
@@ -1966,14 +1971,19 @@ impl BreezServices {
         )
         .await?
         {
-            self.lsp_api
+            let lsp_id = lsp_info.id;
+            let res = self
+                .lsp_api
                 .unregister_payment_notifications(
-                    lsp_info.id,
+                    lsp_id.clone(),
                     lsp_info.lsp_pubkey,
                     webhook_url.clone(),
                     sign_response.signature.clone(),
                 )
-                .await?;
+                .await;
+            if res.is_err() {
+                warn!("Failed to un-register notifications for LSP {lsp_id}: {res:?}");
+            }
         }
 
         Ok(())

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1761,13 +1761,10 @@ impl NodeAPI for Greenlight {
         Ok((hints, has_public_channel))
     }
 
-    async fn get_open_peer_channels(&self) -> NodeResult<HashMap<Vec<u8>, Channel>> {
+    async fn get_open_peers(&self) -> NodeResult<HashSet<Vec<u8>>> {
         let open_peer_channels = self.get_open_peer_channels_pb().await?;
-        let open_peer_channels_converted: HashMap<Vec<u8>, Channel> = open_peer_channels
-            .into_iter()
-            .map(|(k, v)| (k, v.into()))
-            .collect();
-        Ok(open_peer_channels_converted)
+        let open_peers: HashSet<Vec<u8>> = open_peer_channels.into_keys().collect();
+        Ok(open_peers)
     }
 }
 

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1736,6 +1736,11 @@ impl NodeAPI for Greenlight {
         }
         Ok((hints, has_public_channel))
     }
+
+    async fn has_active_channel_to(&self, lsp_info: &LspInformation) -> NodeResult<bool> {
+        let (hints, has_public_channel) = self.get_routing_hints(lsp_info).await?;
+        Ok(has_public_channel || !hints.is_empty())
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -746,7 +746,7 @@ impl Greenlight {
         Ok(max_per_channel)
     }
 
-    /// Get open peer channels as raw protobuf structs, indexed by peer pubkey
+    /// Get open peer channels (private and public) as raw protobuf structs, indexed by peer pubkey
     async fn get_open_peer_channels_pb(
         &self,
     ) -> NodeResult<HashMap<Vec<u8>, cln::ListpeerchannelsChannels>> {
@@ -761,11 +761,7 @@ impl Greenlight {
             .channels
             .into_iter()
             .filter(|c| {
-                let is_private = c.private.unwrap_or_default();
-
-                is_private
-                    && c.state == Some(cln::ChannelState::ChanneldNormal as i32)
-                    && c.peer_id.is_some()
+                c.state == Some(cln::ChannelState::ChanneldNormal as i32) && c.peer_id.is_some()
             })
             .map(|c| (c.peer_id.clone().unwrap(), c))
             .collect();

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1736,11 +1736,6 @@ impl NodeAPI for Greenlight {
         }
         Ok((hints, has_public_channel))
     }
-
-    async fn has_active_channel_to(&self, lsp_info: &LspInformation) -> NodeResult<bool> {
-        let (hints, has_public_channel) = self.get_routing_hints(lsp_info).await?;
-        Ok(has_public_channel || !hints.is_empty())
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]

--- a/libs/sdk-core/src/lsp.rs
+++ b/libs/sdk-core/src/lsp.rs
@@ -61,7 +61,7 @@ impl LspInformation {
             min_htlc_msat: lsp_info.min_htlc_msat,
             lsp_pubkey: lsp_info.lsp_pubkey,
             opening_fee_params_list: OpeningFeeParamsMenu::try_from(
-                lsp_info.opening_fee_params_list,
+                lsp_info.opening_fee_params_menu,
             )?,
         };
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -54,7 +54,10 @@ pub struct Peer {
 /// Trait covering LSP-related functionality
 #[tonic::async_trait]
 pub trait LspAPI: Send + Sync {
+    /// List LSPs available to the given pubkey
     async fn list_lsps(&self, node_pubkey: String) -> SdkResult<Vec<LspInformation>>;
+    /// List all LSPs, active and historical, used by the given pubkey
+    async fn list_used_lsps(&self, node_pubkey: String) -> SdkResult<Vec<LspInformation>>;
     /// Register for webhook callbacks at the given `webhook_url` whenever a new payment is received
     async fn register_payment_notifications(
         &self,

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -182,10 +182,16 @@ pub trait NodeAPI: Send + Sync {
     fn derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
     fn legacy_derive_bip32_key(&self, path: Vec<ChildNumber>) -> NodeResult<ExtendedPrivKey>;
 
-    // Gets the routing hints related to all private channels that the node has.
-    // Also returns a boolean indicating if the node has a public channel or not.
+    /// Gets the routing hints related to all private channels that the node has.
+    /// Also returns a boolean indicating if the node has a public channel or not.
     async fn get_routing_hints(
         &self,
         lsp_info: &LspInformation,
     ) -> NodeResult<(Vec<RouteHint>, bool)>;
+
+    /// Whether or not this node has  an active channel to this LSP
+    async fn has_active_channel_to(
+        &self,
+        lsp_info: &LspInformation,
+    ) -> NodeResult<bool>;
 }

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::pin::Pin;
 
 use anyhow::Result;
@@ -11,7 +12,7 @@ use crate::{
     bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey},
     lightning_invoice::RawBolt11Invoice,
     persist::error::PersistError,
-    CustomMessage, LspInformation, MaxChannelAmount, NodeCredentials, Payment, PaymentResponse,
+    CustomMessage, LspInformation, Channel, MaxChannelAmount, NodeCredentials, Payment, PaymentResponse,
     PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHint, RouteHintHop,
     SyncResponse, TlvEntry, LnUrlAuthError
 };
@@ -188,4 +189,6 @@ pub trait NodeAPI: Send + Sync {
         &self,
         lsp_info: &LspInformation,
     ) -> NodeResult<(Vec<RouteHint>, bool)>;
+    /// Open peer channels, indexed by peer pubkey
+    async fn get_open_peer_channels(&self) -> NodeResult<HashMap<Vec<u8>, Channel>>;
 }

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::pin::Pin;
 
 use anyhow::Result;
@@ -12,7 +12,7 @@ use crate::{
     bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey},
     lightning_invoice::RawBolt11Invoice,
     persist::error::PersistError,
-    CustomMessage, LspInformation, Channel, MaxChannelAmount, NodeCredentials, Payment, PaymentResponse,
+    CustomMessage, LspInformation, MaxChannelAmount, NodeCredentials, Payment, PaymentResponse,
     PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, RouteHint, RouteHintHop,
     SyncResponse, TlvEntry, LnUrlAuthError
 };
@@ -189,6 +189,6 @@ pub trait NodeAPI: Send + Sync {
         &self,
         lsp_info: &LspInformation,
     ) -> NodeResult<(Vec<RouteHint>, bool)>;
-    /// Open peer channels, indexed by peer pubkey
-    async fn get_open_peer_channels(&self) -> NodeResult<HashMap<Vec<u8>, Channel>>;
+    /// Get peers with whom we have an open channel
+    async fn get_open_peers(&self) -> NodeResult<HashSet<Vec<u8>>>;
 }

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -188,10 +188,4 @@ pub trait NodeAPI: Send + Sync {
         &self,
         lsp_info: &LspInformation,
     ) -> NodeResult<(Vec<RouteHint>, bool)>;
-
-    /// Whether or not this node has  an active channel to this LSP
-    async fn has_active_channel_to(
-        &self,
-        lsp_info: &LspInformation,
-    ) -> NodeResult<bool>;
 }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -506,10 +506,6 @@ impl NodeAPI for MockNodeAPI {
     async fn fetch_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>> {
         Ok(None)
     }
-
-    async fn has_active_channel_to(&self, _lsp_info: &LspInformation) -> NodeResult<bool> {
-        Ok(false)
-    }
 }
 
 impl MockNodeAPI {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -44,7 +44,7 @@ use crate::swap_in::swap::create_submarine_swap_script;
 use crate::swap_out::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus};
 use crate::swap_out::error::{ReverseSwapError, ReverseSwapResult};
 use crate::{
-    parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
+    parse_invoice, Channel, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
     OpeningFeeParamsMenu, PaymentResponse, PrepareRedeemOnchainFundsRequest,
     PrepareRedeemOnchainFundsResponse, ReceivePaymentRequest, ReverseSwapPairInfo, RouteHint,
     RouteHintHop, SwapInfo,
@@ -505,6 +505,10 @@ impl NodeAPI for MockNodeAPI {
 
     async fn fetch_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>> {
         Ok(None)
+    }
+
+    async fn get_open_peer_channels(&self) -> NodeResult<HashMap<Vec<u8>, Channel>> {
+        Ok(HashMap::new())
     }
 }
 

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -657,6 +657,10 @@ impl LspAPI for MockBreezServer {
         }])
     }
 
+    async fn list_used_lsps(&self, _node_pubkey: String) -> SdkResult<Vec<LspInformation>> {
+        Ok(vec![])
+    }
+
     async fn register_payment_notifications(
         &self,
         _lsp_id: String,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -506,6 +506,10 @@ impl NodeAPI for MockNodeAPI {
     async fn fetch_bolt11(&self, _payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>> {
         Ok(None)
     }
+
+    async fn has_active_channel_to(&self, _lsp_info: &LspInformation) -> NodeResult<bool> {
+        Ok(false)
+    }
 }
 
 impl MockNodeAPI {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 use std::{mem, vec};
@@ -44,7 +44,7 @@ use crate::swap_in::swap::create_submarine_swap_script;
 use crate::swap_out::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus};
 use crate::swap_out::error::{ReverseSwapError, ReverseSwapResult};
 use crate::{
-    parse_invoice, Channel, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
+    parse_invoice, Config, CustomMessage, LNInvoice, MaxChannelAmount, NodeCredentials,
     OpeningFeeParamsMenu, PaymentResponse, PrepareRedeemOnchainFundsRequest,
     PrepareRedeemOnchainFundsResponse, ReceivePaymentRequest, ReverseSwapPairInfo, RouteHint,
     RouteHintHop, SwapInfo,
@@ -507,8 +507,8 @@ impl NodeAPI for MockNodeAPI {
         Ok(None)
     }
 
-    async fn get_open_peer_channels(&self) -> NodeResult<HashMap<Vec<u8>, Channel>> {
-        Ok(HashMap::new())
+    async fn get_open_peers(&self) -> NodeResult<HashSet<Vec<u8>>> {
+        Ok(HashSet::new())
     }
 }
 


### PR DESCRIPTION
Consider all LSPs used by this node, active and historical, when registering or un-registering for notifications.

Fixes #970