### PR TITLE
"Rename to claim_reverse_swap" cont.

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ConfirmTransaction.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ConfirmTransaction.kt
@@ -52,7 +52,7 @@ class ConfirmTransactionJob(
             }
 
             try {
-                breezSDK.processReverseSwap(address)
+                breezSDK.claimReverseSwap(address)
                 logger.log(TAG, "Found reverse swap for $address", "INFO")
                 return
             } catch (e: Exception) {

--- a/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/Task/ConfirmTransaction.swift
+++ b/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/Task/ConfirmTransaction.swift
@@ -69,7 +69,7 @@ class ConfirmTransactionTask : TaskProtocol {
         }
         
         do {
-            try breezSDK.processReverseSwap(lockupAddress: address)
+            try breezSDK.claimReverseSwap(lockupAddress: address)
             self.logger.log(tag: TAG, line: "Found reverse swap for \(address)", level: "DEBUG")
         } catch let e {
             self.logger.log(tag: TAG, line: "Failed to process reverse swap: \(e)", level: "ERROR")


### PR DESCRIPTION
Applies renaming of `process_reverse_swap` to `claim_reverse_swap` from 
- https://github.com/breez/breez-sdk/pull/953

onto methods on notification service.

Caught when creating [new builds](https://github.com/breez/c-breez/actions/runs/9955256452/job/27502604046#step:19:53) for C-Breez.