### PR TITLE
Use received amount to account for overpayment

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1929,7 +1929,7 @@ impl TryFrom<gl_client::signer::model::greenlight::Invoice> for Payment {
             id: hex::encode(invoice.payment_hash.clone()),
             payment_type: PaymentType::Received,
             payment_time: invoice.payment_time as i64,
-            amount_msat: amount_to_msat(&invoice.amount.unwrap_or_default()),
+            amount_msat: amount_to_msat(&invoice.received.or(invoice.amount).unwrap_or_default()),
             fee_msat: 0,
             status: PaymentStatus::Complete,
             error: None,
@@ -2033,7 +2033,11 @@ impl TryFrom<cln::ListinvoicesInvoices> for Payment {
             id: hex::encode(invoice.payment_hash.clone()),
             payment_type: PaymentType::Received,
             payment_time: invoice.paid_at.map(|i| i as i64).unwrap_or_default(),
-            amount_msat: invoice.amount_msat.map(|a| a.msat).unwrap_or_default(),
+            amount_msat: invoice
+                .amount_received_msat
+                .or(invoice.amount_msat)
+                .map(|a| a.msat)
+                .unwrap_or_default(),
             fee_msat: 0,
             status: PaymentStatus::Complete,
             error: None,

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -432,7 +432,8 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ALTER TABLE channels ADD COLUMN local_balance_msat INTEGER;
         UPDATE channels SET local_balance_msat = spendable_msat;
        ",
-       "DELETE FROM cached_items WHERE key = 'gl_credentials'"
+       "DELETE FROM cached_items WHERE key = 'gl_credentials'",
+       "DELETE FROM cached_items WHERE key = 'last_sync_time'"
     ]
 }
 


### PR DESCRIPTION
Changes Payment mapping to use the received amount instead of invoice amount to account for overpayments.

Example when sending in Phoenix 1500 instead of 1000 msats:
```
Received payment: amount_received_msat: Some(Amount { msat: 1500 }) amount_msat: Some(Amount { msat: 1000 })
```

Fixes #1026 