### PR TITLE
Include SDK data in `execute_dev_command generatediagnosticdata`

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1554,10 +1554,6 @@ impl NodeAPI for Greenlight {
                     .into_inner();
                 Ok(serde_json::to_string_pretty(&resp)?)
             }
-            NodeCommand::GenerateDiagnosticData => {
-                let resp = self.generate_diagnostic_data().await?;
-                Ok(serde_json::to_string_pretty(&resp)?)
-            }
             NodeCommand::Stop => {
                 let resp = self
                     .get_node_client()
@@ -1777,10 +1773,6 @@ impl NodeAPI for Greenlight {
 
 #[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize)]
 enum NodeCommand {
-    /// Generates diagnostic data report.
-    #[strum(serialize = "generatediagnosticdata")]
-    GenerateDiagnosticData,
-
     /// Closes all channels of all peers.
     #[strum(serialize = "closeallchannels")]
     CloseAllChannels,


### PR DESCRIPTION
This PR:
- Changes `execute_dev_command` to handle the `generatediagnosticdata` dev command in BreezServices to collect SDK and node data.
- Handles errors collecting the data and adds a timestamp when the data was collected.

Fixes #1048, fixes #995 