### PR TITLE
Fix reverse swap claim tx fee estimation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,7 +229,6 @@ jobs:
         working-directory: libs/sdk-react-native 
         run: |
           yarn global add tslint typescript
-          brew update
           brew install kotlin ktlint swiftformat
           make react-native
 

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2015,6 +2015,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,12 +3236,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -3250,10 +3257,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/libs/sdk-common/src/lnurl/model.rs
+++ b/libs/sdk-common/src/lnurl/model.rs
@@ -4,8 +4,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// * `Ok` indicates the interaction with the endpoint was valid, and the endpoint
 ///  - started to pay the invoice asynchronously in the case of LNURL-withdraw,
-///  - verified the client signature in the case of LNURL-auth,////// * `Error` indicates a generic issue the LNURL endpoint encountered, including a freetext
-/// description of the reason.
+///  - verified the client signature in the case of LNURL-auth
+/// * `Error` indicates a generic issue the LNURL endpoint encountered, including a freetext
+///    description of the reason.
 ///
 /// Both cases are described in LUD-03 <https://github.com/lnurl/luds/blob/luds/03.md> & LUD-04: <https://github.com/lnurl/luds/blob/luds/04.md>
 #[derive(Clone, Deserialize, Debug, Serialize)]

--- a/libs/sdk-common/src/utils/rest_client.rs
+++ b/libs/sdk-common/src/utils/rest_client.rs
@@ -51,9 +51,9 @@ pub async fn get_and_log_response(
 ///
 /// - `url`: the URL on which GET will be called
 /// - `enforce_status_check`: if true, the HTTP status code is checked in addition to trying to
-/// parse the payload. In this case, an HTTP error code will automatically cause this function to
-/// return `Err`, regardless of the payload. If false, the result type will be determined only
-/// by the result of parsing the payload into the desired target type.
+///    parse the payload. In this case, an HTTP error code will automatically cause this function to
+///    return `Err`, regardless of the payload. If false, the result type will be determined only
+///    by the result of parsing the payload into the desired target type.
 pub async fn get_parse_and_log_response<T>(
     url: &str,
     enforce_status_check: bool,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -175,9 +175,10 @@ impl BreezServices {
     ///
     /// # Arguments
     ///
-    /// * `req` - The connect request containing the `config` SDK configuration and `seed` node private key, typically derived from the mnemonic.
-    /// When using a new `invite_code`, the seed should be derived from a new random mnemonic.
-    /// When re-using an `invite_code`, the same mnemonic should be used as when the `invite_code` was first used.
+    /// * `req` - The connect request containing the `config` SDK configuration and `seed` node
+    ///   private key, typically derived from the mnemonic. When using a new `invite_code`,
+    ///   the seed should be derived from a new random mnemonic. When re-using an `invite_code`,
+    ///   the same mnemonic should be used as when the `invite_code` was first used.
     /// * `event_listener` - Listener to SDK events
     ///
     pub async fn connect(
@@ -523,7 +524,7 @@ impl BreezServices {
     ///
     /// Calling `report_issue` with a [ReportIssueRequest] enum param sends an issue report using the Support API.
     /// - [ReportIssueRequest::PaymentFailure] sends a payment failure report to the Support API
-    /// using the provided `payment_hash` to lookup the failed payment and the current [NodeState].
+    ///   using the provided `payment_hash` to lookup the failed payment and the current [NodeState].
     pub async fn report_issue(&self, req: ReportIssueRequest) -> SdkResult<()> {
         match self.persister.get_node_state()? {
             Some(node_state) => match req {
@@ -955,8 +956,8 @@ impl BreezServices {
     /// ### Errors
     ///
     /// - `OutOfRange`: This indicates the send amount is outside the range of minimum and maximum
-    /// values returned by [BreezServices::onchain_payment_limits]. When you get this error, please first call
-    /// [BreezServices::onchain_payment_limits] to get the new limits, before calling this method again.
+    ///   values returned by [BreezServices::onchain_payment_limits]. When you get this error, please first call
+    ///   [BreezServices::onchain_payment_limits] to get the new limits, before calling this method again.
     pub async fn prepare_onchain_payment(
         &self,
         req: PrepareOnchainPaymentRequest,

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -98,7 +98,7 @@
 //! ### C. Receiving an on-chain transaction (swap-in)
 //!
 //! * [BreezServices::receive_onchain] accepting an optional user-selected [OpeningFeeParams] for
-//! the case when the operation requires a new channel with the LSP
+//!   the case when the operation requires a new channel with the LSP
 //! * [BreezServices::in_progress_swap]
 //! * [BreezServices::list_refundables] to get a list of swaps
 //! * [BreezServices::refund] to broadcast a transaction for failed or expired swaps
@@ -113,7 +113,7 @@
 //!
 //! 1. [parse] the LNURL endpoint URL to get the workflow parameters.
 //! 2. After getting the user input or confirmation, complete the workflow with [BreezServices::lnurl_pay] or
-//! [BreezServices::lnurl_withdraw].
+//!    [BreezServices::lnurl_withdraw].
 //!
 //! ### F. Supporting fiat currencies
 //!

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -6,14 +6,14 @@ use crate::Payment;
 /// Contains the result of the entire LNURL-pay interaction, as reported by the LNURL endpoint.
 ///
 /// * `EndpointSuccess` indicates the payment is complete. The endpoint may return a `SuccessActionProcessed`,
-/// in which case, the wallet has to present it to the user as described in
-/// <https://github.com/lnurl/luds/blob/luds/09.md>
+///   in which case, the wallet has to present it to the user as described in
+///   <https://github.com/lnurl/luds/blob/luds/09.md>
 ///
 /// * `EndpointError` indicates a generic issue the LNURL endpoint encountered, including a freetext
-/// field with the reason.
+///   field with the reason.
 ///
 /// * `PayError` indicates that an error occurred while trying to pay the invoice from the LNURL endpoint.
-/// This includes the payment hash of the failed invoice and the failure reason.
+///   This includes the payment hash of the failed invoice and the failure reason.
 #[derive(Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum LnUrlPayResult {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -279,7 +279,7 @@ impl FullReverseSwapInfo {
     ///
     /// - checks if amount matches the amount requested by the user
     /// - checks if the payment hash is the same preimage hash (derived from local secret bytes)
-    /// included in the create request
+    ///   included in the create request
     pub(crate) fn validate_invoice(&self, expected_amount_msat: u64) -> ReverseSwapResult<()> {
         self.validate_invoice_amount(expected_amount_msat)?;
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -178,7 +178,7 @@ pub struct ReverseSwapInfoCached {
 
 impl FullReverseSwapInfo {
     /// Builds the expected redeem script
-    fn build_expected_reverse_swap_script(
+    pub(crate) fn build_expected_reverse_swap_script(
         preimage_hash: Vec<u8>,
         compressed_pub_key: Vec<u8>,
         sig: Vec<u8>,

--- a/libs/sdk-core/src/swap_out/boltzswap.rs
+++ b/libs/sdk-core/src/swap_out/boltzswap.rs
@@ -168,10 +168,10 @@ pub struct LockTxData {
 ///
 /// Note that Some Boltz statuses are not reflected here, for any of the following reasons:
 /// - we're not using that version of the reverse swap protocol (like `channel.created`,
-/// `transaction.zeroconf.rejected` for zero-conf, or `invoice.pending` and `minerfee.paid` for
-/// Reverse Swap with prepay miner fee where)
+///   `transaction.zeroconf.rejected` for zero-conf, or `invoice.pending` and `minerfee.paid` for
+///   Reverse Swap with prepay miner fee where)
 /// - the statuses refer to normal swaps, not reverse swaps (like `invoice.set`, `invoice.paid`,
-/// `invoice.failedToPay`, `transaction.claimed`)
+///   `invoice.failedToPay`, `transaction.claimed`)
 /// - the statuses affect only non-BTC pairs (like `transaction.lockupFailed`)
 ///
 /// https://docs.boltz.exchange/en/latest/lifecycle/#reverse-submarine-swaps

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -861,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +1911,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2162,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2767,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -2788,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3074,11 +3096,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -3086,16 +3111,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 


### PR DESCRIPTION
When estimating the claim tx fee for reverse swaps (send onchain), we used a dummy tx with a simple input and a simple output. This was a non-segwit tx with a size of 60 Bytes.

However, this tx structure is simpler than the actual claim tx, which is a segwit tx where the input has a witness with 3 elements: a signature, the preimage and the redeem script. A claim tx has approx. 310 Bytes / 148 vBytes. The actual size varies within a few bytes, depending on the output type and on signature size fluctuations (+/-1 Byte).

This PR extracts the low-level creation of the claim tx in it's own `build_claim_tx_inner`, which it then re-uses
- in the actual claim tx: `create_claim_tx`
- in constructing a dummy tx for the purposes of fee estimation: `build_fake_claim_tx`

This way, the claim tx fee estimation is based on a realistic tx.

The PR is split in 2 commits, for easier review: extracting the low-level `build_claim_tx_inner` and adding `build_fake_claim_tx` on top.

Fixes #1054