### PR TITLE
Update versions to 0.5.0

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-core"
-version = "0.4.2-rc3"
+version = "0.5.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "breez_sdk"
-version = "0.4.2-rc3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "breez-sdk-core",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.4.2-rc3"
+version = "0.5.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.2-rc3"
+version = "0.5.0"
 
 [workspace.dependencies]
 aes = "0.8"

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -1,5 +1,5 @@
 group 'com.breez.breez_sdk'
-version '0.4.2-rc3'
+version '0.5.0'
 
 buildscript {
     ext.kotlin_version = '1.8.20'

--- a/libs/sdk-flutter/ios/breez_sdk.podspec
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec
@@ -2,7 +2,7 @@
 # Run `pod lib lint breez_sdk.podspec` to validate before publishing.
 Pod::Spec.new do |s|
   s.name             = 'breez_sdk'
-  s.version          = '0.4.2-rc3'
+  s.version          = '0.5.0'
   s.summary          = 'BreezSDK flutter plugin.'
   s.description      = <<-DESC
   BreezSDK flutter plugin.

--- a/libs/sdk-flutter/ios/breez_sdk.podspec.production
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec.production
@@ -1,4 +1,4 @@
-tag_version = '0.4.2-rc3'
+tag_version = '0.5.0'
 framework = 'breez_sdkFFI.xcframework'
 lib_name = "breez-sdkFFI.#{tag_version}"
 url = "https://github.com/breez/breez-sdk-swift/releases/download/#{tag_version}/#{framework}.zip"

--- a/libs/sdk-flutter/pubspec.yaml
+++ b/libs/sdk-flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: breez_sdk
 description: Flutter bindings for the Breez SDK
 repository: https://github.com/breez/breez-sdk-flutter
-version: 0.4.2-rc3
+version: 0.5.0
 
 environment:
   sdk: '>=3.3.0 <4.0.0'

--- a/libs/sdk-react-native/example/package.json
+++ b/libs/sdk-react-native/example/package.json
@@ -13,7 +13,7 @@
     "rebuild": "rm -rf node_modules && yarn && yarn pods"
   },
   "dependencies": {
-    "@breeztech/react-native-breez-sdk": "0.4.2-rc3",
+    "@breeztech/react-native-breez-sdk": "0.5.0",
     "@dreson4/react-native-quick-bip39": "^0.0.5",
     "react": "18.1.0",
     "react-native": "0.70.15",

--- a/libs/sdk-react-native/package.json
+++ b/libs/sdk-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@breeztech/react-native-breez-sdk",
-  "version": "0.4.2-rc3",
+  "version": "0.5.0",
   "description": "React Native Breez SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-cli"
-version = "0.4.2-rc3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "breez-sdk-core",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-core"
-version = "0.4.2-rc3"
+version = "0.5.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.4.2-rc3"
+version = "0.5.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/tools/sdk-cli/Cargo.toml
+++ b/tools/sdk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breez-sdk-cli"
-version = "0.4.2-rc3"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Bumps the SDK and bindings versions to from `0.4.2-rc3` to `0.5.0`.

(cherry pick of last commit from `v0.5.0` [branch](https://github.com/breez/breez-sdk/commits/v0.5.0/))