### PR TITLE
use invoice destination for trampoline

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -2003,12 +2003,18 @@ impl TryFrom<cln::ListpaysPays> for Payment {
             fee_msat: payment_amount_sent.saturating_sub(payment_amount),
             status,
             error: None,
-            description: ln_invoice.map(|i| i.description).unwrap_or_default(),
+            description: ln_invoice
+                .as_ref()
+                .map(|i| i.description.clone())
+                .unwrap_or_default(),
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
                     payment_hash: hex::encode(payment.payment_hash),
                     label: client_label.unwrap_or_default(),
-                    destination_pubkey: payment.destination.map(hex::encode).unwrap_or_default(),
+                    destination_pubkey: ln_invoice.as_ref().map_or(
+                        payment.destination.map(hex::encode).unwrap_or_default(),
+                        |i| i.payee_pubkey.clone(),
+                    ),
                     payment_preimage: payment.preimage.map(hex::encode).unwrap_or_default(),
                     keysend: payment.bolt11.is_none(),
                     bolt11: payment.bolt11.unwrap_or_default(),


### PR DESCRIPTION
For trampoline, the payment destination is the LSP.
Use the pubkey in the invoice as destination if an invoice is available.