### PR TITLE
Validate invoice expiration

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -261,6 +261,12 @@ impl BreezServices {
     ) -> Result<SendPaymentResponse, SendPaymentError> {
         self.start_node().await?;
         let parsed_invoice = parse_invoice(req.bolt11.as_str())?;
+        let invoice_expiration = parsed_invoice.timestamp + parsed_invoice.expiry;
+        if invoice_expiration < SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() {
+            return Err(SendPaymentError::InvoiceExpired {
+                err: format!("Invoice expired at {}", parsed_invoice.expiry).into(),
+            });
+        }
         let invoice_amount_msat = parsed_invoice.amount_msat.unwrap_or_default();
         let provided_amount_msat = req.amount_msat.unwrap_or_default();
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -262,7 +262,8 @@ impl BreezServices {
         self.start_node().await?;
         let parsed_invoice = parse_invoice(req.bolt11.as_str())?;
         let invoice_expiration = parsed_invoice.timestamp + parsed_invoice.expiry;
-        if invoice_expiration < SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() {
+        let current_time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        if invoice_expiration < current_time {
             return Err(SendPaymentError::InvoiceExpired {
                 err: format!("Invoice expired at {}", invoice_expiration),
             });

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -264,7 +264,7 @@ impl BreezServices {
         let invoice_expiration = parsed_invoice.timestamp + parsed_invoice.expiry;
         if invoice_expiration < SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() {
             return Err(SendPaymentError::InvoiceExpired {
-                err: format!("Invoice expired at {}", parsed_invoice.expiry),
+                err: format!("Invoice expired at {}", invoice_expiration),
             });
         }
         let invoice_amount_msat = parsed_invoice.amount_msat.unwrap_or_default();

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -264,7 +264,7 @@ impl BreezServices {
         let invoice_expiration = parsed_invoice.timestamp + parsed_invoice.expiry;
         if invoice_expiration < SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() {
             return Err(SendPaymentError::InvoiceExpired {
-                err: format!("Invoice expired at {}", parsed_invoice.expiry).into(),
+                err: format!("Invoice expired at {}", parsed_invoice.expiry),
             });
         }
         let invoice_amount_msat = parsed_invoice.amount_msat.unwrap_or_default();


### PR DESCRIPTION
Partially fixes #1057 
Checking the balance is a bit tricky since the local cache might be outdated so we will have to query the node and if that's the case then it is better to leave it for the gl-plugin saving the round trip IMO.